### PR TITLE
Don't take ownership of SerializableArguments in Argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,15 @@ all APIs might be changed.
 
 - `QueryFragment::fragment` and `InlineFragment::fragments` now accept their
   Argument parameters by reference.
+- `define_into_argument_for_scalar` has been renamed to
+  `impl_into_argument_for_options`
+- There's no longer a blanket impl of `SerializableArgument` for any `Scalar`.
+  `SerializableArgument` now needs to be implemented on each `Scalar`.  There's
+  a `impl_serializable_argument_for_scalar` macro that does this.  The `Scalar`
+  derive automatically calls this macro, so this is only a change if you have a
+  custom `Scalar`
+- The `IntoArgument` trait now has an `Output` associated type that is used for
+  the return value of `IntoArgument::into_argument`
 
 ### New Features
 
@@ -25,7 +34,7 @@ all APIs might be changed.
 ### Changes
 
 - A `SerializableArgument` no longer needs to be `'static + Send`.
-- A `FragmentArguments` no longer needs to be `Clone`
+- `FragmentArguments` & `InputObject`s no longer need to be `Clone`.
 
 ## v0.9.0 - 2020-09-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,21 @@ all APIs might be changed.
 
 ## Unreleased - xxxx-xx-xx
 
+### Breaking Changes
+
+- `QueryFragment::fragment` and `InlineFragment::fragments` now accept their
+  Argument parameters by reference.
+
 ### New Features
 
 - The `bson` feature, which allows to use ObjectId in schemas, added.
 - The `uuid` feature, which allows to use Uuid in schemas, added.
 - The `url` feature, which allows to use Url in schemas, added.
+
+### Changes
+
+- A `SerializableArgument` no longer needs to be `'static + Send`.
+- A `FragmentArguments` no longer needs to be `Clone`
 
 ## v0.9.0 - 2020-09-11
 

--- a/cynic-book/src/derives/query-arguments.md
+++ b/cynic-book/src/derives/query-arguments.md
@@ -4,7 +4,7 @@ A heirarchy of QueryFragments can take a struct of arguments. This struct must
 implement `FragmentArguments` which can be derived:
 
 ```
-#[derive(Clone, cynic::FragmentArguments)]
+#[derive(cynic::FragmentArguments)]
 struct FilmArguments {
     id: Option<cynic::Id>,
 }

--- a/cynic-book/src/derives/query-fragments.md
+++ b/cynic-book/src/derives/query-fragments.md
@@ -96,7 +96,7 @@ can also be derived. (See [query arguments][1] for more details)
 Here, we define a query that fetches a film by a particular ID:
 
 ```rust
-#[derive(Clone, cynic::FragmentArguments)]
+#[derive(cynic::FragmentArguments)]
 struct FilmArguments {
     id: Option<cynic::Id>,
 }
@@ -137,8 +137,8 @@ If no nested QueryFragments require arguments, you can omit the
 ### Mutations
 
 Mutations are also constructed using QueryFragments in a very similar way to
-queries.  Instead of selecting query fields you select a mutation, and pass in
-any arguments in exactly the same way.  Instead of calling the
+queries. Instead of selecting query fields you select a mutation, and pass in
+any arguments in exactly the same way. Instead of calling the
 `Operation::query` function to construct an `Operation` you call the
 `Operation::mutation` function.
 

--- a/cynic-codegen/src/enum_derive/mod.rs
+++ b/cynic-codegen/src/enum_derive/mod.rs
@@ -104,7 +104,7 @@ pub fn enum_derive_impl(
                 }
             }
 
-            ::cynic::define_into_argument_for_scalar!(#ident);
+            ::cynic::impl_into_argument_for_options!(#ident);
         })
     } else {
         Err(syn::Error::new(

--- a/cynic-codegen/src/fragment_arguments_derive/mod.rs
+++ b/cynic-codegen/src/fragment_arguments_derive/mod.rs
@@ -7,9 +7,9 @@ pub fn fragment_arguments_derive(ast: &syn::DeriveInput) -> Result<TokenStream, 
     Ok(quote! {
         impl ::cynic::FragmentArguments for #ident {}
 
-        impl ::cynic::FromArguments<#ident> for () {
-            fn from_arguments(_: &#ident) -> () {
-                ()
+        impl<'a> ::cynic::FromArguments<&'a #ident> for &'a () {
+            fn from_arguments(_: &#ident) -> &() {
+                &()
             }
         }
     })

--- a/cynic-codegen/src/fragment_derive/mod.rs
+++ b/cynic-codegen/src/fragment_derive/mod.rs
@@ -189,7 +189,7 @@ impl quote::ToTokens for FieldSelectorCall {
         let inner_selection_tokens = match &self.style {
             SelectorCallStyle::Scalar => quote! {},
             SelectorCallStyle::QueryFragment(field_type) => quote! {
-                #field_type::fragment(FromArguments::from_arguments(&args))
+                #field_type::fragment(FromArguments::from_arguments(args))
             },
             SelectorCallStyle::Enum(enum_type) => quote! {
                 #enum_type::select()
@@ -347,7 +347,7 @@ impl quote::ToTokens for FragmentImpl {
                 type SelectionSet = ::cynic::SelectionSet<'static, Self, #selector_struct>;
                 type Arguments = #argument_struct;
 
-                fn fragment(args: Self::Arguments) -> Self::SelectionSet {
+                fn fragment(args: &Self::Arguments) -> Self::SelectionSet {
                     use ::cynic::{QueryFragment, FromArguments, Enum};
 
                     let new = |#(#constructor_params),*| #target_struct {

--- a/cynic-codegen/src/generic_param.rs
+++ b/cynic-codegen/src/generic_param.rs
@@ -43,12 +43,12 @@ impl GenericConstraint {
             GenericConstraint::Enum(ident) => {
                 let type_path = TypePath::concat(&[path_to_markers, ident.clone().into()]);
 
-                quote! { ::cynic::Enum<#type_path> + ::cynic::SerializableArgument + 'static + Send}
+                quote! { ::cynic::Enum<#type_path> + ::cynic::SerializableArgument }
             }
             GenericConstraint::InputObject(ident) => {
                 let type_path = TypePath::concat(&[path_to_markers, ident.clone().into()]);
 
-                quote! { ::cynic::InputObject<#type_path> + ::cynic::SerializableArgument + 'static + Send}
+                quote! { ::cynic::InputObject<#type_path> + ::cynic::SerializableArgument }
             }
         }
     }

--- a/cynic-codegen/src/inline_fragments_derive/mod.rs
+++ b/cynic-codegen/src/inline_fragments_derive/mod.rs
@@ -105,7 +105,7 @@ impl quote::ToTokens for InlineFragmentsImpl {
                 type TypeLock = #type_lock;
                 type Arguments = #arguments;
 
-                fn fragments(arguments: Self::Arguments) ->
+                fn fragments(arguments: &Self::Arguments) ->
                 Vec<(String, ::cynic::SelectionSet<'static, Self, Self::TypeLock>)>
                 {
                     use ::cynic::QueryFragment;

--- a/cynic-codegen/src/input_object_derive/mod.rs
+++ b/cynic-codegen/src/input_object_derive/mod.rs
@@ -154,8 +154,7 @@ pub fn input_object_derive_impl(
                 }
             }
 
-            // TODO: Figure out if this does what I want...
-            ::cynic::define_into_argument_for_scalar!(#ident);
+            ::cynic::impl_into_argument_for_options!(#ident);
         })
     } else {
         Err(syn::Error::new(

--- a/cynic-codegen/src/scalar_derive/mod.rs
+++ b/cynic-codegen/src/scalar_derive/mod.rs
@@ -39,5 +39,6 @@ pub fn scalar_derive_impl(input: ScalarDeriveInput) -> Result<TokenStream, syn::
             }
         }
 
+        ::cynic::impl_serializable_argument_for_scalar!(#ident);
     })
 }

--- a/cynic-querygen/src/lib.rs
+++ b/cynic-querygen/src/lib.rs
@@ -164,7 +164,7 @@ pub fn document_to_fragment_structs(
                 lines.push("    }\n".into());
             }
             PotentialStruct::InputObject(input_object) => {
-                lines.push("    #[derive(cynic::InputObject, Clone, Debug)]".into());
+                lines.push("    #[derive(cynic::InputObject, Debug)]".into());
                 lines.push(format!(
                     "    #[cynic(graphql_type = \"{}\", rename_all=\"camelCase\")]",
                     input_object.name

--- a/cynic-querygen/src/lib.rs
+++ b/cynic-querygen/src/lib.rs
@@ -150,7 +150,7 @@ pub fn document_to_fragment_structs(
                 lines.push("    }\n".into());
             }
             PotentialStruct::ArgumentStruct(argument_struct) => {
-                lines.push("    #[derive(cynic::FragmentArguments, Clone, Debug)]".into());
+                lines.push("    #[derive(cynic::FragmentArguments, Debug)]".into());
                 lines.push(format!("    pub struct {} {{", argument_struct.name));
 
                 for field in &argument_struct.fields {

--- a/cynic-querygen/src/value_ext.rs
+++ b/cynic-querygen/src/value_ext.rs
@@ -26,13 +26,14 @@ impl<'a> ValueExt for Value<'a, &'a str> {
     ) -> Result<String, Error> {
         Ok(match self {
             Value::Variable(name) => {
-                if input_value.value_type.is_required() {
-                    // Required arguments don't currently go through IntoArgument, so we need
-                    // to manually clone them.
+                if input_value.value_type.inner_name() == "String"
+                    && input_value.value_type.is_required()
+                {
+                    // Required String arguments currently take owned Strings,
+                    // so we need to clone them.
                     format!("args.{}.clone()", name.to_snake_case())
                 } else {
-                    // Optional types go thorugh IntoArgument so we can take a reference
-                    // and trust IntoArgument to convert it to whatever we need.
+                    // Other arguments we're usually OK taking a reference.
                     format!("&args.{}", name.to_snake_case())
                 }
             }

--- a/cynic-querygen/tests/snapshots/github_tests__add_comment_mutation.snap
+++ b/cynic-querygen/tests/snapshots/github_tests__add_comment_mutation.snap
@@ -39,7 +39,7 @@ mod queries {
         pub id: cynic::Id,
     }
 
-    #[derive(cynic::InputObject, Clone, Debug)]
+    #[derive(cynic::InputObject, Debug)]
     #[cynic(graphql_type = "AddCommentInput", rename_all="camelCase")]
     pub struct AddCommentInput {
         pub body: String,

--- a/cynic-querygen/tests/snapshots/github_tests__add_comment_mutation.snap
+++ b/cynic-querygen/tests/snapshots/github_tests__add_comment_mutation.snap
@@ -9,7 +9,7 @@ expression: "document_to_fragment_structs(query, schema,\n                      
 mod queries {
     use super::{query_dsl, types::*};
 
-    #[derive(cynic::FragmentArguments, Clone, Debug)]
+    #[derive(cynic::FragmentArguments, Debug)]
     pub struct CommentOnMutationSupportIssueArguments {
         pub comment_body: String,
     }

--- a/cynic-querygen/tests/snapshots/github_tests__input_object_arguments.snap
+++ b/cynic-querygen/tests/snapshots/github_tests__input_object_arguments.snap
@@ -14,7 +14,7 @@ mod queries {
         pub pr_order: IssueOrder,
     }
 
-    #[derive(cynic::InputObject, Clone, Debug)]
+    #[derive(cynic::InputObject, Debug)]
     #[cynic(graphql_type = "IssueOrder", rename_all="camelCase")]
     pub struct IssueOrder {
         pub direction: OrderDirection,

--- a/cynic-querygen/tests/snapshots/github_tests__input_object_arguments.snap
+++ b/cynic-querygen/tests/snapshots/github_tests__input_object_arguments.snap
@@ -9,7 +9,7 @@ expression: "document_to_fragment_structs(query, schema,\n                      
 mod queries {
     use super::{query_dsl, types::*};
 
-    #[derive(cynic::FragmentArguments, Clone, Debug)]
+    #[derive(cynic::FragmentArguments, Debug)]
     pub struct PullRequestTitlesArguments {
         pub pr_order: IssueOrder,
     }

--- a/cynic-querygen/tests/snapshots/github_tests__input_object_literals.snap
+++ b/cynic-querygen/tests/snapshots/github_tests__input_object_literals.snap
@@ -56,7 +56,7 @@ mod queries {
         Desc,
     }
 
-    #[derive(cynic::InputObject, Clone, Debug)]
+    #[derive(cynic::InputObject, Debug)]
     #[cynic(graphql_type = "IssueOrder", rename_all="camelCase")]
     pub struct IssueOrder {
         pub direction: OrderDirection,

--- a/cynic-querygen/tests/snapshots/starwars_tests__nested_arguments.snap
+++ b/cynic-querygen/tests/snapshots/starwars_tests__nested_arguments.snap
@@ -9,7 +9,7 @@ expression: "document_to_fragment_structs(query, schema,\n                      
 mod queries {
     use super::{query_dsl, types::*};
 
-    #[derive(cynic::FragmentArguments, Clone, Debug)]
+    #[derive(cynic::FragmentArguments, Debug)]
     pub struct NestedArgsQueryArguments {
         pub film_id: cynic::Id,
         pub planet_cursor: Option<String>,

--- a/cynic-querygen/tests/snapshots/starwars_tests__sanity_test_starwars_query.snap
+++ b/cynic-querygen/tests/snapshots/starwars_tests__sanity_test_starwars_query.snap
@@ -9,7 +9,7 @@ expression: "document_to_fragment_structs(query, schema,\n                      
 mod queries {
     use super::{query_dsl, types::*};
 
-    #[derive(cynic::FragmentArguments, Clone, Debug)]
+    #[derive(cynic::FragmentArguments, Debug)]
     pub struct SanityCheckQueryArguments {
         pub film_id: Option<cynic::Id>,
     }

--- a/cynic/src/argument.rs
+++ b/cynic/src/argument.rs
@@ -1,4 +1,4 @@
-use crate::{Scalar, SerializeError};
+use crate::SerializeError;
 
 pub struct Argument {
     pub(crate) name: String,
@@ -52,8 +52,33 @@ impl<T: SerializableArgument> SerializableArgument for Option<T> {
     }
 }
 
-impl<T: Scalar> SerializableArgument for T {
+impl<T: SerializableArgument> SerializableArgument for &T {
     fn serialize(&self) -> Result<serde_json::Value, SerializeError> {
-        self.encode()
+        (*self).serialize()
     }
 }
+
+impl SerializableArgument for &str {
+    fn serialize(&self) -> Result<serde_json::Value, SerializeError> {
+        Ok(serde_json::Value::String(self.to_string()))
+    }
+}
+
+/// Implements serializable argument for scalar types.
+#[macro_export]
+macro_rules! impl_serializable_argument_for_scalar {
+    ($inner:ty) => {
+        impl $crate::SerializableArgument for $inner {
+            fn serialize(&self) -> Result<$crate::serde_json::Value, $crate::SerializeError> {
+                use $crate::Scalar;
+                self.encode()
+            }
+        }
+    };
+}
+
+impl_serializable_argument_for_scalar!(i32);
+impl_serializable_argument_for_scalar!(f64);
+impl_serializable_argument_for_scalar!(String);
+impl_serializable_argument_for_scalar!(bool);
+impl_serializable_argument_for_scalar!(crate::Id);

--- a/cynic/src/bin/simple.rs
+++ b/cynic/src/bin/simple.rs
@@ -3,7 +3,7 @@ fn main() {
 
     println!(
         "{}",
-        cynic::Operation::query(TestStruct::fragment(TestArgs {})).query
+        cynic::Operation::query(TestStruct::fragment(&TestArgs {})).query
     );
 }
 
@@ -15,7 +15,7 @@ mod query_dsl {
 
 use cynic::selection_set;
 
-#[derive(Clone, cynic::FragmentArguments)]
+#[derive(cynic::FragmentArguments)]
 struct TestArgs {}
 
 #[derive(cynic::QueryFragment)]

--- a/cynic/src/bin/simple_v2.rs
+++ b/cynic/src/bin/simple_v2.rs
@@ -22,7 +22,7 @@ use cynic::selection_set;
 mod queries {
     use super::query_dsl;
 
-    #[derive(Clone, cynic::FragmentArguments)]
+    #[derive(cynic::FragmentArguments)]
     pub struct TestArgs {}
 
     #[derive(cynic::QueryFragment)]

--- a/cynic/src/field.rs
+++ b/cynic/src/field.rs
@@ -203,9 +203,9 @@ mod tests {
         assert_eq!(
             arguments
                 .iter()
-                .map(|a| a.value.serialize().unwrap())
+                .map(|a| a.serialize_result.as_ref().unwrap())
                 .collect::<Vec<_>>(),
-            vec![json!(false), json!(true)]
+            vec![&json!(false), &json!(true)]
         );
         assert_eq!(
             arguments

--- a/cynic/src/into_argument.rs
+++ b/cynic/src/into_argument.rs
@@ -11,14 +11,14 @@ use crate::{argument::SerializableArgument, Id};
 /// also generates impls for converting options & refs easily.
 pub trait IntoArgument<Argument>
 where
-    Argument: SerializableArgument + Send + 'static,
+    Argument: SerializableArgument,
 {
     fn into_argument(self) -> Argument;
 }
 
 impl<T> IntoArgument<T> for T
 where
-    T: SerializableArgument + Send + 'static,
+    T: SerializableArgument,
 {
     fn into_argument(self) -> T {
         self

--- a/cynic/src/into_argument.rs
+++ b/cynic/src/into_argument.rs
@@ -9,17 +9,18 @@ use crate::{argument::SerializableArgument, Id};
 /// There are implementations of this for most of the built in scalars to allow
 /// users to express arguments in a simple manner.  The `cynic::Enum` derive
 /// also generates impls for converting options & refs easily.
-pub trait IntoArgument<Argument>
-where
-    Argument: SerializableArgument,
-{
-    fn into_argument(self) -> Argument;
+pub trait IntoArgument<T> {
+    type Output: SerializableArgument;
+
+    fn into_argument(self) -> Self::Output;
 }
 
 impl<T> IntoArgument<T> for T
 where
     T: SerializableArgument,
 {
+    type Output = T;
+
     fn into_argument(self) -> T {
         self
     }
@@ -30,64 +31,78 @@ where
 /// Mostly just converts references to owned via cloning and
 /// non option-wrapped types into Option where appropriate.
 #[macro_export]
-macro_rules! define_into_argument_for_scalar {
+macro_rules! impl_into_argument_for_options {
     ($inner:ty) => {
         impl $crate::IntoArgument<Option<$inner>> for $inner {
+            type Output = Option<$inner>;
+
             fn into_argument(self) -> Option<$inner> {
                 Some(self)
             }
         }
 
-        impl $crate::IntoArgument<Option<$inner>> for &$inner {
-            fn into_argument(self) -> Option<$inner> {
-                Some(self.clone())
+        impl<'a> $crate::IntoArgument<Option<$inner>> for &'a $inner {
+            type Output = Option<&'a $inner>;
+
+            fn into_argument(self) -> Option<&'a $inner> {
+                Some(self)
             }
         }
     };
 }
 
-macro_rules! define_into_argument_for_option_refs {
+macro_rules! impl_into_argument_for_option_refs {
     ($inner:ty) => {
-        impl $crate::IntoArgument<Option<$inner>> for Option<&$inner> {
-            fn into_argument(self) -> Option<$inner> {
-                self.cloned()
+        impl<'a> $crate::IntoArgument<Option<$inner>> for Option<&'a $inner> {
+            type Output = Option<&'a $inner>;
+
+            fn into_argument(self) -> Option<&'a $inner> {
+                self
             }
         }
 
-        impl $crate::IntoArgument<Option<$inner>> for &Option<$inner> {
-            fn into_argument(self) -> Option<$inner> {
-                self.clone()
+        impl<'a> $crate::IntoArgument<Option<$inner>> for &'a Option<$inner> {
+            type Output = Option<&'a $inner>;
+
+            fn into_argument(self) -> Option<&'a $inner> {
+                self.as_ref()
             }
         }
     };
 }
 
-define_into_argument_for_scalar!(i32);
-define_into_argument_for_scalar!(f64);
-define_into_argument_for_scalar!(String);
-define_into_argument_for_scalar!(bool);
-define_into_argument_for_scalar!(Id);
+impl_into_argument_for_options!(i32);
+impl_into_argument_for_options!(f64);
+impl_into_argument_for_options!(String);
+impl_into_argument_for_options!(bool);
+impl_into_argument_for_options!(Id);
 
-define_into_argument_for_option_refs!(i32);
-define_into_argument_for_option_refs!(f64);
-define_into_argument_for_option_refs!(String);
-define_into_argument_for_option_refs!(bool);
-define_into_argument_for_option_refs!(Id);
+impl_into_argument_for_option_refs!(i32);
+impl_into_argument_for_option_refs!(f64);
+impl_into_argument_for_option_refs!(String);
+impl_into_argument_for_option_refs!(bool);
+impl_into_argument_for_option_refs!(Id);
 
-impl IntoArgument<String> for &str {
-    fn into_argument(self) -> String {
-        self.to_string()
+impl<'a> IntoArgument<String> for &'a str {
+    type Output = &'a str;
+
+    fn into_argument(self) -> &'a str {
+        self
     }
 }
 
-impl IntoArgument<Option<String>> for &str {
-    fn into_argument(self) -> Option<String> {
-        Some(self.to_string())
+impl<'a> IntoArgument<Option<String>> for &'a str {
+    type Output = Option<&'a str>;
+
+    fn into_argument(self) -> Option<&'a str> {
+        Some(self)
     }
 }
 
-impl IntoArgument<Option<String>> for Option<&str> {
-    fn into_argument(self) -> Option<String> {
-        self.map(|s| s.to_string())
+impl<'a> IntoArgument<Option<String>> for Option<&'a str> {
+    type Output = Option<&'a str>;
+
+    fn into_argument(self) -> Option<&'a str> {
+        self
     }
 }

--- a/cynic/src/lib.rs
+++ b/cynic/src/lib.rs
@@ -83,7 +83,7 @@
 //!
 //! // You can then build a `cynic::Query` from this fragment
 //! use cynic::QueryFragment;
-//! let operation = cynic::Operation::query(FilmDirectorQuery::fragment(()));
+//! let operation = cynic::Operation::query(FilmDirectorQuery::fragment(&()));
 //!
 //! ```
 //!
@@ -142,7 +142,7 @@
 //! )]
 //! struct FilmDirectorQueryWithArgs {
 //!     // Here we use `args`, which we've declared above to be an instance of `FilmArguments`
-//!     #[arguments(id = args.id.clone())]
+//!     #[arguments(id = &args.id)]
 //!     film: Option<Film>,
 //! }
 //!
@@ -150,7 +150,7 @@
 //! use cynic::QueryFragment;
 //! let operation = cynic::Operation::query(
 //!     FilmDirectorQueryWithArgs::fragment(
-//!         FilmArguments{ id: Some("ZmlsbXM6MQ==".into()) }
+//!         &FilmArguments{ id: Some("ZmlsbXM6MQ==".into()) }
 //!     )
 //! );
 //! ```

--- a/cynic/src/lib.rs
+++ b/cynic/src/lib.rs
@@ -247,7 +247,9 @@ pub trait Enum<TypeLock>: Sized {
 /// It's recommended to derive this trait with the [InputObject](derive.InputObject.html)
 /// derive.  You can also implement it yourself, but you'll be responsible
 /// for implementing the `SerializableArgument` trait if you want to use it.
-pub trait InputObject<TypeLock>: Clone {}
+pub trait InputObject<TypeLock> {}
+
+impl<TypeLock, T> InputObject<TypeLock> for &T where T: InputObject<TypeLock> {}
 
 /// A marker trait for the arguments types on QueryFragments.
 ///

--- a/cynic/src/selection_set.rs
+++ b/cynic/src/selection_set.rs
@@ -672,13 +672,13 @@ mod tests {
                 let mut args = vec![Argument::new(
                     "required_arg",
                     "String!",
-                    serde_json::Value::String(required.required_arg),
+                    required.required_arg,
                 )];
                 if optionals.opt_string.is_some() {
                     args.push(Argument::new(
                         "opt_string",
                         "String",
-                        serde_json::Value::String(optionals.opt_string.unwrap()),
+                        optionals.opt_string.unwrap(),
                     ));
                 }
                 field("nested", args, fields)

--- a/cynic/tests/simple_schema_tests.rs
+++ b/cynic/tests/simple_schema_tests.rs
@@ -6,7 +6,7 @@ mod query_dsl {
 
 use cynic::selection_set;
 
-#[derive(Clone, cynic::FragmentArguments)]
+#[derive(cynic::FragmentArguments)]
 struct TestArgs {}
 
 #[derive(cynic::QueryFragment, PartialEq, Debug)]
@@ -64,7 +64,7 @@ pub enum Dessert {
 fn run_test(input: serde_json::Value, expected_result: TestQuery) {
     use cynic::QueryFragment;
 
-    let query = cynic::Operation::query(TestQuery::fragment(TestArgs {}));
+    let query = cynic::Operation::query(TestQuery::fragment(&TestArgs {}));
 
     let test_data = cynic::GraphQLResponse {
         errors: None,

--- a/examples/examples/github-mutation.rs
+++ b/examples/examples/github-mutation.rs
@@ -43,7 +43,7 @@ fn build_query() -> cynic::Operation<'static, queries::CommentOnMutationSupportI
     use queries::{CommentOnMutationSupportIssue, CommentOnMutationSupportIssueArguments};
 
     cynic::Operation::mutation(CommentOnMutationSupportIssue::fragment(
-        CommentOnMutationSupportIssueArguments {
+        &CommentOnMutationSupportIssueArguments {
             comment_body: "Testing".into(),
         },
     ))

--- a/examples/examples/github-mutation.rs
+++ b/examples/examples/github-mutation.rs
@@ -57,7 +57,7 @@ fn build_query() -> cynic::Operation<'static, queries::CommentOnMutationSupportI
 mod queries {
     use super::{query_dsl, types::*};
 
-    #[derive(cynic::FragmentArguments, Clone, Debug)]
+    #[derive(cynic::FragmentArguments, Debug)]
     pub struct CommentOnMutationSupportIssueArguments {
         pub comment_body: String,
     }

--- a/examples/examples/github.rs
+++ b/examples/examples/github.rs
@@ -60,7 +60,7 @@ fn build_query() -> cynic::Operation<'static, queries::PullRequestTitles> {
 mod queries {
     use super::{query_dsl, types::*};
 
-    #[derive(cynic::FragmentArguments, Clone, Debug)]
+    #[derive(cynic::FragmentArguments, Debug)]
     pub struct PullRequestTitlesArguments {
         pub pr_order: IssueOrder,
     }

--- a/examples/examples/github.rs
+++ b/examples/examples/github.rs
@@ -44,7 +44,7 @@ fn build_query() -> cynic::Operation<'static, queries::PullRequestTitles> {
         IssueOrder, IssueOrderField, OrderDirection, PullRequestTitles, PullRequestTitlesArguments,
     };
 
-    cynic::Operation::query(PullRequestTitles::fragment(PullRequestTitlesArguments {
+    cynic::Operation::query(PullRequestTitles::fragment(&PullRequestTitlesArguments {
         pr_order: IssueOrder {
             direction: OrderDirection::Asc,
             field: IssueOrderField::CreatedAt,

--- a/examples/examples/starwars.rs
+++ b/examples/examples/starwars.rs
@@ -13,7 +13,7 @@ struct Film {
     director: Option<String>,
 }
 
-#[derive(Clone, cynic::FragmentArguments)]
+#[derive(cynic::FragmentArguments)]
 struct FilmArguments {
     id: Option<cynic::Id>,
 }
@@ -51,7 +51,7 @@ fn run_query() -> cynic::GraphQLResponse<FilmDirectorQuery> {
 
 fn build_query() -> cynic::Operation<'static, FilmDirectorQuery> {
     use cynic::QueryFragment;
-    cynic::Operation::query(FilmDirectorQuery::fragment(FilmArguments {
+    cynic::Operation::query(FilmDirectorQuery::fragment(&FilmArguments {
         id: Some("ZmlsbXM6MQ==".into()),
     }))
 }

--- a/tests/querygen-compile-run/build.rs
+++ b/tests/querygen-compile-run/build.rs
@@ -20,7 +20,7 @@ fn main() {
             &starwars_schema,
             "../../cynic-querygen/tests/queries/starwars/sanity.graphql",
             r#"queries::SanityCheckQuery::fragment(
-                queries::SanityCheckQueryArguments {
+                &queries::SanityCheckQueryArguments {
                     film_id: Some("ZmlsbXM6MQ==".into())
                 }
             )"#,
@@ -29,7 +29,7 @@ fn main() {
             &starwars_schema,
             "../../cynic-querygen/tests/queries/starwars/nested-arguments.graphql",
             r#"queries::NestedArgsQuery::fragment(
-                queries::NestedArgsQueryArguments {
+                &queries::NestedArgsQueryArguments {
                     film_id: "ZmlsbXM6MQ==".into(),
                     planet_cursor: None,
                     resident_connection: None
@@ -39,18 +39,18 @@ fn main() {
         TestCase::query(
             &starwars_schema,
             "../../cynic-querygen/tests/queries/starwars/bare-selection-set.graphql",
-            r#"queries::UnnamedQuery::fragment(())"#,
+            r#"queries::UnnamedQuery::fragment(&())"#,
         ),
         TestCase::query(
             &jobs_schema,
             "tests/queries/graphql.jobs/london-jobs.graphql",
-            r#"queries::Jobs::fragment(())"#,
+            r#"queries::Jobs::fragment(&())"#,
         ),
         TestCase::query(
             &jobs_schema,
             "tests/queries/graphql.jobs/jobs.graphql",
             r#"queries::Jobs::fragment(
-                queries::JobsArguments {
+                &queries::JobsArguments {
                     input: queries::LocationInput {
                         slug: "london".into()
                     }
@@ -61,7 +61,7 @@ fn main() {
             &github_schema,
             "../../cynic-querygen/tests/queries/github/add-comment-mutation.graphql",
             r#"queries::CommentOnMutationSupportIssue::fragment(
-                queries::CommentOnMutationSupportIssueArguments {
+                &queries::CommentOnMutationSupportIssueArguments {
                     comment_body: "This is a test comment, posted by the new cynic mutation support"
                         .into(),
                 },
@@ -71,7 +71,7 @@ fn main() {
             &github_schema,
             "../../cynic-querygen/tests/queries/github/input-object-arguments.graphql",
             r#"queries::PullRequestTitles::fragment(
-                queries::PullRequestTitlesArguments {
+                &queries::PullRequestTitlesArguments {
                     pr_order: queries::IssueOrder {
                         direction: queries::OrderDirection::Asc,
                         field: queries::IssueOrderField::CreatedAt,
@@ -83,7 +83,7 @@ fn main() {
             &github_schema,
             "tests/queries/github/nested-arguments.graphql",
             r#"queries::PullRequestTitles::fragment(
-                queries::PullRequestTitlesArguments {
+                &queries::PullRequestTitlesArguments {
                     owner: "obmarg".into(),
                     repo: "cynic".into(),
                     pr_order: queries::IssueOrder {
@@ -96,7 +96,7 @@ fn main() {
         TestCase::query_norun(
             &github_schema,
             "../../cynic-querygen/tests/queries/github/input-object-literals.graphql",
-            r#"queries::PullRequestTitles::fragment(())"#,
+            r#"queries::PullRequestTitles::fragment(&())"#,
         ),
         /*
         TestCase::query_norun(


### PR DESCRIPTION
#### Why are we making this change?

Prior to this change `Argument` contained a `Box<SerializableArgument>`.  This
had a few knock on effects on the API of cynic:

1. A `SerializableArgument` had to be `'static`, as `Argument` had no lifetime
   parameter.
2. A `SerializableArgument` had to be `Send` if I wanted cynic to be used
   across async/await boundaries (which I do).
3. As `Argument` couldn't take anything by reference, most things that impl
   `SerializableArgument` had to be `Clone` - `InputObjects`, `Enums`, etc.

It was raised in #88 that this isn't great generally.

#### What effects does this change have?

This reworks `Argument` to serialize it's `SerializableArgument` at the point
of creating the `Argument` and store the result of this inside `Argument`.
This allows us to pass in references and avoid taking ownership, which lets us
get rid of a lot of constraints, and a lot of un-neccesary `clones`.

I've also updated `IntoArgument` to support returning references instead of
always returning owned objects as the constraints on Argument::new were the
only thing preventing this.