### PR TITLE
Add skip_serializing_if to omit fields from InputObjects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,9 @@ all APIs might be changed.
   don't have to write it themselves.
 - The `reqwest` & `reqwest-blocking` features, which add support for the
   `reqwest` HTTP client. 
+- Optional fields on an InputObject may now be annotated with
+  `skip_serializing_if="path"`, similar to serde.  This allows users to omit
+  fields from InputObjects under certain circumstances.
 
 ### Changes
 

--- a/cynic-book/src/derives/input-objects.md
+++ b/cynic-book/src/derives/input-objects.md
@@ -51,3 +51,7 @@ Each field can also have it's own attributes:
 
 - `rename="someFieldName"` can be used to map a field to a completely different
   GraphQL field name.
+- `skip_serializing_if="path"` can be used on optional fields to skip
+  serializing them.  By default an `Option` field will be sent as `null` to
+  servers, but if you provide `skip_serializing_if="Option::is_none"` then the
+  field will not be provided at all.

--- a/cynic-codegen/src/input_object_derive/field_serializer.rs
+++ b/cynic-codegen/src/input_object_derive/field_serializer.rs
@@ -38,6 +38,13 @@ impl<'a> FieldSerializer<'a> {
             return Some(e);
         }
 
+        if self.rust_field.skip_serializing_if.is_some() && !self.graphql_field_type.is_nullable() {
+            return Some(syn::Error::new(
+                self.rust_field.skip_serializing_if.as_ref().unwrap().span(),
+                format!("You can't specify skip_serializing_if on a required field"),
+            ));
+        }
+
         None
     }
 
@@ -80,6 +87,7 @@ impl<'a> FieldSerializer<'a> {
         };
 
         if let Some(skip_check_fn) = &self.rust_field.skip_serializing_if {
+            let skip_check_fn = &**skip_check_fn;
             quote! {
                 if !#skip_check_fn(&self.#rust_field_name) {
                     #insert_call

--- a/cynic-codegen/src/input_object_derive/field_serializer.rs
+++ b/cynic-codegen/src/input_object_derive/field_serializer.rs
@@ -1,6 +1,6 @@
 use proc_macro2::TokenStream;
 use quote::{quote, quote_spanned};
-use syn::{spanned::Spanned, TypePath};
+use syn::spanned::Spanned;
 
 use super::InputObjectDeriveField;
 use crate::{
@@ -83,7 +83,7 @@ impl<'a> FieldSerializer<'a> {
         // For each field we just call our type checking function with the current field
         // and insert it into the output Map.
         let insert_call = quote_spanned! { field_span =>
-            output.insert(#gql_field_name.to_string(), #rust_field_name(&self.#rust_field_name)?);
+            #output_struct.insert(#gql_field_name.to_string(), #rust_field_name(&self.#rust_field_name)?);
         };
 
         if let Some(skip_check_fn) = &self.rust_field.skip_serializing_if {

--- a/cynic-codegen/src/input_object_derive/field_serializer.rs
+++ b/cynic-codegen/src/input_object_derive/field_serializer.rs
@@ -1,0 +1,92 @@
+use proc_macro2::TokenStream;
+use quote::{quote, quote_spanned};
+use syn::{spanned::Spanned, TypePath};
+
+use super::InputObjectDeriveField;
+use crate::{
+    schema::InputValue, type_validation::check_types_are_compatible, FieldType, Ident, TypeIndex,
+};
+
+pub struct FieldSerializer<'a> {
+    rust_field: &'a InputObjectDeriveField,
+    graphql_field: &'a InputValue,
+    graphql_field_type: FieldType,
+    query_module: &'a Ident,
+}
+
+impl<'a> FieldSerializer<'a> {
+    pub fn new(
+        rust_field: &'a InputObjectDeriveField,
+        graphql_field: &'a InputValue,
+        type_index: &TypeIndex,
+        query_module: &'a Ident,
+    ) -> FieldSerializer<'a> {
+        FieldSerializer {
+            rust_field,
+            graphql_field,
+            graphql_field_type: FieldType::from_schema_type(&graphql_field.value_type, &type_index),
+            query_module,
+        }
+    }
+
+    /// Validates the FieldSerializer definition, returning errors if there are any.
+    pub fn validate(&self) -> Option<syn::Error> {
+        // First, check for type errors
+        if let Err(e) =
+            check_types_are_compatible(&self.graphql_field_type, &self.rust_field.ty, false)
+        {
+            return Some(e);
+        }
+
+        None
+    }
+
+    pub fn type_check_fn(&self) -> TokenStream {
+        // The check_types_are_compatible call in validate only checks for Option
+        // and Vec wrappers - we don't have access to any info
+        // about the types of fields within our current struct.
+        //
+        // So, we have to construct some functions with constraints
+        // in order to make sure the fields are of the right type.
+
+        let generic_param = self.graphql_field_type.generic_parameter(Ident::new("T"));
+        let arg_type = self.graphql_field_type.to_tokens(
+            generic_param.as_ref().map(|p| p.name.clone()),
+            self.query_module.clone().into(),
+        );
+
+        let rust_field_name = &self.rust_field.ident;
+        let generic_param_definition =
+            generic_param.map(|p| p.to_tokens(self.query_module.clone().into()));
+
+        quote! {
+            fn #rust_field_name<#generic_param_definition>(data: &#arg_type) ->
+                Result<::cynic::serde_json::Value, ::cynic::SerializeError> {
+                    data.serialize()
+                }
+        }
+    }
+
+    pub fn field_insert_call(&self, output_struct: &proc_macro2::Ident) -> TokenStream {
+        let field_span = self.rust_field.ident.span();
+        let rust_field_name = &self.rust_field.ident;
+
+        let gql_field_name = proc_macro2::Literal::string(&self.graphql_field.name);
+
+        // For each field we just call our type checking function with the current field
+        // and insert it into the output Map.
+        let insert_call = quote_spanned! { field_span =>
+            output.insert(#gql_field_name.to_string(), #rust_field_name(&self.#rust_field_name)?);
+        };
+
+        if let Some(skip_check_fn) = &self.rust_field.skip_serializing_if {
+            quote! {
+                if !#skip_check_fn(&self.#rust_field_name) {
+                    #insert_call
+                }
+            }
+        } else {
+            insert_call
+        }
+    }
+}

--- a/cynic-codegen/src/input_object_derive/input.rs
+++ b/cynic-codegen/src/input_object_derive/input.rs
@@ -26,7 +26,7 @@ pub struct InputObjectDeriveField {
     pub(super) ty: syn::Type,
 
     #[darling(default)]
-    pub(super) skip_serializing_if: Option<syn::Path>,
+    pub(super) skip_serializing_if: Option<SpannedValue<syn::Path>>,
 
     #[darling(default)]
     pub(super) rename: Option<SpannedValue<String>>,

--- a/cynic-codegen/src/input_object_derive/input.rs
+++ b/cynic-codegen/src/input_object_derive/input.rs
@@ -26,5 +26,8 @@ pub struct InputObjectDeriveField {
     pub(super) ty: syn::Type,
 
     #[darling(default)]
+    pub(super) skip_serializing_if: Option<syn::Path>,
+
+    #[darling(default)]
     pub(super) rename: Option<SpannedValue<String>>,
 }

--- a/cynic-codegen/src/input_object_derive/mod.rs
+++ b/cynic-codegen/src/input_object_derive/mod.rs
@@ -6,8 +6,7 @@ use crate::{
     ident::{RenameAll, RenameRule},
     load_schema,
     schema::{Definition, Document, InputObjectType, InputValue, TypeDefinition},
-    type_validation::check_types_are_compatible,
-    FieldType, Ident, TypeIndex,
+    Ident, TypeIndex,
 };
 
 mod field_serializer;
@@ -37,7 +36,7 @@ pub fn input_object_derive_impl(
     schema: &Document,
     struct_span: Span,
 ) -> Result<TokenStream, syn::Error> {
-    use quote::{quote, quote_spanned};
+    use quote::quote;
 
     let input_object_def = schema.definitions.iter().find_map(|def| {
         if let Definition::TypeDefinition(TypeDefinition::InputObject(obj)) = def {

--- a/cynic/tests/input-object-tests.rs
+++ b/cynic/tests/input-object-tests.rs
@@ -1,0 +1,59 @@
+//! Tests of the generated serialization code for InputObjects
+
+use serde_json::json;
+
+mod query_dsl {
+    cynic::query_dsl!("tests/test-schema.graphql");
+}
+
+#[test]
+fn test_input_object_renames() {
+    #![allow(non_snake_case)]
+
+    use cynic::SerializableArgument;
+
+    #[derive(cynic::InputObject)]
+    #[cynic(
+        graphql_type = "BlogPost",
+        schema_path = "tests/test-schema.graphql",
+        query_module = "query_dsl",
+        rename_all = "lowercase"
+    )]
+    struct BlogPost {
+        Content: String,
+        #[cynic(rename = "author")]
+        writer: Option<String>,
+    }
+
+    let post = BlogPost {
+        Content: "hi".into(),
+        writer: Some("Me".into()),
+    }.serialize().unwrap();
+
+    assert_eq!(post, json!({ "content": "hi", "author": "Me" }));
+}
+
+#[test]
+fn test_input_object_skip_serializing() {
+    use cynic::SerializableArgument;
+
+    #[derive(cynic::InputObject)]
+    #[cynic(graphql_type = "BlogPost", schema_path = "tests/test-schema.graphql", query_module = "query_dsl")]
+    struct BlogPost {
+        content: String,
+        #[cynic(skip_serializing_if = "Option::is_none")]
+        author: Option<String>,
+    }
+
+    let without_author = BlogPost {
+        content: "hi".into(),
+        author: None,
+    }.serialize().unwrap();
+    assert_eq!(without_author, json!({ "content": "hi" }));
+
+    let with_author = BlogPost {
+        content: "hi".into(),
+        author: Some("Me".into()),
+    }.serialize().unwrap();
+    assert_eq!(with_author, json!({ "content": "hi", "author": "Me" }));
+}

--- a/cynic/tests/input-object-tests.rs
+++ b/cynic/tests/input-object-tests.rs
@@ -28,7 +28,9 @@ fn test_input_object_renames() {
     let post = BlogPost {
         Content: "hi".into(),
         writer: Some("Me".into()),
-    }.serialize().unwrap();
+    }
+    .serialize()
+    .unwrap();
 
     assert_eq!(post, json!({ "content": "hi", "author": "Me" }));
 }
@@ -38,7 +40,11 @@ fn test_input_object_skip_serializing() {
     use cynic::SerializableArgument;
 
     #[derive(cynic::InputObject)]
-    #[cynic(graphql_type = "BlogPost", schema_path = "tests/test-schema.graphql", query_module = "query_dsl")]
+    #[cynic(
+        graphql_type = "BlogPost",
+        schema_path = "tests/test-schema.graphql",
+        query_module = "query_dsl"
+    )]
     struct BlogPost {
         content: String,
         #[cynic(skip_serializing_if = "Option::is_none")]
@@ -48,12 +54,16 @@ fn test_input_object_skip_serializing() {
     let without_author = BlogPost {
         content: "hi".into(),
         author: None,
-    }.serialize().unwrap();
+    }
+    .serialize()
+    .unwrap();
     assert_eq!(without_author, json!({ "content": "hi" }));
 
     let with_author = BlogPost {
         content: "hi".into(),
         author: Some("Me".into()),
-    }.serialize().unwrap();
+    }
+    .serialize()
+    .unwrap();
     assert_eq!(with_author, json!({ "content": "hi", "author": "Me" }));
 }

--- a/cynic/tests/test-schema.graphql
+++ b/cynic/tests/test-schema.graphql
@@ -1,0 +1,4 @@
+input BlogPost {
+  author: String
+  content: String!
+}


### PR DESCRIPTION
#### Why are we making this change?

Optional input fields/arguments in GraphQL don't map precisely into an
`Option<T>` in Rust.  Optional inputs in GraphQL can be null, but they can also
be omitted and [the spec requires you to treat these two cases differently][1].

#### What effects does this change have?

This adds some initial support for omitting optional fields in `InputObject`s
following a similar pattern to serde.  You can annotate fields with
`#[serde(skip_serializing_if = "Option::is_none")]` or similar and cynic will
omit them from the serialized outputs.

This isn't all the work we need to do around this feature, but should help.
The rest of this is tracked in #125.

#### Still To Do

- [x] Update CHANGELOG
- [x] Validate skip_serializing_if - it should only be valid on optional fields.
- [x] Update book to include this attr in the docs

[1]: https://spec.graphql.org/June2018/#sec-Null-Value