### PR TITLE
Fix hardcoded enum querygen

### DIFF
--- a/cynic-querygen/src/lib.rs
+++ b/cynic-querygen/src/lib.rs
@@ -10,7 +10,6 @@ mod value_ext;
 use query_parsing::PotentialStruct;
 use type_ext::TypeExt;
 use type_index::TypeIndex;
-use value_ext::ValueExt;
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
@@ -37,6 +36,9 @@ pub enum Error {
 
     #[error("couldn't find an argument named `{0}`")]
     UnknownArgument(String),
+
+    #[error("an enum-like value was provided to an argument that is not an enum")]
+    ArgumentNotEnum,
 }
 
 #[derive(Debug)]
@@ -107,8 +109,8 @@ pub fn document_to_fragment_structs(
                         let arguments_string = field
                             .arguments
                             .iter()
-                            .map(|(name, val)| format!("{} = {}", name, val.to_literal()))
-                            .collect::<Vec<_>>()
+                            .map(|arg| Ok(format!("{} = {}", arg.name, arg.to_literal()?)))
+                            .collect::<Result<Vec<_>, Error>>()?
                             .join(", ");
 
                         lines.push(format!("        #[cynic_arguments({})]", arguments_string));

--- a/cynic-querygen/src/value_ext.rs
+++ b/cynic-querygen/src/value_ext.rs
@@ -1,30 +1,40 @@
 use graphql_parser::query::Value;
+use inflector::Inflector;
+
+use crate::schema::TypeDefinition;
+use crate::Error;
 
 /// Extension trait for graphql_parser::common::Value;
 pub trait ValueExt {
-    fn to_literal(&self) -> String;
+    fn to_literal(&self, type_definition: &TypeDefinition<'_>) -> Result<String, Error>;
 }
 
 impl<'a> ValueExt for Value<'a, &'a str> {
-    fn to_literal(&self) -> String {
-        match self {
+    fn to_literal(&self, type_definition: &TypeDefinition<'_>) -> Result<String, Error> {
+        Ok(match self {
             Value::Variable(name) => format!("args.{}", name),
             Value::Int(num) => num.as_i64().unwrap().to_string(),
             Value::Float(num) => num.to_string(),
             Value::String(s) => format!("\"{}\".to_string()", s),
             Value::Boolean(b) => b.to_string(),
             Value::Null => "None".into(),
-            Value::Enum(v) => v.to_string(),
+            Value::Enum(v) => {
+                if let TypeDefinition::Enum(en) = type_definition {
+                    format!("{}::{}", en.name.to_pascal_case(), v.to_pascal_case())
+                } else {
+                    return Err(Error::ArgumentNotEnum);
+                }
+            }
             Value::List(values) => {
                 let inner = values
                     .iter()
-                    .map(|v| v.to_literal())
-                    .collect::<Vec<_>>()
+                    .map(|v| Ok(v.to_literal(type_definition)?))
+                    .collect::<Result<Vec<_>, Error>>()?
                     .join(", ");
 
                 format!("vec![{}]", inner)
             }
             Value::Object(_) => "TODO".into(),
-        }
+        })
     }
 }

--- a/cynic-querygen/tests/github-tests.rs
+++ b/cynic-querygen/tests/github-tests.rs
@@ -1,0 +1,22 @@
+use insta::assert_snapshot;
+
+use cynic_querygen::{document_to_fragment_structs, QueryGenOptions};
+
+macro_rules! test_query {
+    ($name:ident, $filename:literal) => {
+        #[test]
+        fn $name() {
+            let schema = include_str!("schemas/github.graphql");
+            let query = include_str!(concat!("queries/github/", $filename));
+
+            assert_snapshot!(document_to_fragment_structs(
+                query,
+                schema,
+                &QueryGenOptions::default()
+            )
+            .expect("QueryGen Failed"))
+        }
+    };
+}
+
+test_query!(literal_enums, "literal-enums.graphql");

--- a/cynic-querygen/tests/queries/github/literal-enums.graphql
+++ b/cynic-querygen/tests/queries/github/literal-enums.graphql
@@ -1,0 +1,9 @@
+query {
+  repository(owner: "obmarg", name: "cynic") {
+    issues(states: OPEN, first: 10) {
+      nodes {
+        title
+      }
+    }
+  }
+}

--- a/cynic-querygen/tests/snapshots/github_tests__literal_enums.snap
+++ b/cynic-querygen/tests/snapshots/github_tests__literal_enums.snap
@@ -1,0 +1,88 @@
+---
+source: cynic-querygen/tests/github-tests.rs
+expression: "document_to_fragment_structs(query, schema,\n                             &QueryGenOptions::default()).expect(\"QueryGen Failed\")"
+---
+#[cynic::query_module(
+    schema_path = "schema.graphql",
+    query_module = "query_dsl",
+)]
+mod queries {
+    use super::{query_dsl, types::*};
+
+    #[derive(cynic::QueryFragment)]
+    #[cynic(graphql_type = "Query")]
+    pub struct Query {
+        #[cynic_arguments(owner = "obmarg".to_string(), name = "cynic".to_string())]
+        pub repository: Option<Repository>,
+    }
+
+    #[derive(cynic::QueryFragment)]
+    #[cynic(graphql_type = "Repository")]
+    pub struct Repository {
+        #[cynic_arguments(states = IssueState::Open, first = 10)]
+        pub issues: IssueConnection,
+    }
+
+    #[derive(cynic::QueryFragment)]
+    #[cynic(graphql_type = "IssueConnection")]
+    pub struct IssueConnection {
+        pub nodes: Option<Vec<Option<Issue>>>,
+    }
+
+    #[derive(cynic::QueryFragment)]
+    #[cynic(graphql_type = "Issue")]
+    pub struct Issue {
+        pub title: String,
+    }
+
+    #[derive(cynic::Enum, Clone, Copy, Debug)]
+    #[cynic(graphql_type = "IssueState")]
+    pub enum IssueState {
+        Closed,
+        Open,
+    }
+
+}
+
+#[cynic::query_module(
+    schema_path = "schema.graphql",
+    query_module = "query_dsl",
+)]
+mod types {
+    #[derive(cynic::Scalar, Debug)]
+    pub struct Date(String);
+
+    #[derive(cynic::Scalar, Debug)]
+    pub struct DateTime(String);
+
+    #[derive(cynic::Scalar, Debug)]
+    pub struct GitObjectID(String);
+
+    #[derive(cynic::Scalar, Debug)]
+    pub struct GitRefname(String);
+
+    #[derive(cynic::Scalar, Debug)]
+    pub struct GitSSHRemote(String);
+
+    #[derive(cynic::Scalar, Debug)]
+    pub struct GitTimestamp(String);
+
+    #[derive(cynic::Scalar, Debug)]
+    pub struct Html(String);
+
+    #[derive(cynic::Scalar, Debug)]
+    pub struct PreciseDateTime(String);
+
+    #[derive(cynic::Scalar, Debug)]
+    pub struct Uri(String);
+
+    #[derive(cynic::Scalar, Debug)]
+    pub struct X509Certificate(String);
+
+}
+
+mod query_dsl{
+    use super::types::*;
+    cynic::query_dsl!("schema.graphql");
+}
+

--- a/cynic-querygen/tests/starwars-tests.rs
+++ b/cynic-querygen/tests/starwars-tests.rs
@@ -1,0 +1,24 @@
+use insta::assert_snapshot;
+
+use cynic_querygen::{document_to_fragment_structs, QueryGenOptions};
+
+macro_rules! test_query_file {
+    ($name:ident, $filename:literal) => {
+        #[test]
+        fn $name() {
+            let schema = include_str!("../../examples/examples/starwars.schema.graphql");
+            let query = include_str!(concat!("queries/starwars/", $filename));
+
+            assert_snapshot!(document_to_fragment_structs(
+                query,
+                schema,
+                &QueryGenOptions::default()
+            )
+            .expect("QueryGen Failed"))
+        }
+    };
+}
+
+test_query_file!(sanity_test_starwars_query, "sanity.graphql");
+test_query_file!(test_nested_arguments, "nested-arguments.graphql");
+test_query_file!(bare_selection_sets, "bare-selection-set.graphql");


### PR DESCRIPTION
#### Why do we need this change?

When processing queries with enum literals as arguments, querygen was incorrectly just putting the GQL variant name in as the argument value `VARIANT_NAME`, instead of the correct `EnumName::Variant` format.

#### What effects does this change have?

This fixes that, and adds tests of it via the GitHub schema.

Fixes #33 
