### PR TITLE
Fix the casing of arguments in querygen

### DIFF
--- a/cynic-querygen/src/lib.rs
+++ b/cynic-querygen/src/lib.rs
@@ -119,7 +119,13 @@ pub fn document_to_fragment_structs(
                         let arguments_string = field
                             .arguments
                             .iter()
-                            .map(|arg| Ok(format!("{} = {}", arg.name, arg.to_literal()?)))
+                            .map(|arg| {
+                                Ok(format!(
+                                    "{} = {}",
+                                    arg.name.to_snake_case(),
+                                    arg.to_literal()?
+                                ))
+                            })
                             .collect::<Result<Vec<_>, Error>>()?
                             .join(", ");
 
@@ -152,7 +158,7 @@ pub fn document_to_fragment_structs(
                 for field in &argument_struct.fields {
                     lines.push(format!(
                         "        pub {}: {},",
-                        field.name,
+                        field.name.to_snake_case(),
                         field.field_type.type_spec(&type_index)
                     ));
                 }

--- a/cynic-querygen/src/value_ext.rs
+++ b/cynic-querygen/src/value_ext.rs
@@ -12,7 +12,7 @@ pub trait ValueExt {
 impl<'a> ValueExt for Value<'a, &'a str> {
     fn to_literal(&self, type_definition: &TypeDefinition<'_>) -> Result<String, Error> {
         Ok(match self {
-            Value::Variable(name) => format!("args.{}", name),
+            Value::Variable(name) => format!("args.{}", name.to_snake_case()),
             Value::Int(num) => num.as_i64().unwrap().to_string(),
             Value::Float(num) => num.to_string(),
             Value::String(s) => format!("\"{}\".to_string()", s),

--- a/cynic-querygen/tests/snapshots/starwars_tests__nested_arguments.snap
+++ b/cynic-querygen/tests/snapshots/starwars_tests__nested_arguments.snap
@@ -11,15 +11,15 @@ mod queries {
 
     #[derive(Clone, cynic::FragmentArguments)]
     pub struct NestedArgsQueryArguments {
-        pub filmId: cynic::Id,
-        pub planetCursor: Option<String>,
-        pub residentConnection: Option<String>,
+        pub film_id: cynic::Id,
+        pub planet_cursor: Option<String>,
+        pub resident_connection: Option<String>,
     }
 
     #[derive(cynic::QueryFragment)]
     #[cynic(graphql_type = "Root", argument_struct = "NestedArgsQueryArguments")]
     pub struct NestedArgsQuery {
-        #[arguments(id = args.filmId)]
+        #[arguments(id = args.film_id)]
         pub film: Option<Film>,
     }
 
@@ -28,7 +28,7 @@ mod queries {
     pub struct Film {
         pub title: Option<String>,
         pub director: Option<String>,
-        #[arguments(after = args.planetCursor)]
+        #[arguments(after = args.planet_cursor)]
         pub planetConnection: Option<FilmPlanetsConnection>,
     }
 
@@ -41,7 +41,7 @@ mod queries {
     #[derive(cynic::QueryFragment)]
     #[cynic(graphql_type = "Planet", argument_struct = "NestedArgsQueryArguments")]
     pub struct Planet {
-        #[arguments(after = args.residentConnection)]
+        #[arguments(after = args.resident_connection)]
         pub residentConnection: Option<PlanetResidentsConnection>,
     }
 

--- a/cynic-querygen/tests/snapshots/starwars_tests__sanity_test_starwars_query.snap
+++ b/cynic-querygen/tests/snapshots/starwars_tests__sanity_test_starwars_query.snap
@@ -11,13 +11,13 @@ mod queries {
 
     #[derive(Clone, cynic::FragmentArguments)]
     pub struct SanityCheckQueryArguments {
-        pub filmId: Option<cynic::Id>,
+        pub film_id: Option<cynic::Id>,
     }
 
     #[derive(cynic::QueryFragment)]
     #[cynic(graphql_type = "Root", argument_struct = "SanityCheckQueryArguments")]
     pub struct SanityCheckQuery {
-        #[arguments(id = args.filmId)]
+        #[arguments(id = args.film_id)]
         pub film: Option<Film>,
     }
 


### PR DESCRIPTION
#### Why are we making this change?

Querygen wasn't snake casing argument names.  This appeared to work, but isn't
what I wanted to happen.

#### What effects does this change have?

Updates querygen to snake case argument names in the places they're used.

Fixes #34
