### PR TITLE
Make SerializableArguments require Send.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ all APIs might be changed.
 
 ## Unreleased - xxxx-xx-xx
 
+### Breaking Changes
+
+- `SerializableArgument`s are now required to be `Send`.  Found this was
+  required for using cynic in an async context.  May revisit at some point to
+  see if it's 100% required.
+
 ## v0.6.0 - 2020-06-17
 
 ### New Features

--- a/cynic-codegen/src/field_argument.rs
+++ b/cynic-codegen/src/field_argument.rs
@@ -86,12 +86,12 @@ impl GenericConstraint {
             GenericConstraint::Enum(ident) => {
                 let type_path = TypePath::concat(&[path_to_markers, ident.clone().into()]);
 
-                quote! { ::cynic::Enum<#type_path> + ::cynic::SerializableArgument + 'static}
+                quote! { ::cynic::Enum<#type_path> + ::cynic::SerializableArgument + 'static + Send}
             }
             GenericConstraint::InputObject(ident) => {
                 let type_path = TypePath::concat(&[path_to_markers, ident.clone().into()]);
 
-                quote! { ::cynic::InputObject<#type_path> + ::cynic::SerializableArgument + 'static}
+                quote! { ::cynic::InputObject<#type_path> + ::cynic::SerializableArgument + 'static + Send}
             }
         }
     }

--- a/cynic/src/argument.rs
+++ b/cynic/src/argument.rs
@@ -2,12 +2,16 @@ use crate::{Scalar, SerializeError};
 
 pub struct Argument {
     pub(crate) name: String,
-    pub(crate) value: Box<dyn SerializableArgument>,
+    pub(crate) value: Box<dyn SerializableArgument + Send>,
     pub(crate) type_: String,
 }
 
 impl Argument {
-    pub fn new(name: &str, gql_type: &str, value: impl SerializableArgument + 'static) -> Argument {
+    pub fn new(
+        name: &str,
+        gql_type: &str,
+        value: impl SerializableArgument + 'static + Send,
+    ) -> Argument {
         Argument {
             name: name.to_string(),
             value: Box::new(value),


### PR DESCRIPTION
#### Why do we need this change?

I've been adding cynic to an async app using surf.  In order for the query to persist over an await, it 
needs to be `Send`.  This is needed, as we need to be able to decode after the `Send`.

#### What effects does this change have?

This updates various generic & dyn constraints to require `Send` when a `SerializableAgument` is
used.  This solves the above problem, though I'm not 100% happy with the approach.
