### PR TITLE
Fix book cynic arguments

### DIFF
--- a/cynic-book/src/derives/query-arguments.md
+++ b/cynic-book/src/derives/query-arguments.md
@@ -18,7 +18,7 @@ don't use them at all you should get dead code warnings from Rust.
 
 To use any fields of this struct as an argument to a QueryFragment, the struct
 must define an `argument_struct` parameter that points to the `FilmArguments`
-struct.  This allows arguments to be passed in using the `cynic_arguments`
+struct.  This allows arguments to be passed in using the `arguments`
 attribute on the fields where you wish to pass them.
 
 ```rust
@@ -30,7 +30,7 @@ attribute on the fields where you wish to pass them.
     argument_struct = "FilmArguments"
 )]
 struct FilmQuery {
-    #[cynic_arguments(id = args.id.clone())]
+    #[arguments(id = args.id.clone())]
     film: Option<Film>,
 }
 ```

--- a/cynic-book/src/derives/query-fragments.md
+++ b/cynic-book/src/derives/query-fragments.md
@@ -109,12 +109,12 @@ struct FilmArguments {
     argument_struct = "FilmArguments"
 )]
 struct FilmQuery {
-    #[cynic_arguments(id = args.id.clone())]
+    #[arguments(id = args.id.clone())]
     film: Option<Film>,
 }
 ```
 
-Currently `cynic_arguments` takes ownership of arguments so you may need to
+Currently `arguments` takes ownership of arguments so you may need to
 clone as above.  Optional arguments are also wrapped in `Option<>` so to
 provide these you'll need to wrap them in `Some`.
 


### PR DESCRIPTION
#### Why do we need this change?

PR #80 renamed the cynic_arguments attr to just arguments, but forgot to update the book.

#### What effects does this change have?

Updates the book to reference arguments instead of cynic_arguments
