### PR TITLE
Don't call derive macros in query_module.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ all APIs might be changed.
 
 - `cynic-codegen` will now build with the rustfmt feature disabled.
 - Removed some unwraps that I lazily put in and forgot to remove.
+- Using a `query_module` should no longer cause errors on an individual derive
+  to be attributed to the `query_module` span - the error information should
+  now be associated with the derive it originated from.
 
 ## 0.4.0 - 2020-06-12
 

--- a/cynic-codegen/Cargo.toml
+++ b/cynic-codegen/Cargo.toml
@@ -13,6 +13,7 @@ documentation = "https://docs.rs/cynic-codegen"
 [features]
 default = ["rustfmt"]
 rustfmt = []
+optimised-query-modules = []
 
 [dependencies]
 graphql-parser = { git = "https://github.com/obmarg/graphql-parser.git" }

--- a/cynic-codegen/src/query_module/mod.rs
+++ b/cynic-codegen/src/query_module/mod.rs
@@ -39,30 +39,50 @@ fn transform_query_module_impl(
     if let None = query_module.content {
         return Ok(quote! { #query_module });
     }
-    let (_, module_items) = query_module.content.as_ref().unwrap();
 
-    let derives: Vec<TokenStream> = module_items
-        .into_iter()
-        .map(|i| derive_for_item(i, &args, &schema, &fragment_derive_schema))
-        .collect();
+    if cfg!(feature = "optimised-query-modules") {
+        let (_, module_items) = query_module.content.as_ref().unwrap();
 
-    let (_, module_items) = query_module.content.unwrap();
-    let module_items: Vec<_> = module_items
-        .into_iter()
-        .map(utils::strip_cynic_attrs)
-        .collect();
+        let derives: Vec<TokenStream> = module_items
+            .into_iter()
+            .map(|i| derive_for_item(i, &args, &schema, &fragment_derive_schema))
+            .collect();
 
-    let attrs = query_module.attrs;
-    let visibility = query_module.vis;
-    let module_name = query_module.ident;
+        let (_, module_items) = query_module.content.unwrap();
+        let module_items: Vec<_> = module_items
+            .into_iter()
+            .map(utils::strip_cynic_attrs)
+            .collect();
 
-    Ok(quote! {
-        #(#attrs)*
-        #visibility mod #module_name {
-            #(#module_items)*
-            #(#derives)*
-        }
-    })
+        let attrs = query_module.attrs;
+        let visibility = query_module.vis;
+        let module_name = query_module.ident;
+
+        Ok(quote! {
+            #(#attrs)*
+            #visibility mod #module_name {
+                #(#module_items)*
+                #(#derives)*
+            }
+        })
+    } else {
+        let (_, module_items) = query_module.content.unwrap();
+
+        let module_items = module_items
+            .into_iter()
+            .map(|item| insert_cynic_attrs(&args, item));
+
+        let attrs = query_module.attrs;
+        let visibility = query_module.vis;
+        let module_name = query_module.ident;
+
+        Ok(quote! {
+            #(#attrs)*
+            #visibility mod #module_name {
+                #(#module_items)*
+            }
+        })
+    }
 }
 
 fn derive_for_item(
@@ -197,5 +217,139 @@ fn scalar_derive(item: &syn::Item) -> TokenStream {
     match scalar_derive_impl(input) {
         Ok(res) => res,
         Err(e) => e.to_compile_error(),
+    }
+}
+
+fn insert_cynic_attrs(args: &TransformModuleArgs, item: syn::Item) -> syn::Item {
+    use darling::FromDeriveInput;
+    use syn::Item;
+
+    match utils::find_derives(&item).get(0) {
+        None => item,
+        Some(Derive::Scalar) => item,
+        Some(Derive::InlineFragments) | Some(Derive::Enum) => {
+            if let Item::Enum(mut en) = item {
+                let attrs = PresentAttributes::from_attributes(&en.attrs);
+                attrs.add_missing_attributes(&mut en.attrs, args);
+                Item::Enum(en)
+            } else {
+                item
+            }
+        }
+        Some(Derive::QueryFragment) => {
+            if let Item::Struct(mut st) = item {
+                let attrs = PresentAttributes::from_attributes(&st.attrs);
+                attrs.add_missing_attributes(&mut st.attrs, args);
+                Item::Struct(st)
+            } else {
+                item
+            }
+        }
+    }
+}
+
+#[derive(Default, Debug)]
+struct PresentAttributes {
+    pub has_schema_path: bool,
+    pub has_query_module: bool,
+}
+
+impl PresentAttributes {
+    fn from_attributes(attrs: &[syn::Attribute]) -> Self {
+        use syn::{Meta, NestedMeta};
+
+        let mut rv = PresentAttributes::default();
+        for attr in attrs {
+            if attr.path.is_ident("cynic") {
+                if let Ok(Meta::List(meta_list)) = attr.parse_meta() {
+                    for nested in meta_list.nested {
+                        if let NestedMeta::Meta(Meta::NameValue(name_val)) = nested {
+                            if name_val.path.is_ident("schema_path") {
+                                rv.has_schema_path = true;
+                            } else if name_val.path.is_ident("query_module") {
+                                rv.has_query_module = true;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        rv
+    }
+
+    fn add_missing_attributes(self, attrs: &mut Vec<syn::Attribute>, args: &TransformModuleArgs) {
+        if !self.has_schema_path {
+            let schema_path = proc_macro2::Literal::string(&args.schema_path);
+            attrs.push(syn::parse_quote! {
+                #[cynic(schema_path = #schema_path)]
+            })
+        }
+
+        if !self.has_query_module {
+            let query_module = proc_macro2::Literal::string(&args.query_module);
+            attrs.push(syn::parse_quote! {
+                #[cynic(query_module = #query_module)]
+            })
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn args() -> TransformModuleArgs {
+        TransformModuleArgs {
+            schema_path: "test.graphql".to_string().into(),
+            query_module: "query_dsl".to_string().into(),
+        }
+    }
+
+    #[test]
+    fn test_insert_cynic_attrs() {
+        let item: syn::Item = syn::parse_quote! {
+            #[derive(cynic::QueryFragment)]
+            struct Test {
+                a: String
+            }
+        };
+
+        let result = insert_cynic_attrs(&args(), item);
+
+        assert_eq!(
+            result,
+            syn::parse_quote! {
+                #[derive(cynic::QueryFragment)]
+                #[cynic(schema_path = "test.graphql")]
+                #[cynic(query_module = "query_dsl")]
+                struct Test {
+                    a: String
+                }
+            }
+        )
+    }
+
+    #[test]
+    fn test_insert_cynic_attrs_when_already_inserted() {
+        let item: syn::Item = syn::parse_quote! {
+            #[derive(cynic::QueryFragment)]
+            #[cynic(schema_path = "other.graphql", query_module = "something")]
+            struct Test {
+                a: String
+            }
+        };
+
+        let result = insert_cynic_attrs(&args(), item);
+
+        assert_eq!(
+            result,
+            syn::parse_quote! {
+                #[derive(cynic::QueryFragment)]
+                #[cynic(schema_path = "other.graphql", query_module = "something")]
+                struct Test {
+                    a: String
+                }
+            }
+        )
     }
 }


### PR DESCRIPTION
Projects using cynic compile fairly slowly when pointed at a large
graphql schema (such as the GitHub schema).  I initially thought that
this was down to the time taken parsing the schema when each individual
derive macro has to do it.

`query_modules` were supposed to fix this - they parse the schema a
single time and then call the derive macro manually using that single
parsed schema.  However this did not have the impact on build times that
I expected it to  - builds on the GitHub schema are still exceptionally
slow.  Seems that most of the time is actually spent parsing the 100k+
lines of query_dsl

Unfortunately doing the derive inside the query_module invocation also
messed up error messages for the derives - certian classes of error are
attributed to the query_module declaration themselves rather than the
derives they originated from.  See #38 for details.

`query_modules` aren't entirely useless though - they cut down on the
repitition of `schema_path` & `query_module` on every single derive,
which is nice.  So, this PR changes the default behaviour of
query_modules to just insert these attributes on each derive rather than
doing the derive itself.  I'm leaving the old code available behind a
feature flag for now - I haven't tested the new implementation against
the GitHub API yet to check how bad performance really is.

Fixes #38 