### PR TITLE
Add support for Url scalars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ all APIs might be changed.
 
 - The `bson` feature, which allows to use ObjectId in schemas, added.
 - The `uuid` feature, which allows to use Uuid in schemas, added.
+- The `url` feature, which allows to use Url in schemas, added.
 
 ## v0.9.0 - 2020-09-11
 

--- a/cynic/Cargo.toml
+++ b/cynic/Cargo.toml
@@ -14,7 +14,7 @@ documentation = "https://docs.rs/cynic"
 
 [features]
 default = []
-all = ["chrono", "bson", "uuid"]
+all = ["chrono", "bson", "uuid", "url"]
 
 [dependencies]
 json-decode = "0.5.0"
@@ -24,6 +24,7 @@ cynic-proc-macros = { path = "../cynic-proc-macros", version = "0.9.0" }
 chrono = { version = "0.4.11", optional = true}
 bson = { version = "1.1.0", optional = true}
 uuid = { version = "0.8.1", optional = true}
+url = { version = "2.1.1", optional = true}
 
 [dev-dependencies]
 maplit = "1.0.2"

--- a/cynic/src/integrations/mod.rs
+++ b/cynic/src/integrations/mod.rs
@@ -11,3 +11,7 @@ pub mod bson;
 #[cfg(feature = "uuid")]
 /// Cynic support for [uuid](https://doc.rust-lang.org/uuid/uuid/struct.Uuid.html) types.
 pub mod uuid;
+
+#[cfg(feature = "url")]
+/// Cynic support for [url](https://github.com/servo/rust-url) types.
+pub mod url;

--- a/cynic/src/integrations/url.rs
+++ b/cynic/src/integrations/url.rs
@@ -1,0 +1,34 @@
+use json_decode::DecodeError;
+use url::Url;
+
+use crate::{scalar::Scalar, SerializeError};
+
+impl Scalar for Url {
+    fn decode(value: &serde_json::Value) -> Result<Self, DecodeError> {
+        match value {
+            serde_json::Value::String(s) => {
+                Ok(Url::parse(s).map_err(|err| DecodeError::Other(err.to_string()))?)
+            }
+            _ => Err(DecodeError::IncorrectType(
+                "String".to_string(),
+                value.to_string(),
+            )),
+        }
+    }
+
+    fn encode(&self) -> Result<serde_json::Value, SerializeError> {
+        Ok(serde_json::Value::String(self.as_str().to_owned()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_bson_object_id_scalar() {
+        let url: Url = Url::parse("https://example.net/").unwrap();
+
+        assert_eq!(Url::decode(&url.encode().unwrap()), Ok(url));
+    }
+}

--- a/cynic/src/lib.rs
+++ b/cynic/src/lib.rs
@@ -162,6 +162,8 @@
 //! - `chrono` adds support for chrono::DateTime scalars.
 //! - `uuid` adds support for Uuid scalars
 //! - `bson` adds support for ObjectId scalars
+//! - `url` adds support for Url scalars \
+//!   Note: `url` feature could increase output [file size](https://github.com/servo/rust-url/issues/557)
 
 mod argument;
 mod field;

--- a/cynic/src/lib.rs
+++ b/cynic/src/lib.rs
@@ -164,9 +164,9 @@
 //! - `bson` adds support for ObjectId scalars
 //! - `url` adds support for Url scalars \
 //!
-//! It's worth noting that each of these features pulls in extra 
-//! dependencies, which may impact your build size.  Particularly 
-//! if you're targetting WASM.  In particular the `url` crate has 
+//! It's worth noting that each of these features pulls in extra
+//! dependencies, which may impact your build size.  Particularly
+//! if you're targetting WASM.  In particular the `url` crate has
 //! [known issues](https://github.com/servo/rust-url/issues/557) when
 //! targetting web assembly.
 

--- a/cynic/src/lib.rs
+++ b/cynic/src/lib.rs
@@ -163,7 +163,12 @@
 //! - `uuid` adds support for Uuid scalars
 //! - `bson` adds support for ObjectId scalars
 //! - `url` adds support for Url scalars \
-//!   Note: `url` feature could increase output [file size](https://github.com/servo/rust-url/issues/557)
+//!
+//! It's worth noting that each of these features pulls in extra 
+//! dependencies, which may impact your build size.  Particularly 
+//! if you're targetting WASM.  In particular the `url` crate has 
+//! [known issues](https://github.com/servo/rust-url/issues/557) when
+//! targetting web assembly.
 
 mod argument;
 mod field;


### PR DESCRIPTION
#### Why are we making this change?

GraphQL schema could contain such type as url::Url and deriving QueryFragment for a struct will failed.

#### What effects does this change have?

* Adds url feature
* Add test for url integration

Fixes #110 