### PR TITLE
Don't require all fields in InputObject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ all APIs might be changed.
   custom `Scalar`
 - The `IntoArgument` trait now has an `Output` associated type that is used for
   the return value of `IntoArgument::into_argument`
+- The `InputObject` derive no longer complains if you omit optional fields.
+  The old behaviour can be brought back by attaching a `require_all_fields`
+  annotation to the InputObject.
 
 ### New Features
 

--- a/cynic-book/src/derives/input-objects.md
+++ b/cynic-book/src/derives/input-objects.md
@@ -1,7 +1,7 @@
 # InputObject
 
 Some fields in GraphQL expect you to provide an input object rather than just
-simple scalar types.  The `cynic::InputObject` trait is used to define an
+simple scalar types. The `cynic::InputObject` trait is used to define an
 input object and the easiest way to define that trait is to derive it:
 
 ```rust
@@ -14,11 +14,40 @@ pub struct IssueOrder {
 ```
 
 The derive will work on any struct that matches the format of the input object
-- it may contain scalar values or other `InputObject`s. If there are any extra
-or missing fields the derive will emit errors.
+and it may contain scalar values or other `InputObject`s.
 
 By default the field names are expected to match the GraphQL variants
 exactly, but this can be controlled with either the `rename_all` top level
 attribute or the rename attribute on individual fields.
 
-<!-- TODO: example of the above?  Better wording.  Detailed docs on attrs -->
+If there are any fields in the struct that are not on the GraphQL input type
+the derive will emit errors. Any required fields that are on the GraphQL input
+type but not the rust struct will also error. Optional fields may be omitted
+without error. This maintains the same backwards compatability guarantees as
+most GraphQL clients: adding a required field is a breaking change, but adding
+an optional field is not.
+
+Currently any missing optional fields will not be serialized in queries,
+whereas optional fields that are present in the struct but set to None will be
+sent as `null`.
+
+<!-- TODO: example of the above?  Better wording. -->
+
+#### Struct Attributes
+
+An InputObject can be configured with several attributes on the struct itself:
+
+- `graphql_type = "AType"` is required and tells cynic which type in the
+  GraphQL schema to map this struct to
+- `rename_all="camelCase"` tells cynic to rename all the rust field names with a particular
+  rule to match their GraphQL counterparts. Typically this would be set to
+  `camelCase` but others are supported.
+- `require_all_fields` can be provided when you want cynic to make sure your
+  struct has all of the fields defined in the GraphQL schema.
+
+#### Field Attributes
+
+Each field can also have it's own attributes:
+
+- `rename="someFieldName"` can be used to map a field to a completely different
+  GraphQL field name.

--- a/cynic-codegen/src/input_object_derive/input.rs
+++ b/cynic-codegen/src/input_object_derive/input.rs
@@ -13,6 +13,9 @@ pub struct InputObjectDeriveInput {
     pub graphql_type: SpannedValue<String>,
 
     #[darling(default)]
+    pub require_all_fields: bool,
+
+    #[darling(default)]
     pub(super) rename_all: Option<RenameAll>,
 }
 

--- a/cynic/tests/simple_schema_tests.rs
+++ b/cynic/tests/simple_schema_tests.rs
@@ -4,8 +4,6 @@ mod query_dsl {
     cynic::query_dsl!("src/bin/simple.graphql");
 }
 
-use cynic::selection_set;
-
 #[derive(cynic::FragmentArguments)]
 struct TestArgs {}
 


### PR DESCRIPTION
#### Why are we making this change?

It was pointed out in #125 that there's currently no way to omit fields from an
InputObject, even if they're optional. This causes two problems:

1. It breaks the usual backwards compatibility guarantees of GraphQL: adding
   optional fields to an InputObject should be a non breaking change, but this
   would cause cynic based apps to fail to build.
2. It means users have to spell out a potentially large number of Nones even if
   they are never intending on using certain fields.

#### What effects does this change have?

This updates the default behaviour of the InputObject derive to not require all
fields of an InputObject to be present: any optional fields may be omitted
without complaint.

I've also added an attribute to the InputObject derive that brings back the old
behaviour should users want it