### PR TITLE
Add reqwest & reqwest-blocking.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ all APIs might be changed.
   recursive `InputObject` types.
 - The `surf` feature enables integration with the `surf` HTTP client, so users
   don't have to write it themselves.
+- The `reqwest` & `reqwest-blocking` features, which add support for the
+  `reqwest` HTTP client. 
 
 ### Changes
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -451,6 +451,7 @@ dependencies = [
  "cynic-proc-macros 0.9.0",
  "json-decode 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "maplit 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "reqwest 0.10.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.116 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.57 (registry+https://github.com/rust-lang/crates.io-index)",
  "surf 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -487,6 +487,7 @@ dependencies = [
  "reqwest 0.10.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.57 (registry+https://github.com/rust-lang/crates.io-index)",
  "surf 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1990,6 +1991,17 @@ dependencies = [
  "num_cpus 1.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pin-project-lite 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-macros 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2582,6 +2594,7 @@ dependencies = [
 "checksum time-macros-impl 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e5c3be1edfad6027c69f5491cf4cb310d1a71ecd6af742788c6ff8bced86b8fa"
 "checksum tinyvec 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "238ce071d267c5710f9d31451efec16c5ee22de34df17cc05e56cbc92e967117"
 "checksum tokio 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)" = "5d34ca54d84bf2b5b4d7d31e901a8464f7b60ac145a284fba25ceb801f2ddccd"
+"checksum tokio-macros 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "f0c3acc6aa564495a0f2e1d59fab677cd7f81a19994cfc7f3ad0e64301560389"
 "checksum tokio-tls 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9a70f4fcd7b3b24fb194f837560168208f669ca8cb70d0c4b862944452396343"
 "checksum tokio-util 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "be8242891f2b6cbef26a2d7e8605133c2c554cd35b3e4948ea892d6d68436499"
 "checksum toml 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ffc92d160b1eef40665be3a05630d003936a3bc7da7421277846c2613e92c71a"

--- a/cynic/Cargo.toml
+++ b/cynic/Cargo.toml
@@ -14,7 +14,8 @@ documentation = "https://docs.rs/cynic"
 
 [features]
 default = []
-all = ["chrono", "bson", "uuid", "url", "surf"]
+all = ["chrono", "bson", "uuid", "url", "surf", "reqwest", "reqwest-blocking"]
+reqwest-blocking = ["reqwest/blocking"]
 
 [dependencies]
 json-decode = "0.5.0"
@@ -31,6 +32,9 @@ url = { version = "2.1.1", optional = true}
 
 # Surf feature deps
 surf = { version = "2.0.0", optional = true }
+
+# Reqwest feature deps
+reqwest = { version = "0.10", optional = true }
 
 [dev-dependencies]
 maplit = "1.0.2"

--- a/cynic/src/http.rs
+++ b/cynic/src/http.rs
@@ -4,6 +4,15 @@
 //! heavy dependencies, and there's several options to choose from.
 
 #[cfg(feature = "surf")]
+pub use self::surf_ext::SurfExt;
+
+#[cfg(feature = "reqwest")]
+pub use reqwest_ext::ReqwestExt;
+
+#[cfg(feature = "reqwest-blocking")]
+pub use reqwest_blocking_ext::ReqwestBlockingExt;
+
+#[cfg(feature = "surf")]
 mod surf_ext {
     use serde_json::json;
     use std::{future::Future, pin::Pin};
@@ -67,35 +76,214 @@ mod surf_ext {
         ///
         /// If a `json_decode::Error` occurs it can be obtained via downcast_ref on
         /// the `surf::Error`.
-        fn run_graphql<'a, ResponseData>(
+        fn run_graphql<'a, ResponseData: 'a>(
             self,
             operation: Operation<'a, ResponseData>,
-        ) -> BoxFuture<'a, Result<GraphQLResponse<ResponseData>, surf::Error>>
-        where
-            ResponseData: 'static;
+        ) -> BoxFuture<'a, Result<GraphQLResponse<ResponseData>, surf::Error>>;
     }
 
     impl SurfExt for surf::RequestBuilder {
-        fn run_graphql<'a, ResponseData>(
+        fn run_graphql<'a, ResponseData: 'a>(
             self,
             operation: Operation<'a, ResponseData>,
-        ) -> BoxFuture<'a, Result<GraphQLResponse<ResponseData>, surf::Error>>
-        where
-            ResponseData: 'static,
-        {
+        ) -> BoxFuture<'a, Result<GraphQLResponse<ResponseData>, surf::Error>> {
             Box::pin(async move {
                 self.body(json!(&operation))
                     .recv_json::<GraphQLResponse<serde_json::Value>>()
                     .await
-                    .and_then(|response| {
-                        operation
-                            .decode_response(response)
-                            .map_err(|e| surf::Error::new(surf::StatusCode::Ok, e))
-                    })
+                    .and_then(|response| operation.decode_response(response).map_err(|e| e.into()))
             })
         }
     }
 }
 
-#[cfg(feature = "surf")]
-pub use self::surf_ext::SurfExt;
+#[cfg(any(feature = "reqwest", feature = "reqwest-blocking"))]
+#[derive(thiserror::Error, Debug)]
+pub enum CynicReqwestError {
+    #[error("Error making HTTP request: {0}")]
+    ReqwestError(#[from] reqwest::Error),
+    #[error("Error decoding GraphQL response: {0}")]
+    DecodeError(#[from] json_decode::DecodeError),
+}
+
+#[cfg(feature = "reqwest")]
+mod reqwest_ext {
+    use super::CynicReqwestError;
+    use std::{future::Future, pin::Pin};
+
+    use crate::{GraphQLResponse, Operation};
+
+    type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + 'a>>;
+
+    /// An extension trait for reqwest::RequestBuilder.
+    ///
+    /// ```rust,no_run
+    /// # mod query_dsl {
+    /// #   cynic::query_dsl!("../examples/examples/starwars.schema.graphql");
+    /// # }
+    /// #
+    /// # #[derive(cynic::QueryFragment)]
+    /// # #[cynic(
+    /// #    schema_path = "../examples/examples/starwars.schema.graphql",
+    /// #    query_module = "query_dsl",
+    /// #    graphql_type = "Film"
+    /// # )]
+    /// # struct Film {
+    /// #    title: Option<String>,
+    /// #    director: Option<String>
+    /// # }
+    /// #
+    /// # #[derive(cynic::QueryFragment)]
+    /// # #[cynic(
+    /// #     schema_path = "../examples/examples/starwars.schema.graphql",
+    /// #     query_module = "query_dsl",
+    /// #     graphql_type = "Root"
+    /// # )]
+    /// # struct FilmDirectorQuery {
+    /// #     #[arguments(id = cynic::Id::new("ZmlsbXM6MQ=="))]
+    /// #     film: Option<Film>,
+    /// # }
+    /// use cynic::{http::ReqwestExt, QueryFragment};
+    ///
+    /// # async move {
+    /// let operation = cynic::Operation::query(
+    ///     FilmDirectorQuery::fragment(&())
+    /// );
+    ///
+    /// let client = reqwest::Client::new();
+    /// let response = client.post("https://swapi-graphql.netlify.com/.netlify/functions/index")
+    ///     .run_graphql(operation)
+    ///     .await
+    ///     .unwrap();
+    ///
+    /// println!(
+    ///     "The director is {}",
+    ///     response.data
+    ///         .and_then(|d| d.film)
+    ///         .and_then(|f| f.director)
+    ///         .unwrap()
+    /// );
+    /// # };
+    /// ```
+    pub trait ReqwestExt {
+        /// Runs a GraphQL query with the parameters in RequestBuilder, decodes
+        /// the and returns the result.
+        ///
+        /// If a `json_decode::Error` occurs it can be obtained via downcast_ref on
+        /// the `surf::Error`.
+        fn run_graphql<'a, ResponseData: 'a>(
+            self,
+            operation: Operation<'a, ResponseData>,
+        ) -> BoxFuture<'a, Result<GraphQLResponse<ResponseData>, CynicReqwestError>>;
+    }
+
+    impl ReqwestExt for reqwest::RequestBuilder {
+        fn run_graphql<'a, ResponseData: 'a>(
+            self,
+            operation: Operation<'a, ResponseData>,
+        ) -> BoxFuture<'a, Result<GraphQLResponse<ResponseData>, CynicReqwestError>> {
+            Box::pin(async move {
+                match self
+                    .json(&operation)
+                    .send()
+                    //.recv_json::<GraphQLResponse<serde_json::Value>>()
+                    .await
+                {
+                    Ok(response) => response
+                        .json::<GraphQLResponse<serde_json::Value>>()
+                        .await
+                        .map_err(CynicReqwestError::ReqwestError)
+                        .and_then(|gql_response| {
+                            operation
+                                .decode_response(gql_response)
+                                .map_err(CynicReqwestError::DecodeError)
+                        }),
+                    Err(e) => Err(CynicReqwestError::ReqwestError(e)),
+                }
+            })
+        }
+    }
+}
+
+#[cfg(feature = "reqwest-blocking")]
+mod reqwest_blocking_ext {
+    use super::CynicReqwestError;
+
+    use crate::{GraphQLResponse, Operation};
+
+    /// An extension trait for reqwest::blocking::RequestBuilder.
+    ///
+    /// ```rust,no_run
+    /// # mod query_dsl {
+    /// #   cynic::query_dsl!("../examples/examples/starwars.schema.graphql");
+    /// # }
+    /// #
+    /// # #[derive(cynic::QueryFragment)]
+    /// # #[cynic(
+    /// #    schema_path = "../examples/examples/starwars.schema.graphql",
+    /// #    query_module = "query_dsl",
+    /// #    graphql_type = "Film"
+    /// # )]
+    /// # struct Film {
+    /// #    title: Option<String>,
+    /// #    director: Option<String>
+    /// # }
+    /// #
+    /// # #[derive(cynic::QueryFragment)]
+    /// # #[cynic(
+    /// #     schema_path = "../examples/examples/starwars.schema.graphql",
+    /// #     query_module = "query_dsl",
+    /// #     graphql_type = "Root"
+    /// # )]
+    /// # struct FilmDirectorQuery {
+    /// #     #[arguments(id = cynic::Id::new("ZmlsbXM6MQ=="))]
+    /// #     film: Option<Film>,
+    /// # }
+    /// use cynic::{http::ReqwestBlockingExt, QueryFragment};
+    ///
+    /// let operation = cynic::Operation::query(
+    ///     FilmDirectorQuery::fragment(&())
+    /// );
+    ///
+    /// let client = reqwest::blocking::Client::new();
+    /// let response = client.post("https://swapi-graphql.netlify.com/.netlify/functions/index")
+    ///     .run_graphql(operation)
+    ///     .unwrap();
+    ///
+    /// println!(
+    ///     "The director is {}",
+    ///     response.data
+    ///         .and_then(|d| d.film)
+    ///         .and_then(|f| f.director)
+    ///         .unwrap()
+    /// );
+    /// ```
+    pub trait ReqwestBlockingExt {
+        /// Runs a GraphQL query with the parameters in RequestBuilder, decodes
+        /// the and returns the result.
+        ///
+        /// If a `json_decode::Error` occurs it can be obtained via downcast_ref on
+        /// the `surf::Error`.
+        fn run_graphql<'a, ResponseData: 'a>(
+            self,
+            operation: Operation<'a, ResponseData>,
+        ) -> Result<GraphQLResponse<ResponseData>, CynicReqwestError>;
+    }
+
+    impl ReqwestBlockingExt for reqwest::blocking::RequestBuilder {
+        fn run_graphql<'a, ResponseData: 'a>(
+            self,
+            operation: Operation<'a, ResponseData>,
+        ) -> Result<GraphQLResponse<ResponseData>, CynicReqwestError> {
+            self.json(&operation)
+                .send()
+                .and_then(|response| response.json::<GraphQLResponse<serde_json::Value>>())
+                .map_err(CynicReqwestError::ReqwestError)
+                .and_then(|gql_response| {
+                    operation
+                        .decode_response(gql_response)
+                        .map_err(CynicReqwestError::DecodeError)
+                })
+        }
+    }
+}

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -10,12 +10,13 @@ edition = "2018"
 github = ["serde_json"]
 
 [dependencies]
-cynic = { path = "../cynic", features = ["surf"] }
+cynic = { path = "../cynic", features = ["surf", "reqwest-blocking"] }
 cynic-codegen = { path = "../cynic-codegen" }
 serde_json = { version = "1.0", optional = true }
 
 # Reqwest example requirements
 reqwest = { version = "0.10.1", features = ["json", "blocking"] }
+tokio = { version = "0.2", features = ["macros"] }
 
 # Surf example requirements
 surf = "2.0.0-alpha.7"

--- a/examples/examples/github-mutation.rs
+++ b/examples/examples/github-mutation.rs
@@ -6,6 +6,8 @@
 //! around 100k lines of rust), and it's too much for normal development.
 //!
 //! If you want to use this example be sure to remove all the feature flagging.
+//!
+//! This example also requires the `reqwest-blocking` feature to be active.
 
 fn main() {
     #[cfg(feature = "github")]

--- a/examples/examples/github-mutation.rs
+++ b/examples/examples/github-mutation.rs
@@ -17,23 +17,17 @@ fn main() {
 
 #[cfg(feature = "github")]
 fn run_query() -> cynic::GraphQLResponse<queries::CommentOnMutationSupportIssue> {
+    use cynic::http::ReqwestBlockingExt;
+
     let query = build_query();
 
     let token = std::env::var("GITHUB_TOKEN").expect("GITHUB_TOKEN env var must be set");
 
-    let response = reqwest::blocking::Client::new()
+    reqwest::blocking::Client::new()
         .post("https://api.github.com/graphql")
         .header("Authorization", format!("Bearer {}", token))
         .header("User-Agent", "obmarg")
-        .json(&query)
-        .send()
-        .unwrap();
-
-    let response_body = response.text().unwrap();
-    println!("{:?}", &response_body);
-
-    query
-        .decode_response(serde_json::from_str(&response_body).unwrap())
+        .run_graphql(query)
         .unwrap()
 }
 

--- a/examples/examples/github.rs
+++ b/examples/examples/github.rs
@@ -6,6 +6,8 @@
 //! around 100k lines of rust), and it's too much for normal development.
 //!
 //! If you want to use this example be sure to remove all the feature flagging.
+//!
+//! This example also requires the `reqwest-blocking` feature to be active.
 
 fn main() {
     #[cfg(feature = "github")]

--- a/examples/examples/github.rs
+++ b/examples/examples/github.rs
@@ -17,23 +17,17 @@ fn main() {
 
 #[cfg(feature = "github")]
 fn run_query() -> cynic::GraphQLResponse<queries::PullRequestTitles> {
+    use cynic::http::ReqwestBlockingExt;
+
     let query = build_query();
 
     let token = std::env::var("GITHUB_TOKEN").expect("GITHUB_TOKEN env var must be set");
 
-    let response = reqwest::blocking::Client::new()
+    reqwest::blocking::Client::new()
         .post("https://api.github.com/graphql")
         .header("Authorization", format!("Bearer {}", token))
         .header("User-Agent", "obmarg")
-        .json(&query)
-        .send()
-        .unwrap();
-
-    let response_body = response.text().unwrap();
-    println!("{:?}", &response_body);
-
-    query
-        .decode_response(serde_json::from_str(&response_body).unwrap())
+        .run_graphql(query)
         .unwrap()
 }
 

--- a/examples/examples/reqwest-async.rs
+++ b/examples/examples/reqwest-async.rs
@@ -30,19 +30,21 @@ struct FilmDirectorQuery {
     film: Option<Film>,
 }
 
-fn main() {
-    let result = run_query();
+#[tokio::main]
+async fn main() {
+    let result = run_query().await;
     println!("{:?}", result);
 }
 
-fn run_query() -> cynic::GraphQLResponse<FilmDirectorQuery> {
-    use cynic::http::ReqwestBlockingExt;
+async fn run_query() -> cynic::GraphQLResponse<FilmDirectorQuery> {
+    use cynic::http::ReqwestExt;
 
     let query = build_query();
 
-    reqwest::blocking::Client::new()
+    reqwest::Client::new()
         .post("https://swapi-graphql.netlify.com/.netlify/functions/index")
         .run_graphql(query)
+        .await
         .unwrap()
 }
 
@@ -68,9 +70,9 @@ mod test {
         insta::assert_snapshot!(query.query);
     }
 
-    #[test]
-    fn test_running_query() {
-        let result = run_query();
+    #[tokio::test]
+    async fn test_running_query() {
+        let result = run_query().await;
         if result.errors.is_some() {
             assert_eq!(result.errors.unwrap().len(), 0);
         }

--- a/examples/examples/snapshots/manual_reqwest__test__running_query.snap
+++ b/examples/examples/snapshots/manual_reqwest__test__running_query.snap
@@ -1,0 +1,18 @@
+---
+source: examples/examples/manual-reqwest.rs
+expression: result.data
+---
+Some(
+    FilmDirectorQuery {
+        film: Some(
+            Film {
+                title: Some(
+                    "A New Hope",
+                ),
+                director: Some(
+                    "George Lucas",
+                ),
+            },
+        ),
+    },
+)

--- a/examples/examples/snapshots/manual_reqwest__test__snapshot_test_menu_query.snap
+++ b/examples/examples/snapshots/manual_reqwest__test__snapshot_test_menu_query.snap
@@ -1,0 +1,11 @@
+---
+source: examples/examples/manual-reqwest.rs
+expression: query.query
+---
+query Query($_0: ID) {
+  film(id: $_0) {
+    title
+    director
+  }
+}
+

--- a/examples/examples/snapshots/reqwest_async__test__running_query.snap
+++ b/examples/examples/snapshots/reqwest_async__test__running_query.snap
@@ -1,0 +1,18 @@
+---
+source: examples/examples/reqwest-async.rs
+expression: result.data
+---
+Some(
+    FilmDirectorQuery {
+        film: Some(
+            Film {
+                title: Some(
+                    "A New Hope",
+                ),
+                director: Some(
+                    "George Lucas",
+                ),
+            },
+        ),
+    },
+)

--- a/examples/examples/snapshots/reqwest_async__test__snapshot_test_menu_query.snap
+++ b/examples/examples/snapshots/reqwest_async__test__snapshot_test_menu_query.snap
@@ -1,0 +1,11 @@
+---
+source: examples/examples/reqwest-async.rs
+expression: query.query
+---
+query Query($_0: ID) {
+  film(id: $_0) {
+    title
+    director
+  }
+}
+

--- a/examples/examples/starwars.rs
+++ b/examples/examples/starwars.rs
@@ -1,3 +1,5 @@
+//! An example of querying the starwars API using the reqwest-blocking feature
+
 mod query_dsl {
     cynic::query_dsl!("examples/starwars.schema.graphql");
 }

--- a/examples/examples/surf-client.rs
+++ b/examples/examples/surf-client.rs
@@ -1,3 +1,8 @@
+//! An example of querying the starwars API using surf via the cynic
+//! integration.
+//!
+//! This example requires the `surf` feature to be active.
+
 mod query_dsl {
     cynic::query_dsl!("examples/starwars.schema.graphql");
 }


### PR DESCRIPTION
#### Why are we making this change?

I want to provide integrations with common HTTP clients to make getting started
with cynic easier.  #123 added support for `surf` as part of this

#### What effects does this change have?

Adds support for `reqwest` under the `reqwest` feature and `reqwest::blocking`
under the `reqwest-blocking` feature.

Fixes #64 