### PR TITLE
Rename `cynic_arguments` -> `arguments`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ all APIs might be changed.
 
 - Integer fields are now i32 rather than i64 inline with the GraphQL spec.  If
   larger integers are required a custom scalar should be used.
+- The `cynic_arguments` attribute for passing arguments to GraphQL fields is
+  now named `arguments`
 
 ### New Features
 

--- a/cynic-codegen/src/fragment_derive/arguments.rs
+++ b/cynic-codegen/src/fragment_derive/arguments.rs
@@ -7,7 +7,7 @@ use syn::{
 
 pub fn arguments_from_field_attrs(attrs: &Vec<syn::Attribute>) -> Result<Vec<FieldArgument>> {
     for attr in attrs {
-        if attr.path.is_ident("cynic_arguments") {
+        if attr.path.is_ident("arguments") {
             let parsed: CynicArguments = attr.parse_args()?;
             return Ok(parsed.arguments.into_iter().collect());
         }
@@ -15,7 +15,7 @@ pub fn arguments_from_field_attrs(attrs: &Vec<syn::Attribute>) -> Result<Vec<Fie
     Ok(vec![])
 }
 
-/// Implements syn::Parse to parse out arguments from the cynic_arguments
+/// Implements syn::Parse to parse out arguments from the arguments
 /// attribute.
 #[derive(PartialEq, Debug)]
 struct CynicArguments {

--- a/cynic-codegen/src/fragment_derive/input.rs
+++ b/cynic-codegen/src/fragment_derive/input.rs
@@ -14,7 +14,7 @@ pub struct FragmentDeriveInput {
 }
 
 #[derive(darling::FromField)]
-#[darling(attributes(cynic), forward_attrs(cynic_arguments))]
+#[darling(attributes(cynic), forward_attrs(arguments))]
 pub struct FragmentDeriveField {
     pub(super) ident: Option<proc_macro2::Ident>,
     pub(super) ty: syn::Type,

--- a/cynic-codegen/src/fragment_derive/mod.rs
+++ b/cynic-codegen/src/fragment_derive/mod.rs
@@ -4,13 +4,13 @@ use proc_macro2::{Span, TokenStream};
 
 use crate::{load_schema, FieldType, Ident, TypePath};
 
-mod cynic_arguments;
+mod arguments;
 mod schema_parsing;
 mod type_validation;
 
 pub(crate) mod input;
 
-use cynic_arguments::{arguments_from_field_attrs, FieldArgument};
+use arguments::{arguments_from_field_attrs, FieldArgument};
 use schema_parsing::{Field, Object};
 use type_validation::check_types_are_compatible;
 
@@ -401,7 +401,7 @@ fn validate_and_group_args(
 
         return Err(syn::Error::new(
             missing_arg_span,
-            format!("Missing cynic_arguments: {}", missing_args),
+            format!("Missing arguments: {}", missing_args),
         ));
     }
 

--- a/cynic-codegen/src/query_module/utils.rs
+++ b/cynic-codegen/src/query_module/utils.rs
@@ -89,7 +89,7 @@ pub fn strip_cynic_attrs(item: syn::Item) -> syn::Item {
 }
 
 fn is_cynic_attr(path: &syn::Path) -> bool {
-    path.is_ident("cynic_arguments") || path.is_ident("cynic")
+    path.is_ident("arguments") || path.is_ident("cynic")
 }
 
 fn filter_cynic_attrs(attrs: Vec<Attribute>) -> Vec<Attribute> {
@@ -173,7 +173,7 @@ mod tests {
             #[cynic(query_path = "something")]
             #[serde(something)]
             struct Something {
-                #[cynic_arguments(x = "1")]
+                #[arguments(x = "1")]
                 field: i32,
                 other_field: f32
             }

--- a/cynic-codegen/src/scalar_derive/input.rs
+++ b/cynic-codegen/src/scalar_derive/input.rs
@@ -6,7 +6,7 @@ pub struct ScalarDeriveInput {
 }
 
 #[derive(darling::FromField)]
-#[darling(forward_attrs(cynic_arguments))]
+#[darling(forward_attrs(arguments))]
 pub struct ScalarDeriveField {
     pub(super) ty: syn::Type,
 }

--- a/cynic-proc-macros/src/lib.rs
+++ b/cynic-proc-macros/src/lib.rs
@@ -18,7 +18,7 @@ pub fn query_dsl(input: TokenStream) -> TokenStream {
     rv
 }
 
-#[proc_macro_derive(QueryFragment, attributes(cynic, cynic_arguments))]
+#[proc_macro_derive(QueryFragment, attributes(cynic, arguments))]
 pub fn query_fragment_derive(input: TokenStream) -> TokenStream {
     let ast = syn::parse_macro_input!(input as syn::DeriveInput);
 

--- a/cynic-querygen/src/lib.rs
+++ b/cynic-querygen/src/lib.rs
@@ -113,7 +113,7 @@ pub fn document_to_fragment_structs(
                             .collect::<Result<Vec<_>, Error>>()?
                             .join(", ");
 
-                        lines.push(format!("        #[cynic_arguments({})]", arguments_string));
+                        lines.push(format!("        #[arguments({})]", arguments_string));
                     }
                     // TODO: print out arguments
                     lines.push(format!(

--- a/cynic-querygen/tests/snapshots/github_tests__literal_enums.snap
+++ b/cynic-querygen/tests/snapshots/github_tests__literal_enums.snap
@@ -12,14 +12,14 @@ mod queries {
     #[derive(cynic::QueryFragment)]
     #[cynic(graphql_type = "Query")]
     pub struct Query {
-        #[cynic_arguments(owner = "obmarg".to_string(), name = "cynic".to_string())]
+        #[arguments(owner = "obmarg".to_string(), name = "cynic".to_string())]
         pub repository: Option<Repository>,
     }
 
     #[derive(cynic::QueryFragment)]
     #[cynic(graphql_type = "Repository")]
     pub struct Repository {
-        #[cynic_arguments(states = IssueState::Open, first = 10)]
+        #[arguments(states = IssueState::Open, first = 10)]
         pub issues: IssueConnection,
     }
 

--- a/cynic-querygen/tests/snapshots/starwars_tests__nested_arguments.snap
+++ b/cynic-querygen/tests/snapshots/starwars_tests__nested_arguments.snap
@@ -19,7 +19,7 @@ mod queries {
     #[derive(cynic::QueryFragment)]
     #[cynic(graphql_type = "Query", argument_struct = "QueryArguments")]
     pub struct Query {
-        #[cynic_arguments(id = args.filmId)]
+        #[arguments(id = args.filmId)]
         pub film: Option<Film>,
     }
 
@@ -28,7 +28,7 @@ mod queries {
     pub struct Film {
         pub title: Option<String>,
         pub director: Option<String>,
-        #[cynic_arguments(after = args.planetCursor)]
+        #[arguments(after = args.planetCursor)]
         pub planetConnection: Option<FilmPlanetsConnection>,
     }
 
@@ -41,7 +41,7 @@ mod queries {
     #[derive(cynic::QueryFragment)]
     #[cynic(graphql_type = "Planet", argument_struct = "QueryArguments")]
     pub struct Planet {
-        #[cynic_arguments(after = args.residentConnection)]
+        #[arguments(after = args.residentConnection)]
         pub residentConnection: Option<PlanetResidentsConnection>,
     }
 

--- a/cynic-querygen/tests/snapshots/starwars_tests__sanity_test_starwars_query.snap
+++ b/cynic-querygen/tests/snapshots/starwars_tests__sanity_test_starwars_query.snap
@@ -17,7 +17,7 @@ mod queries {
     #[derive(cynic::QueryFragment)]
     #[cynic(graphql_type = "Query", argument_struct = "QueryArguments")]
     pub struct Query {
-        #[cynic_arguments(id = args.filmId)]
+        #[arguments(id = args.filmId)]
         pub film: Option<Film>,
     }
 

--- a/cynic/examples/simple.rs
+++ b/cynic/examples/simple.rs
@@ -21,7 +21,7 @@ struct TestArgs {}
     argument_struct = "TestArgs"
 )]
 struct TestStruct {
-    #[cynic_arguments(x = Some(1), y = Some("1".to_string()))]
+    #[arguments(x = Some(1), y = Some("1".to_string()))]
     field_one: String,
     nested: Nested,
     opt_nested: Option<Nested>,
@@ -45,7 +45,7 @@ struct Nested {
     graphql_type = "TestStruct"
 )]
 struct Test {
-    #[cynic_arguments(x = Some(1), y = Some("1".to_string()))]
+    #[arguments(x = Some(1), y = Some("1".to_string()))]
     field_one: String,
 }
 

--- a/cynic/examples/simple_v2.rs
+++ b/cynic/examples/simple_v2.rs
@@ -28,7 +28,7 @@ mod queries {
     #[derive(cynic::QueryFragment)]
     #[cynic(graphql_type = "TestStruct", argument_struct = "TestArgs")]
     pub struct TestStruct {
-        #[cynic_arguments(x = Some(1), y = Some("1".to_string()))]
+        #[arguments(x = Some(1), y = Some("1".to_string()))]
         field_one: String,
         nested: Nested,
         opt_nested: Option<Nested>,
@@ -45,7 +45,7 @@ mod queries {
     #[derive(cynic::QueryFragment)]
     #[cynic(graphql_type = "TestStruct")]
     pub struct Test {
-        #[cynic_arguments(x = Some(1), y = Some("1".to_string()))]
+        #[arguments(x = Some(1), y = Some("1".to_string()))]
         field_one: String,
     }
 

--- a/cynic/src/lib.rs
+++ b/cynic/src/lib.rs
@@ -72,11 +72,11 @@
 //!     graphql_type = "Root"
 //! )]
 //! struct FilmDirectorQuery {
-//!     // Here we use the `#[cynic_arguments()]` attribute on the `film` field to provide a
+//!     // Here we use the `#[arguments()]` attribute on the `film` field to provide a
 //!     // hard coded film ID to look up.  Though useful for demonstration, hard coded
 //!     // arguments like this aren't much use in reality.  For more details on providing
 //!     // runtime arguments please see below.
-//!     #[cynic_arguments(id = Some("ZmlsbXM6MQ==".into()))]
+//!     #[arguments(id = Some("ZmlsbXM6MQ==".into()))]
 //!     film: Option<Film>,
 //! }
 //!
@@ -136,12 +136,12 @@
 //!     query_module = "query_dsl",
 //!     graphql_type = "Root",
 //!     // By adding the `argument_struct` parameter to our `QueryFragment` we've made a variable
-//!     // named `args` avaiable for use in the `cynic_arguments` attribute.
+//!     // named `args` avaiable for use in the `arguments` attribute.
 //!     argument_struct = "FilmArguments"
 //! )]
 //! struct FilmDirectorQueryWithArgs {
 //!     // Here we use `args`, which we've declared above to be an instance of `FilmArguments`
-//!     #[cynic_arguments(id = args.id.clone())]
+//!     #[arguments(id = args.id.clone())]
 //!     film: Option<Film>,
 //! }
 //!

--- a/cynic/tests/simple_schema_tests.rs
+++ b/cynic/tests/simple_schema_tests.rs
@@ -20,7 +20,7 @@ struct TestStruct {
     // TODO: Could automatically add Some here, though
     // honestly not sure, as what if the argument itself is some optional in a struct.
     // for now this doesn't seem like the worst decision.
-    //#[cynic_arguments(x = Some(1), y = Some("1".to_string()))]
+    //#[arguments(x = Some(1), y = Some("1".to_string()))]
     field_one: String,
     nested: Nested,
     opt_nested: Option<Nested>,

--- a/examples/examples/starwars.rs
+++ b/examples/examples/starwars.rs
@@ -26,7 +26,7 @@ struct FilmArguments {
     argument_struct = "FilmArguments"
 )]
 struct FilmDirectorQuery {
-    #[cynic_arguments(id = args.id.clone())]
+    #[arguments(id = args.id.clone())]
     film: Option<Film>,
 }
 


### PR DESCRIPTION
#### Why do we need this change?

Arguments are added to a field with the cynic_arguments attribute.
But after working with this for a while I feel it's too verbose.

#### What effects does this change have?

Renames the field to `arguments` which seems to convey the idea
just as well, but with less noise.  Seems unlikely that it'll clash with 
anything else, and if it happens I'll figure out how to deal with it.

Fixes #69