### PR TITLE
Allow fields on `InputObject` to be inside `Box`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ all APIs might be changed.
 - The `bson` feature, which allows to use ObjectId in schemas, added.
 - The `uuid` feature, which allows to use Uuid in schemas, added.
 - The `url` feature, which allows to use Url in schemas, added.
+- `InputObject`s may now contain fields inside a `Box`.  This allows for
+  recursive `InputObject` types.
 
 ### Changes
 

--- a/cynic-codegen/src/input_object_derive/mod.rs
+++ b/cynic-codegen/src/input_object_derive/mod.rs
@@ -139,6 +139,9 @@ pub fn input_object_derive_impl(
             impl ::cynic::InputObject<#query_module::#input_marker_ident> for #ident {}
 
             #[automatically_derived]
+            impl ::cynic::InputObject<#query_module::#input_marker_ident> for Box<#ident> {}
+
+            #[automatically_derived]
             impl ::cynic::SerializableArgument for #ident {
                 fn serialize(&self) -> Result<::cynic::serde_json::Value, ::cynic::SerializeError> {
                     use ::cynic::{Scalar, Enum, SerializableArgument};
@@ -151,6 +154,13 @@ pub fn input_object_derive_impl(
                             #gql_field_names: #field_values,
                         )*
                     }))
+                }
+            }
+
+            #[automatically_derived]
+            impl ::cynic::SerializableArgument for Box<#ident> {
+                fn serialize(&self) -> Result<::cynic::serde_json::Value, ::cynic::SerializeError> {
+                    #ident::serialize(self)
                 }
             }
 

--- a/cynic-codegen/src/input_object_derive/mod.rs
+++ b/cynic-codegen/src/input_object_derive/mod.rs
@@ -139,9 +139,6 @@ pub fn input_object_derive_impl(
             impl ::cynic::InputObject<#query_module::#input_marker_ident> for #ident {}
 
             #[automatically_derived]
-            impl ::cynic::InputObject<#query_module::#input_marker_ident> for Box<#ident> {}
-
-            #[automatically_derived]
             impl ::cynic::SerializableArgument for #ident {
                 fn serialize(&self) -> Result<::cynic::serde_json::Value, ::cynic::SerializeError> {
                     use ::cynic::{Scalar, Enum, SerializableArgument};
@@ -154,13 +151,6 @@ pub fn input_object_derive_impl(
                             #gql_field_names: #field_values,
                         )*
                     }))
-                }
-            }
-
-            #[automatically_derived]
-            impl ::cynic::SerializableArgument for Box<#ident> {
-                fn serialize(&self) -> Result<::cynic::serde_json::Value, ::cynic::SerializeError> {
-                    #ident::serialize(self)
                 }
             }
 

--- a/cynic-codegen/src/type_validation.rs
+++ b/cynic-codegen/src/type_validation.rs
@@ -10,14 +10,20 @@ pub fn check_types_are_compatible(
 
     let parsed_type = parse_type(rust_type);
 
-    if parsed_type == ParsedType::Unknown {
-        return Err(syn::Error::new(
-            rust_type.span(),
-            "Cynic does not understand this type. Only un-parameterised types, Vecs & Options are accepted currently.",
-        ));
+    match parsed_type {
+        ParsedType::Unknown => {
+            return Err(syn::Error::new(
+                rust_type.span(),
+                "Cynic does not understand this type. Only un-parameterised types, Vecs, Options & Box are accepted currently.",
+            ))
+        },
+        ParsedType::Box(inner) => {
+            // Box is a transparent container for the purposes of checking compatability
+            // so just recurse
+            return check_types_are_compatible(gql_type, inner, flattening);
+        }
+        _ => {}
     }
-
-    // @TODO process `ParsedType::Box`?
 
     if gql_type.is_nullable() {
         if let ParsedType::Optional(inner) = parsed_type {
@@ -80,35 +86,23 @@ fn parse_type<'a>(ty: &'a syn::Type) -> ParsedType<'a> {
     if let syn::Type::Path(type_path) = ty {
         if let Some(last_segment) = type_path.path.segments.last() {
             if last_segment.ident.to_string() == "Box" {
-                if let syn::PathArguments::AngleBracketed(angle_bracketed) = &last_segment.arguments
-                {
-                    for arg in &angle_bracketed.args {
-                        if let syn::GenericArgument::Type(inner_type) = arg {
-                            return ParsedType::Box(inner_type);
-                        }
-                    }
+                if let Some(inner_type) = extract_generic_argument(last_segment) {
+                    return ParsedType::Box(inner_type);
                 }
+
                 return ParsedType::Unknown;
             }
             if last_segment.ident.to_string() == "Option" {
-                if let syn::PathArguments::AngleBracketed(angle_bracketed) = &last_segment.arguments
-                {
-                    for arg in &angle_bracketed.args {
-                        if let syn::GenericArgument::Type(inner_type) = arg {
-                            return ParsedType::Optional(inner_type);
-                        }
-                    }
+                if let Some(inner_type) = extract_generic_argument(last_segment) {
+                    return ParsedType::Optional(inner_type);
                 }
+
                 return ParsedType::Unknown;
             } else if last_segment.ident.to_string() == "Vec" {
-                if let syn::PathArguments::AngleBracketed(angle_bracketed) = &last_segment.arguments
-                {
-                    for arg in &angle_bracketed.args {
-                        if let syn::GenericArgument::Type(inner_type) = arg {
-                            return ParsedType::List(inner_type);
-                        }
-                    }
+                if let Some(inner_type) = extract_generic_argument(last_segment) {
+                    return ParsedType::List(inner_type);
                 }
+
                 return ParsedType::Unknown;
             }
 
@@ -119,6 +113,19 @@ fn parse_type<'a>(ty: &'a syn::Type) -> ParsedType<'a> {
     }
 
     ParsedType::Unknown
+}
+
+/// Takes a PathSegment like `Vec<T>` and extracts the `T`
+fn extract_generic_argument<'a>(segment: &'a syn::PathSegment) -> Option<&'a syn::Type> {
+    if let syn::PathArguments::AngleBracketed(angle_bracketed) = &segment.arguments {
+        for arg in &angle_bracketed.args {
+            if let syn::GenericArgument::Type(inner_type) = arg {
+                return Some(inner_type);
+            }
+        }
+    }
+
+    None
 }
 
 #[cfg(test)]

--- a/cynic/src/argument.rs
+++ b/cynic/src/argument.rs
@@ -52,6 +52,12 @@ impl<T: SerializableArgument> SerializableArgument for Option<T> {
     }
 }
 
+impl<T: SerializableArgument> SerializableArgument for Box<T> {
+    fn serialize(&self) -> Result<serde_json::Value, SerializeError> {
+        self.as_ref().serialize()
+    }
+}
+
 impl<T: SerializableArgument> SerializableArgument for &T {
     fn serialize(&self) -> Result<serde_json::Value, SerializeError> {
         (*self).serialize()

--- a/cynic/src/lib.rs
+++ b/cynic/src/lib.rs
@@ -250,6 +250,7 @@ pub trait Enum<TypeLock>: Sized {
 pub trait InputObject<TypeLock> {}
 
 impl<TypeLock, T> InputObject<TypeLock> for &T where T: InputObject<TypeLock> {}
+impl<TypeLock, T> InputObject<TypeLock> for Box<T> where T: InputObject<TypeLock> {}
 
 /// A marker trait for the arguments types on QueryFragments.
 ///


### PR DESCRIPTION
#### Why are we making this change?

Sometimes it's desirable to have a recursive `InputObject` in GraphQL.
Currently Rust only supports recursive types if they're behind some sort of
pointer type: `Box`, `Rc` or `Arc` mainly.

#### What effects does this change have?

This updates the `InputObject` code to allow fields to be inside `Box` so that
we can support recursive `InputObject` types.

Fixes #116 