### PR TITLE
Rework argument & query serialization

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,5 +13,7 @@ jobs:
       run: cargo build --verbose
     - name: Run tests
       run: cargo test --verbose --all-features
+    - name: Test examples
+      run: cargo test --examples
     - name: Check formatting
       run: cargo fmt -- --check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ all APIs might be changed.
 ### Bug Fixes
 
 - `cynic-codegen` will now build with the rustfmt feature disabled.
+- Removed some unwraps that I lazily put in and forgot to remove.
 
 ## 0.4.0 - 2020-06-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,9 @@ all APIs might be changed.
   previously exposed by `Query::body()` will now be surfaced when serializing a
   Query.
 - `Argument::new` has been updated to take a `SerialiableArgument` itself.
-
+- Removed `selection_set::Error`.
+- `SerializableArgument::serialize` & `Scalar::encode` now return
+  `Box<std::error::Error>` errors rather than `()`
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ all APIs might be changed.
 
 ## Unreleased - xxxx-xx-xx
 
+### Breaking Changes
+
+- `Query::body` no longer exists, the `Query` itself is now directly
+  serializable, and exposes the `query` type itself.  Errors that were
+  previously exposed by `Query::body()` will now be surfaced when serializing a
+  Query.
+- `Argument::new` has been updated to take a `SerialiableArgument` itself.
+
+
 ### Bug Fixes
 
 - `cynic-codegen` will now build with the rustfmt feature disabled.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,6 +28,16 @@ version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "hermit-abi 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.71 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -83,6 +93,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "clicolors-control"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "atty 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.71 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "combine"
 version = "3.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -92,6 +113,20 @@ dependencies = [
  "either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "console"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "clicolors-control 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "encode_unicode 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.71 (registry+https://github.com/rust-lang/crates.io-index)",
+ "terminal_size 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "termios 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -161,6 +196,7 @@ version = "0.4.0"
 dependencies = [
  "cynic 0.4.0",
  "cynic-codegen 0.4.0",
+ "insta 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.10.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -232,6 +268,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "difference"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "discard"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -249,6 +290,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "enclose"
 version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "encode_unicode"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -556,6 +602,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "insta"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "console 0.10.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "difference 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.55 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_yaml 0.8.13 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "iovec"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -603,6 +662,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "libc"
 version = "0.2.71"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1086,6 +1150,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.8.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "dtoa 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "linked-hash-map 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
+ "yaml-rust 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "sha1"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1190,6 +1265,23 @@ dependencies = [
  "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
  "remove_dir_all 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.71 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "termios"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.71 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1544,11 +1636,20 @@ dependencies = [
  "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
+[[package]]
+name = "yaml-rust"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "linked-hash-map 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
 [metadata]
 "checksum Inflector 0.11.4 (registry+https://github.com/rust-lang/crates.io-index)" = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
 "checksum aho-corasick 0.7.10 (registry+https://github.com/rust-lang/crates.io-index)" = "8716408b8bc624ed7f65d223ddb9ac2d044c0547b6fa4b0d554f3a9540496ada"
 "checksum ascii 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "eab1c04a571841102f5345a8fc0f6bb3d31c315dec879b5c6e42e40ce7ffa34e"
 "checksum assert_matches 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7deb0a829ca7bcfaf5da70b073a8d128619259a7be8216a355e23f00763059e5"
+"checksum atty 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 "checksum autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
 "checksum base-x 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "1b20b618342cf9891c292c4f5ac2cde7287cc5c87e87e9c769d617793607dec1"
 "checksum base64 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)" = "53d1ccbaf7d9ec9537465a97bf19edc1a4e158ecb49fc16178202238c569cc42"
@@ -1559,7 +1660,9 @@ dependencies = [
 "checksum cc 1.0.54 (registry+https://github.com/rust-lang/crates.io-index)" = "7bbb73db36c1246e9034e307d0fba23f9a2e251faa47ade70c1bd252220c8311"
 "checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 "checksum chrono 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)" = "80094f509cf8b5ae86a4966a39b3ff66cd7e2a3e594accec3743ff3fabeab5b2"
+"checksum clicolors-control 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "90082ee5dcdd64dc4e9e0d37fbf3ee325419e39c0092191e0393df65518f741e"
 "checksum combine 3.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "da3da6baa321ec19e1cc41d31bf599f00c783d0517095cdaf0332e3fe8d20680"
+"checksum console 0.10.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2586208b33573b7f76ccfbe5adb076394c88deaf81b84d7213969805b0a952a7"
 "checksum console_error_panic_hook 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "b8d976903543e0c48546a91908f21588a680a8c8f984df9a5d69feccb2b2a211"
 "checksum cookie 0.13.3 (registry+https://github.com/rust-lang/crates.io-index)" = "0c60ef6d0bbf56ad2674249b6bb74f2c6aeb98b98dd57b5d3e37cace33011d69"
 "checksum core-foundation 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "57d24c7a13c43e870e37c1556b74555437870a04514f7685f5b354e090567171"
@@ -1568,10 +1671,12 @@ dependencies = [
 "checksum darling_core 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f0c960ae2da4de88a91b2d920c2a7233b400bc33cb28453a2987822d8392519b"
 "checksum darling_macro 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d9b5a2f4ac4969822c62224815d069952656cadc7084fdca9751e6d959189b72"
 "checksum dbg 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4677188513e0e9d7adced5997cf9a1e7a3c996c994f90093325c5332c1a8b221"
+"checksum difference 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
 "checksum discard 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
 "checksum dtoa 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "4358a9e11b9a09cf52383b451b49a169e8d797b68aa02301ff586d70d9661ea3"
 "checksum either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
 "checksum enclose 1.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "1056f553da426e9c025a662efa48b52e62e0a3a7648aa2d15aeaaf7f0d329357"
+"checksum encode_unicode 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 "checksum encoding_rs 0.8.23 (registry+https://github.com/rust-lang/crates.io-index)" = "e8ac63f94732332f44fe654443c46f6375d1939684c17b0afb6cb56b0456e171"
 "checksum fnv 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)" = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 "checksum foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
@@ -1604,6 +1709,7 @@ dependencies = [
 "checksum ident_case 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 "checksum idna 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "02e2673c30ee86b5b96a9cb52ad15718aa1f966f5ab9ad54a8b95d5ca33120a9"
 "checksum indexmap 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c398b2b113b55809ceb9ee3e753fcbac793f1956663f3c36549c1346015c2afe"
+"checksum insta 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8386e795fb3927131ea4cede203c529a333652eb6dc4ff29616b832b27e9b096"
 "checksum iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
 "checksum itoa 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "b8b7a7c0c47db5545ed3fef7468ee7bb5b74691498139e4b3f6a20685dc6dd8e"
 "checksum js-sys 0.3.40 (registry+https://github.com/rust-lang/crates.io-index)" = "ce10c23ad2ea25ceca0093bd3192229da4c5b3c0f2de499c1ecac0d98d452177"
@@ -1611,6 +1717,7 @@ dependencies = [
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 "checksum libc 0.2.71 (registry+https://github.com/rust-lang/crates.io-index)" = "9457b06509d27052635f90d6466700c65095fdf75409b3fbdd903e988b886f49"
+"checksum linked-hash-map 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8dd5a6d5999d9907cda8ed67bbd137d3af8085216c2ac62de5be860bd41f304a"
 "checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
 "checksum maplit 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 "checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
@@ -1664,6 +1771,7 @@ dependencies = [
 "checksum serde_derive 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)" = "3f2c3ac8e6ca1e9c80b8be1023940162bf81ae3cffbb1809474152f2ce1eb250"
 "checksum serde_json 1.0.55 (registry+https://github.com/rust-lang/crates.io-index)" = "ec2c5d7e739bc07a3e73381a39d61fdb5f671c60c1df26a130690665803d8226"
 "checksum serde_urlencoded 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9ec5d77e2d4c73717816afac02670d5c4f534ea95ed430442cad02e7a6e32c97"
+"checksum serde_yaml 0.8.13 (registry+https://github.com/rust-lang/crates.io-index)" = "ae3e2dd40a7cdc18ca80db804b7f461a39bb721160a85c9a1fa30134bf3c02a5"
 "checksum sha1 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2579985fda508104f7587689507983eadd6a6e84dd35d6d115361f530916fa0d"
 "checksum slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 "checksum smallvec 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c7cb5678e1615754284ec264d9bb5b4c27d2018577fd90ac0ceb578591ed5ee4"
@@ -1676,6 +1784,8 @@ dependencies = [
 "checksum strsim 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c"
 "checksum syn 1.0.31 (registry+https://github.com/rust-lang/crates.io-index)" = "b5304cfdf27365b7585c25d4af91b35016ed21ef88f17ced89c7093b43dba8b6"
 "checksum tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
+"checksum terminal_size 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "8038f95fc7a6f351163f4b964af631bd26c9e828f7db085f2a84aca56f70d13b"
+"checksum termios 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6f0fcee7b24a25675de40d5bb4de6e41b0df07bc9856295e7e2b3a3600c400c2"
 "checksum thiserror 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)" = "b13f926965ad00595dd129fa12823b04bbf866e9085ab0a5f2b05b850fbfc344"
 "checksum thiserror-impl 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)" = "893582086c2f98cde18f906265a65b5030a074b1046c674ae898be6519a7f479"
 "checksum thread_local 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
@@ -1718,3 +1828,4 @@ dependencies = [
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 "checksum winreg 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
 "checksum ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
+"checksum yaml-rust 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "39f0c922f1a334134dc2f7a8b67dc5d25f0735263feec974345ff706bcf20b0d"

--- a/cynic-codegen/src/enum_derive/mod.rs
+++ b/cynic-codegen/src/enum_derive/mod.rs
@@ -93,12 +93,12 @@ pub fn enum_derive_impl(
             }
 
             impl ::cynic::SerializableArgument for #ident {
-                fn serialize(&self) -> Result<serde_json::Value, ()> {
-                    ::serde_json::to_value(match self {
+                fn serialize(&self) -> Result<serde_json::Value, ::cynic::SerializeError> {
+                    Ok(::serde_json::to_value(match self {
                         #(
                             #ident::#variants => #string_literals.to_string(),
                         )*
-                    }).map_err(|_| ())
+                    })?)
                 }
             }
         })

--- a/cynic-codegen/src/field_argument.rs
+++ b/cynic-codegen/src/field_argument.rs
@@ -86,12 +86,12 @@ impl GenericConstraint {
             GenericConstraint::Enum(ident) => {
                 let type_path = TypePath::concat(&[path_to_markers, ident.clone().into()]);
 
-                quote! { ::cynic::Enum<#type_path> + ::cynic::SerializableArgument }
+                quote! { ::cynic::Enum<#type_path> + ::cynic::SerializableArgument + 'static}
             }
             GenericConstraint::InputObject(ident) => {
                 let type_path = TypePath::concat(&[path_to_markers, ident.clone().into()]);
 
-                quote! { ::cynic::InputObject<#type_path> + ::cynic::SerializableArgument }
+                quote! { ::cynic::InputObject<#type_path> + ::cynic::SerializableArgument + 'static}
             }
         }
     }

--- a/cynic-codegen/src/query_dsl/field_selector.rs
+++ b/cynic-codegen/src/query_dsl/field_selector.rs
@@ -91,7 +91,7 @@ impl quote::ToTokens for FieldSelector {
             ) -> #selection_builder {
                 #selection_builder::new(vec![
                     #(
-                        ::cynic::Argument::from_serializable(
+                        ::cynic::Argument::new(
                             #argument_strings,
                             #argument_gql_types,
                             #argument_names

--- a/cynic-codegen/src/query_dsl/selection_builder.rs
+++ b/cynic-codegen/src/query_dsl/selection_builder.rs
@@ -134,7 +134,7 @@ impl quote::ToTokens for FieldSelectionBuilder {
                         mut self, #argument_names: #argument_types
                     ) -> Self {
                         self.args.push(
-                            ::cynic::Argument::from_serializable(
+                            ::cynic::Argument::new(
                                 #argument_strings,
                                 #argument_gql_types,
                                 #argument_names

--- a/cynic-codegen/src/scalar_derive/mod.rs
+++ b/cynic-codegen/src/scalar_derive/mod.rs
@@ -34,7 +34,7 @@ pub fn scalar_derive_impl(input: ScalarDeriveInput) -> Result<TokenStream, syn::
             fn decode(value: &serde_json::Value) -> Result<Self, ::cynic::DecodeError> {
                 Ok(#ident(<#inner_type as ::cynic::Scalar>::decode(value)?))
             }
-            fn encode(&self) -> Result<serde_json::Value, ()> {
+            fn encode(&self) -> Result<serde_json::Value, ::cynic::SerializeError> {
                 Ok(self.0.encode()?)
             }
         }

--- a/cynic/examples/simple.rs
+++ b/cynic/examples/simple.rs
@@ -121,7 +121,7 @@ mod test {
         fn decode(_: &serde_json::Value) -> Result<Self, json_decode::DecodeError> {
             Ok(DateTime {})
         }
-        fn encode(&self) -> Result<serde_json::Value, ()> {
+        fn encode(&self) -> Result<serde_json::Value, ::cynic::SerializeError> {
             todo!()
         }
     }

--- a/cynic/examples/simple_v2.rs
+++ b/cynic/examples/simple_v2.rs
@@ -83,7 +83,7 @@ mod test {
         fn decode(_: &serde_json::Value) -> Result<Self, json_decode::DecodeError> {
             Ok(DateTime {})
         }
-        fn encode(&self) -> Result<serde_json::Value, ()> {
+        fn encode(&self) -> Result<serde_json::Value, ::cynic::SerializeError> {
             todo!()
         }
     }

--- a/cynic/src/argument.rs
+++ b/cynic/src/argument.rs
@@ -25,8 +25,7 @@ impl serde::Serialize for Argument {
 
         match self.value.serialize() {
             Ok(json_val) => serde::Serialize::serialize(&json_val, serializer),
-            // TODO: Better error here...
-            Err(e) => Err(S::Error::custom("Could not serialize")),
+            Err(e) => Err(S::Error::custom(e.to_string())),
         }
     }
 }

--- a/cynic/src/argument.rs
+++ b/cynic/src/argument.rs
@@ -1,4 +1,4 @@
-use crate::Scalar;
+use crate::{Scalar, SerializeError};
 
 pub struct Argument {
     pub(crate) name: String,
@@ -32,18 +32,18 @@ impl serde::Serialize for Argument {
 }
 
 pub trait SerializableArgument {
-    fn serialize(&self) -> Result<serde_json::Value, ()>;
+    fn serialize(&self) -> Result<serde_json::Value, SerializeError>;
 }
 
 // All Input objects are serializable.
 impl<TypeLock> SerializableArgument for dyn crate::InputObject<TypeLock> {
-    fn serialize(&self) -> Result<serde_json::Value, ()> {
+    fn serialize(&self) -> Result<serde_json::Value, SerializeError> {
         self.serialize()
     }
 }
 
 impl<T: SerializableArgument> SerializableArgument for Vec<T> {
-    fn serialize(&self) -> Result<serde_json::Value, ()> {
+    fn serialize(&self) -> Result<serde_json::Value, SerializeError> {
         self.iter()
             .map(|s| s.serialize())
             .collect::<Result<Vec<_>, _>>()
@@ -52,7 +52,7 @@ impl<T: SerializableArgument> SerializableArgument for Vec<T> {
 }
 
 impl<T: SerializableArgument> SerializableArgument for Option<T> {
-    fn serialize(&self) -> Result<serde_json::Value, ()> {
+    fn serialize(&self) -> Result<serde_json::Value, SerializeError> {
         match self {
             Some(inner) => Ok(inner.serialize()?),
             None => Ok(serde_json::Value::Null),
@@ -61,7 +61,7 @@ impl<T: SerializableArgument> SerializableArgument for Option<T> {
 }
 
 impl<T: Scalar> SerializableArgument for T {
-    fn serialize(&self) -> Result<serde_json::Value, ()> {
+    fn serialize(&self) -> Result<serde_json::Value, SerializeError> {
         self.encode()
     }
 }

--- a/cynic/src/field.rs
+++ b/cynic/src/field.rs
@@ -9,15 +9,14 @@ pub enum Field {
 
 impl Field {
     pub(crate) fn query<'a>(
-        &'a self,
+        self,
         indent: usize,
         indent_size: usize,
-        argument_values: &mut Vec<Result<&'a serde_json::Value, ()>>,
-        argument_types: &mut Vec<&'a str>,
+        arguments_out: &mut Vec<Argument>,
     ) -> String {
         match self {
             Field::Leaf(field_name, args) => {
-                let arguments = handle_field_arguments(args, argument_values, argument_types);
+                let arguments = handle_field_arguments(args, arguments_out);
                 format!(
                     "{:indent$}{field_name}{arguments}\n",
                     "",
@@ -27,17 +26,10 @@ impl Field {
                 )
             }
             Field::Composite(field_name, args, child_fields) => {
-                let arguments = handle_field_arguments(args, argument_values, argument_types);
+                let arguments = handle_field_arguments(args, arguments_out);
                 let child_query: String = child_fields
-                    .iter()
-                    .map(|f| {
-                        f.query(
-                            indent + indent_size,
-                            indent_size,
-                            argument_values,
-                            argument_types,
-                        )
-                    })
+                    .into_iter()
+                    .map(|f| f.query(indent + indent_size, indent_size, arguments_out))
                     .collect();
 
                 format!(
@@ -51,15 +43,8 @@ impl Field {
             }
             Field::InlineFragment(type_name, child_fields) => {
                 let child_query: String = child_fields
-                    .iter()
-                    .map(|f| {
-                        f.query(
-                            indent + indent_size,
-                            indent_size,
-                            argument_values,
-                            argument_types,
-                        )
-                    })
+                    .into_iter()
+                    .map(|f| f.query(indent + indent_size, indent_size, arguments_out))
                     .collect();
 
                 format!(
@@ -72,18 +57,11 @@ impl Field {
             }
             Field::Root(fields) => {
                 let child_query: String = fields
-                    .iter()
-                    .map(|f| {
-                        f.query(
-                            indent + indent_size,
-                            indent_size,
-                            argument_values,
-                            argument_types,
-                        )
-                    })
+                    .into_iter()
+                    .map(|f| f.query(indent + indent_size, indent_size, arguments_out))
                     .collect();
 
-                let arguments = handle_query_arguments(argument_types);
+                let arguments = handle_query_arguments(arguments_out);
 
                 format!(
                     "query Query{arguments} {{\n{child_query}}}\n",
@@ -97,21 +75,19 @@ impl Field {
 
 /// Extracts any argument values & returns a string to be used in a query.
 fn handle_field_arguments<'a>(
-    arguments: &'a Vec<Argument>,
-    argument_values: &mut Vec<Result<&'a serde_json::Value, ()>>,
-    argument_types: &mut Vec<&'a str>,
+    arguments: Vec<Argument>,
+    arguments_out: &mut Vec<Argument>,
 ) -> String {
     if arguments.is_empty() {
         "".to_string()
     } else {
-        let mut argument_index = argument_values.len();
+        let mut argument_index = arguments_out.len();
 
         let comma_seperated = arguments
-            .iter()
+            .into_iter()
             .map(|arg| {
-                argument_values.push(arg.value.as_ref().map_err(|_| ()).clone());
-                argument_types.push(&arg.type_);
                 let rv = format!("{}: $_{}", arg.name, argument_index);
+                arguments_out.push(arg);
                 argument_index += 1;
                 rv
             })
@@ -123,14 +99,14 @@ fn handle_field_arguments<'a>(
 }
 
 /// Extracts any argument values & returns a string to be used in a query.
-fn handle_query_arguments<'a>(argument_types: &'a Vec<&str>) -> String {
-    if argument_types.is_empty() {
+fn handle_query_arguments<'a>(arguments: &'a Vec<Argument>) -> String {
+    if arguments.is_empty() {
         "".to_string()
     } else {
-        let comma_seperated = argument_types
+        let comma_seperated = arguments
             .iter()
             .enumerate()
-            .map(|(i, arg_type)| format!("$_{}: {}", i, arg_type))
+            .map(|(i, arg)| format!("$_{}: {}", i, arg.type_))
             .collect::<Vec<_>>()
             .join(", ");
 
@@ -141,6 +117,7 @@ fn handle_query_arguments<'a>(argument_types: &'a Vec<&str>) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::json;
 
     #[test]
     fn test_query_building() {
@@ -157,14 +134,12 @@ mod tests {
             ],
         );
         let mut arguments = vec![];
-        let mut argument_types = vec![];
 
         assert_eq!(
-            fields.query(0, 2, &mut arguments, &mut argument_types),
+            fields.query(0, 2, &mut arguments),
             "test_struct {\n  field_one\n  nested {\n    a_string\n  }\n}\n"
         );
         assert!(arguments.is_empty());
-        assert!(argument_types.is_empty());
     }
 
     #[test]
@@ -185,9 +160,8 @@ mod tests {
             ],
         );
         let mut arguments = vec![];
-        let mut argument_types = vec![];
         assert_eq!(
-            fields.query(0, 2, &mut arguments, &mut argument_types),
+            fields.query(0, 2, &mut arguments),
             "test {\n  __typename\n  ... on TypeOne {\n    a_field\n  }\n  ... on TypeTwo {\n    another_field\n  }\n}\n"
         );
     }
@@ -196,11 +170,7 @@ mod tests {
     fn test_query_with_arguments() {
         let fields = Field::Composite(
             "test_struct".to_string(),
-            vec![Argument::new(
-                "an_arg",
-                "Bool!",
-                serde_json::Value::Bool(false),
-            )],
+            vec![Argument::new("an_arg", "Bool!", false)],
             vec![
                 Field::Leaf("field_one".to_string(), vec![]),
                 Field::Composite(
@@ -208,29 +178,30 @@ mod tests {
                     vec![],
                     vec![Field::Leaf(
                         "a_string".to_string(),
-                        vec![Argument::new(
-                            "another_arg",
-                            "Bool!",
-                            serde_json::Value::Bool(true),
-                        )],
+                        vec![Argument::new("another_arg", "Bool!", true)],
                     )],
                 ),
             ],
         );
         let mut arguments = vec![];
-        let mut argument_types = vec![];
 
         assert_eq!(
-            fields.query(0, 2, &mut arguments, &mut argument_types),
+            fields.query(0, 2, &mut arguments),
             "test_struct(an_arg: $_0) {\n  field_one\n  nested {\n    a_string(another_arg: $_1)\n  }\n}\n"
         );
         assert_eq!(
             arguments
-                .into_iter()
-                .map(|v| serde_json::from_value::<bool>(v.unwrap().clone()).unwrap())
+                .iter()
+                .map(|a| a.value.serialize().unwrap())
                 .collect::<Vec<_>>(),
-            vec![false, true]
+            vec![json!(false), json!(true)]
         );
-        assert_eq!(argument_types, vec!["Bool!", "Bool!"]);
+        assert_eq!(
+            arguments
+                .iter()
+                .map(|a| a.type_.clone())
+                .collect::<Vec<_>>(),
+            vec!["Bool!", "Bool!"]
+        );
     }
 }

--- a/cynic/src/id.rs
+++ b/cynic/src/id.rs
@@ -1,3 +1,5 @@
+use crate::SerializeError;
+
 #[derive(Clone, Debug)]
 pub struct Id(String);
 
@@ -22,7 +24,7 @@ impl crate::Scalar for Id {
         String::decode(value).map(Into::into)
     }
 
-    fn encode(&self) -> Result<serde_json::Value, ()> {
+    fn encode(&self) -> Result<serde_json::Value, SerializeError> {
         self.0.encode()
     }
 }

--- a/cynic/src/lib.rs
+++ b/cynic/src/lib.rs
@@ -1,6 +1,6 @@
 //! # Cynic
 //!
-//! Cynic is a GraphQL query builder & data mapper for Rust.  
+//! Cynic is a GraphQL query builder & data mapper for Rust.
 //!
 //! See [the README on GitHub](https://github.com/polyandglot/cynic) for more details.
 //!
@@ -258,9 +258,9 @@ where
 pub trait QueryRoot {}
 
 #[derive(Debug, serde::Serialize)]
-pub struct QueryBody<'a> {
+pub struct QueryBody {
     pub query: String,
-    pub variables: HashMap<String, &'a serde_json::Value>,
+    pub variables: HashMap<String, serde_json::Value>,
 }
 
 pub use cynic_proc_macros::{

--- a/cynic/src/lib.rs
+++ b/cynic/src/lib.rs
@@ -208,6 +208,8 @@ where
     }
 }
 
+pub type SerializeError = Box<dyn std::error::Error>;
+
 /// A trait for GraphQL enums.
 ///
 /// This trait is generic over some TypeLock which is used to tie an Enum
@@ -223,7 +225,7 @@ pub trait Enum<TypeLock>: Sized {
 /// back into it's GraphQL input object.  Generally this will be some type
 /// generated in the GQL code.
 pub trait InputObject<TypeLock> {
-    fn serialize(&self) -> Result<serde_json::Value, ()>;
+    fn serialize(&self) -> Result<serde_json::Value, SerializeError>;
 }
 
 /// A marker trait for the arguments types on QueryFragments.
@@ -256,12 +258,6 @@ where
 }
 
 pub trait QueryRoot {}
-
-#[derive(Debug, serde::Serialize)]
-pub struct QueryBody {
-    pub query: String,
-    pub variables: HashMap<String, serde_json::Value>,
-}
 
 pub use cynic_proc_macros::{
     query_dsl, query_module, Enum, FragmentArguments, InlineFragments, QueryFragment, Scalar,

--- a/cynic/src/lib.rs
+++ b/cynic/src/lib.rs
@@ -92,7 +92,7 @@
 //! ```rust,ignore
 //! let response = reqwest::blocking::Client::new()
 //!                     .post("a_url")
-//!                     .json(&query.body()?)
+//!                     .json(&query)
 //!                     .send()?;
 //! let result = query.decode_response(response.json()?)?;
 //! ```

--- a/cynic/src/lib.rs
+++ b/cynic/src/lib.rs
@@ -153,7 +153,6 @@
 //!     )
 //! );
 //! ```
-use std::collections::HashMap;
 
 mod argument;
 mod field;

--- a/cynic/src/query.rs
+++ b/cynic/src/query.rs
@@ -19,7 +19,7 @@ impl<'a, ResponseData: 'a> Query<'a, ResponseData> {
         let variables = arguments
             .into_iter()
             .enumerate()
-            .map(|(i, a)| (format!("$_{}", i), a))
+            .map(|(i, a)| (format!("_{}", i), a))
             .collect();
 
         Query {

--- a/cynic/src/query.rs
+++ b/cynic/src/query.rs
@@ -1,31 +1,34 @@
-use crate::{selection_set, GraphQLResponse, QueryBody, QueryRoot, SelectionSet};
+use json_decode::BoxDecoder;
+use std::collections::HashMap;
 
+use crate::{
+    selection_set::query_root, Argument, GraphQLResponse, QueryBody, QueryRoot, SelectionSet,
+};
+
+#[derive(serde::Serialize)]
 pub struct Query<'a, ResponseData> {
-    selection_set: SelectionSet<'a, ResponseData, ()>,
+    pub query: String,
+    pub variables: HashMap<String, Argument>,
+    #[serde(skip)]
+    decoder: BoxDecoder<'a, ResponseData>,
+    // selection_set: SelectionSet<'a, ResponseData, ()>,
 }
 
-impl<'a, ResponseData> Query<'a, ResponseData>
-where
-    ResponseData: 'a,
-{
+impl<'a, ResponseData: 'a> Query<'a, ResponseData> {
     pub fn new<Root: QueryRoot>(selection_set: SelectionSet<'a, ResponseData, Root>) -> Self {
+        let (query, arguments, decoder) = query_root(selection_set).query_arguments_and_decoder();
+
+        let variables = arguments
+            .into_iter()
+            .enumerate()
+            .map(|(i, a)| (format!("$_{}", i), a))
+            .collect();
+
         Query {
-            selection_set: selection_set::query_root(selection_set),
+            query,
+            variables,
+            decoder,
         }
-    }
-
-    pub fn body<'b>(&'b self) -> Result<QueryBody<'b>, ()> {
-        self.selection_set
-            .query_and_arguments()
-            .map(|(query, arguments)| {
-                let variables = arguments
-                    .into_iter()
-                    .enumerate()
-                    .map(|(i, value)| (format!("_{}", i), value))
-                    .collect();
-
-                QueryBody { query, variables }
-            })
     }
 
     pub fn decode_response(
@@ -35,7 +38,7 @@ where
         if let Some(data) = response.data {
             Ok(GraphQLResponse {
                 // TODO: GET RID OF UNWRAP.  I am being extremely lazy by calling it.
-                data: Some(self.selection_set.decode(&data).unwrap()),
+                data: Some(self.decoder.decode(&data).unwrap()),
                 errors: response.errors,
             })
         } else {

--- a/cynic/src/query.rs
+++ b/cynic/src/query.rs
@@ -9,7 +9,6 @@ pub struct Query<'a, ResponseData> {
     pub variables: HashMap<String, Argument>,
     #[serde(skip)]
     decoder: BoxDecoder<'a, ResponseData>,
-    // selection_set: SelectionSet<'a, ResponseData, ()>,
 }
 
 impl<'a, ResponseData: 'a> Query<'a, ResponseData> {

--- a/cynic/src/query.rs
+++ b/cynic/src/query.rs
@@ -35,8 +35,7 @@ impl<'a, ResponseData: 'a> Query<'a, ResponseData> {
     ) -> Result<GraphQLResponse<ResponseData>, json_decode::DecodeError> {
         if let Some(data) = response.data {
             Ok(GraphQLResponse {
-                // TODO: GET RID OF UNWRAP.  I am being extremely lazy by calling it.
-                data: Some(self.decoder.decode(&data).unwrap()),
+                data: Some(self.decoder.decode(&data)?),
                 errors: response.errors,
             })
         } else {

--- a/cynic/src/query.rs
+++ b/cynic/src/query.rs
@@ -1,9 +1,7 @@
 use json_decode::BoxDecoder;
 use std::collections::HashMap;
 
-use crate::{
-    selection_set::query_root, Argument, GraphQLResponse, QueryBody, QueryRoot, SelectionSet,
-};
+use crate::{selection_set::query_root, Argument, GraphQLResponse, QueryRoot, SelectionSet};
 
 #[derive(serde::Serialize)]
 pub struct Query<'a, ResponseData> {

--- a/cynic/src/scalar.rs
+++ b/cynic/src/scalar.rs
@@ -1,9 +1,11 @@
 use json_decode::{BoxDecoder, DecodeError, Decoder};
 use std::marker::PhantomData;
 
+use crate::SerializeError;
+
 pub trait Scalar: Sized {
     fn decode(value: &serde_json::Value) -> Result<Self, DecodeError>;
-    fn encode(&self) -> Result<serde_json::Value, ()>;
+    fn encode(&self) -> Result<serde_json::Value, SerializeError>;
 }
 
 pub fn decoder<'a, S>() -> BoxDecoder<'a, S>
@@ -20,7 +22,7 @@ impl Scalar for i64 {
         json_decode::integer().decode(value)
     }
 
-    fn encode(&self) -> Result<serde_json::Value, ()> {
+    fn encode(&self) -> Result<serde_json::Value, SerializeError> {
         Ok((*self).into())
     }
 }
@@ -30,7 +32,7 @@ impl Scalar for f64 {
         json_decode::float().decode(value)
     }
 
-    fn encode(&self) -> Result<serde_json::Value, ()> {
+    fn encode(&self) -> Result<serde_json::Value, SerializeError> {
         Ok((*self).into())
     }
 }
@@ -40,7 +42,7 @@ impl Scalar for bool {
         json_decode::boolean().decode(value)
     }
 
-    fn encode(&self) -> Result<serde_json::Value, ()> {
+    fn encode(&self) -> Result<serde_json::Value, SerializeError> {
         Ok((*self).into())
     }
 }
@@ -50,7 +52,7 @@ impl Scalar for String {
         json_decode::string().decode(value)
     }
 
-    fn encode(&self) -> Result<serde_json::Value, ()> {
+    fn encode(&self) -> Result<serde_json::Value, SerializeError> {
         Ok(self.clone().into())
     }
 }
@@ -60,7 +62,7 @@ impl Scalar for serde_json::Value {
         json_decode::json().decode(value)
     }
 
-    fn encode(&self) -> Result<serde_json::Value, ()> {
+    fn encode(&self) -> Result<serde_json::Value, SerializeError> {
         Ok(self.clone())
     }
 }
@@ -94,7 +96,7 @@ impl Scalar for chrono::DateTime<chrono::FixedOffset> {
         }
     }
 
-    fn encode(&self) -> Result<serde_json::Value, ()> {
+    fn encode(&self) -> Result<serde_json::Value, SerializeError> {
         Ok(serde_json::Value::String(self.to_rfc3339()))
     }
 }
@@ -115,7 +117,7 @@ impl Scalar for chrono::DateTime<chrono::Utc> {
         }
     }
 
-    fn encode(&self) -> Result<serde_json::Value, ()> {
+    fn encode(&self) -> Result<serde_json::Value, SerializeError> {
         Ok(serde_json::Value::String(self.to_rfc3339()))
     }
 }

--- a/cynic/src/selection_set.rs
+++ b/cynic/src/selection_set.rs
@@ -294,8 +294,9 @@ struct FragmentDecoder<'a, DecodesTo> {
 
 impl<'a, DecodesTo> json_decode::Decoder<'a, DecodesTo> for FragmentDecoder<'a, DecodesTo> {
     fn decode(&self, value: &serde_json::Value) -> Result<DecodesTo, DecodeError> {
-        // TODO: Don't unwrap
-        let typename = value["__typename"].as_str().unwrap();
+        let typename = value["__typename"].as_str().ok_or_else(|| {
+            json_decode::DecodeError::MissingField("__typename".into(), value.to_string())
+        })?;
 
         if let Some(decoder) = self.decoders.get(typename) {
             decoder.decode(value)

--- a/cynic/src/selection_set.rs
+++ b/cynic/src/selection_set.rs
@@ -24,13 +24,6 @@ use std::marker::PhantomData;
 
 use crate::{field::Field, scalar, Argument, QueryRoot};
 
-/// An error used by SelectionSet functions.
-#[derive(Debug, PartialEq)]
-pub(crate) enum Error {
-    /// Something went wrong when decoding the results of query.
-    DecodeError(json_decode::DecodeError),
-}
-
 /// A marker trait used to encode GraphQL subtype relationships into the Rust
 /// typesystem.
 pub trait HasSubtype<Subtype> {}
@@ -122,15 +115,15 @@ impl<'a, DecodesTo, TypeLock> SelectionSet<'a, DecodesTo, TypeLock> {
         }
     }
 
-    pub(crate) fn decode(&self, value: &serde_json::Value) -> Result<DecodesTo, Error> {
-        (*self.decoder).decode(value).map_err(Error::DecodeError)
+    #[cfg(test)]
+    fn decode(&self, value: &serde_json::Value) -> Result<DecodesTo, DecodeError> {
+        (*self.decoder).decode(value)
     }
 
     pub(crate) fn query_arguments_and_decoder(
         self,
     ) -> (String, Vec<Argument>, BoxDecoder<'a, DecodesTo>) {
         let mut arguments: Vec<Argument> = vec![];
-        let mut argument_types: Vec<&str> = vec![];
         let query = self
             .fields
             .into_iter()

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -10,3 +10,6 @@ edition = "2018"
 cynic = { path = "../cynic" }
 cynic-codegen = { path = "../cynic-codegen" }
 reqwest = { version = "0.10.1", features = ["json", "blocking"] }
+
+[dev-dependencies]
+insta = "0.16.0"

--- a/examples/examples/snapshots/starwars__test__running_query.snap
+++ b/examples/examples/snapshots/starwars__test__running_query.snap
@@ -1,0 +1,18 @@
+---
+source: examples/examples/starwars.rs
+expression: result.data
+---
+Some(
+    FilmDirectorQuery {
+        film: Some(
+            Film {
+                title: Some(
+                    "A New Hope",
+                ),
+                director: Some(
+                    "George Lucas",
+                ),
+            },
+        ),
+    },
+)

--- a/examples/examples/snapshots/starwars__test__snapshot_test_menu_query.snap
+++ b/examples/examples/snapshots/starwars__test__snapshot_test_menu_query.snap
@@ -1,0 +1,11 @@
+---
+source: examples/examples/starwars.rs
+expression: query.query
+---
+query Query($_0: ID) {
+  film(id: $_0) {
+    title
+    director
+  }
+}
+

--- a/examples/examples/starwars.rs
+++ b/examples/examples/starwars.rs
@@ -31,15 +31,11 @@ struct FilmDirectorQuery {
 }
 
 fn main() {
-    use cynic::QueryFragment;
-
-    let query = cynic::Query::new(FilmDirectorQuery::fragment(FilmArguments {
-        id: Some("ZmlsbXM6MQ==".into()),
-    }));
+    let query = build_query();
 
     let response = reqwest::blocking::Client::new()
         .post("https://swapi-graphql.netlify.com/.netlify/functions/index")
-        .json(&query.body().unwrap())
+        .json(&query)
         .send()
         .unwrap();
 
@@ -48,4 +44,27 @@ fn main() {
     let result = query.decode_response(response.json().unwrap()).unwrap();
 
     println!("{:?}", result);
+}
+
+fn build_query() -> cynic::Query<'static, FilmDirectorQuery> {
+    use cynic::QueryFragment;
+    cynic::Query::new(FilmDirectorQuery::fragment(FilmArguments {
+        id: Some("ZmlsbXM6MQ==".into()),
+    }))
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn snapshot_test_menu_query() {
+        // Running a snapshot test of the query building functionality as that gives us
+        // a place to copy and paste the actual GQL we're using for running elsewhere,
+        // and also helps ensure we don't change queries by mistake
+
+        let query = build_query();
+
+        insta::assert_snapshot!(query.query);
+    }
 }

--- a/examples/examples/starwars.rs
+++ b/examples/examples/starwars.rs
@@ -31,6 +31,11 @@ struct FilmDirectorQuery {
 }
 
 fn main() {
+    let result = run_query();
+    println!("{:?}", result);
+}
+
+fn run_query() -> cynic::GraphQLResponse<FilmDirectorQuery> {
     let query = build_query();
 
     let response = reqwest::blocking::Client::new()
@@ -41,9 +46,7 @@ fn main() {
 
     println!("{:?}", response);
 
-    let result = query.decode_response(response.json().unwrap()).unwrap();
-
-    println!("{:?}", result);
+    query.decode_response(response.json().unwrap()).unwrap()
 }
 
 fn build_query() -> cynic::Query<'static, FilmDirectorQuery> {
@@ -66,5 +69,14 @@ mod test {
         let query = build_query();
 
         insta::assert_snapshot!(query.query);
+    }
+
+    #[test]
+    fn test_running_query() {
+        let result = run_query();
+        if result.errors.is_some() {
+            assert_eq!(result.errors.unwrap().len(), 0);
+        }
+        insta::assert_debug_snapshot!(result.data);
     }
 }


### PR DESCRIPTION
Prior to this change we serialized arguments when building up the
selection set, and stored the results of that serialization in the
Argument struct.  This worked, but led to an awkward API where you build
the selection set, convert it to a QueryBody which could fail, and
_then_ convert it to JSON which could also fail.

This updates the Argument struct to store a `Box<SerializableArgument>`
instead.  This simplifies things: we can now serialize the Query
directly, and the Argument serialization will happen there, leading to a
single point of failure rather than multiple.

Also updated the serialize & encode functions to return `Box<Error> `
rather than `()`.

Fixes #42
Fixes #45 