### PR TITLE
Querygen now puts `argument_struct` attr in correct place.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ all APIs might be changed.
   a query and crashed out if it was wrong (which was often).
 - Fixed an issue where querygen would fail if given a query with a hardcoded
   enum value (#33)
+- Querygen now puts `argument_struct` attrs on types that have arguments rather
+  than just types that have children with arguments. (#37)
 
 ## v0.7.0 - 2020-06-23
 

--- a/cynic-querygen/tests/queries/nested-arguments.graphql
+++ b/cynic-querygen/tests/queries/nested-arguments.graphql
@@ -1,0 +1,15 @@
+query Query($filmId: ID, $planetCursor: String, $residentConnection: String) {
+  film(id: $filmId) {
+    title
+    director
+    planetConnection(after: $planetCursor) {
+      planets {
+        residentConnection(after: $residentConnection) {
+          residents {
+            name
+          }
+        }
+      }
+    }
+  }
+}

--- a/cynic-querygen/tests/queries/starwars-sanity.graphql
+++ b/cynic-querygen/tests/queries/starwars-sanity.graphql
@@ -1,0 +1,6 @@
+query Query($filmId: ID) {
+  film(id: $filmId) {
+    title
+    director
+  }
+}

--- a/cynic-querygen/tests/snapshots/starwars_querygen__nested_arguments.snap
+++ b/cynic-querygen/tests/snapshots/starwars_querygen__nested_arguments.snap
@@ -1,0 +1,73 @@
+---
+source: cynic-querygen/tests/starwars-querygen.rs
+expression: "document_to_fragment_structs(query, schema,\n                             &QueryGenOptions::default()).expect(\"QueryGen Failed\")"
+---
+#[cynic::query_module(
+    schema_path = "schema.graphql",
+    query_module = "query_dsl",
+)]
+mod queries {
+    use super::{query_dsl, types::*};
+
+    #[derive(Clone, cynic::FragmentArguments)]
+    pub struct QueryArguments {
+        pub filmId: Option<cynic::Id>,
+        pub planetCursor: Option<String>,
+        pub residentConnection: Option<String>,
+    }
+
+    #[derive(cynic::QueryFragment)]
+    #[cynic(graphql_type = "Query", argument_struct = "QueryArguments")]
+    pub struct Query {
+        #[cynic_arguments(id = args.filmId)]
+        pub film: Option<Film>,
+    }
+
+    #[derive(cynic::QueryFragment)]
+    #[cynic(graphql_type = "Film", argument_struct = "QueryArguments")]
+    pub struct Film {
+        pub title: Option<String>,
+        pub director: Option<String>,
+        #[cynic_arguments(after = args.planetCursor)]
+        pub planetConnection: Option<FilmPlanetsConnection>,
+    }
+
+    #[derive(cynic::QueryFragment)]
+    #[cynic(graphql_type = "FilmPlanetsConnection", argument_struct = "QueryArguments")]
+    pub struct FilmPlanetsConnection {
+        pub planets: Option<Vec<Option<Planet>>>,
+    }
+
+    #[derive(cynic::QueryFragment)]
+    #[cynic(graphql_type = "Planet", argument_struct = "QueryArguments")]
+    pub struct Planet {
+        #[cynic_arguments(after = args.residentConnection)]
+        pub residentConnection: Option<PlanetResidentsConnection>,
+    }
+
+    #[derive(cynic::QueryFragment)]
+    #[cynic(graphql_type = "PlanetResidentsConnection")]
+    pub struct PlanetResidentsConnection {
+        pub residents: Option<Vec<Option<Person>>>,
+    }
+
+    #[derive(cynic::QueryFragment)]
+    #[cynic(graphql_type = "Person")]
+    pub struct Person {
+        pub name: Option<String>,
+    }
+
+}
+
+#[cynic::query_module(
+    schema_path = "schema.graphql",
+    query_module = "query_dsl",
+)]
+mod types {
+}
+
+mod query_dsl{
+    use super::types::*;
+    cynic::query_dsl!("schema.graphql");
+}
+

--- a/cynic-querygen/tests/snapshots/starwars_querygen__sanity_test_starwars_query.snap
+++ b/cynic-querygen/tests/snapshots/starwars_querygen__sanity_test_starwars_query.snap
@@ -15,7 +15,7 @@ mod queries {
     }
 
     #[derive(cynic::QueryFragment)]
-    #[cynic(graphql_type = "Query")]
+    #[cynic(graphql_type = "Query", argument_struct = "QueryArguments")]
     pub struct Query {
         #[cynic_arguments(id = args.filmId)]
         pub film: Option<Film>,

--- a/cynic-querygen/tests/starwars-querygen.rs
+++ b/cynic-querygen/tests/starwars-querygen.rs
@@ -9,13 +9,18 @@ macro_rules! test_query_file {
             let schema = include_str!("../../examples/examples/starwars.schema.graphql");
             let query = include_str!($filename);
 
-            assert_snapshot!(
-                document_to_fragment_structs(query, schema, &QueryGenOptions::default())
-                    .expect("QueryGen Failed")
+            assert_snapshot!(document_to_fragment_structs(
+                query,
+                schema,
+                &QueryGenOptions::default()
             )
+            .expect("QueryGen Failed"))
         }
-    }
+    };
 }
 
-test_query_file!(sanity_test_starwars_query, "queries/starwars-sanity.graphql");
+test_query_file!(
+    sanity_test_starwars_query,
+    "queries/starwars-sanity.graphql"
+);
 test_query_file!(test_nested_arguments, "queries/nested-arguments.graphql");

--- a/cynic-querygen/tests/starwars-querygen.rs
+++ b/cynic-querygen/tests/starwars-querygen.rs
@@ -2,20 +2,20 @@ use insta::assert_snapshot;
 
 use cynic_querygen::{document_to_fragment_structs, QueryGenOptions};
 
-#[test]
-fn sanity_test_starwars_query() {
-    let schema = include_str!("../../examples/examples/starwars.schema.graphql");
-    let query = r#"
-        query Query($filmId: ID) {
-            film(id: $filmId) {
-                title
-                director
-            }
-        }
-    "#;
+macro_rules! test_query_file {
+    ($name:ident, $filename:literal) => {
+        #[test]
+        fn $name() {
+            let schema = include_str!("../../examples/examples/starwars.schema.graphql");
+            let query = include_str!($filename);
 
-    assert_snapshot!(
-        document_to_fragment_structs(query, schema, &QueryGenOptions::default())
-            .expect("QueryGen Failed")
-    )
+            assert_snapshot!(
+                document_to_fragment_structs(query, schema, &QueryGenOptions::default())
+                    .expect("QueryGen Failed")
+            )
+        }
+    }
 }
+
+test_query_file!(sanity_test_starwars_query, "queries/starwars-sanity.graphql");
+test_query_file!(test_nested_arguments, "queries/nested-arguments.graphql");


### PR DESCRIPTION
#### Why do we need this change?

There's an issue in querygen where it doesn't put `argument_struct` annotations
on structs that have arguments.  It only puts them on structs that have
children with arguments.

#### What effects does this change have?

This fixes that issue.

Fixes #37