### PR TITLE
Comma separate argument constructor calls in query_dsl.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ all APIs might be changed.
 
 ## Unreleased - xxxx-xx-xx
 
+### Bug Fixes
+
+- Fixed a compile issue in the generated `query_dsl` for schemas with fields
+  with > 1 required argument.
+
 ## v0.8.0 - 2020-08-16
 
 ### Breaking Changes

--- a/cynic-codegen/src/query_dsl/field_selector.rs
+++ b/cynic-codegen/src/query_dsl/field_selector.rs
@@ -95,7 +95,7 @@ impl quote::ToTokens for FieldSelector {
                             #argument_strings,
                             #argument_gql_types,
                             #argument_names
-                        )
+                        ),
                     )*
                 ])
             }


### PR DESCRIPTION
#### Why are we making this change?

Tested the query_dsl code against the GitHub schema, but was getting
"unexpected token ::" errors from the query_dsl macro output.

Tracked it down to the `Argument::new` calls in the `FieldSelector`
output - wasn't separating them with commas so if any fields had > 1
required argument it would fail to compile.

#### What effects does this change have?

Comma separates the `Argument::new()` calls in the FieldSelector output, 
fixing the error.
