### PR TITLE
Rename enum members to SCREAMING_SNAKE_CASE by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ all APIs might be changed.
   with > 1 required argument.
 - Fixed an issue that required users to add `serde_json` to their dependencies.
   We now re-export it as `cynic::serde_json` and use that in our derive output.
+- querygen now adds `rename_all="SCREAMING_SNAKE_CASE"` to Enums by default -
+  the GQL convention is to have them in this format and querygen was already
+  doing the transformation into the `PascalCase` rust usually uses so this
+  should make things more likely to work by default.
 
 ## v0.8.0 - 2020-08-16
 

--- a/cynic-querygen/src/lib.rs
+++ b/cynic-querygen/src/lib.rs
@@ -143,7 +143,10 @@ pub fn document_to_fragment_structs(
             PotentialStruct::Enum(en) => {
                 let type_name = en.def.name;
                 lines.push("    #[derive(cynic::Enum, Clone, Copy, Debug)]".into());
-                lines.push(format!("    #[cynic(graphql_type = \"{}\")]", type_name));
+                lines.push("    #[cynic(".into());
+                lines.push(format!("        graphql_type = \"{}\",", type_name));
+                lines.push("        rename_all = \"SCREAMING_SNAKE_CASE\"))]".into());
+                lines.push("    ))]".into());
                 lines.push(format!("    pub enum {} {{", type_name.to_pascal_case()));
 
                 for variant in &en.def.values {

--- a/cynic-querygen/tests/snapshots/github_tests__literal_enums.snap
+++ b/cynic-querygen/tests/snapshots/github_tests__literal_enums.snap
@@ -36,7 +36,10 @@ mod queries {
     }
 
     #[derive(cynic::Enum, Clone, Copy, Debug)]
-    #[cynic(graphql_type = "IssueState")]
+    #[cynic(
+        graphql_type = "IssueState",
+        rename_all = "SCREAMING_SNAKE_CASE"))]
+    ))]
     pub enum IssueState {
         Closed,
         Open,


### PR DESCRIPTION
#### Why are we making this change?

GraphQL enum variants are usually SCREAMING_SNAKE_CASE.  Rust enum variants are
usually PascalCase.  Querygen was converting the enums it generated into
PascalCase, but cynic still expected SCREAMING_SNAKE_CASE.

#### What effects does this change have?

This adds the `rename_all` attr to any generated Enums, which makes it more
likely that the generated code will just work.