### PR TITLE
Run clippy & fix lints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ all APIs might be changed.
 - Cynic now supports recursive queries via the `#[cynic(recurse="N")]`
   attribute on fields that recurse.
 - The generator now understands query fragments, spreads and inline fragment
-  spreads.  Inline fragments for interface/union types are not yet supported.
+  spreads. Inline fragments for interface/union types are not yet supported.
 
 ### Bug Fixes
 
@@ -32,6 +32,7 @@ all APIs might be changed.
 - Paths output as part of generator are now all raw strings, so should support
   windows path separators.
 - The generator now correctly wraps literal ID parameters with `cynic::Id::New`
+- Cynic derives (and cynic itself) no longer emit clippy warnings (on 1.48 at least)
 
 ### Changes
 
@@ -44,7 +45,7 @@ all APIs might be changed.
   - Generates partial InputObjects when faced with literals with missing fields
     (previously it would generate all fields even when unused)
   - Correctly generates different argument structs if a single type with
-    arguments is used in multiple queries.  Though the correct IntoArgument impl
+    arguments is used in multiple queries. Though the correct IntoArgument impl
     is not yet generated.
 
 ## v0.10.1 - 2020-11-04
@@ -52,7 +53,7 @@ all APIs might be changed.
 ## Bug Fixes
 
 - Implemented SerializableArgument for the various scalars in the
-  `integrations` folder.  This was preventing them actually being used as
+  `integrations` folder. This was preventing them actually being used as
   scalars in input contexts.
 
 ## v0.10.0 - 2020-10-11

--- a/cynic-codegen/src/enum_derive/mod.rs
+++ b/cynic-codegen/src/enum_derive/mod.rs
@@ -21,7 +21,7 @@ pub fn enum_derive(ast: &syn::DeriveInput) -> Result<TokenStream, syn::Error> {
 
     match EnumDeriveInput::from_derive_input(ast) {
         Ok(input) => load_schema(&*input.schema_path)
-            .map_err(|e| e.to_syn_error(input.schema_path.span()))
+            .map_err(|e| e.into_syn_error(input.schema_path.span()))
             .and_then(|schema| enum_derive_impl(input, &schema, enum_span))
             .or_else(|e| Ok(e.to_compile_error())),
         Err(e) => Ok(e.write_errors()),
@@ -109,7 +109,7 @@ pub fn enum_derive_impl(
     } else {
         Err(syn::Error::new(
             enum_span,
-            format!("Enum can only be derived from an enum"),
+            "Enum can only be derived from an enum".to_string(),
         ))
     }
 }
@@ -157,7 +157,7 @@ fn join_variants<'a>(
         let missing_variants_string = missing_variants.join(", ");
         errors.extend(
             syn::Error::new(
-                enum_span.clone(),
+                *enum_span,
                 format!("Missing variants: {}", missing_variants_string),
             )
             .to_compile_error(),

--- a/cynic-codegen/src/field_type.rs
+++ b/cynic-codegen/src/field_type.rs
@@ -69,7 +69,7 @@ impl FieldType {
                         nullable,
                     )
                 } else {
-                    FieldType::Other(Ident::for_type(name).into(), nullable)
+                    FieldType::Other(Ident::for_type(name), nullable)
                 }
             }
         }
@@ -115,11 +115,11 @@ impl FieldType {
 
     pub fn is_nullable(&self) -> bool {
         match self {
-            FieldType::List(_, nullable) => nullable.clone(),
-            FieldType::Scalar(_, nullable) => nullable.clone(),
-            FieldType::Enum(_, nullable) => nullable.clone(),
-            FieldType::InputObject(_, nullable) => nullable.clone(),
-            FieldType::Other(_, nullable) => nullable.clone(),
+            FieldType::List(_, nullable) => *nullable,
+            FieldType::Scalar(_, nullable) => *nullable,
+            FieldType::Enum(_, nullable) => *nullable,
+            FieldType::InputObject(_, nullable) => *nullable,
+            FieldType::Other(_, nullable) => *nullable,
         }
     }
 
@@ -127,7 +127,7 @@ impl FieldType {
         match self {
             FieldType::List(inner, _) => inner.as_type_lock(path_to_types),
             // TODO: I think this is wrong for scalars, but whatever.
-            FieldType::Scalar(ident, _) => TypePath::concat(&[path_to_types, ident.clone().into()]),
+            FieldType::Scalar(path, _) => TypePath::concat(&[path_to_types, path.clone()]),
             FieldType::Enum(_, _) => TypePath::void(),
             FieldType::InputObject(ident, _) => {
                 TypePath::concat(&[path_to_types, ident.clone().into()])

--- a/cynic-codegen/src/fragment_derive/arguments.rs
+++ b/cynic-codegen/src/fragment_derive/arguments.rs
@@ -5,7 +5,7 @@ use syn::{
     Expr, Ident, Result, Token,
 };
 
-pub fn arguments_from_field_attrs(attrs: &Vec<syn::Attribute>) -> Result<Vec<FieldArgument>> {
+pub fn arguments_from_field_attrs(attrs: &[syn::Attribute]) -> Result<Vec<FieldArgument>> {
     for attr in attrs {
         if attr.path.is_ident("arguments") {
             let parsed: CynicArguments = attr.parse_args()?;
@@ -63,7 +63,7 @@ impl std::convert::TryFrom<Expr> for ArgumentExpression {
             }
             _ => Err(syn::Error::new(
                 expr.span(),
-                format!("Must be a literal or an expression of the form args.an_argument"),
+                "Must be a literal or an expression of the form args.an_argument".to_string(),
             )),
         }
     }

--- a/cynic-codegen/src/fragment_derive/schema_parsing.rs
+++ b/cynic-codegen/src/fragment_derive/schema_parsing.rs
@@ -15,12 +15,9 @@ impl From<schema::Document> for Schema {
         let mut objects = HashMap::new();
 
         for definition in &document.definitions {
-            match definition {
-                Definition::TypeDefinition(TypeDefinition::Object(object)) => {
-                    let object = Object::from_object(object, &type_index);
-                    objects.insert(object.name.clone(), object);
-                }
-                _ => {}
+            if let Definition::TypeDefinition(TypeDefinition::Object(object)) = definition {
+                let object = Object::from_object(object, &type_index);
+                objects.insert(object.name.clone(), object);
             }
         }
 

--- a/cynic-codegen/src/inline_fragments_derive/mod.rs
+++ b/cynic-codegen/src/inline_fragments_derive/mod.rs
@@ -24,7 +24,7 @@ pub(crate) fn inline_fragments_derive_impl(
     use quote::{quote, quote_spanned};
 
     let schema =
-        load_schema(&*input.schema_path).map_err(|e| e.to_syn_error(input.schema_path.span()))?;
+        load_schema(&*input.schema_path).map_err(|e| e.into_syn_error(input.schema_path.span()))?;
 
     if !find_union_type(&input.graphql_type, &schema) {
         return Err(syn::Error::new(
@@ -58,7 +58,7 @@ pub(crate) fn inline_fragments_derive_impl(
     } else {
         Err(syn::Error::new(
             Span::call_site(),
-            format!("InlineFragments can only be derived from an enum"),
+            "InlineFragments can only be derived from an enum".to_string(),
         ))
     }
 }
@@ -136,14 +136,12 @@ impl quote::ToTokens for InlineFragmentsImpl {
 fn find_union_type(name: &str, schema: &schema::Document) -> bool {
     for definition in &schema.definitions {
         use graphql_parser::schema::{Definition, TypeDefinition};
-        match definition {
-            Definition::TypeDefinition(TypeDefinition::Union(union)) => {
-                if union.name == name {
-                    return true;
-                }
+        if let Definition::TypeDefinition(TypeDefinition::Union(union)) = definition {
+            if union.name == name {
+                return true;
             }
-            _ => {}
         }
     }
-    return false;
+
+    false
 }

--- a/cynic-codegen/src/input_object_derive/field_serializer.rs
+++ b/cynic-codegen/src/input_object_derive/field_serializer.rs
@@ -45,7 +45,7 @@ impl<'a> FieldSerializer<'a> {
         if self.rust_field.skip_serializing_if.is_some() && !self.graphql_field_type.is_nullable() {
             return Some(syn::Error::new(
                 self.rust_field.skip_serializing_if.as_ref().unwrap().span(),
-                format!("You can't specify skip_serializing_if on a required field"),
+                "You can't specify skip_serializing_if on a required field".to_string(),
             ));
         }
 
@@ -71,6 +71,7 @@ impl<'a> FieldSerializer<'a> {
             generic_param.map(|p| p.to_tokens(self.query_module.clone().into()));
 
         quote! {
+            #[allow(clippy::ptr_arg)]
             fn #rust_field_name<#generic_param_definition>(data: &#arg_type) ->
                 Result<::cynic::serde_json::Value, ::cynic::SerializeError> {
                     data.serialize()

--- a/cynic-codegen/src/query_dsl/schema_roots.rs
+++ b/cynic-codegen/src/query_dsl/schema_roots.rs
@@ -64,21 +64,18 @@ impl RootTypes {
         let mut rv = RootTypes::default();
 
         for definition in definitions {
-            match definition {
-                Definition::SchemaDefinition(schema) => {
-                    if let Some(query_type) = &schema.query {
-                        rv.query = query_type.clone();
-                    }
-                    if let Some(mutation_type) = &schema.mutation {
-                        rv.mutation = mutation_type.clone();
-                    }
-                    break;
+            if let Definition::SchemaDefinition(schema) = definition {
+                if let Some(query_type) = &schema.query {
+                    rv.query = query_type.clone();
                 }
-                _ => {}
+                if let Some(mutation_type) = &schema.mutation {
+                    rv.mutation = mutation_type.clone();
+                }
+                break;
             }
         }
 
-        return rv;
+        rv
     }
 
     pub fn root_from_selector_struct(&self, selector: &SelectorStruct) -> Option<SchemaRoot> {

--- a/cynic-codegen/src/query_dsl/selector_struct.rs
+++ b/cynic-codegen/src/query_dsl/selector_struct.rs
@@ -56,7 +56,7 @@ impl SelectorStruct {
         }
 
         SelectorStruct {
-            name: name.clone(),
+            name,
             graphql_name: obj.name.clone(),
             fields: processed_fields,
             selection_builders,

--- a/cynic-codegen/src/query_dsl/union_struct.rs
+++ b/cynic-codegen/src/query_dsl/union_struct.rs
@@ -16,7 +16,7 @@ impl UnionStruct {
     pub fn from_union(union: &schema::UnionType) -> Self {
         UnionStruct {
             name: Ident::for_type(&union.name),
-            subtypes: union.types.iter().map(|ty| Ident::for_type(ty)).collect(),
+            subtypes: union.types.iter().map(Ident::for_type).collect(),
         }
     }
 }

--- a/cynic-codegen/src/query_module/mod.rs
+++ b/cynic-codegen/src/query_module/mod.rs
@@ -29,7 +29,7 @@ fn transform_query_module_impl(
 ) -> Result<TokenStream, syn::Error> {
     use quote::quote;
 
-    if let None = query_module.content {
+    if query_module.content.is_none() {
         return Ok(quote! { #query_module });
     }
 

--- a/cynic-codegen/src/query_module/utils.rs
+++ b/cynic-codegen/src/query_module/utils.rs
@@ -20,7 +20,7 @@ pub fn find_derives(item: &Item) -> Vec<Derive> {
 fn derive_from_attributes(attrs: &[Attribute]) -> Vec<Derive> {
     let attr = attrs.iter().find(|attr| attr.path.is_ident("derive"));
 
-    if let None = attr {
+    if attr.is_none() {
         return vec![];
     }
     let attr = attr.unwrap();
@@ -53,7 +53,8 @@ fn derive_for_nested_meta(nested: &NestedMeta) -> Option<Derive> {
             }
         }
     }
-    return None;
+
+    None
 }
 
 #[cfg(test)]

--- a/cynic-codegen/src/scalar_derive/mod.rs
+++ b/cynic-codegen/src/scalar_derive/mod.rs
@@ -23,7 +23,7 @@ pub fn scalar_derive_impl(input: ScalarDeriveInput) -> Result<TokenStream, syn::
         .take_struct()
         .expect("Expected enum")
         .into_iter()
-        .nth(0)
+        .next()
         .expect("Expected enum with one variant");
 
     let ident = input.ident;

--- a/cynic-codegen/src/schema.rs
+++ b/cynic-codegen/src/schema.rs
@@ -58,7 +58,7 @@ pub enum SchemaLoadError {
 }
 
 impl SchemaLoadError {
-    pub fn to_syn_error(self, schema_span: proc_macro2::Span) -> syn::Error {
+    pub fn into_syn_error(self, schema_span: proc_macro2::Span) -> syn::Error {
         let message = match self {
             SchemaLoadError::IoError(e) => format!("Could not load schema file: {}", e),
             SchemaLoadError::ParseError(e) => format!("Could not parse schema file: {}", e),
@@ -96,7 +96,7 @@ impl FieldExt for Field {
                 // we only want to know if things are required
                 FieldArgument::from_input_value(arg, &TypeIndex::empty()).is_required()
             })
-            .map(|a| a.clone())
+            .cloned()
             .collect()
     }
 
@@ -108,7 +108,7 @@ impl FieldExt for Field {
                 // we only want to know if things are required
                 !FieldArgument::from_input_value(arg, &TypeIndex::empty()).is_required()
             })
-            .map(|a| a.clone())
+            .cloned()
             .collect()
     }
 }
@@ -138,10 +138,7 @@ impl TypeExt for Type {
     }
 
     fn is_required(&self) -> bool {
-        match self {
-            Type::NonNullType(_) => true,
-            _ => false,
-        }
+        matches!(self, Type::NonNullType(_))
     }
 }
 
@@ -151,9 +148,6 @@ pub trait ScalarTypeExt {
 
 impl ScalarTypeExt for ScalarType {
     fn is_builtin(&self) -> bool {
-        match self.name.as_ref() {
-            "String" | "Int" | "Boolean" | "ID" => true,
-            _ => false,
-        }
+        matches!(self.name.as_ref(), "String" | "Int" | "Boolean" | "ID")
     }
 }

--- a/cynic-codegen/src/type_index.rs
+++ b/cynic-codegen/src/type_index.rs
@@ -17,11 +17,8 @@ impl<'a> TypeIndex<'a> {
     pub fn for_schema(document: &'a Document) -> Self {
         let mut types = HashMap::new();
         for definition in &document.definitions {
-            match definition {
-                Definition::TypeDefinition(type_def) => {
-                    types.insert(name_for_type(type_def), type_def);
-                }
-                _ => {}
+            if let Definition::TypeDefinition(type_def) = definition {
+                types.insert(name_for_type(type_def), type_def);
             }
         }
 
@@ -29,6 +26,7 @@ impl<'a> TypeIndex<'a> {
     }
 
     pub fn lookup_type(&self, name: &str) -> Option<&'a TypeDefinition> {
+        #[allow(clippy::map_clone)]
         self.types.get(name).map(|d| *d)
     }
 

--- a/cynic-codegen/src/type_path.rs
+++ b/cynic-codegen/src/type_path.rs
@@ -16,7 +16,7 @@ pub struct TypePath {
 impl TypePath {
     pub fn new(path: Vec<Ident>) -> Self {
         TypePath {
-            path: path,
+            path,
             relative: true,
             is_void: false,
             builtin: false,
@@ -25,7 +25,7 @@ impl TypePath {
 
     pub fn new_absolute(path: Vec<Ident>) -> Self {
         TypePath {
-            path: path,
+            path,
             relative: false,
             is_void: false,
             builtin: false,

--- a/cynic-codegen/src/type_validation.rs
+++ b/cynic-codegen/src/type_validation.rs
@@ -128,7 +128,8 @@ enum ParsedType<'a> {
     Unknown,
 }
 
-fn parse_type<'a>(ty: &'a syn::Type) -> ParsedType<'a> {
+#[allow(clippy::cmp_owned)]
+fn parse_type(ty: &'_ syn::Type) -> ParsedType<'_> {
     if let syn::Type::Path(type_path) = ty {
         if let Some(last_segment) = type_path.path.segments.last() {
             if last_segment.ident.to_string() == "Box" {
@@ -162,7 +163,7 @@ fn parse_type<'a>(ty: &'a syn::Type) -> ParsedType<'a> {
 }
 
 /// Takes a PathSegment like `Vec<T>` and extracts the `T`
-fn extract_generic_argument<'a>(segment: &'a syn::PathSegment) -> Option<&'a syn::Type> {
+fn extract_generic_argument(segment: &syn::PathSegment) -> Option<&syn::Type> {
     if let syn::PathArguments::AngleBracketed(angle_bracketed) = &segment.arguments {
         for arg in &angle_bracketed.args {
             if let syn::GenericArgument::Type(inner_type) = arg {

--- a/cynic-proc-macros/src/lib.rs
+++ b/cynic-proc-macros/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::let_and_return)]
+
 extern crate proc_macro;
 
 use proc_macro::TokenStream;

--- a/cynic-querygen-web/src/lib.rs
+++ b/cynic-querygen-web/src/lib.rs
@@ -1,7 +1,7 @@
 // (Lines like the one below ignore selected Clippy rules
 //  - it's useful when you want to check your code with `cargo make verify`
 // but some rules are too "annoying" or are not applicable for your case.)
-#![allow(clippy::wildcard_imports)]
+#![allow(clippy::wildcard_imports, clippy::enum_variant_names)]
 
 use seed::prelude::*;
 

--- a/cynic-querygen/src/lib.rs
+++ b/cynic-querygen/src/lib.rs
@@ -153,7 +153,7 @@ pub fn document_to_fragment_structs(
                 field.field_type.type_spec()
             ))
         }
-        lines.push(format!("    }}\n"));
+        lines.push("    }}\n".to_string());
     }
 
     for en in output.enums {
@@ -200,15 +200,12 @@ pub fn document_to_fragment_structs(
     // Note that currently our query_dsl needs _all_ scalars in a schema
     // so we're parsing this out from schema.definitons rather than output.scalars
     for def in &schema.definitions {
-        match def {
-            schema::Definition::TypeDefinition(schema::TypeDefinition::Scalar(scalar)) => {
-                lines.push("    #[derive(cynic::Scalar, Debug)]".into());
-                lines.push(format!(
-                    "    pub struct {}(String);\n",
-                    scalar.name.to_pascal_case()
-                ));
-            }
-            _ => (),
+        if let schema::Definition::TypeDefinition(schema::TypeDefinition::Scalar(scalar)) = def {
+            lines.push("    #[derive(cynic::Scalar, Debug)]".into());
+            lines.push(format!(
+                "    pub struct {}(String);\n",
+                scalar.name.to_pascal_case()
+            ));
         }
     }
     lines.push("}\n".into());

--- a/cynic-querygen/src/lib.rs
+++ b/cynic-querygen/src/lib.rs
@@ -153,7 +153,7 @@ pub fn document_to_fragment_structs(
                 field.field_type.type_spec()
             ))
         }
-        lines.push("    }}\n".to_string());
+        lines.push("    }\n".to_string());
     }
 
     for en in output.enums {

--- a/cynic-querygen/src/query_parsing/arguments.rs
+++ b/cynic-querygen/src/query_parsing/arguments.rs
@@ -95,9 +95,7 @@ impl<'query, 'schema, 'doc> SelectionArguments<'query, 'schema, 'doc> {
                         // This particular childs arguments are only used by it,
                         // so we can safely lift them up into our argument struct
                         output_mapping.selection_structs.remove(&nested_struct.id);
-                        output_mapping
-                            .remappings
-                            .insert(nested_struct.id, our_id.clone());
+                        output_mapping.remappings.insert(nested_struct.id, our_id);
 
                         Rc::try_unwrap(nested_struct).unwrap().fields
                     } else {
@@ -108,7 +106,7 @@ impl<'query, 'schema, 'doc> SelectionArguments<'query, 'schema, 'doc> {
             .collect();
 
         let rv = Rc::new(ArgumentStruct {
-            id: our_id.clone(),
+            id: our_id,
             name: format!("{}Arguments", self.target_selection.target_type.name()),
             fields,
         });
@@ -130,7 +128,7 @@ impl<'query, 'schema, 'doc> SelectionArguments<'query, 'schema, 'doc> {
                 parent_map
                     .entry(child)
                     .or_insert_with(HashSet::new)
-                    .insert(self.clone());
+                    .insert(self);
             }
         }
     }

--- a/cynic-querygen/src/query_parsing/inputs.rs
+++ b/cynic-querygen/src/query_parsing/inputs.rs
@@ -120,15 +120,12 @@ pub fn extract_input_objects_from_values<'query, 'schema>(
 
                 let field_type = field.value_type.inner_ref().lookup()?;
 
-                match field_type {
-                    InputType::InputObject(inner_obj) => {
-                        adjacents.push(extract_input_objects_from_values(
-                            &inner_obj,
-                            field_val,
-                            input_objects,
-                        )?);
-                    }
-                    _ => {}
+                if let InputType::InputObject(inner_obj) = field_type {
+                    adjacents.push(extract_input_objects_from_values(
+                        &inner_obj,
+                        field_val,
+                        input_objects,
+                    )?);
                 }
 
                 fields.push(field.clone());
@@ -202,11 +199,8 @@ fn extract_whole_input_object<'schema>(
     for field in &input_object.fields {
         let field_type = field.value_type.inner_ref().lookup()?;
 
-        match field_type {
-            InputType::InputObject(inner_obj) => {
-                adjacents.push(extract_whole_input_object(&inner_obj, input_objects)?);
-            }
-            _ => {}
+        if let InputType::InputObject(inner_obj) = field_type {
+            adjacents.push(extract_whole_input_object(&inner_obj, input_objects)?);
         }
 
         fields.push(field.clone());

--- a/cynic-querygen/src/query_parsing/mod.rs
+++ b/cynic-querygen/src/query_parsing/mod.rs
@@ -108,7 +108,7 @@ fn make_query_fragment<'text>(
     })
 }
 
-fn make_input_object<'text>(input: Rc<inputs::InputObject>) -> Result<output::InputObject, Error> {
+fn make_input_object(input: Rc<inputs::InputObject>) -> Result<output::InputObject, Error> {
     Ok(output::InputObject {
         name: input.schema_type.name.to_string(),
         fields: input.fields.clone(),

--- a/cynic-querygen/src/query_parsing/naming.rs
+++ b/cynic-querygen/src/query_parsing/naming.rs
@@ -37,7 +37,7 @@ where
         let used_count = self.used_names.entry(requested_name.clone()).or_insert(0);
         *used_count += 1;
         let name = if *used_count == 1 {
-            requested_name.to_string()
+            requested_name
         } else {
             format!("{}{}", requested_name, used_count)
         };

--- a/cynic-querygen/src/query_parsing/output.rs
+++ b/cynic-querygen/src/query_parsing/output.rs
@@ -92,7 +92,7 @@ impl RustOutputFieldType {
         self.output_type_spec_imp(true)
     }
 
-    fn output_type_spec_imp<'schema>(&self, nullable: bool) -> String {
+    fn output_type_spec_imp(&self, nullable: bool) -> String {
         if let RustOutputFieldType::NonNullType(inner) = self {
             return inner.output_type_spec_imp(false);
         }
@@ -117,7 +117,7 @@ impl RustOutputFieldType {
                     _ => {}
                 }
 
-                return s.clone();
+                s.clone()
             }
         }
     }

--- a/cynic-querygen/src/query_parsing/sorting.rs
+++ b/cynic-querygen/src/query_parsing/sorting.rs
@@ -63,6 +63,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::many_single_char_names)]
     fn test_sorting_works() {
         let a = TestVertex::new("a", &[]);
         let b = TestVertex::new("b", &[]);

--- a/cynic-querygen/src/query_parsing/value.rs
+++ b/cynic-querygen/src/query_parsing/value.rs
@@ -145,7 +145,9 @@ impl<'query, 'schema> TypedValue<'query, 'schema> {
                 }
             }
             TypedValue::Int(num, _) => num.to_string(),
-            TypedValue::Float(num, _) => num.map(|d| d.to_string()).unwrap_or("null".to_string()),
+            TypedValue::Float(num, _) => num
+                .map(|d| d.to_string())
+                .unwrap_or_else(|| "null".to_string()),
             TypedValue::String(s, field_type) => {
                 if field_type.inner_name() == "ID" {
                     format!("cynic::Id::new(\"{}\")", s)

--- a/cynic-querygen/src/schema/fields.rs
+++ b/cynic-querygen/src/schema/fields.rs
@@ -121,10 +121,7 @@ impl<'schema> InputFieldType<'schema> {
     }
 
     pub fn is_required(&self) -> bool {
-        match self {
-            InputFieldType::NonNullType(_) => true,
-            _ => false,
-        }
+        matches!(self, InputFieldType::NonNullType(_))
     }
 
     pub fn type_spec(&self) -> Cow<'schema, str> {

--- a/cynic-querygen/src/schema/mod.rs
+++ b/cynic-querygen/src/schema/mod.rs
@@ -122,10 +122,7 @@ impl<'schema> Type<'schema> {
 
 impl<'schema> ScalarDetails<'schema> {
     pub fn is_builtin(&self) -> bool {
-        match self.name {
-            "String" | "Int" | "Boolean" | "ID" => true,
-            _ => false,
-        }
+        matches!(self.name, "String" | "Int" | "Boolean" | "ID")
     }
 }
 

--- a/cynic-querygen/src/schema/parser.rs
+++ b/cynic-querygen/src/schema/parser.rs
@@ -14,9 +14,6 @@ pub trait ScalarTypeExt {
 
 impl<'a> ScalarTypeExt for ScalarType<'a> {
     fn is_builtin(&self) -> bool {
-        match self.name {
-            "String" | "Int" | "Boolean" | "ID" => true,
-            _ => false,
-        }
+        matches!(self.name, "String" | "Int" | "Boolean" | "ID")
     }
 }

--- a/cynic-querygen/src/schema/type_index.rs
+++ b/cynic-querygen/src/schema/type_index.rs
@@ -110,25 +110,23 @@ impl<'schema> TypeIndex<'schema> {
             [first] => fields
                 .iter()
                 .find(|field| field.name == *first)
-                .ok_or(Error::UnknownField(
-                    first.to_string(),
-                    current_type_name.to_string(),
-                )),
+                .ok_or_else(|| {
+                    Error::UnknownField(first.to_string(), current_type_name.to_string())
+                }),
             [first, rest @ ..] => {
                 let inner_name = fields
                     .iter()
                     .find(|field| field.name == *first)
-                    .ok_or(Error::UnknownField(
-                        first.to_string(),
-                        current_type_name.to_string(),
-                    ))?
+                    .ok_or_else(|| {
+                        Error::UnknownField(first.to_string(), current_type_name.to_string())
+                    })?
                     .field_type
                     .inner_name();
 
                 let inner_type = self
                     .types
                     .get(inner_name)
-                    .ok_or(Error::UnknownType(inner_name.to_string()))?;
+                    .ok_or_else(|| Error::UnknownType(inner_name.to_string()))?;
 
                 if let TypeDefinition::Object(object) = inner_type {
                     self.find_field_recursive(&object.fields, &inner_name, rest)

--- a/cynic/src/fragments.rs
+++ b/cynic/src/fragments.rs
@@ -69,7 +69,7 @@ impl<'a, Args> FragmentContext<'a, Args> {
     pub fn with_args<'b, NewArgs>(&self, args: &'b NewArgs) -> FragmentContext<'b, NewArgs> {
         FragmentContext {
             args,
-            recurse_depth: self.recurse_depth.clone(),
+            recurse_depth: self.recurse_depth,
         }
     }
 

--- a/cynic/src/id.rs
+++ b/cynic/src/id.rs
@@ -8,11 +8,11 @@ impl Id {
         Id(s.into())
     }
     pub fn inner(&self) -> &str {
-        return &self.0;
+        &self.0
     }
 
     pub fn into_inner(self) -> String {
-        return self.0;
+        self.0
     }
 }
 

--- a/cynic/src/selection_set/field.rs
+++ b/cynic/src/selection_set/field.rs
@@ -13,7 +13,7 @@ pub enum Field {
 }
 
 impl Field {
-    pub fn query<'a>(
+    pub fn query(
         self,
         indent: usize,
         indent_size: usize,
@@ -85,10 +85,7 @@ impl Field {
 }
 
 /// Extracts any argument values & returns a string to be used in a query.
-fn handle_field_arguments<'a>(
-    arguments: Vec<Argument>,
-    arguments_out: &mut Vec<Argument>,
-) -> String {
+fn handle_field_arguments(arguments: Vec<Argument>, arguments_out: &mut Vec<Argument>) -> String {
     if arguments.is_empty() {
         "".to_string()
     } else {
@@ -110,7 +107,7 @@ fn handle_field_arguments<'a>(
 }
 
 /// Extracts any argument values & returns a string to be used in a query.
-fn handle_query_arguments<'a>(arguments: &'a Vec<Argument>) -> String {
+fn handle_query_arguments(arguments: &[Argument]) -> String {
     if arguments.is_empty() {
         "".to_string()
     } else {

--- a/cynic/src/selection_set/mod.rs
+++ b/cynic/src/selection_set/mod.rs
@@ -353,6 +353,7 @@ macro_rules! define_map {
         ///     field::<_, (), ()>("email", vec![], string()),
         /// );
         /// ```
+        #[allow(clippy::too_many_arguments)]
         pub fn $fn_name<'a, F, $($i, )+ NewDecodesTo, TypeLock>(
             func: F,
             $($i: SelectionSet<'a, $i, TypeLock>,)+
@@ -565,7 +566,7 @@ where
 ///
 /// See the [`SelectionSet::and_then`](cynic::selection_set::SelectionSet::and_then)
 /// docs for an example.
-pub fn fail<'a, V>(err: impl Into<String>) -> SelectionSet<'static, V, ()> {
+pub fn fail<V>(err: impl Into<String>) -> SelectionSet<'static, V, ()> {
     SelectionSet::new(vec![], json_decode::fail(err))
 }
 

--- a/cynic/src/utils.rs
+++ b/cynic/src/utils.rs
@@ -11,13 +11,13 @@ impl<T> FlattenFrom<Option<Vec<Option<T>>>> for Option<Vec<T>> {
 impl<T> FlattenFrom<Option<Vec<Option<T>>>> for Vec<T> {
     fn flatten_from(args: Option<Vec<Option<T>>>) -> Vec<T> {
         args.map(|v| v.into_iter().flatten().collect())
-            .unwrap_or_else(|| vec![])
+            .unwrap_or_else(Vec::new)
     }
 }
 
 impl<T> FlattenFrom<Option<Vec<T>>> for Vec<T> {
     fn flatten_from(args: Option<Vec<T>>) -> Vec<T> {
-        args.unwrap_or_else(|| vec![])
+        args.unwrap_or_else(Vec::new)
     }
 }
 

--- a/tests/querygen-compile-run/src/lib.rs
+++ b/tests/querygen-compile-run/src/lib.rs
@@ -14,7 +14,7 @@ pub fn send_query<'a, ResponseData: 'a, Root: cynic::QueryRoot>(
     let response_data = query.decode_response(response.json()?)?;
     if let Some(_errors) = response_data.errors {
         println!("{:?}", _errors);
-        Err("GraphQL server returned errors")?
+        return Err("GraphQL server returned errors".into());
         // TODO: Better errors here
         //Err(errors)?
     }
@@ -38,7 +38,7 @@ pub fn send_mutation<'a, ResponseData: 'a, Root: cynic::MutationRoot>(
     let response_data = query.decode_response(response.json()?)?;
     if let Some(_errors) = response_data.errors {
         println!("{:?}", _errors);
-        Err("GraphQL server returned errors")?
+        return Err("GraphQL server returned errors".into());
         // TODO: Better errors here
         //Err(errors)?
     }


### PR DESCRIPTION
#### Why are we making this change?

I've had some problems getting clippy working in the past, and fell out of the
habit of using it.  As a result, cynic is literred with clippy lints.

#### What effects does this change have?

This fixes every lint that clippy throws up in the cynic codebase.