### PR TITLE
Add GitHub example

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,11 +9,13 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - name: Check formatting
+      run: cargo fmt -- --check
     - name: Build
       run: cargo build --verbose
     - name: Run tests
       run: cargo test --verbose --all-features
     - name: Test examples
       run: cargo test --examples
-    - name: Check formatting
-      run: cargo fmt -- --check
+    - name: Build GitHub example
+      run: cargo check --example github --all-features

--- a/examples/examples/github.rs
+++ b/examples/examples/github.rs
@@ -1,0 +1,200 @@
+//! An example using the GitHub API
+//!
+//! Note that a lot of this example is feature flagged: this is because rust-analyzer
+//! wants to build it as part of the cynic package when I'm working on cynic.  It
+//! builds quite slow because of the size of the GitHub API (the query_dsl output is
+//! around 100k lines of rust), and it's too much for normal development.
+//!
+//! If you want to use this example be sure to remove all the feature flagging.
+
+fn main() {
+    #[cfg(feature = "github")]
+    {
+        let result = run_query();
+        println!("{:?}", result);
+    }
+}
+
+#[cfg(feature = "github")]
+fn run_query() -> cynic::GraphQLResponse<queries::PullRequestTitles> {
+    let query = build_query();
+
+    let token = std::env::var("GITHUB_TOKEN").expect("GITHUB_TOKEN env var must be set");
+
+    let response = reqwest::blocking::Client::new()
+        .post("https://api.github.com/graphql")
+        .header("Authorization", format!("Bearer {}", token))
+        .header("User-Agent", "obmarg")
+        .json(&query)
+        .send()
+        .unwrap();
+
+    let response_body = response.text().unwrap();
+    println!("{:?}", &response_body);
+
+    query
+        .decode_response(serde_json::from_str(&response_body).unwrap())
+        .unwrap()
+}
+
+#[cfg(feature = "github")]
+fn build_query() -> cynic::Query<'static, queries::PullRequestTitles> {
+    use cynic::QueryFragment;
+    use queries::{
+        IssueOrder, IssueOrderField, OrderDirection, PullRequestTitles, PullRequestTitlesArguments,
+    };
+
+    cynic::Query::new(PullRequestTitles::fragment(PullRequestTitlesArguments {
+        pr_order: IssueOrder {
+            direction: OrderDirection::Asc,
+            field: IssueOrderField::CreatedAt,
+        },
+    }))
+}
+
+#[cfg(feature = "github")]
+#[cynic::query_module(
+    schema_path = "../cynic-querygen/tests/schemas/github.graphql",
+    query_module = "query_dsl"
+)]
+mod queries {
+    use super::{query_dsl, types::*};
+
+    #[derive(cynic::FragmentArguments, Clone, Debug)]
+    pub struct PullRequestTitlesArguments {
+        pub pr_order: IssueOrder,
+    }
+
+    #[derive(cynic::InputObject, Clone, Debug)]
+    #[cynic(graphql_type = "IssueOrder", rename_all = "camelCase")]
+    pub struct IssueOrder {
+        pub direction: OrderDirection,
+        pub field: IssueOrderField,
+    }
+
+    #[derive(cynic::Enum, Clone, Copy, Debug)]
+    #[cynic(graphql_type = "OrderDirection", rename_all = "SCREAMING_SNAKE_CASE")]
+    pub enum OrderDirection {
+        Asc,
+        Desc,
+    }
+
+    #[derive(cynic::Enum, Clone, Copy, Debug)]
+    #[cynic(graphql_type = "IssueOrderField", rename_all = "SCREAMING_SNAKE_CASE")]
+    pub enum IssueOrderField {
+        Comments,
+        CreatedAt,
+        UpdatedAt,
+    }
+
+    #[derive(cynic::QueryFragment, Debug)]
+    #[cynic(graphql_type = "Query", argument_struct = "PullRequestTitlesArguments")]
+    pub struct PullRequestTitles {
+        #[arguments(name = "cynic".to_string(), owner = "obmarg".to_string())]
+        pub repository: Option<Repository>,
+    }
+
+    #[derive(cynic::QueryFragment, Debug)]
+    #[cynic(
+        graphql_type = "Repository",
+        argument_struct = "PullRequestTitlesArguments"
+    )]
+    pub struct Repository {
+        #[arguments(order_by = &args.pr_order, first = 10)]
+        pub pull_requests: PullRequestConnection,
+    }
+
+    #[derive(cynic::QueryFragment, Debug)]
+    #[cynic(graphql_type = "PullRequestConnection")]
+    pub struct PullRequestConnection {
+        #[cynic(flatten)]
+        pub nodes: Vec<PullRequest>,
+    }
+
+    #[derive(cynic::QueryFragment, Debug)]
+    #[cynic(graphql_type = "PullRequest")]
+    pub struct PullRequest {
+        pub title: String,
+    }
+}
+
+#[cfg(feature = "github")]
+#[cynic::query_module(
+    schema_path = "../cynic-querygen/tests/schemas/github.graphql",
+    query_module = "query_dsl"
+)]
+mod types {
+    #[derive(cynic::Scalar, Debug)]
+    pub struct Date(String);
+
+    #[derive(cynic::Scalar, Debug)]
+    pub struct DateTime(String);
+
+    #[derive(cynic::Scalar, Debug)]
+    pub struct GitObjectID(String);
+
+    #[derive(cynic::Scalar, Debug)]
+    pub struct GitRefname(String);
+
+    #[derive(cynic::Scalar, Debug)]
+    pub struct GitSSHRemote(String);
+
+    #[derive(cynic::Scalar, Debug)]
+    pub struct GitTimestamp(String);
+
+    #[derive(cynic::Scalar, Debug)]
+    pub struct Html(String);
+
+    #[derive(cynic::Scalar, Debug)]
+    pub struct PreciseDateTime(String);
+
+    #[derive(cynic::Scalar, Debug)]
+    pub struct Uri(String);
+
+    #[derive(cynic::Scalar, Debug)]
+    pub struct X509Certificate(String);
+}
+
+#[cfg(feature = "github")]
+mod query_dsl {
+    use super::types::*;
+    cynic::query_dsl!("../cynic-querygen/tests/schemas/github.graphql");
+}
+
+#[cfg(all(test, feature = "github"))]
+mod test {
+    use super::*;
+
+    #[test]
+    fn snapshot_test_query() {
+        // Running a snapshot test of the query building functionality as that gives us
+        // a place to copy and paste the actual GQL we're using for running elsewhere,
+        // and also helps ensure we don't change queries by mistake
+
+        let query = build_query();
+
+        insta::assert_snapshot!(query.query);
+    }
+
+    #[test]
+    fn test_running_query() {
+        let result = run_query();
+        if result.errors.is_some() {
+            assert_eq!(result.errors.unwrap().len(), 0);
+        }
+        assert_eq!(
+            result
+                .data
+                .as_ref()
+                .unwrap()
+                .repository
+                .as_ref()
+                .unwrap()
+                .pull_requests
+                .nodes
+                .len(),
+            10
+        );
+        insta::assert_debug_snapshot!(result.data);
+    }
+}

--- a/examples/examples/snapshots/github__test__running_query.snap
+++ b/examples/examples/snapshots/github__test__running_query.snap
@@ -1,0 +1,46 @@
+---
+source: examples/examples/github.rs
+expression: result.data
+---
+Some(
+    PullRequestTitles {
+        repository: Some(
+            Repository {
+                pull_requests: PullRequestConnection {
+                    nodes: [
+                        PullRequest {
+                            title: "Add CI using Github Actions",
+                        },
+                        PullRequest {
+                            title: "Simple type validation in QueryFragment derive.",
+                        },
+                        PullRequest {
+                            title: "Add support for union types via InlineFragments trait.",
+                        },
+                        PullRequest {
+                            title: "Add scalars_as_strings.",
+                        },
+                        PullRequest {
+                            title: "Convert parsing of derive input to use darling",
+                        },
+                        PullRequest {
+                            title: "Fix cynic_arguments parsing with darling",
+                        },
+                        PullRequest {
+                            title: "Added `flatten` option at the field level.",
+                        },
+                        PullRequest {
+                            title: "Optimisations",
+                        },
+                        PullRequest {
+                            title: "First attempt at querygen & web interface",
+                        },
+                        PullRequest {
+                            title: "Added query_module attribute macro.",
+                        },
+                    ],
+                },
+            },
+        ),
+    },
+)

--- a/examples/examples/snapshots/github__test__snapshot_test_query.snap
+++ b/examples/examples/snapshots/github__test__snapshot_test_query.snap
@@ -1,0 +1,14 @@
+---
+source: examples/examples/github.rs
+expression: query.query
+---
+query Query($_0: String!, $_1: String!, $_2: Int, $_3: IssueOrder) {
+  repository(name: $_0, owner: $_1) {
+    pullRequests(first: $_2, orderBy: $_3) {
+      nodes {
+        title
+      }
+    }
+  }
+}
+


### PR DESCRIPTION
#### Why are we making this change?

The current example uses the StarWars API.  This is good, but doesn't have a
lot of GraphQL functionality - in particular InputObjects aren't used at all.
I'm in the middle of adding InputObject support so it'd be good to have an
example (and therefore a test) of InputObject support.

#### What effects does this change have?

It adds a GitHub example that queries the cynic PRs to the repo.  This both
documents the feature and allows us to test it by running the example.

Unfortunately the GitHub API is too big to compile a cynic example quickly so I
had to resort to feature flagging bits of the example.  This diminishes it's
usefulness as documentation so I should probably look into how to do this
better in the future.

This test currently does nothing as the feature flag I've added is only declared 
in #95.  Going to merge this and then merge it into #95 to test.