### PR TITLE
Add automatically_derived annotation in cynic-codegen.

### DIFF
--- a/cynic-codegen/src/enum_derive/mod.rs
+++ b/cynic-codegen/src/enum_derive/mod.rs
@@ -79,6 +79,7 @@ pub fn enum_derive_impl(
         let enum_marker_ident = Ident::for_type(&*input.graphql_type);
 
         Ok(quote! {
+            #[automatically_derived]
             impl ::cynic::Enum<#query_module::#enum_marker_ident> for #ident {
                 fn select() -> cynic::SelectionSet<'static, Self, ()> {
                     ::cynic::selection_set::string().and_then(|s| {
@@ -92,6 +93,7 @@ pub fn enum_derive_impl(
                 }
             }
 
+            #[automatically_derived]
             impl ::cynic::SerializableArgument for #ident {
                 fn serialize(&self) -> Result<serde_json::Value, ::cynic::SerializeError> {
                     Ok(::serde_json::to_value(match self {

--- a/cynic-codegen/src/fragment_derive/mod.rs
+++ b/cynic-codegen/src/fragment_derive/mod.rs
@@ -344,12 +344,12 @@ impl quote::ToTokens for FragmentImpl {
         let map_function = quote::format_ident!("map{}", fields.len());
 
         tokens.append_all(quote! {
+            #[automatically_derived]
             impl ::cynic::QueryFragment for #target_struct {
                 type SelectionSet = ::cynic::SelectionSet<'static, Self, #selector_struct>;
                 type Arguments = #argument_struct;
 
                 fn fragment(args: Self::Arguments) -> Self::SelectionSet {
-                    #[allow(unused_imports)]
                     use ::cynic::{QueryFragment, FromArguments, Enum};
 
                     let new = |#(#constructor_params),*| #target_struct {

--- a/cynic-codegen/src/inline_fragments_derive/mod.rs
+++ b/cynic-codegen/src/inline_fragments_derive/mod.rs
@@ -100,6 +100,7 @@ impl quote::ToTokens for InlineFragmentsImpl {
         let graphql_type = proc_macro2::Literal::string(&self.graphql_type_name);
 
         tokens.append_all(quote! {
+            #[automatically_derived]
             impl ::cynic::InlineFragments for #target_struct {
                 type TypeLock = #type_lock;
                 type Arguments = #arguments;


### PR DESCRIPTION
#### Why do we need this change?

We've got a bunch of automatically generated code that sometimes has unused
imports etc. in it.

#### What effects does this change have?

Adding the automatically_derived annotation _appears_ to disable some of the
linting around unused variables.  I can't find any specific documentation on it
though, just found it in some other rust code.  Could be that this is not a
good idea, but one way to find out.

Fixes #75
