### PR TITLE
Support hardcoded query values in cynic-querygen.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ all APIs might be changed.
 
 - Fixed an issue with cynic-querygen where it guessed the name for the root of
   a query and crashed out if it was wrong (which was often).
+- Fixed an issue where querygen would fail if given a query with a hardcoded
+  enum value (#33)
 
 ## v0.7.0 - 2020-06-23
 

--- a/cynic-querygen/src/schema.rs
+++ b/cynic-querygen/src/schema.rs
@@ -1,0 +1,22 @@
+// Alias all the graphql_parser schema types so we don't have to specify generic parameters
+// everywhere
+pub type Document<'a> = graphql_parser::schema::Document<'a, &'a str>;
+pub type Type<'a> = graphql_parser::schema::Type<'a, &'a str>;
+pub type Field<'a> = graphql_parser::schema::Field<'a, &'a str>;
+pub type Definition<'a> = graphql_parser::schema::Definition<'a, &'a str>;
+pub type TypeDefinition<'a> = graphql_parser::schema::TypeDefinition<'a, &'a str>;
+pub type EnumType<'a> = graphql_parser::schema::EnumType<'a, &'a str>;
+pub type ScalarType<'a> = graphql_parser::schema::ScalarType<'a, &'a str>;
+
+pub trait ScalarTypeExt {
+    fn is_builtin(&self) -> bool;
+}
+
+impl<'a> ScalarTypeExt for ScalarType<'a> {
+    fn is_builtin(&self) -> bool {
+        match self.name {
+            "String" | "Int" | "Boolean" | "ID" => true,
+            _ => false,
+        }
+    }
+}

--- a/cynic-querygen/src/type_ext.rs
+++ b/cynic-querygen/src/type_ext.rs
@@ -2,7 +2,7 @@ use graphql_parser::query::Type;
 use inflector::Inflector;
 use std::borrow::Cow;
 
-use crate::{FieldType, TypeIndex};
+use crate::{schema::TypeDefinition, TypeIndex};
 
 pub trait TypeExt<'a> {
     fn inner_name(&self) -> &str;
@@ -46,8 +46,8 @@ fn type_spec_imp<'a>(
         Type::NamedType("Boolean") => Cow::Borrowed("bool"),
         Type::NamedType("ID") => Cow::Borrowed("cynic::Id"),
         Type::NamedType(s) => match type_index.lookup_type(s) {
-            Some(FieldType::Enum(_)) => Cow::Owned(s.to_pascal_case()),
-            Some(FieldType::Object(_)) => Cow::Owned(s.to_pascal_case()),
+            Some(TypeDefinition::Enum(_)) => Cow::Owned(s.to_pascal_case()),
+            Some(TypeDefinition::Object(_)) => Cow::Owned(s.to_pascal_case()),
             _ => Cow::Borrowed(s),
         },
     }


### PR DESCRIPTION
This fixes an issue where we were trying to lookup enums by the name of
one of their variants rather than by the name of the enum itself.

Also tidied up a lot of the stuff around the TypeIndex in querygen - now
uses raw schema types for a lot of things, and supports returning the
actual Field value rather than just the Type of the Field.

Fixes #33