### PR TITLE
Make http extension futures Send

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ all APIs might be changed.
 - The `InputObject` derive no longer complains if you omit optional fields.
   The old behaviour can be brought back by attaching a `require_all_fields`
   annotation to the InputObject.
+- SerializeError now requires Send + Sync on it's boxed value.
 
 ### New Features
 

--- a/cynic/src/http.rs
+++ b/cynic/src/http.rs
@@ -19,7 +19,7 @@ mod surf_ext {
 
     use crate::{GraphQLResponse, Operation};
 
-    type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + 'a>>;
+    type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
 
     /// An extension trait for surf::RequestBuilder.
     ///
@@ -113,7 +113,7 @@ mod reqwest_ext {
 
     use crate::{GraphQLResponse, Operation};
 
-    type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + 'a>>;
+    type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
 
     /// An extension trait for reqwest::RequestBuilder.
     ///

--- a/cynic/src/lib.rs
+++ b/cynic/src/lib.rs
@@ -231,7 +231,7 @@ where
     }
 }
 
-pub type SerializeError = Box<dyn std::error::Error>;
+pub type SerializeError = Box<dyn std::error::Error + Send + Sync>;
 
 /// A trait for GraphQL enums.
 ///


### PR DESCRIPTION
#### Why are we making this change?

I just tested out the new SurfExt trait with some of my production code.  I was
having trouble getting it working, as the futures it returns were not Send.
This was mostly because `SerializeError` was not `Send + Sync`.

#### What effects does this change have?

This adds `Send + Sync` constraints to `SerializeError` which allows the
futures in `SurfExt` & `ReqwestExt` to be `Send`.

Possible that the API could have been reworked to do this without updating the
constraints on `SerializeError`, but I'm fairly sure having errors as Send +
Sync is good practice anyway.