### PR TITLE
Support bare selection sets in cynic-querygen.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ all APIs might be changed.
 
 - querygen-web now incorporates graphiql & graphiql explorer, to make testing &
   building queries easier.
+- querygen now supports bare selection sets, they're assumed to be queries.
+  Quite easy to create these in GraphiQL/GraphqlExplorer, and they work for
+  queries so seemed important.
 
 ### Bug Fixes
 

--- a/cynic-querygen/tests/queries/bare-selection-set.graphql
+++ b/cynic-querygen/tests/queries/bare-selection-set.graphql
@@ -1,0 +1,8 @@
+{
+  allFilms {
+    films {
+      id
+      title
+    }
+  }
+}

--- a/cynic-querygen/tests/snapshots/starwars_querygen__bare_selection_sets.snap
+++ b/cynic-querygen/tests/snapshots/starwars_querygen__bare_selection_sets.snap
@@ -1,0 +1,44 @@
+---
+source: cynic-querygen/tests/starwars-querygen.rs
+expression: "document_to_fragment_structs(query, schema,\n                             &QueryGenOptions::default()).expect(\"QueryGen Failed\")"
+---
+#[cynic::query_module(
+    schema_path = "schema.graphql",
+    query_module = "query_dsl",
+)]
+mod queries {
+    use super::{query_dsl, types::*};
+
+    #[derive(cynic::QueryFragment)]
+    #[cynic(graphql_type = "UnnamedQuery")]
+    pub struct UnnamedQuery {
+        pub allFilms: Option<FilmsConnection>,
+    }
+
+    #[derive(cynic::QueryFragment)]
+    #[cynic(graphql_type = "FilmsConnection")]
+    pub struct FilmsConnection {
+        pub films: Option<Vec<Option<Film>>>,
+    }
+
+    #[derive(cynic::QueryFragment)]
+    #[cynic(graphql_type = "Film")]
+    pub struct Film {
+        pub id: cynic::Id,
+        pub title: Option<String>,
+    }
+
+}
+
+#[cynic::query_module(
+    schema_path = "schema.graphql",
+    query_module = "query_dsl",
+)]
+mod types {
+}
+
+mod query_dsl{
+    use super::types::*;
+    cynic::query_dsl!("schema.graphql");
+}
+

--- a/cynic-querygen/tests/starwars-querygen.rs
+++ b/cynic-querygen/tests/starwars-querygen.rs
@@ -24,3 +24,4 @@ test_query_file!(
     "queries/starwars-sanity.graphql"
 );
 test_query_file!(test_nested_arguments, "queries/nested-arguments.graphql");
+test_query_file!(bare_selection_sets, "queries/bare-selection-set.graphql");


### PR DESCRIPTION
#### Why do we need this change?

When working on the GraphiQL version of querygen, I noticed that it was quite
easy to generate a bare selection set (as in a query without the query prefix).
GraphiQL supports this, and GraphQL explorer will even create one under certain
circumstances.

#### What effects does this change have?

This updates querygen to do the right thing for these bare selection sets - it
assumes they're queries and generates code accordingly.  Not sure if these can
also be mutations, may get to that when/if we support them.