### PR TITLE
Add support for interface types via InlineFragments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ all APIs might be changed.
   attribute on fields that recurse.
 - The generator now understands query fragments, spreads and inline fragment
   spreads. Inline fragments for interface/union types are not yet supported.
+- Interfaces can be queried via `#[derive(InlineFragments)]` on an enum.  
 
 ### Bug Fixes
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ supported:
 The following features are not well supported or tested and may not work well,
 or at all:
 
-- Fetching union and interface types and via inline fragments
+- Fetching union and interface types via inline fragments
 
 The following features are not yet supported, though should be soon (if you
 want to help out with the project I'd be happy for someone else to try and

--- a/README.md
+++ b/README.md
@@ -64,14 +64,13 @@ supported:
 The following features are not well supported or tested and may not work well,
 or at all:
 
-- Fetching union types via inline fragments
+- Fetching union and interface types and via inline fragments
 
 The following features are not yet supported, though should be soon (if you
 want to help out with the project I'd be happy for someone else to try and
 implement these - if you open an issue I'd be happy to give pointers on how to
 go about implementing any of them)
 
-- Fetching interface types.
 - Directives
 - GraphQL subscriptions.
 - Potentially other things (please open an issue if you find anything obviously

--- a/cynic-codegen/src/inline_fragments_derive/mod.rs
+++ b/cynic-codegen/src/inline_fragments_derive/mod.rs
@@ -26,7 +26,7 @@ pub(crate) fn inline_fragments_derive_impl(
     let schema =
         load_schema(&*input.schema_path).map_err(|e| e.into_syn_error(input.schema_path.span()))?;
 
-    if !find_union_type_or_interface(&input.graphql_type, &schema) {
+    if !find_union_or_interface_type(&input.graphql_type, &schema) {
         return Err(syn::Error::new(
             input.graphql_type.span(),
             format!(
@@ -136,7 +136,7 @@ impl quote::ToTokens for InlineFragmentsImpl {
     }
 }
 
-fn find_union_type_or_interface(name: &str, schema: &schema::Document) -> bool {
+fn find_union_or_interface_type(name: &str, schema: &schema::Document) -> bool {
     for definition in &schema.definitions {
         use graphql_parser::schema::{Definition, TypeDefinition};
         match definition {

--- a/cynic-codegen/src/query_dsl/interfaces_implementations.rs
+++ b/cynic-codegen/src/query_dsl/interfaces_implementations.rs
@@ -1,0 +1,44 @@
+use proc_macro2::TokenStream;
+
+use crate::{schema, Ident};
+
+/// We generate an InterfaceImplementation for each type that implements interface.
+///
+/// These are output as `HasSubtype` implementations.
+#[derive(Debug)]
+pub struct InterfacesImplementations {
+    pub implementor: Ident,
+    pub interfaces: Vec<Ident>,
+}
+
+impl InterfacesImplementations {
+    pub fn from_object(obj: &schema::ObjectType) -> Option<Self> {
+        if obj.implements_interfaces.is_empty() {
+            return None;
+        }
+
+        Some(Self {
+            implementor: Ident::for_type(&obj.name),
+            interfaces: obj
+                .implements_interfaces
+                .iter()
+                .map(|interface| Ident::for_type(interface))
+                .collect(),
+        })
+    }
+}
+
+impl quote::ToTokens for InterfacesImplementations {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        use quote::{quote, TokenStreamExt};
+
+        let implementor = &self.implementor;
+        let interfaces = &self.interfaces;
+
+        tokens.append_all(quote! {
+            #(
+                impl ::cynic::selection_set::HasSubtype<#implementor> for #interfaces {}
+            )*
+        });
+    }
+}

--- a/cynic-codegen/src/query_dsl/interfaces_implementations.rs
+++ b/cynic-codegen/src/query_dsl/interfaces_implementations.rs
@@ -22,7 +22,7 @@ impl InterfacesImplementations {
             interfaces: obj
                 .implements_interfaces
                 .iter()
-                .map(|interface| Ident::for_type(interface))
+                .map(Ident::for_type)
                 .collect(),
         })
     }

--- a/cynic-codegen/src/query_dsl/mod.rs
+++ b/cynic-codegen/src/query_dsl/mod.rs
@@ -166,7 +166,7 @@ impl quote::ToTokens for QueryDsl {
                 #schema_roots
             )*
             #(
-                interfaces_implementations
+                #interfaces_implementations
             )*
         })
     }


### PR DESCRIPTION
#### Why are we making this change?

For now there is no way to accept interface types.

#### What effects does this change have?

This adds ability to support interface types via `InlineFragmets` derive macro on an enum.
Works exactly like union types.
