### PR TITLE
Add argument support to cynic-querygen

### DIFF
--- a/cynic-querygen/src/lib.rs
+++ b/cynic-querygen/src/lib.rs
@@ -27,6 +27,9 @@ pub enum Error {
 
     #[error("could not find enum `{0}`")]
     UnknownEnum(String),
+
+    #[error("could not find type `{0}`")]
+    UnknownType(String),
 }
 
 #[derive(Debug)]

--- a/cynic-querygen/src/query_parsing.rs
+++ b/cynic-querygen/src/query_parsing.rs
@@ -48,6 +48,7 @@ impl<'a> ArgumentStruct<'a> {
                 .map(|var| Field {
                     name: var.name,
                     field_type: &var.var_type,
+                    arguments: vec![],
                 })
                 .collect(),
         }
@@ -65,10 +66,7 @@ pub enum PotentialStruct<'a> {
 impl PotentialStruct<'_> {
     fn uses_arguments(&self) -> bool {
         match self {
-            PotentialStruct::QueryFragment(q) => {
-                // TODO: Check if query fragment uses arguments
-                false
-            }
+            PotentialStruct::QueryFragment(q) => q.fields.iter().any(|f| !f.arguments.is_empty()),
             _ => false,
         }
     }
@@ -180,6 +178,7 @@ fn selection_set_to_structs<'a, 'b>(
                 this_fragment.fields.push(Field {
                     name: field.name,
                     field_type,
+                    arguments: field.arguments.clone(),
                 });
 
                 rv.extend(selection_set_to_structs(

--- a/cynic-querygen/src/query_parsing.rs
+++ b/cynic-querygen/src/query_parsing.rs
@@ -1,18 +1,28 @@
-use graphql_parser::query::{Definition, Document, OperationDefinition, Selection, SelectionSet};
-use graphql_parser::schema::EnumType;
+use graphql_parser::query::{
+    Definition, Document, OperationDefinition, Selection, SelectionSet, Value, VariableDefinition,
+};
+use graphql_parser::schema::{EnumType, Type};
 
 use crate::type_index::ScalarKind;
-use crate::{Error, GraphqlType, TypeExt, TypeIndex};
+use crate::{Error, FieldType, TypeExt, TypeIndex};
 
 #[derive(Debug, PartialEq)]
 pub struct Field<'a> {
     pub name: &'a str,
+    pub field_type: &'a Type<'a, &'a str>,
+
+    pub arguments: Vec<(&'a str, Value<'a, &'a str>)>,
 }
 
 #[derive(Debug, PartialEq)]
 pub struct QueryFragment<'a> {
     pub fields: Vec<Field<'a>>,
     pub path: Vec<&'a str>,
+
+    pub argument_struct_name: Option<String>,
+
+    // QueryFragments get the query name if they're at the root of a query
+    pub name: Option<&'a str>,
 }
 
 #[derive(Debug, PartialEq)]
@@ -21,14 +31,47 @@ pub struct Enum<'a> {
 }
 
 #[derive(Debug, PartialEq)]
-pub struct InlineFragment {}
+pub struct ArgumentStruct<'a> {
+    pub name: String,
+    pub fields: Vec<Field<'a>>,
+}
+
+impl<'a> ArgumentStruct<'a> {
+    fn from_variables(
+        variables: &'a Vec<VariableDefinition<'a, &'a str>>,
+        query_name: Option<&'a str>,
+    ) -> ArgumentStruct<'a> {
+        ArgumentStruct {
+            name: format!("{}Arguments", query_name.unwrap_or("")),
+            fields: variables
+                .iter()
+                .map(|var| Field {
+                    name: var.name,
+                    field_type: &var.var_type,
+                })
+                .collect(),
+        }
+    }
+}
 
 #[derive(Debug, PartialEq)]
 pub enum PotentialStruct<'a> {
     QueryFragment(QueryFragment<'a>),
-    InlineFragment(InlineFragment),
     Enum(Enum<'a>),
     Scalar(String),
+    ArgumentStruct(ArgumentStruct<'a>),
+}
+
+impl PotentialStruct<'_> {
+    fn uses_arguments(&self) -> bool {
+        match self {
+            PotentialStruct::QueryFragment(q) => {
+                // TODO: Check if query fragment uses arguments
+                false
+            }
+            _ => false,
+        }
+    }
 }
 
 pub fn parse_query_document<'a>(
@@ -40,12 +83,34 @@ pub fn parse_query_document<'a>(
         .map(|definition| {
             match definition {
                 Definition::Operation(OperationDefinition::Query(query)) => {
-                    let mut structs =
-                        selection_set_to_structs(&query.selection_set, vec![], type_index)?;
+                    let mut structs = vec![];
+
+                    let argument_struct_name = if !query.variable_definitions.is_empty() {
+                        let argument_struct =
+                            ArgumentStruct::from_variables(&query.variable_definitions, query.name);
+
+                        let argument_struct_name = argument_struct.name.clone();
+
+                        structs.push(PotentialStruct::ArgumentStruct(argument_struct));
+
+                        Some(argument_struct_name)
+                    } else {
+                        None
+                    };
+
+                    let mut selection_structs = selection_set_to_structs(
+                        &query.selection_set,
+                        vec![],
+                        type_index,
+                        query.name,
+                        argument_struct_name.as_deref(),
+                    )?;
 
                     // selection_set_to_structs traverses the tree in post-order
                     // (sort of), so we reverse to get the root node first.
-                    structs.reverse();
+                    selection_structs.reverse();
+
+                    structs.append(&mut selection_structs);
 
                     Ok(structs)
                 }
@@ -75,10 +140,12 @@ pub fn parse_query_document<'a>(
         .map(|vec| vec.into_iter().flatten().collect())
 }
 
-fn selection_set_to_structs<'a>(
+fn selection_set_to_structs<'a, 'b>(
     selection_set: &'a SelectionSet<'a, &'a str>,
     path: Vec<&'a str>,
     type_index: &TypeIndex<'a>,
+    query_name: Option<&'a str>,
+    argument_struct_name: Option<&'b str>,
 ) -> Result<Vec<PotentialStruct<'a>>, Error> {
     let mut rv = Vec::new();
 
@@ -87,10 +154,8 @@ fn selection_set_to_structs<'a>(
     if !path.is_empty() {
         let type_name = type_index.type_for_path(&path)?.inner_name();
         match type_index.lookup_type(type_name) {
-            Some(GraphqlType::Enum(en)) => {
-                return Ok(vec![PotentialStruct::Enum(Enum { def: en })])
-            }
-            Some(GraphqlType::Scalar(ScalarKind::Custom)) => {
+            Some(FieldType::Enum(en)) => return Ok(vec![PotentialStruct::Enum(Enum { def: en })]),
+            Some(FieldType::Scalar(ScalarKind::Custom)) => {
                 return Ok(vec![PotentialStruct::Scalar(type_name.to_string())]);
             }
             _ => (),
@@ -100,20 +165,29 @@ fn selection_set_to_structs<'a>(
     let mut this_fragment = QueryFragment {
         path: path.clone(),
         fields: Vec::new(),
+        name: query_name,
+        argument_struct_name: None,
     };
 
     for item in &selection_set.items {
         match item {
             Selection::Field(field) => {
-                this_fragment.fields.push(Field { name: field.name });
-
                 let mut new_path = path.clone();
                 new_path.push(field.name);
+
+                let field_type = type_index.type_for_path(&new_path)?;
+
+                this_fragment.fields.push(Field {
+                    name: field.name,
+                    field_type,
+                });
 
                 rv.extend(selection_set_to_structs(
                     &field.selection_set,
                     new_path,
                     type_index,
+                    None,
+                    argument_struct_name,
                 )?);
             }
             Selection::FragmentSpread(_) => {
@@ -130,6 +204,10 @@ fn selection_set_to_structs<'a>(
     }
 
     if !this_fragment.fields.is_empty() {
+        if rv.iter().any(|s| s.uses_arguments()) {
+            this_fragment.argument_struct_name = argument_struct_name.map(|name| name.to_string());
+        }
+
         rv.push(PotentialStruct::QueryFragment(this_fragment));
     }
 

--- a/cynic-querygen/src/type_ext.rs
+++ b/cynic-querygen/src/type_ext.rs
@@ -2,7 +2,7 @@ use graphql_parser::query::Type;
 use inflector::Inflector;
 use std::borrow::Cow;
 
-use crate::{GraphqlType, TypeIndex};
+use crate::{FieldType, TypeIndex};
 
 pub trait TypeExt<'a> {
     fn inner_name(&self) -> &str;
@@ -46,8 +46,8 @@ fn type_spec_imp<'a>(
         Type::NamedType("Boolean") => Cow::Borrowed("bool"),
         Type::NamedType("ID") => Cow::Borrowed("cynic::Id"),
         Type::NamedType(s) => match type_index.lookup_type(s) {
-            Some(GraphqlType::Enum(_)) => Cow::Owned(s.to_pascal_case()),
-            Some(GraphqlType::Object(_)) => Cow::Owned(s.to_pascal_case()),
+            Some(FieldType::Enum(_)) => Cow::Owned(s.to_pascal_case()),
+            Some(FieldType::Object(_)) => Cow::Owned(s.to_pascal_case()),
             _ => Cow::Borrowed(s),
         },
     }

--- a/cynic-querygen/src/value_ext.rs
+++ b/cynic-querygen/src/value_ext.rs
@@ -1,0 +1,30 @@
+use graphql_parser::query::Value;
+
+/// Extension trait for graphql_parser::common::Value;
+pub trait ValueExt {
+    fn to_literal(&self) -> String;
+}
+
+impl<'a> ValueExt for Value<'a, &'a str> {
+    fn to_literal(&self) -> String {
+        match self {
+            Value::Variable(name) => format!("args.{}", name),
+            Value::Int(num) => num.as_i64().unwrap().to_string(),
+            Value::Float(num) => num.to_string(),
+            Value::String(s) => format!("\"{}\"", s),
+            Value::Boolean(b) => b.to_string(),
+            Value::Null => "None".into(),
+            Value::Enum(v) => v.to_string(),
+            Value::List(values) => {
+                let inner = values
+                    .iter()
+                    .map(|v| v.to_literal())
+                    .collect::<Vec<_>>()
+                    .join(", ");
+
+                format!("vec![{}]", inner)
+            }
+            Value::Object(_) => "TODO".into(),
+        }
+    }
+}

--- a/cynic-querygen/src/value_ext.rs
+++ b/cynic-querygen/src/value_ext.rs
@@ -11,7 +11,7 @@ impl<'a> ValueExt for Value<'a, &'a str> {
             Value::Variable(name) => format!("args.{}", name),
             Value::Int(num) => num.as_i64().unwrap().to_string(),
             Value::Float(num) => num.to_string(),
-            Value::String(s) => format!("\"{}\"", s),
+            Value::String(s) => format!("\"{}\".to_string()", s),
             Value::Boolean(b) => b.to_string(),
             Value::Null => "None".into(),
             Value::Enum(v) => v.to_string(),

--- a/cynic/src/id.rs
+++ b/cynic/src/id.rs
@@ -1,3 +1,4 @@
+#[derive(Clone, Debug)]
 pub struct Id(String);
 
 impl Id {


### PR DESCRIPTION
This updates cynic-querygen to:

- Generate argument structs for any query arguments in the queries
  passed to it.
- Annotate any structs in the heirarchy that need the arguments with the
  argument_struct attribute
- Names the root query type more appropriately.
- Annotates fields with cynic_arguments when they have arguments in the query.