### PR TITLE
Fix builds on windows

### DIFF
--- a/cynic-querygen/src/lib.rs
+++ b/cynic-querygen/src/lib.rs
@@ -73,7 +73,7 @@ pub fn document_to_fragment_structs(
     let mut lines = vec![];
 
     lines.push("#[cynic::query_module(".into());
-    lines.push(format!("    schema_path = \"{}\",", options.schema_path));
+    lines.push(format!("    schema_path = r#\"{}\"#,", options.schema_path));
     lines.push(format!("    query_module = \"{}\",", options.query_module));
     lines.push(")]\nmod queries {".into());
     lines.push(format!(
@@ -187,7 +187,7 @@ pub fn document_to_fragment_structs(
     lines.push("}\n".into());
 
     lines.push("#[cynic::query_module(".into());
-    lines.push(format!("    schema_path = \"{}\",", options.schema_path));
+    lines.push(format!("    schema_path = r#\"{}\"#,", options.schema_path));
     lines.push(format!("    query_module = \"{}\",", options.query_module));
     lines.push(")]\nmod types {".into());
 
@@ -209,7 +209,7 @@ pub fn document_to_fragment_structs(
     lines.push(format!("mod {}{{", options.query_module));
     lines.push("    use super::types::*;".into());
     lines.push(format!(
-        "    cynic::query_dsl!(\"{}\");",
+        "    cynic::query_dsl!(r#\"{}\"#);",
         options.schema_path
     ));
     lines.push("}\n".into());

--- a/cynic-querygen/tests/snapshots/github_tests__add_comment_mutation.snap
+++ b/cynic-querygen/tests/snapshots/github_tests__add_comment_mutation.snap
@@ -3,7 +3,7 @@ source: cynic-querygen/tests/github-tests.rs
 expression: "document_to_fragment_structs(query, schema,\n                             &QueryGenOptions::default()).expect(\"QueryGen Failed\")"
 ---
 #[cynic::query_module(
-    schema_path = "schema.graphql",
+    schema_path = r#"schema.graphql"#,
     query_module = "query_dsl",
 )]
 mod queries {
@@ -50,7 +50,7 @@ mod queries {
 }
 
 #[cynic::query_module(
-    schema_path = "schema.graphql",
+    schema_path = r#"schema.graphql"#,
     query_module = "query_dsl",
 )]
 mod types {
@@ -88,6 +88,6 @@ mod types {
 
 mod query_dsl{
     use super::types::*;
-    cynic::query_dsl!("schema.graphql");
+    cynic::query_dsl!(r#"schema.graphql"#);
 }
 

--- a/cynic-querygen/tests/snapshots/github_tests__input_object_arguments.snap
+++ b/cynic-querygen/tests/snapshots/github_tests__input_object_arguments.snap
@@ -3,7 +3,7 @@ source: cynic-querygen/tests/github-tests.rs
 expression: "document_to_fragment_structs(query, schema,\n                             &QueryGenOptions::default()).expect(\"QueryGen Failed\")"
 ---
 #[cynic::query_module(
-    schema_path = "schema.graphql",
+    schema_path = r#"schema.graphql"#,
     query_module = "query_dsl",
 )]
 mod queries {
@@ -71,7 +71,7 @@ mod queries {
 }
 
 #[cynic::query_module(
-    schema_path = "schema.graphql",
+    schema_path = r#"schema.graphql"#,
     query_module = "query_dsl",
 )]
 mod types {
@@ -109,6 +109,6 @@ mod types {
 
 mod query_dsl{
     use super::types::*;
-    cynic::query_dsl!("schema.graphql");
+    cynic::query_dsl!(r#"schema.graphql"#);
 }
 

--- a/cynic-querygen/tests/snapshots/github_tests__input_object_literals.snap
+++ b/cynic-querygen/tests/snapshots/github_tests__input_object_literals.snap
@@ -3,7 +3,7 @@ source: cynic-querygen/tests/github-tests.rs
 expression: "document_to_fragment_structs(query, schema,\n                             &QueryGenOptions::default()).expect(\"QueryGen Failed\")"
 ---
 #[cynic::query_module(
-    schema_path = "schema.graphql",
+    schema_path = r#"schema.graphql"#,
     query_module = "query_dsl",
 )]
 mod queries {
@@ -66,7 +66,7 @@ mod queries {
 }
 
 #[cynic::query_module(
-    schema_path = "schema.graphql",
+    schema_path = r#"schema.graphql"#,
     query_module = "query_dsl",
 )]
 mod types {
@@ -104,6 +104,6 @@ mod types {
 
 mod query_dsl{
     use super::types::*;
-    cynic::query_dsl!("schema.graphql");
+    cynic::query_dsl!(r#"schema.graphql"#);
 }
 

--- a/cynic-querygen/tests/snapshots/github_tests__literal_enums.snap
+++ b/cynic-querygen/tests/snapshots/github_tests__literal_enums.snap
@@ -3,7 +3,7 @@ source: cynic-querygen/tests/github-tests.rs
 expression: "document_to_fragment_structs(query, schema,\n                             &QueryGenOptions::default()).expect(\"QueryGen Failed\")"
 ---
 #[cynic::query_module(
-    schema_path = "schema.graphql",
+    schema_path = r#"schema.graphql"#,
     query_module = "query_dsl",
 )]
 mod queries {
@@ -48,7 +48,7 @@ mod queries {
 }
 
 #[cynic::query_module(
-    schema_path = "schema.graphql",
+    schema_path = r#"schema.graphql"#,
     query_module = "query_dsl",
 )]
 mod types {
@@ -86,6 +86,6 @@ mod types {
 
 mod query_dsl{
     use super::types::*;
-    cynic::query_dsl!("schema.graphql");
+    cynic::query_dsl!(r#"schema.graphql"#);
 }
 

--- a/cynic-querygen/tests/snapshots/starwars_tests__bare_selection_sets.snap
+++ b/cynic-querygen/tests/snapshots/starwars_tests__bare_selection_sets.snap
@@ -3,7 +3,7 @@ source: cynic-querygen/tests/starwars-tests.rs
 expression: "document_to_fragment_structs(query, schema,\n                             &QueryGenOptions::default()).expect(\"QueryGen Failed\")"
 ---
 #[cynic::query_module(
-    schema_path = "schema.graphql",
+    schema_path = r#"schema.graphql"#,
     query_module = "query_dsl",
 )]
 mod queries {
@@ -31,7 +31,7 @@ mod queries {
 }
 
 #[cynic::query_module(
-    schema_path = "schema.graphql",
+    schema_path = r#"schema.graphql"#,
     query_module = "query_dsl",
 )]
 mod types {
@@ -39,6 +39,6 @@ mod types {
 
 mod query_dsl{
     use super::types::*;
-    cynic::query_dsl!("schema.graphql");
+    cynic::query_dsl!(r#"schema.graphql"#);
 }
 

--- a/cynic-querygen/tests/snapshots/starwars_tests__nested_arguments.snap
+++ b/cynic-querygen/tests/snapshots/starwars_tests__nested_arguments.snap
@@ -3,7 +3,7 @@ source: cynic-querygen/tests/starwars-tests.rs
 expression: "document_to_fragment_structs(query, schema,\n                             &QueryGenOptions::default()).expect(\"QueryGen Failed\")"
 ---
 #[cynic::query_module(
-    schema_path = "schema.graphql",
+    schema_path = r#"schema.graphql"#,
     query_module = "query_dsl",
 )]
 mod queries {
@@ -60,7 +60,7 @@ mod queries {
 }
 
 #[cynic::query_module(
-    schema_path = "schema.graphql",
+    schema_path = r#"schema.graphql"#,
     query_module = "query_dsl",
 )]
 mod types {
@@ -68,6 +68,6 @@ mod types {
 
 mod query_dsl{
     use super::types::*;
-    cynic::query_dsl!("schema.graphql");
+    cynic::query_dsl!(r#"schema.graphql"#);
 }
 

--- a/cynic-querygen/tests/snapshots/starwars_tests__sanity_test_starwars_query.snap
+++ b/cynic-querygen/tests/snapshots/starwars_tests__sanity_test_starwars_query.snap
@@ -3,7 +3,7 @@ source: cynic-querygen/tests/starwars-tests.rs
 expression: "document_to_fragment_structs(query, schema,\n                             &QueryGenOptions::default()).expect(\"QueryGen Failed\")"
 ---
 #[cynic::query_module(
-    schema_path = "schema.graphql",
+    schema_path = r#"schema.graphql"#,
     query_module = "query_dsl",
 )]
 mod queries {
@@ -31,7 +31,7 @@ mod queries {
 }
 
 #[cynic::query_module(
-    schema_path = "schema.graphql",
+    schema_path = r#"schema.graphql"#,
     query_module = "query_dsl",
 )]
 mod types {
@@ -39,6 +39,6 @@ mod types {
 
 mod query_dsl{
     use super::types::*;
-    cynic::query_dsl!("schema.graphql");
+    cynic::query_dsl!(r#"schema.graphql"#);
 }
 


### PR DESCRIPTION
#### Why are we making this change?

Cynics tests don't currently build on windows.  I don't use windows, but I'd like to allow others who do to contribute.

#### What effects does this change have?

It updates the code generation to make schema paths raw strings so the windows path separator isn't interpreted as an escape.

Fixes #118 
