### PR TITLE
Rework argument code for more lenient typing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@ all APIs might be changed.
 - querygen now supports bare selection sets, they're assumed to be queries.
   Quite easy to create these in GraphiQL/GraphqlExplorer, and they work for
   queries so seemed important.
+- Arguments are now converted using the `IntoArgument<T>` trait - default
+  conversions are provided for `Option` and reference types, so users don't
+  always have to wrap Options in `Some` or explicitly clone their arguments.
+- As a result of the above, cynic will no longer stop compiling when a schema 
+  changes a required argument to optional.
 
 ### Bug Fixes
 

--- a/cynic-book/src/SUMMARY.md
+++ b/cynic-book/src/SUMMARY.md
@@ -14,3 +14,4 @@
   - [Selection Sets](./building-queries/selection-sets.md)
   - [The Query DSL](./building-queries/query-dsl.md)
   - [Writing Query Fragments](./building-queries/query-fragments.md)
+- [Struct Attributes](./struct-attributes.md)

--- a/cynic-book/src/derives/enums.md
+++ b/cynic-book/src/derives/enums.md
@@ -1,7 +1,7 @@
 # Enums
 
 Much like with query structs cynic expects you to own any enums you want to
-query for, or provide as arguments.  The `cynic::Enum` trait controls is used
+query for, or provide as arguments. The `cynic::Enum` trait controls is used
 to define an enum, and the easiest way to define that trait is to derive it:
 
 ```rust
@@ -14,7 +14,7 @@ pub enum Market {
 ```
 
 The derive will work on any enum that only has unit variants that match up with
-the variants on the enum in the schema.  If there are any extra or missing
+the variants on the enum in the schema. If there are any extra or missing
 variants, the derive will emit errors.
 
 By default the variant names are expected to match the GraphQL variants

--- a/cynic-book/src/derives/query-arguments.md
+++ b/cynic-book/src/derives/query-arguments.md
@@ -1,6 +1,6 @@
 # Query Arguments
 
-A heirarchy of QueryFragments can take a struct of arguments.  This struct must
+A heirarchy of QueryFragments can take a struct of arguments. This struct must
 implement `FragmentArguments` which can be derived:
 
 ```
@@ -17,8 +17,8 @@ don't use them at all you should get dead code warnings from Rust.
 ### Using FragmentArguments
 
 To use any fields of this struct as an argument to a QueryFragment, the struct
-must define an `argument_struct` parameter that points to the `FilmArguments`
-struct.  This allows arguments to be passed in using the `arguments`
+must provide an `argument_struct` parameter that points to the `FilmArguments`
+struct. This allows arguments to be passed in using the `arguments`
 attribute on the fields where you wish to pass them.
 
 ```rust
@@ -30,7 +30,7 @@ attribute on the fields where you wish to pass them.
     argument_struct = "FilmArguments"
 )]
 struct FilmQuery {
-    #[arguments(id = args.id.clone())]
+    #[arguments(id = &args.id)]
     film: Option<Film>,
 }
 ```
@@ -39,7 +39,22 @@ This example uses our `FilmArguments` at the root of the query to specify which
 film we want to fetch.
 
 It's also possible to pass arguments down to lower levels of the query using
-the same technique.  Though it's worth noting that all the QueryFragments from
+the same technique. Though it's worth noting that all the QueryFragments from
 the Root to the point that requires arguments must define the same
-`argument_struct` in their cynic attribute.  If no nested QueryFragments
+`argument_struct` in their cynic attribute. If no nested QueryFragments
 require any arguments then it's OK to omit `argument_struct`.
+
+### IntoArguments
+
+Cynic uses the `IntoArguments` trait to convert arguments into the correct type.
+You can provide your own definition of this trait, but built in conversions are
+provided for:
+
+1. Converting bare scalars & enums into Options. This means you don't have to
+   explicitly wrap an argument in `Some`. This also allows cynic to be tolerant
+   of schemas changing a required argument into an optional argument (which
+   would usually be considered a non-breaking change when your client in a
+   dynamic language)
+2. Converting references to scalars & enums into owned arguments via `clone`.
+   Cynic doesn't currently support taking arguments by reference, but this
+   convenience saves users from having to explicitly clone.

--- a/cynic-book/src/derives/query-fragments.md
+++ b/cynic-book/src/derives/query-fragments.md
@@ -141,6 +141,6 @@ If no nested QueryFragments require arguments, you can omit the
 - [Struct Level Attributes][2] can be added to a QueryFragment.
 - [cynic::Query Reference Docs][3]
 
-[1]: ./fragment_arguments.html
-[2]: ../struct_attributes.html
+[1]: ./query-arguments.html
+[2]: ../struct-attributes.html
 [quickstart]: ../quickstart.html

--- a/cynic-book/src/derives/query-fragments.md
+++ b/cynic-book/src/derives/query-fragments.md
@@ -1,6 +1,6 @@
 # Query Fragments
 
-QueryFragments are the main tool for building queries in cynic.  A
+QueryFragments are the main tool for building queries in cynic. A
 QueryFragment tells cynic what fields to select from a GraphQL object, and how
 to decode those fields into a struct.
 
@@ -20,7 +20,7 @@ struct Film {
 ```
 
 When this struct is used in a query it will select the `title` & `director`
-fields of the `Film` type, which are both optional strings.  QueryFragments can
+fields of the `Film` type, which are both optional strings. QueryFragments can
 be nested inside each other, like so:
 
 ```rust
@@ -54,7 +54,7 @@ must be a `Vec`.
 ### Making a Query with QueryFragments
 
 QueryFragments that apply to the Query type (otherwise known as the Root type)
-of a schema can be used to build a `cynic::Query`.  This is the type that can
+of a schema can be used to build a `cynic::Query`. This is the type that can
 be sent to a server and used to decode the response.
 
 If we wanted to use our FilmConnection to get all the films from the star wars
@@ -80,7 +80,7 @@ let query = cynic::Query::new(AllFilmsQuery::fragment(());
 
 This `Query` can be converted into JSON using `serde`, sent to a server, and
 then then it's `decode_response` function can be used to decode the response
-itself.  An example of this is in the [Quickstart][Quickstart].
+itself. An example of this is in the [Quickstart][quickstart].
 
 The empty `()` we pass to fragment is for the arguments - this particular query
 has no arguments so we pass `Void`.
@@ -88,10 +88,10 @@ has no arguments so we pass `Void`.
 ### Passing Arguments
 
 To pass arguments into queries you must pass an `argument_struct` parameter
-to the `cynic` attribute, and then add `cynic_argument` attributes to the
-fields for which you want to provide arugments.   The `argument_struct`
+to the `cynic` attribute, and then add `arguments` attributes to the
+fields for which you want to provide arugments. The `argument_struct`
 parameter must name a struct that implements `cynic::FragmentArguments`, which
-can also be derived.   (See [fragment arguments][1] for more details)
+can also be derived. (See [query arguments][1] for more details)
 
 Here, we define a query that fetches a film by a particular ID:
 
@@ -109,14 +109,10 @@ struct FilmArguments {
     argument_struct = "FilmArguments"
 )]
 struct FilmQuery {
-    #[arguments(id = args.id.clone())]
+    #[arguments(id = &args.id)]
     film: Option<Film>,
 }
 ```
-
-Currently `arguments` takes ownership of arguments so you may need to
-clone as above.  Optional arguments are also wrapped in `Option<>` so to
-provide these you'll need to wrap them in `Some`.
 
 This can be converted into a query in a similar way we just need to provide
 the arguments:
@@ -129,10 +125,10 @@ let query = cynic::Query::new(FilmQuery::fragment(FilmArguments{
 
 #### Nested Arguments
 
-The example above showed how to pass arguments to the top level of a query.  If
+The example above showed how to pass arguments to the top level of a query. If
 you want to pass arguments to a nested QueryFragment then all it's parent
 `QueryFragment`s must specify the same `argument_struct` in their `cynic`
-attribute.  This is neccesary so that the `FragmentArgument` struct gets passed
+attribute. This is neccesary so that the `FragmentArgument` struct gets passed
 down to that level of a query.
 
 If no nested QueryFragments require arguments, you can omit the
@@ -143,8 +139,8 @@ If no nested QueryFragments require arguments, you can omit the
 - [FragmentArguments][1] are used to provide arguments to the fields of a
   QueryFragment.
 - [Struct Level Attributes][2] can be added to a QueryFragment.
-- [cynic::Query Reference Docs][3] 
+- [cynic::Query Reference Docs][3]
 
 [1]: ./fragment_arguments.html
 [2]: ../struct_attributes.html
-[Quickstart]: ../quickstart.html
+[quickstart]: ../quickstart.html

--- a/cynic-codegen/src/enum_derive/mod.rs
+++ b/cynic-codegen/src/enum_derive/mod.rs
@@ -103,6 +103,8 @@ pub fn enum_derive_impl(
                     })?)
                 }
             }
+
+            ::cynic::define_into_argument_for_scalar!(#ident);
         })
     } else {
         Err(syn::Error::new(

--- a/cynic-codegen/src/query_dsl/selection_builder.rs
+++ b/cynic-codegen/src/query_dsl/selection_builder.rs
@@ -131,13 +131,13 @@ impl quote::ToTokens for FieldSelectionBuilder {
 
                 #(
                     pub fn #argument_names #argument_generics(
-                        mut self, #argument_names: #argument_types
+                        mut self, #argument_names: impl ::cynic::IntoArgument<#argument_types>
                     ) -> Self {
                         self.args.push(
                             ::cynic::Argument::new(
                                 #argument_strings,
                                 #argument_gql_types,
-                                #argument_names
+                                #argument_names.into_argument()
                             )
                         );
 

--- a/cynic/examples/simple.rs
+++ b/cynic/examples/simple.rs
@@ -21,7 +21,7 @@ struct TestArgs {}
     argument_struct = "TestArgs"
 )]
 struct TestStruct {
-    #[cynic_arguments(x = Some(1), y = Some("1".to_string()))]
+    #[cynic_arguments(x = Some(1), y = "1")]
     field_one: String,
     nested: Nested,
     opt_nested: Option<Nested>,

--- a/cynic/examples/simple_v2.rs
+++ b/cynic/examples/simple_v2.rs
@@ -28,7 +28,7 @@ mod queries {
     #[derive(cynic::QueryFragment)]
     #[cynic(graphql_type = "TestStruct", argument_struct = "TestArgs")]
     pub struct TestStruct {
-        #[cynic_arguments(x = Some(1), y = Some("1".to_string()))]
+        #[cynic_arguments(x = 1, y = "1")]
         field_one: String,
         nested: Nested,
         opt_nested: Option<Nested>,
@@ -45,7 +45,7 @@ mod queries {
     #[derive(cynic::QueryFragment)]
     #[cynic(graphql_type = "TestStruct")]
     pub struct Test {
-        #[cynic_arguments(x = Some(1), y = Some("1".to_string()))]
+        #[cynic_arguments(x = 1, y = "1")]
         field_one: String,
     }
 

--- a/cynic/src/into_argument.rs
+++ b/cynic/src/into_argument.rs
@@ -1,14 +1,85 @@
 // TODO: docs.
+use std::borrow::Cow;
 
-pub trait IntoArgument<Argument> {
-    fn into_argument(self) -> Argument;
+use crate::{argument::SerializableArgument, Id};
+
+pub trait IntoArgument<'a, Argument> {
+    type Output: SerializableArgument + Send + 'a;
+
+    fn into_argument(self) -> Self::Output;
 }
 
-impl<T> IntoArgument<Option<T>> for T {
-    fn into_argument(self) -> Option<T> {
-        Some(self)
+/*
+pub trait IntoArgument2<'a, Argument> {
+    fn into_argument(&'a self) -> &'a Argument;
+    // Think this is problematic because lifetimes become required _even if_ we're
+    // taking ownership
+}
+*/
+
+impl<'a, T, B> IntoArgument<'a, Option<B>> for T
+where
+    T: IntoArgument<'a, B>,
+{
+    type Output = Option<T::Output>;
+
+    fn into_argument(self) -> Option<T::Output> {
+        Some(self.into_argument())
     }
 }
+
+macro_rules! define_for_owned {
+    ($inner:ty) => {
+        impl IntoArgument<'static, $inner> for $inner {
+            type Output = $inner;
+
+            fn into_argument(self) -> $inner {
+                self
+            }
+        }
+
+        impl IntoArgument<'static, Option<$inner>> for Option<$inner> {
+            type Output = Option<$inner>;
+
+            fn into_argument(self) -> Option<$inner> {
+                self
+            }
+        }
+    };
+}
+
+macro_rules! define_for_borrow {
+    ($inner:ty) => {
+        impl<'a> IntoArgument<'a, $inner> for &'a $inner {
+            type Output = &'a $inner;
+
+            fn into_argument(self) -> &'a $inner {
+                self
+            }
+        }
+
+        impl<'a> IntoArgument<'a, Option<$inner>> for Option<&'a $inner> {
+            type Output = Option<&'a $inner>;
+
+            fn into_argument(self) -> Option<&'a $inner> {
+                self
+            }
+        }
+
+        // TODO: probably also want &'a Option<inner>?
+    };
+}
+
+macro_rules! define_for_scalar {
+    ($inner:ty) => {
+        define_for_owned!($inner);
+        define_for_borrow!($inner);
+    };
+}
+
+define_for_scalar!(i32);
+define_for_scalar!(String);
+define_for_scalar!(Id);
 
 // TODO: Can I take advantage of the fact that there's a limited
 // subset of things that can be arguments here, and actually enumerate
@@ -19,24 +90,42 @@ impl<T> IntoArgument<Option<T>> for T {
 // Actually very simple.
 // Also worth noting that these are the only types that need to be serialized, and
 // _also_ currently the only types SerializableArgument are implemented for...
+/*
 impl<T> IntoArgument<T> for T {
     fn into_argument(self) -> T {
         self
     }
-}
+}*/
 
-impl IntoArgument<String> for &str {
-    fn into_argument(self) -> String {
-        self.to_string()
+// TODO: Ok, so ideas:
+// Maybe do an IntoArgument<T> for T
+// Then just be specific about all the conversions we want to support,
+// using macros to cut down on the pain of defining all of them...
+
+impl<'a> IntoArgument<'a, String> for &'a str {
+    type Output = &'a str;
+
+    fn into_argument(self) -> &'a str {
+        self
     }
 }
 
-impl IntoArgument<Option<String>> for &str {
-    fn into_argument(self) -> Option<String> {
-        Some(self.to_string())
+impl<'a> IntoArgument<'a, Option<String>> for Option<&'a str> {
+    type Output = Option<&'a str>;
+
+    fn into_argument(self) -> Option<&'a str> {
+        self
     }
 }
 
-// TODO: IntoArgument for Cow etc. ?
+// Things I want to accept:
+// - T for T.
+// - T for Option<T>
+// - &T for T
+// - &T for Option<T>?
+// - DeRefs for T (just manually define these probably)
+// Cow etc. ?
 
-// TODO: Can I consolidate IntoArgument with Serializable argument somehow?
+// Can't neccesarily use T for some of these but the set of
+// T is limited so just implement it manually for those things.
+// Essentially scalars, enums, input types

--- a/cynic/src/into_argument.rs
+++ b/cynic/src/into_argument.rs
@@ -24,21 +24,36 @@ where
     }
 }
 
-macro_rules! define_for_scalar {
+/// Defines useful argument conversions for scalar-like types
+///
+/// Mostly just converts references to owned via cloning and
+/// non option-wrapped types into Option where appropriate.
+#[macro_export]
+macro_rules! define_into_argument_for_scalar {
     ($inner:ty) => {
-        impl IntoArgument<Option<$inner>> for $inner {
+        impl $crate::IntoArgument<Option<$inner>> for $inner {
+            fn into_argument(self) -> Option<$inner> {
+                Some(self)
+            }
+        }
+
+        impl $crate::IntoArgument<Option<$inner>> for &$inner {
             fn into_argument(self) -> Option<$inner> {
                 Some(self.clone())
             }
         }
+    };
+}
 
-        impl IntoArgument<Option<$inner>> for Option<&$inner> {
+macro_rules! define_into_argument_for_option_refs {
+    ($inner:ty) => {
+        impl $crate::IntoArgument<Option<$inner>> for Option<&$inner> {
             fn into_argument(self) -> Option<$inner> {
                 self.cloned()
             }
         }
 
-        impl IntoArgument<Option<$inner>> for &Option<$inner> {
+        impl $crate::IntoArgument<Option<$inner>> for &Option<$inner> {
             fn into_argument(self) -> Option<$inner> {
                 self.clone()
             }
@@ -46,11 +61,17 @@ macro_rules! define_for_scalar {
     };
 }
 
-define_for_scalar!(i32);
-define_for_scalar!(f64);
-define_for_scalar!(String);
-define_for_scalar!(bool);
-define_for_scalar!(Id);
+define_into_argument_for_scalar!(i32);
+define_into_argument_for_scalar!(f64);
+define_into_argument_for_scalar!(String);
+define_into_argument_for_scalar!(bool);
+define_into_argument_for_scalar!(Id);
+
+define_into_argument_for_option_refs!(i32);
+define_into_argument_for_option_refs!(f64);
+define_into_argument_for_option_refs!(String);
+define_into_argument_for_option_refs!(bool);
+define_into_argument_for_option_refs!(Id);
 
 impl IntoArgument<String> for &str {
     fn into_argument(self) -> String {

--- a/cynic/src/into_argument.rs
+++ b/cynic/src/into_argument.rs
@@ -69,19 +69,8 @@ impl IntoArgument<Option<String>> for Option<&str> {
         self.map(|s| s.to_string())
     }
 }
+
 // TODO: Do I also want to define things for Vecs?
 
-// TODO: Define for Enums/InputObjects, though maybe want the derives to take care
+// TODO: Define some more for Enums & InputObjects, though maybe want the derives to take care
 //       of that.
-
-// Things I definitely want to accept:
-// - T for T.
-// - T for Option<T>
-// - &T for T
-// - &T for Option<T>?
-// - DeRefs for T (just manually define these probably)
-// Cow etc. ?
-
-// Can't neccesarily use T for some of these but the set of
-// T is limited so just implement it manually for those things.
-// Essentially scalars, enums, input types

--- a/cynic/src/into_argument.rs
+++ b/cynic/src/into_argument.rs
@@ -7,7 +7,8 @@ use crate::{argument::SerializableArgument, Id};
 /// accept any `IntoArgument<Option<String>>`.
 ///
 /// There are implementations of this for most of the built in scalars to allow
-/// users to express arguments in a simple manner.
+/// users to express arguments in a simple manner.  The `cynic::Enum` derive
+/// also generates impls for converting options & refs easily.
 pub trait IntoArgument<Argument>
 where
     Argument: SerializableArgument + Send + 'static,

--- a/cynic/src/into_argument.rs
+++ b/cynic/src/into_argument.rs
@@ -1,0 +1,42 @@
+// TODO: docs.
+
+pub trait IntoArgument<Argument> {
+    fn into_argument(self) -> Argument;
+}
+
+impl<T> IntoArgument<Option<T>> for T {
+    fn into_argument(self) -> Option<T> {
+        Some(self)
+    }
+}
+
+// TODO: Can I take advantage of the fact that there's a limited
+// subset of things that can be arguments here, and actually enumerate
+// every possibility rather than adding this generic impl.
+// This would give me a lot more leeway to do stuff with AsRef etc.
+
+// Things that can be arguments: scalars, input types, vecs<other_args>, options<other_args>
+// Actually very simple.
+// Also worth noting that these are the only types that need to be serialized, and
+// _also_ currently the only types SerializableArgument are implemented for...
+impl<T> IntoArgument<T> for T {
+    fn into_argument(self) -> T {
+        self
+    }
+}
+
+impl IntoArgument<String> for &str {
+    fn into_argument(self) -> String {
+        self.to_string()
+    }
+}
+
+impl IntoArgument<Option<String>> for &str {
+    fn into_argument(self) -> Option<String> {
+        Some(self.to_string())
+    }
+}
+
+// TODO: IntoArgument for Cow etc. ?
+
+// TODO: Can I consolidate IntoArgument with Serializable argument somehow?

--- a/cynic/src/into_argument.rs
+++ b/cynic/src/into_argument.rs
@@ -46,12 +46,6 @@ define_for_scalar!(String);
 define_for_scalar!(bool);
 define_for_scalar!(Id);
 
-#[cfg(feature = "chrono")]
-define_for_scalar!(chrono::FixedOffset);
-
-#[cfg(feature = "chrono")]
-define_for_scalar!(chrono::DateTime<chrono::Utc>);
-
 impl IntoArgument<String> for &str {
     fn into_argument(self) -> String {
         self.to_string()

--- a/cynic/src/into_argument.rs
+++ b/cynic/src/into_argument.rs
@@ -90,8 +90,3 @@ impl IntoArgument<Option<String>> for Option<&str> {
         self.map(|s| s.to_string())
     }
 }
-
-// TODO: Do I also want to define things for Vecs?
-
-// TODO: Define some more for Enums & InputObjects, though maybe want the derives to take care
-//       of that.

--- a/cynic/src/into_argument.rs
+++ b/cynic/src/into_argument.rs
@@ -1,7 +1,13 @@
-// TODO: docs.
-
 use crate::{argument::SerializableArgument, Id};
 
+/// IntoArgument is used to type-check arguments to queries in cynic.
+///
+/// A GraphQL argument that accepts `String!` will accept any type that is
+/// `IntoArgument<String>`.  Similarly, an optional `String` in GraphQL will
+/// accept any `IntoArgument<Option<String>>`.
+///
+/// There are implementations of this for most of the built in scalars to allow
+/// users to express arguments in a simple manner.
 pub trait IntoArgument<Argument>
 where
     Argument: SerializableArgument + Send + 'static,

--- a/cynic/src/lib.rs
+++ b/cynic/src/lib.rs
@@ -157,6 +157,7 @@
 mod argument;
 mod field;
 mod id;
+mod into_argument;
 mod query;
 mod result;
 mod scalar;
@@ -172,6 +173,8 @@ pub use query::Query;
 pub use result::{GraphQLError, GraphQLResponse, GraphQLResult, PossiblyParsedData};
 pub use scalar::Scalar;
 pub use selection_set::SelectionSet;
+
+pub use into_argument::IntoArgument;
 
 pub trait QueryFragment {
     type SelectionSet;

--- a/cynic/src/lib.rs
+++ b/cynic/src/lib.rs
@@ -2,7 +2,8 @@
 //!
 //! Cynic is a GraphQL query builder & data mapper for Rust.
 //!
-//! See [the README on GitHub](https://github.com/polyandglot/cynic) for more details.
+//! This documentation is primarily intended to be a reference for specific functions,
+//! for a guide to using `Cynic` see the website: [cynic-rs.dev](https://cynic-rs.dev).
 //!
 //! ## Overview
 //!

--- a/cynic/src/lib.rs
+++ b/cynic/src/lib.rs
@@ -76,7 +76,7 @@
 //!     // hard coded film ID to look up.  Though useful for demonstration, hard coded
 //!     // arguments like this aren't much use in reality.  For more details on providing
 //!     // runtime arguments please see below.
-//!     #[cynic_arguments(id = Some("ZmlsbXM6MQ==".into()))]
+//!     #[cynic_arguments(id = cynic::Id::new("ZmlsbXM6MQ=="))]
 //!     film: Option<Film>,
 //! }
 //!

--- a/examples/examples/starwars.rs
+++ b/examples/examples/starwars.rs
@@ -26,7 +26,7 @@ struct FilmArguments {
     argument_struct = "FilmArguments"
 )]
 struct FilmDirectorQuery {
-    #[cynic_arguments(id = args.id.clone())]
+    #[cynic_arguments(id = &args.id)]
     film: Option<Film>,
 }
 


### PR DESCRIPTION
#### Why do we need this change?

Currently, the `cynic_arguments` attribute is pretty strict in what it accepts.  

- If an argument is `String!` you need to explicitly provide a `String` (a `&str` isn't good enough). 
- If an argument is `String` you need to explicitly provide an `Option<String>` - none of `String`, '&str`, or `Option<&str>` is acceptable.

This leads to some noisy `cynic_argument` attributes.

This also causes otherwise backwards compatible GraphQL schema changes to cause compilation errors - if a field was required before and is now optional, you'll have to explicitly add that `Some` to your definition.

#### What effects does this change have?

This PR adds an `IntoArguments<T>` trait where `T` is the type of the argument.  This trait handles converting various arguments into their expected form.

I considered using some of the built in traits like `AsRef` or `Into` but they all seemed to come with limitations for what I wanted to do.

Fixes #48 

#### Note on Lifetimes

I spent some time trying to solve #46 at the same time - at one point `IntoArgument` had a `Output` associated type that I could use to control the type being serialized.  I used this to borrow `&str` and feed it into a new lifetime on `Argument`.  This new lifetime ended up bleeding up to the `Query` struct which made things a bit unergonomic.  See note on #46 for more details on that.  At the time of writing this alternative implementation can be found on the `into-arguments` branch, though it may not stay around forever.  This PR was a partial rebase of that original branch, with some re-work afterwards.

#### TODOs:

- [x] Documentation in file.
- [x] Implementations for Enum (InputObjects are a whole other problem, briefly documented in #82)
- [x] General Tidy Up
- [x] Update the book/other documentation to mention this.
- [x] Update CHANGELOG
- [x] More testing (particularly around enums & input objects)