### PR TITLE
Support raw identifier fields in fragment derives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ all APIs might be changed.
   arguments. This can be constructed with `FragmentContext::new` if you have
   arguments or `FragmentContext::empty` if not. This change was neccesary to
   support recursive queries.
+- GraphQL fields with names that match rust keywords will no longer be
+  postfixed with a `_` - you should now use a raw identifier (or rename) for
+  these fields.
 
 ### New Features
 
@@ -33,6 +36,8 @@ all APIs might be changed.
   windows path separators.
 - The generator now correctly wraps literal ID parameters with `cynic::Id::New`
 - Cynic derives (and cynic itself) no longer emit clippy warnings (on 1.48 at least)
+- We now support raw identifiers in QueryFragment derives, useful for fields
+  named `type` or similar.
 
 ### Changes
 

--- a/cynic-codegen/src/field_argument.rs
+++ b/cynic-codegen/src/field_argument.rs
@@ -27,6 +27,6 @@ impl FieldArgument {
 
     pub fn generic_parameter(&self) -> Option<GenericParameter> {
         self.argument_type
-            .generic_parameter(Ident::for_type(format!("{}T", self.name)))
+            .generic_parameter(Ident::for_type(format!("{}T", self.name.rust_name())))
     }
 }

--- a/cynic-codegen/src/fragment_derive/mod.rs
+++ b/cynic-codegen/src/fragment_derive/mod.rs
@@ -353,7 +353,6 @@ impl FragmentImpl {
 
                 let arguments = arguments_from_field_attrs(&field.attrs)?;
 
-
                 if let Some(gql_field) = object.fields.get(&field_name) {
                     check_types_are_compatible(
                         &gql_field.field_type,

--- a/cynic-codegen/src/fragment_derive/mod.rs
+++ b/cynic-codegen/src/fragment_derive/mod.rs
@@ -342,16 +342,17 @@ impl FragmentImpl {
         }
 
         for field in &fields.fields {
-            if let Some(ident) = &field.ident {
-                let field_name = ident.to_string();
+            if let Some(macro_ident) = &field.ident {
+                let field_name_span = macro_ident.span();
+                let field_name = Ident::from(macro_ident.clone());
+
                 constructor_params.push(ConstructorParameter {
-                    name: Ident::new(&field_name),
+                    name: field_name.clone(),
                     type_path: field.ty.clone(),
                 });
 
                 let arguments = arguments_from_field_attrs(&field.attrs)?;
 
-                let field_name = Ident::for_field(&field_name);
 
                 if let Some(gql_field) = object.fields.get(&field_name) {
                     check_types_are_compatible(
@@ -361,7 +362,7 @@ impl FragmentImpl {
                     )?;
 
                     let (required_arguments, optional_arguments) =
-                        validate_and_group_args(arguments, gql_field, ident.span())?;
+                        validate_and_group_args(arguments, gql_field, field_name_span)?;
 
                     field_selectors.push(FieldSelectorCall {
                         selector_function: FieldTypeSelectorCall::for_field(
@@ -386,10 +387,11 @@ impl FragmentImpl {
                     })
                 } else {
                     return Err(syn::Error::new(
-                        ident.span(),
+                        field_name_span,
                         format!(
                             "Field {} does not exist on the GraphQL type {}",
-                            field_name, graphql_type_name
+                            field_name.graphql_name(),
+                            graphql_type_name
                         ),
                     ));
                 }
@@ -478,7 +480,7 @@ fn validate_and_group_args(
 
     let missing_args: Vec<_> = all_required
         .difference(&provided_names)
-        .map(|s| s.to_string())
+        .map(|s| s.graphql_name())
         .collect();
     if !missing_args.is_empty() {
         let missing_args = missing_args.join(", ");
@@ -494,7 +496,7 @@ fn validate_and_group_args(
 
     let unknown_args: Vec<_> = provided_names
         .difference(&all_arg_names)
-        .map(|s| s.to_string())
+        .map(|s| s.graphql_name())
         .collect();
 
     if !unknown_args.is_empty() {

--- a/cynic-codegen/src/fragment_derive/schema_parsing.rs
+++ b/cynic-codegen/src/fragment_derive/schema_parsing.rs
@@ -46,6 +46,7 @@ impl Object {
     }
 }
 
+#[derive(Debug)]
 pub struct Field {
     pub arguments: Vec<Argument>,
     pub name: Ident,
@@ -66,6 +67,7 @@ impl Field {
     }
 }
 
+#[derive(Debug)]
 pub struct Argument {
     pub name: Ident,
     pub required: bool,

--- a/cynic-codegen/src/input_object_derive/mod.rs
+++ b/cynic-codegen/src/input_object_derive/mod.rs
@@ -179,7 +179,8 @@ fn join_fields<'a>(
                     field.ident.span(),
                     format!(
                         "Could not find a field {} in the GraphQL InputObject {}",
-                        transformed_ident, input_object_name
+                        transformed_ident.graphql_name(),
+                        input_object_name
                     ),
                 )
                 .to_compile_error(),

--- a/cynic-codegen/src/query_dsl/selector_struct.rs
+++ b/cynic-codegen/src/query_dsl/selector_struct.rs
@@ -46,7 +46,7 @@ impl SelectorStruct {
                 Ident::for_module(&obj.name),
                 field.required_arguments(),
                 TypePath::new(vec![
-                    Ident::for_module(&name.to_string()),
+                    Ident::for_module(&name.rust_name()),
                     selection_builder.name.clone(),
                 ]),
                 type_index,

--- a/cynic-codegen/src/type_validation.rs
+++ b/cynic-codegen/src/type_validation.rs
@@ -187,8 +187,8 @@ mod tests {
 
     #[test]
     fn test_required_validation() {
-        let required_field = FieldType::Scalar(Ident::new("").into(), false);
-        let optional_field = FieldType::Scalar(Ident::new("").into(), true);
+        let required_field = FieldType::Scalar(Ident::new("test").into(), false);
+        let optional_field = FieldType::Scalar(Ident::new("test").into(), true);
 
         assert_matches!(
             check_types_are_compatible(
@@ -227,15 +227,15 @@ mod tests {
     #[test]
     fn test_list_validation() {
         let list = FieldType::List(
-            Box::new(FieldType::Scalar(Ident::new("").into(), false)),
+            Box::new(FieldType::Scalar(Ident::new("test").into(), false)),
             false,
         );
         let optional_list = FieldType::List(
-            Box::new(FieldType::Scalar(Ident::new("").into(), false)),
+            Box::new(FieldType::Scalar(Ident::new("test").into(), false)),
             true,
         );
         let option_list_option = FieldType::List(
-            Box::new(FieldType::Scalar(Ident::new("").into(), true)),
+            Box::new(FieldType::Scalar(Ident::new("test").into(), true)),
             true,
         );
 
@@ -292,15 +292,15 @@ mod tests {
     #[test]
     fn test_validation_when_flattening() {
         let list = FieldType::List(
-            Box::new(FieldType::Scalar(Ident::new("").into(), false)),
+            Box::new(FieldType::Scalar(Ident::new("test").into(), false)),
             false,
         );
         let optional_list = FieldType::List(
-            Box::new(FieldType::Scalar(Ident::new("").into(), false)),
+            Box::new(FieldType::Scalar(Ident::new("test").into(), false)),
             true,
         );
         let option_list_option = FieldType::List(
-            Box::new(FieldType::Scalar(Ident::new("").into(), true)),
+            Box::new(FieldType::Scalar(Ident::new("test").into(), true)),
             true,
         );
 


### PR DESCRIPTION
#### Why are we making this change?

It's not uncommon for a GraphQL schema to have field names that clash with rust
keywords.  Previously cynic handled this by appending a `_` to the name to
avoid the clash.  This works, but isn't great.  The two obvious better options
are:

1. Support field renaming such that we can avoid this.
2. Support raw identifiers, e.g. `r#type`.

#### What effects does this change have?

This updates the fragment derive code to support raw identifiers, and to avoid                                                                                                                                                                              appending `_` to clashing names.  This required a bit of a rethink around
`TypePaths` & `Idents`.  TypePaths now have specific support for the `super`
keyword as converting this to a raw identifier just doesn't work.  Idents now
carry around a rust identifier in addition to a GraphQL name.  Not sure this is
the 100% best solution, but it seems to work for now.

Fixes #154