### PR TITLE
Add `thiserror` crate

### DIFF
--- a/cynic/Cargo.toml
+++ b/cynic/Cargo.toml
@@ -20,6 +20,7 @@ all = ["chrono", "bson", "uuid", "url"]
 json-decode = "0.5.0"
 serde = { version = "1.0.104", features = [ "derive" ] }
 serde_json = "1.0"
+thiserror = "1.0.20"
 cynic-proc-macros = { path = "../cynic-proc-macros", version = "0.9.0" }
 chrono = { version = "0.4.11", optional = true}
 bson = { version = "1.1.0", optional = true}

--- a/cynic/src/result.rs
+++ b/cynic/src/result.rs
@@ -28,7 +28,8 @@ impl<T> GraphQLResponse<T> {
     }
 }*/
 
-#[derive(Debug, serde::Deserialize)]
+#[derive(Debug, serde::Deserialize, thiserror::Error)]
+#[error("{message}")]
 pub struct GraphQLError {
     message: String,
 }


### PR DESCRIPTION
#### Why are we making this change?

Error types should implement std::error::Error trait

#### What effects does this change have?

cynic use `thiserror` to implement std::error::Error traits
