### PR TITLE
impl SerializableArgument for scalars in `integrations`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ all APIs might be changed.
 
 ## Unreleased - xxxx-xx-xx
 
+## Bug Fixes
+
+- Implemented SerializableArgument for the various scalars in the
+  `integrations` folder.  This was preventing them actually being used as
+  scalars in input contexts.
+
 ## v0.10.0 - 2020-10-11
 
 ### Breaking Changes

--- a/cynic/src/integrations/bson.rs
+++ b/cynic/src/integrations/bson.rs
@@ -21,6 +21,8 @@ impl Scalar for ObjectId {
     }
 }
 
+crate::impl_serializable_argument_for_scalar!(ObjectId);
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/cynic/src/integrations/chrono.rs
+++ b/cynic/src/integrations/chrono.rs
@@ -21,6 +21,8 @@ impl Scalar for DateTime<FixedOffset> {
     }
 }
 
+crate::impl_serializable_argument_for_scalar!(DateTime<FixedOffset>);
+
 impl Scalar for DateTime<Utc> {
     fn decode(value: &serde_json::Value) -> Result<Self, DecodeError> {
         match value {
@@ -38,6 +40,8 @@ impl Scalar for DateTime<Utc> {
         Ok(serde_json::Value::String(self.to_rfc3339()))
     }
 }
+
+crate::impl_serializable_argument_for_scalar!(DateTime<Utc>);
 
 fn chrono_decode_error(err: chrono::ParseError) -> DecodeError {
     DecodeError::Other(err.to_string())

--- a/cynic/src/integrations/url.rs
+++ b/cynic/src/integrations/url.rs
@@ -21,6 +21,8 @@ impl Scalar for Url {
     }
 }
 
+crate::impl_serializable_argument_for_scalar!(Url);
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/cynic/src/integrations/uuid.rs
+++ b/cynic/src/integrations/uuid.rs
@@ -21,6 +21,8 @@ impl Scalar for Uuid {
     }
 }
 
+crate::impl_serializable_argument_for_scalar!(Uuid);
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
#### Why are we making this change?

I was trying to use a `DateTime<Utc>` in an input object, but getting the following error:

```
error[E0599]: no method named `serialize` found for reference `&std::option::Option<chrono::DateTime<chrono::Utc>>` in the current scope
   --> orders-api/src/pos/transformer_client.rs:128:14
    |
128 |     #[derive(cynic::InputObject, Clone, Debug)]
    |              ^^^^^^^^^^^^^^^^^^ method not found in `&std::option::Option<chrono::DateTime<chrono::Utc>>`
    |
   ::: /Users/graeme/.rustup/toolchains/stable-x86_64-apple-darwin/lib/rustlib/src/rust/library/core/src/option.rs:145:1
    |
145 | pub enum Option<T> {
    | ------------------ doesn't satisfy `_: cynic::SerializableArgument`
    |
   ::: /Users/graeme/.cargo/registry/src/github.com-1ecc6299db9ec823/chrono-0.4.19/src/datetime.rs:70:1
    |
70  | pub struct DateTime<Tz: TimeZone> {
    | --------------------------------- doesn't satisfy `_: cynic::SerializableArgument`
    |
    = note: the method `serialize` exists but the following trait bounds were not satisfied:
            `chrono::DateTime<chrono::Utc>: cynic::SerializableArgument`
            which is required by `std::option::Option<chrono::DateTime<chrono::Utc>>: cynic::SerializableArgument`
            `std::option::Option<chrono::DateTime<chrono::Utc>>: cynic::SerializableArgument`
            which is required by `&std::option::Option<chrono::DateTime<chrono::Utc>>: cynic::SerializableArgument`
    = help: items from traits can only be used if the trait is in scope
    = note: the following trait is implemented but not in scope; perhaps add a `use` for it:
            `use crate::features::_IMPL_DESERIALIZE_FOR_Feature::_serde::Serialize;`
    = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
```

This was because we'd forgottent to impl `SerializableArgument` for the scalars in integrations

#### What effects does this change have?

Calls the macro to impl `SerializableArgument` for all the scalars in integrations.

This will likely be released as 0.10.1