### PR TITLE
Fix literal ID support in the generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ all APIs might be changed.
   windows.
 - Paths output as part of generator are now all raw strings, so should support
   windows path separators.
+- The generator now correctly wraps literal ID parameters with `cynic::Id::New`
 
 ### Changes
 

--- a/cynic-querygen/src/query_parsing/value.rs
+++ b/cynic-querygen/src/query_parsing/value.rs
@@ -146,7 +146,13 @@ impl<'query, 'schema> TypedValue<'query, 'schema> {
             }
             TypedValue::Int(num, _) => num.to_string(),
             TypedValue::Float(num, _) => num.map(|d| d.to_string()).unwrap_or("null".to_string()),
-            TypedValue::String(s, _) => format!("\"{}\".into()", s),
+            TypedValue::String(s, field_type) => {
+                if field_type.inner_name() == "ID" {
+                    format!("cynic::Id::new(\"{}\")", s)
+                } else {
+                    format!("\"{}\".into()", s)
+                }
+            }
             TypedValue::Boolean(b, _) => b.to_string(),
             TypedValue::Null(_) => "None".into(),
             TypedValue::Enum(v, field_type) => {

--- a/cynic-querygen/tests/snapshots/github_tests__add_comment_mutation.snap
+++ b/cynic-querygen/tests/snapshots/github_tests__add_comment_mutation.snap
@@ -17,7 +17,7 @@ mod queries {
     #[derive(cynic::QueryFragment, Debug)]
     #[cynic(graphql_type = "Mutation", argument_struct = "CommentOnMutationSupportIssueArguments")]
     pub struct CommentOnMutationSupportIssue {
-        #[arguments(input = AddCommentInput { body: args.comment_body.clone(), subject_id: "MDU6SXNzdWU2ODU4NzUxMzQ=".into() })]
+        #[arguments(input = AddCommentInput { body: args.comment_body.clone(), subject_id: cynic::Id::new("MDU6SXNzdWU2ODU4NzUxMzQ=") })]
         pub add_comment: Option<AddCommentPayload>,
     }
 


### PR DESCRIPTION
#### Why are we making this change?

I wrote a test on another branch that used literal IDs in a query, and it didn't work as the generator printed

```
#[arguments(id = "abcd".into())]
```

This failed as the ID type is `IntoArgument<Option<Id>>` so the type for `.into()` couldn't be resolved.
 
#### What effects does this change have?

Fixes this case.