### PR TITLE
Update integer fields to use i32 not i64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,19 @@ all APIs might be changed.
 
 ## Unreleased - xxxx-xx-xx
 
+### Breaking Changes
+
+- Integer fields are now i32 rather than i64 inline with the GraphQL spec.  If
+  larger integers are required a custom scalar should be used.
+
 ### Bug Fixes
 
 - Fixed an issue with cynic-querygen where it guessed the name for the root of
   a query and crashed out if it was wrong (which was often).
 - Fixed an issue where querygen would fail if given a query with a hardcoded
   enum value (#33)
+- Integers are now i32 rather than i64, inline with the GraphQL spec.  If
+  larger integers are required a custom scalar should be used.
 
 ## v0.7.0 - 2020-06-23
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,7 +146,7 @@ dependencies = [
  "assert_matches 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "cynic-proc-macros 0.7.0",
- "json-decode 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "json-decode 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "maplit 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.55 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -607,7 +607,7 @@ dependencies = [
 
 [[package]]
 name = "json-decode"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1680,7 +1680,7 @@ dependencies = [
 "checksum iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
 "checksum itoa 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "b8b7a7c0c47db5545ed3fef7468ee7bb5b74691498139e4b3f6a20685dc6dd8e"
 "checksum js-sys 0.3.40 (registry+https://github.com/rust-lang/crates.io-index)" = "ce10c23ad2ea25ceca0093bd3192229da4c5b3c0f2de499c1ecac0d98d452177"
-"checksum json-decode 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d9ada4c5fc2d99f9c329820c16f1e5241cbb70422c373b775b0e6fabd9f0b94f"
+"checksum json-decode 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0450444ba98be6f4a931b2d256be9da433fa578013d1818bd94fa6ddb2f3d213"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 "checksum libc 0.2.71 (registry+https://github.com/rust-lang/crates.io-index)" = "9457b06509d27052635f90d6466700c65095fdf75409b3fbdd903e988b886f49"

--- a/cynic-book/src/derives/scalars.md
+++ b/cynic-book/src/derives/scalars.md
@@ -1,12 +1,11 @@
 # Scalars
 
-Cynic supports all the built in GraphQL scalars by default.  If you want to
+Cynic supports all the built in GraphQL scalars by default. If you want to
 query a field of one of these types add a field of the corresponding Rust type
 to your `QueryFragment` struct.
 
 - `String` fields in GraphQL should be `String` fields in Rust.
-- `Int` fields in GraphQL should be `i64` in Rust (though this will be changing
-  to i32 soon, to align with the GraphQL spec).
+- `Int` fields in GraphQL should be `i32` in Rust.
 - `Boolean` fields in GraphQL map to `bool` in Rust.
 - `ID` fields in GraphQL map to the `cynic::Id` type in Rust.
 

--- a/cynic-codegen/src/field_type.rs
+++ b/cynic-codegen/src/field_type.rs
@@ -42,7 +42,7 @@ impl FieldType {
                     FieldType::InputObject(Ident::for_type(name), nullable)
                 } else if name == "Int" {
                     FieldType::Scalar(
-                        TypePath::new_builtin(Ident::for_inbuilt_scalar("i64")),
+                        TypePath::new_builtin(Ident::for_inbuilt_scalar("i32")),
                         nullable,
                     )
                 } else if name == "Float" {

--- a/cynic-querygen/src/type_ext.rs
+++ b/cynic-querygen/src/type_ext.rs
@@ -41,7 +41,7 @@ fn type_spec_imp<'a>(
             Cow::Owned(format!("Vec<{}>", type_spec_imp(inner, true, type_index)))
         }
         Type::NonNullType(_) => panic!("NonNullType somehow got past an if let"),
-        Type::NamedType("Int") => Cow::Borrowed("i64"),
+        Type::NamedType("Int") => Cow::Borrowed("i32"),
         Type::NamedType("Float") => Cow::Borrowed("f64"),
         Type::NamedType("Boolean") => Cow::Borrowed("bool"),
         Type::NamedType("ID") => Cow::Borrowed("cynic::Id"),
@@ -61,7 +61,7 @@ mod tests {
     #[rstest(
         input,
         expected,
-        case(Type::NamedType("Int"), "Option<i64>"),
+        case(Type::NamedType("Int"), "Option<i32>"),
         case(Type::NamedType("Float"), "Option<f64>"),
         case(Type::NamedType("Boolean"), "Option<bool>"),
         case(Type::NamedType("ID"), "Option<cynic::Id>"),

--- a/cynic/Cargo.toml
+++ b/cynic/Cargo.toml
@@ -16,7 +16,7 @@ default = []
 all = ["chrono"]
 
 [dependencies]
-json-decode = "0.4.1"
+json-decode = "0.5.0"
 serde = { version = "1.0.104", features = [ "derive" ] }
 serde_json = "1.0.44"
 cynic-proc-macros = { path = "../cynic-proc-macros", version = "0.7.0" }

--- a/cynic/src/scalar.rs
+++ b/cynic/src/scalar.rs
@@ -17,7 +17,7 @@ where
     })
 }
 
-impl Scalar for i64 {
+impl Scalar for i32 {
     fn decode(value: &serde_json::Value) -> Result<Self, DecodeError> {
         json_decode::integer().decode(value)
     }

--- a/cynic/src/selection_set.rs
+++ b/cynic/src/selection_set.rs
@@ -143,8 +143,8 @@ pub fn string() -> SelectionSet<'static, String, ()> {
     }
 }
 
-/// Creates a `SelectionSet` that will decode an `i64`
-pub fn integer() -> SelectionSet<'static, i64, ()> {
+/// Creates a `SelectionSet` that will decode an `i32`
+pub fn integer() -> SelectionSet<'static, i32, ()> {
     SelectionSet {
         fields: vec![],
         decoder: json_decode::integer(),
@@ -354,13 +354,13 @@ macro_rules! define_map {
         /// ```
         /// # use cynic::selection_set::{field, map3, string, integer};
         /// struct User {
-        ///     id: i64,
+        ///     id: i32,
         ///     name: String,
         ///     email: String,
         /// }
         ///
         /// impl User {
-        ///     fn new(id: i64, name: String, email: String) -> User {
+        ///     fn new(id: i32, name: String, email: String) -> User {
         ///         User { id, name, email }
         ///     }
         /// }


### PR DESCRIPTION
#### Why do we need this change?

The GraphQL spec states that integers should be i32.  I mistakenly made them
i64.

#### What effects does this change have?

Updates cynic to use i32 for integer fields, in line with the spec.

Fixes #52 