### PR TITLE
Re-export serde_json and use that in derives.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ all APIs might be changed.
 
 - Fixed a compile issue in the generated `query_dsl` for schemas with fields
   with > 1 required argument.
+- Fixed an issue that required users to add `serde_json` to their dependencies.
+  We now re-export it as `cynic::serde_json` and use that in our derive output.
 
 ## v0.8.0 - 2020-08-16
 

--- a/cynic-codegen/src/enum_derive/mod.rs
+++ b/cynic-codegen/src/enum_derive/mod.rs
@@ -95,8 +95,8 @@ pub fn enum_derive_impl(
 
             #[automatically_derived]
             impl ::cynic::SerializableArgument for #ident {
-                fn serialize(&self) -> Result<serde_json::Value, ::cynic::SerializeError> {
-                    Ok(::serde_json::to_value(match self {
+                fn serialize(&self) -> Result<::cynic::serde_json::Value, ::cynic::SerializeError> {
+                    Ok(::cynic::serde_json::to_value(match self {
                         #(
                             #ident::#variants => #string_literals.to_string(),
                         )*

--- a/cynic-codegen/src/scalar_derive/mod.rs
+++ b/cynic-codegen/src/scalar_derive/mod.rs
@@ -31,10 +31,10 @@ pub fn scalar_derive_impl(input: ScalarDeriveInput) -> Result<TokenStream, syn::
 
     Ok(quote! {
         impl ::cynic::Scalar for #ident {
-            fn decode(value: &serde_json::Value) -> Result<Self, ::cynic::DecodeError> {
+            fn decode(value: &::cynic::serde_json::Value) -> Result<Self, ::cynic::DecodeError> {
                 Ok(#ident(<#inner_type as ::cynic::Scalar>::decode(value)?))
             }
-            fn encode(&self) -> Result<serde_json::Value, ::cynic::SerializeError> {
+            fn encode(&self) -> Result<::cynic::serde_json::Value, ::cynic::SerializeError> {
                 Ok(self.0.encode()?)
             }
         }

--- a/cynic/Cargo.toml
+++ b/cynic/Cargo.toml
@@ -19,7 +19,7 @@ all = ["chrono"]
 [dependencies]
 json-decode = "0.5.0"
 serde = { version = "1.0.104", features = [ "derive" ] }
-serde_json = "1.0.44"
+serde_json = "1.0"
 cynic-proc-macros = { path = "../cynic-proc-macros", version = "0.8.0" }
 chrono = { version = "0.4.11", optional = true}
 

--- a/cynic/src/lib.rs
+++ b/cynic/src/lib.rs
@@ -265,3 +265,8 @@ pub trait QueryRoot {}
 pub use cynic_proc_macros::{
     query_dsl, query_module, Enum, FragmentArguments, InlineFragments, QueryFragment, Scalar,
 };
+
+// We re-export serde_json as the output from a lot of our derive macros require it,
+// and this way we can point at our copy rather than forcing users to add it to
+// their Cargo.toml
+pub use serde_json;


### PR DESCRIPTION
#### Why are we making this change?

Many of the derive macros output code that uses serde_json.  As the output of
derives ends up in the users code, they needed to add serde_json to their
dependencies.  While this isn't the end of the world, it'd be nice if things
just worked.  In particular, errors complaining that `serde_json` can't be
found in code that the user can't even see might be confusing to newer rust
developers.

#### What effects does this change have?

This adds a re-export of serde_json at the top level of `cynic` and updates
the derives to use that reference to cynic instead.

I'm a tiny bit concerned that version mismatches between the serde_json cynic
uses and the serde_json the user uses could cause issues down the line, so I've
relaxed the version requirement on serde_json for us to help make this less
likely.  Otherwise can deal with when and if it happens.

Fixes #90 