### PR TITLE
Refactor generator output code.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ all APIs might be changed.
   - Correctly generates different argument structs if a single type with
     arguments is used in multiple queries. Though the correct IntoArgument impl
     is not yet generated.
+- The generator now generates scalars with public fields
 
 ## v0.10.1 - 2020-11-04
 

--- a/cynic-querygen/Cargo.toml
+++ b/cynic-querygen/Cargo.toml
@@ -9,10 +9,10 @@ repository = "https://github.com/obmarg/cynic"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+Inflector = "0.11.4"
 graphql-parser = "0.3"
 rust_decimal = "1.8"
 thiserror = "1.0.13"
-Inflector = "0.11.4"
 uuid = { version = "0.8", features = ["v4"] }
 
 [dev-dependencies]

--- a/cynic-querygen/src/lib.rs
+++ b/cynic-querygen/src/lib.rs
@@ -122,37 +122,21 @@ pub fn document_to_fragment_structs(
     }
 
     for en in output.enums {
-        let type_name = en.name;
-        lines.push("    #[derive(cynic::Enum, Clone, Copy, Debug)]".into());
-        lines.push("    #[cynic(".into());
-        lines.push(format!("        graphql_type = \"{}\",", type_name));
-        lines.push("        rename_all = \"SCREAMING_SNAKE_CASE\"".into());
-        lines.push("    )]".into());
-        lines.push(format!("    pub enum {} {{", type_name.to_pascal_case()));
+        use output::indented;
+        use std::fmt::Write;
 
-        for variant in &en.values {
-            lines.push(format!("        {},", variant.to_pascal_case()))
-        }
-        lines.push("    }\n".into());
+        let mut s = String::new();
+        write!(indented(&mut s, 4), "{}", en).unwrap();
+        lines.push(s);
     }
 
     for input_object in output.input_objects {
-        lines.push("    #[derive(cynic::InputObject, Debug)]".into());
-        lines.push(format!(
-            "    #[cynic(graphql_type = \"{}\", rename_all=\"camelCase\")]",
-            input_object.name
-        ));
-        lines.push(format!("    pub struct {} {{", input_object.name));
+        use output::indented;
+        use std::fmt::Write;
 
-        for field in input_object.fields {
-            lines.push(format!(
-                "        pub {}: {},",
-                field.name.to_snake_case(),
-                field.type_spec()
-            ))
-        }
-
-        lines.push("    }\n".into());
+        let mut s = String::new();
+        write!(indented(&mut s, 4), "{}", input_object).unwrap();
+        lines.push(s);
     }
     lines.push("}\n".into());
 

--- a/cynic-querygen/src/lib.rs
+++ b/cynic-querygen/src/lib.rs
@@ -103,7 +103,7 @@ pub fn document_to_fragment_structs(
         options.query_module
     ));
 
-    for (struct_name, argument_struct) in output.argument_structs {
+    for argument_struct in output.argument_structs {
         use output::indented;
         use std::fmt::Write;
 

--- a/cynic-querygen/src/lib.rs
+++ b/cynic-querygen/src/lib.rs
@@ -1,6 +1,8 @@
 use inflector::Inflector;
 use std::rc::Rc;
 
+mod naming;
+mod output;
 mod query_parsing;
 mod schema;
 mod type_ext;
@@ -102,18 +104,12 @@ pub fn document_to_fragment_structs(
     ));
 
     for (struct_name, argument_struct) in output.argument_structs {
-        lines.push("    #[derive(cynic::FragmentArguments, Debug)]".into());
-        lines.push(format!("    pub struct {} {{", struct_name));
+        use output::indented;
+        use std::fmt::Write;
 
-        for field in &argument_struct.fields {
-            lines.push(format!(
-                "        pub {}: {},",
-                field.name().to_snake_case(),
-                field.type_spec()
-            ));
-        }
-
-        lines.push("    }\n".into());
+        let mut s = String::new();
+        write!(indented(&mut s, 4), "{}", argument_struct).unwrap();
+        lines.push(s);
     }
 
     for fragment in output.query_fragments {

--- a/cynic-querygen/src/lib.rs
+++ b/cynic-querygen/src/lib.rs
@@ -113,43 +113,12 @@ pub fn document_to_fragment_structs(
     }
 
     for fragment in output.query_fragments {
-        let argument_struct_param = if let Some(name) = fragment.argument_struct_name {
-            format!(", argument_struct = \"{}\"", name)
-        } else {
-            "".to_string()
-        };
+        use output::indented;
+        use std::fmt::Write;
 
-        lines.push("    #[derive(cynic::QueryFragment, Debug)]".into());
-        lines.push(format!(
-            "    #[cynic(graphql_type = \"{}\"{})]",
-            fragment.target_type, argument_struct_param
-        ));
-        lines.push(format!("    pub struct {} {{", fragment.name));
-
-        for field in fragment.fields {
-            if !field.arguments.is_empty() {
-                let arguments_string = field
-                    .arguments
-                    .iter()
-                    .map(|arg| {
-                        Ok(format!(
-                            "{} = {}",
-                            arg.name.to_snake_case(),
-                            arg.to_literal()?
-                        ))
-                    })
-                    .collect::<Result<Vec<_>, Error>>()?
-                    .join(", ");
-
-                lines.push(format!("        #[arguments({})]", arguments_string));
-            }
-            lines.push(format!(
-                "        pub {}: {},",
-                field.name.to_snake_case(),
-                field.field_type.type_spec()
-            ))
-        }
-        lines.push("    }\n".to_string());
+        let mut s = String::new();
+        write!(indented(&mut s, 4), "{}", fragment).unwrap();
+        lines.push(s);
     }
 
     for en in output.enums {

--- a/cynic-querygen/src/naming.rs
+++ b/cynic-querygen/src/naming.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, hash::Hash, rc::Rc};
+use std::{collections::HashMap, hash::Hash};
 
 pub trait Nameable: Eq + Hash {
     fn requested_name(&self) -> String;

--- a/cynic-querygen/src/naming.rs
+++ b/cynic-querygen/src/naming.rs
@@ -48,12 +48,6 @@ where
     }
 }
 
-impl<'query, 'schema> Nameable for Rc<super::normalisation::SelectionSet<'query, 'schema>> {
-    fn requested_name(&self) -> String {
-        self.target_type.name().to_owned()
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/cynic-querygen/src/output/argument_struct.rs
+++ b/cynic-querygen/src/output/argument_struct.rs
@@ -1,0 +1,66 @@
+use inflector::Inflector;
+use std::rc::Rc;
+use uuid::Uuid;
+
+use crate::query_parsing::Variable;
+
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ArgumentStruct<'query, 'schema> {
+    pub id: Uuid,
+    pub target_type_name: String,
+    pub fields: Vec<ArgumentStructField<'query, 'schema>>,
+}
+
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum ArgumentStructField<'query, 'schema> {
+    Variable(Variable<'query, 'schema>),
+    NestedStruct(Rc<ArgumentStruct<'query, 'schema>>),
+}
+
+impl<'query, 'schema> ArgumentStructField<'query, 'schema> {
+    pub fn name(&self) -> String {
+        match self {
+            ArgumentStructField::Variable(var) => var.name.to_string(),
+            ArgumentStructField::NestedStruct(arg_struct) => arg_struct.name.to_snake_case(),
+        }
+    }
+
+    pub fn type_spec(&self) -> String {
+        match self {
+            ArgumentStructField::Variable(var) => var.value_type.type_spec().to_string(),
+            ArgumentStructField::NestedStruct(arg_struct) => arg_struct.name.clone(),
+        }
+    }
+}
+
+impl std::fmt::Display for ArgumentStruct<'_, '_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        use super::indented;
+        use std::fmt::Write;
+
+        writeln!(f, "#[derive(cynic::FragmentArguments, Debug)]")?;
+        writeln!(f, "pub struct {} {{", self.name)?;
+
+        for field in &self.fields {
+            write!(indented(f, 4), "{}", field)?;
+        }
+        writeln!(f, "}}")
+    }
+}
+
+impl std::fmt::Display for ArgumentStructField<'_, '_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(
+            f,
+            "pub {}: {},",
+            self.name().to_snake_case(),
+            self.type_spec()
+        )
+    }
+}
+
+impl<'query, 'schema> crate::naming::Nameable for Rc<ArgumentStruct<'query, 'schema>> {
+    fn requested_name(&self) -> String {
+        self.requested_name.clone()
+    }
+}

--- a/cynic-querygen/src/output/enums.rs
+++ b/cynic-querygen/src/output/enums.rs
@@ -1,0 +1,21 @@
+use inflector::Inflector;
+
+use crate::schema::EnumDetails;
+
+impl std::fmt::Display for EnumDetails<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let type_name = self.name;
+
+        writeln!(f, "#[derive(cynic::Enum, Clone, Copy, Debug)]")?;
+        writeln!(f, "#[cynic(")?;
+        writeln!(f, "    graphql_type = \"{}\",", type_name)?;
+        writeln!(f, "    rename_all = \"SCREAMING_SNAKE_CASE\"")?;
+        writeln!(f, ")]")?;
+        writeln!(f, "pub enum {} {{", type_name.to_pascal_case())?;
+
+        for variant in &self.values {
+            writeln!(f, "    {},", variant.to_pascal_case())?;
+        }
+        writeln!(f, "}}")
+    }
+}

--- a/cynic-querygen/src/output/indent.rs
+++ b/cynic-querygen/src/output/indent.rs
@@ -1,0 +1,94 @@
+use std::fmt;
+
+pub struct Indented<'a, D: ?Sized> {
+    inner: &'a mut D,
+    level: usize,
+    indent_required: bool,
+}
+
+/// Helper function for creating a default indenter
+pub fn indented<D: ?Sized>(f: &mut D, level: usize) -> Indented<'_, D> {
+    Indented {
+        inner: f,
+        level,
+        indent_required: true,
+    }
+}
+
+impl<T> fmt::Write for Indented<'_, T>
+where
+    T: fmt::Write + ?Sized,
+{
+    fn write_str(&mut self, s: &str) -> fmt::Result {
+        for (ind, line) in s.split('\n').enumerate() {
+            if ind > 0 {
+                self.inner.write_char('\n')?;
+                self.indent_required = true;
+            }
+
+            if self.indent_required && !line.is_empty() {
+                write!(self.inner, "{:indent$}{}", "", line, indent = self.level)?;
+                self.indent_required = false;
+            } else if !line.is_empty() {
+                write!(self.inner, "{}", line)?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::fmt::Write;
+
+    #[test]
+    fn test_simple() {
+        let output = &mut String::new();
+        let input = "Hello!";
+        let expected = "    Hello!";
+
+        write!(indented(output, 4), "{}", input).unwrap();
+
+        assert_eq!(output, expected);
+    }
+
+    #[test]
+    fn test_multi_line() {
+        let output = &mut String::new();
+        let input = "Hello!\nThere!";
+        let expected = "    Hello!\n    There!";
+
+        write!(indented(output, 4), "{}", input).unwrap();
+
+        assert_eq!(output, expected);
+    }
+
+    #[test]
+    fn test_multi_write() {
+        let output = &mut String::new();
+        let input = "Hello!\nThere!";
+        let expected = "    Hello!\n    There!\n    Hello!\n    There!\n";
+
+        writeln!(indented(output, 4), "{}", input).unwrap();
+        writeln!(indented(output, 4), "{}", input).unwrap();
+
+        assert_eq!(output, expected);
+    }
+
+    #[test]
+    fn test_nested_indents() {
+        let output = &mut String::new();
+        let input = "Hello!\nThere!";
+
+        let mut level1 = indented(output, 2);
+        writeln!(level1, "{}", input).unwrap();
+
+        let mut level2 = indented(&mut level1, 2);
+        writeln!(level2, "{}", input).unwrap();
+
+        assert_eq!(output, "  Hello!\n  There!\n    Hello!\n    There!\n")
+    }
+}

--- a/cynic-querygen/src/output/input_object.rs
+++ b/cynic-querygen/src/output/input_object.rs
@@ -1,0 +1,35 @@
+use std::fmt::Write;
+
+use inflector::Inflector;
+
+use super::indented;
+use crate::schema::InputField;
+
+#[derive(Debug, PartialEq)]
+pub struct InputObject<'schema> {
+    pub name: String,
+    pub fields: Vec<InputField<'schema>>,
+}
+
+impl std::fmt::Display for InputObject<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "#[derive(cynic::InputObject, Debug)]")?;
+        writeln!(
+            f,
+            "#[cynic(graphql_type = \"{}\", rename_all=\"camelCase\")]",
+            self.name
+        )?;
+        writeln!(f, "pub struct {} {{", self.name)?;
+
+        for field in &self.fields {
+            writeln!(
+                indented(f, 4),
+                "pub {}: {},",
+                field.name.to_snake_case(),
+                field.type_spec()
+            )?;
+        }
+
+        writeln!(f, "}}")
+    }
+}

--- a/cynic-querygen/src/output/mod.rs
+++ b/cynic-querygen/src/output/mod.rs
@@ -1,8 +1,4 @@
-use inflector::Inflector;
-use std::rc::Rc;
-use uuid::Uuid;
-
-use crate::query_parsing::{TypedValue, Variable};
+use crate::query_parsing::TypedValue;
 use crate::schema::{EnumDetails, InputField, OutputFieldType};
 use crate::Error;
 
@@ -17,7 +13,7 @@ pub struct Output<'query, 'schema> {
     pub input_objects: Vec<InputObject<'schema>>,
     pub enums: Vec<EnumDetails<'schema>>,
     pub scalars: Vec<Scalar<'schema>>,
-    pub argument_structs: Vec<(String, Rc<ArgumentStruct<'query, 'schema>>)>,
+    pub argument_structs: Vec<ArgumentStruct<'query, 'schema>>,
 }
 
 pub struct Scalar<'schema>(pub &'schema str);

--- a/cynic-querygen/src/output/mod.rs
+++ b/cynic-querygen/src/output/mod.rs
@@ -1,11 +1,14 @@
-use crate::schema::{EnumDetails, InputField};
+use crate::schema::EnumDetails;
 
 mod argument_struct;
+mod enums;
 mod indent;
+mod input_object;
 pub mod query_fragment;
 
 pub use argument_struct::{ArgumentStruct, ArgumentStructField};
 pub use indent::indented;
+pub use input_object::InputObject;
 pub use query_fragment::QueryFragment;
 
 pub struct Output<'query, 'schema> {
@@ -17,9 +20,3 @@ pub struct Output<'query, 'schema> {
 }
 
 pub struct Scalar<'schema>(pub &'schema str);
-
-#[derive(Debug, PartialEq)]
-pub struct InputObject<'schema> {
-    pub name: String,
-    pub fields: Vec<InputField<'schema>>,
-}

--- a/cynic-querygen/src/output/mod.rs
+++ b/cynic-querygen/src/output/mod.rs
@@ -2,9 +2,15 @@ use inflector::Inflector;
 use std::rc::Rc;
 use uuid::Uuid;
 
-use super::{normalisation::Variable, value::TypedValue};
+use crate::query_parsing::{TypedValue, Variable};
 use crate::schema::{EnumDetails, InputField, OutputFieldType};
 use crate::Error;
+
+mod argument_struct;
+mod indent;
+
+pub use argument_struct::{ArgumentStruct, ArgumentStructField};
+pub use indent::indented;
 
 pub struct Output<'query, 'schema> {
     pub query_fragments: Vec<QueryFragment<'query, 'schema>>,
@@ -23,35 +29,6 @@ pub struct QueryFragment<'query, 'schema> {
     pub argument_struct_name: Option<String>,
 
     pub name: String,
-}
-
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct ArgumentStruct<'query, 'schema> {
-    pub id: Uuid,
-    pub(super) name: String,
-    pub fields: Vec<ArgumentStructField<'query, 'schema>>,
-}
-
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub enum ArgumentStructField<'query, 'schema> {
-    Variable(Variable<'query, 'schema>),
-    NestedStruct(Rc<ArgumentStruct<'query, 'schema>>),
-}
-
-impl<'query, 'schema> ArgumentStructField<'query, 'schema> {
-    pub fn name(&self) -> String {
-        match self {
-            ArgumentStructField::Variable(var) => var.name.to_string(),
-            ArgumentStructField::NestedStruct(arg_struct) => arg_struct.name.to_snake_case(),
-        }
-    }
-
-    pub fn type_spec(&self) -> String {
-        match self {
-            ArgumentStructField::Variable(var) => var.value_type.type_spec().to_string(),
-            ArgumentStructField::NestedStruct(arg_struct) => arg_struct.name.clone(),
-        }
-    }
 }
 
 #[derive(Debug, PartialEq)]

--- a/cynic-querygen/src/output/query_fragment.rs
+++ b/cynic-querygen/src/output/query_fragment.rs
@@ -1,0 +1,153 @@
+use std::fmt::Write;
+
+use inflector::Inflector;
+
+use super::indented;
+use crate::{query_parsing::TypedValue, schema::OutputFieldType, Error};
+
+#[derive(Debug, PartialEq)]
+pub struct QueryFragment<'query, 'schema> {
+    pub fields: Vec<OutputField<'query, 'schema>>,
+    pub target_type: String,
+    pub argument_struct_name: Option<String>,
+
+    pub name: String,
+}
+
+impl std::fmt::Display for QueryFragment<'_, '_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let argument_struct_param = if let Some(name) = &self.argument_struct_name {
+            format!(", argument_struct = \"{}\"", name)
+        } else {
+            "".to_string()
+        };
+
+        writeln!(f, "#[derive(cynic::QueryFragment, Debug)]")?;
+        writeln!(
+            f,
+            "#[cynic(graphql_type = \"{}\"{})]",
+            self.target_type, argument_struct_param
+        )?;
+        writeln!(f, "pub struct {} {{", self.name)?;
+        for field in &self.fields {
+            write!(indented(f, 4), "{}", field)?;
+        }
+
+        writeln!(f, "}}")
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub struct OutputField<'query, 'schema> {
+    pub name: &'schema str,
+    pub field_type: RustOutputFieldType,
+
+    pub arguments: Vec<FieldArgument<'query, 'schema>>,
+}
+
+impl std::fmt::Display for OutputField<'_, '_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if !self.arguments.is_empty() {
+            let arguments_string = self
+                .arguments
+                .iter()
+                .map(|arg| {
+                    Ok(format!(
+                        "{} = {}",
+                        arg.name.to_snake_case(),
+                        arg.to_literal()?
+                    ))
+                })
+                .collect::<Result<Vec<_>, Error>>()
+                // TODO: This unwrap needs ditched somehow...
+                .unwrap()
+                .join(", ");
+
+            writeln!(f, "#[arguments({})]", arguments_string)?;
+        }
+
+        writeln!(
+            f,
+            "pub {}: {},",
+            self.name.to_snake_case(),
+            self.field_type.type_spec()
+        )
+    }
+}
+
+/// An OutputFieldType that has been given a rust-land name.  Allows for
+/// the fact that there may be several rust structs that refer to the same schema
+/// type.
+#[derive(Debug, PartialEq)]
+pub enum RustOutputFieldType {
+    NamedType(String),
+    ListType(Box<RustOutputFieldType>),
+    NonNullType(Box<RustOutputFieldType>),
+}
+
+impl RustOutputFieldType {
+    pub fn from_schema_type(
+        schema_type: &OutputFieldType<'_>,
+        inner_name: String,
+    ) -> RustOutputFieldType {
+        match schema_type {
+            OutputFieldType::NonNullType(inner) => RustOutputFieldType::NonNullType(Box::new(
+                RustOutputFieldType::from_schema_type(inner, inner_name),
+            )),
+            OutputFieldType::ListType(inner) => RustOutputFieldType::ListType(Box::new(
+                RustOutputFieldType::from_schema_type(inner, inner_name),
+            )),
+            OutputFieldType::NamedType(_) => RustOutputFieldType::NamedType(inner_name),
+        }
+    }
+
+    pub fn type_spec(&self) -> String {
+        self.output_type_spec_imp(true)
+    }
+
+    fn output_type_spec_imp(&self, nullable: bool) -> String {
+        if let RustOutputFieldType::NonNullType(inner) = self {
+            return inner.output_type_spec_imp(false);
+        }
+
+        if nullable {
+            return format!("Option<{}>", self.output_type_spec_imp(false));
+        }
+
+        match self {
+            RustOutputFieldType::ListType(inner) => {
+                format!("Vec<{}>", inner.output_type_spec_imp(true))
+            }
+
+            RustOutputFieldType::NonNullType(_) => panic!("NonNullType somehow got past an if let"),
+
+            RustOutputFieldType::NamedType(s) => {
+                match s.as_ref() {
+                    "Int" => return "i32".into(),
+                    "Float" => return "f64".into(),
+                    "Boolean" => return "bool".into(),
+                    "ID" => return "cynic::Id".into(),
+                    _ => {}
+                }
+
+                s.clone()
+            }
+        }
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub struct FieldArgument<'query, 'schema> {
+    pub name: &'schema str,
+    value: TypedValue<'query, 'schema>,
+}
+
+impl<'query, 'schema> FieldArgument<'query, 'schema> {
+    pub fn new(name: &'schema str, value: TypedValue<'query, 'schema>) -> Self {
+        FieldArgument { name, value }
+    }
+
+    pub fn to_literal(&self) -> Result<String, Error> {
+        self.value.to_literal()
+    }
+}

--- a/cynic-querygen/src/query_parsing/arguments.rs
+++ b/cynic-querygen/src/query_parsing/arguments.rs
@@ -6,9 +6,9 @@ use std::{
 };
 use uuid::Uuid;
 
-use super::{
-    naming::{Nameable, Namer},
-    normalisation::{Field, NormalisedDocument, Selection, SelectionSet, Variable},
+use super::normalisation::{Field, NormalisedDocument, Selection, SelectionSet, Variable};
+use crate::{
+    naming::Namer,
     output::{ArgumentStruct, ArgumentStructField},
 };
 
@@ -107,7 +107,7 @@ impl<'query, 'schema, 'doc> SelectionArguments<'query, 'schema, 'doc> {
 
         let rv = Rc::new(ArgumentStruct {
             id: our_id,
-            name: format!("{}Arguments", self.target_selection.target_type.name()),
+            target_type_name: format!("{}Arguments", self.target_selection.target_type.name()),
             fields,
         });
 
@@ -195,11 +195,5 @@ impl<'query, 'schema, 'doc> ArgumentStructDetails<'query, 'schema, 'doc> {
     ) {
         self.lookup_args_for_selection(selection_set)
             .map(|arg_struct| self.namer.borrow_mut().force_name(arg_struct, name));
-    }
-}
-
-impl<'query, 'schema> Nameable for Rc<ArgumentStruct<'query, 'schema>> {
-    fn requested_name(&self) -> String {
-        self.name.clone()
     }
 }

--- a/cynic-querygen/src/query_parsing/leaf_types.rs
+++ b/cynic-querygen/src/query_parsing/leaf_types.rs
@@ -1,7 +1,8 @@
 //! Handles "leaf types" - i.e. enums & scalars that don't have any nested fields.
 
-use super::{inputs::InputObjectSet, normalisation::NormalisedDocument, output::Scalar};
+use super::{inputs::InputObjectSet, normalisation::NormalisedDocument};
 use crate::{
+    output::Scalar,
     schema::{EnumDetails, Type, TypeRef},
     Error,
 };

--- a/cynic-querygen/src/query_parsing/mod.rs
+++ b/cynic-querygen/src/query_parsing/mod.rs
@@ -3,19 +3,18 @@ use std::rc::Rc;
 mod arguments;
 mod inputs;
 mod leaf_types;
-mod naming;
 mod normalisation;
-mod output;
 mod parser;
 mod sorting;
 mod value;
 
 use arguments::ArgumentStructDetails;
-use naming::Namer;
-use output::Output;
 use parser::Document;
 
-use crate::{Error, TypeIndex};
+pub use normalisation::Variable;
+pub use value::TypedValue;
+
+use crate::{naming::Namer, output::Output, Error, TypeIndex};
 
 pub fn parse_query_document<'text>(
     doc: &Document<'text>,
@@ -66,9 +65,9 @@ fn make_query_fragment<'text>(
     selection: Rc<normalisation::SelectionSet<'text, 'text>>,
     namer: &mut Namer<Rc<normalisation::SelectionSet<'text, 'text>>>,
     argument_struct_details: &ArgumentStructDetails<'text, 'text, '_>,
-) -> Result<output::QueryFragment<'text, 'text>, Error> {
+) -> Result<crate::output::QueryFragment<'text, 'text>, Error> {
+    use crate::output::{FieldArgument, OutputField, QueryFragment, RustOutputFieldType};
     use normalisation::{Field, Selection};
-    use output::{FieldArgument, OutputField, QueryFragment, RustOutputFieldType};
 
     Ok(QueryFragment {
         fields: selection
@@ -108,8 +107,8 @@ fn make_query_fragment<'text>(
     })
 }
 
-fn make_input_object(input: Rc<inputs::InputObject>) -> Result<output::InputObject, Error> {
-    Ok(output::InputObject {
+fn make_input_object(input: Rc<inputs::InputObject>) -> Result<crate::output::InputObject, Error> {
+    Ok(crate::output::InputObject {
         name: input.schema_type.name.to_string(),
         fields: input.fields.clone(),
     })

--- a/cynic-querygen/src/query_parsing/mod.rs
+++ b/cynic-querygen/src/query_parsing/mod.rs
@@ -66,7 +66,9 @@ fn make_query_fragment<'text>(
     namer: &mut Namer<Rc<normalisation::SelectionSet<'text, 'text>>>,
     argument_struct_details: &ArgumentStructDetails<'text, 'text, '_>,
 ) -> Result<crate::output::QueryFragment<'text, 'text>, Error> {
-    use crate::output::{FieldArgument, OutputField, QueryFragment, RustOutputFieldType};
+    use crate::output::query_fragment::{
+        FieldArgument, OutputField, QueryFragment, RustOutputFieldType,
+    };
     use normalisation::{Field, Selection};
 
     Ok(QueryFragment {

--- a/cynic-querygen/src/query_parsing/normalisation.rs
+++ b/cynic-querygen/src/query_parsing/normalisation.rs
@@ -402,6 +402,12 @@ impl<'query, 'schema> SelectionSet<'query, 'schema> {
     }
 }
 
+impl<'query, 'schema> crate::naming::Nameable for Rc<SelectionSet<'query, 'schema>> {
+    fn requested_name(&self) -> String {
+        self.target_type.name().to_owned()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/cynic-querygen/tests/snapshots/github_tests__add_comment_mutation.snap
+++ b/cynic-querygen/tests/snapshots/github_tests__add_comment_mutation.snap
@@ -54,34 +54,34 @@ mod queries {
 )]
 mod types {
     #[derive(cynic::Scalar, Debug)]
-    pub struct Date(String);
+    pub struct Date(pub String);
 
     #[derive(cynic::Scalar, Debug)]
-    pub struct DateTime(String);
+    pub struct DateTime(pub String);
 
     #[derive(cynic::Scalar, Debug)]
-    pub struct GitObjectID(String);
+    pub struct GitObjectID(pub String);
 
     #[derive(cynic::Scalar, Debug)]
-    pub struct GitRefname(String);
+    pub struct GitRefname(pub String);
 
     #[derive(cynic::Scalar, Debug)]
-    pub struct GitSSHRemote(String);
+    pub struct GitSSHRemote(pub String);
 
     #[derive(cynic::Scalar, Debug)]
-    pub struct GitTimestamp(String);
+    pub struct GitTimestamp(pub String);
 
     #[derive(cynic::Scalar, Debug)]
-    pub struct Html(String);
+    pub struct Html(pub String);
 
     #[derive(cynic::Scalar, Debug)]
-    pub struct PreciseDateTime(String);
+    pub struct PreciseDateTime(pub String);
 
     #[derive(cynic::Scalar, Debug)]
-    pub struct Uri(String);
+    pub struct Uri(pub String);
 
     #[derive(cynic::Scalar, Debug)]
-    pub struct X509Certificate(String);
+    pub struct X509Certificate(pub String);
 
 }
 

--- a/cynic-querygen/tests/snapshots/github_tests__input_object_arguments.snap
+++ b/cynic-querygen/tests/snapshots/github_tests__input_object_arguments.snap
@@ -76,34 +76,34 @@ mod queries {
 )]
 mod types {
     #[derive(cynic::Scalar, Debug)]
-    pub struct Date(String);
+    pub struct Date(pub String);
 
     #[derive(cynic::Scalar, Debug)]
-    pub struct DateTime(String);
+    pub struct DateTime(pub String);
 
     #[derive(cynic::Scalar, Debug)]
-    pub struct GitObjectID(String);
+    pub struct GitObjectID(pub String);
 
     #[derive(cynic::Scalar, Debug)]
-    pub struct GitRefname(String);
+    pub struct GitRefname(pub String);
 
     #[derive(cynic::Scalar, Debug)]
-    pub struct GitSSHRemote(String);
+    pub struct GitSSHRemote(pub String);
 
     #[derive(cynic::Scalar, Debug)]
-    pub struct GitTimestamp(String);
+    pub struct GitTimestamp(pub String);
 
     #[derive(cynic::Scalar, Debug)]
-    pub struct Html(String);
+    pub struct Html(pub String);
 
     #[derive(cynic::Scalar, Debug)]
-    pub struct PreciseDateTime(String);
+    pub struct PreciseDateTime(pub String);
 
     #[derive(cynic::Scalar, Debug)]
-    pub struct Uri(String);
+    pub struct Uri(pub String);
 
     #[derive(cynic::Scalar, Debug)]
-    pub struct X509Certificate(String);
+    pub struct X509Certificate(pub String);
 
 }
 

--- a/cynic-querygen/tests/snapshots/github_tests__input_object_literals.snap
+++ b/cynic-querygen/tests/snapshots/github_tests__input_object_literals.snap
@@ -71,34 +71,34 @@ mod queries {
 )]
 mod types {
     #[derive(cynic::Scalar, Debug)]
-    pub struct Date(String);
+    pub struct Date(pub String);
 
     #[derive(cynic::Scalar, Debug)]
-    pub struct DateTime(String);
+    pub struct DateTime(pub String);
 
     #[derive(cynic::Scalar, Debug)]
-    pub struct GitObjectID(String);
+    pub struct GitObjectID(pub String);
 
     #[derive(cynic::Scalar, Debug)]
-    pub struct GitRefname(String);
+    pub struct GitRefname(pub String);
 
     #[derive(cynic::Scalar, Debug)]
-    pub struct GitSSHRemote(String);
+    pub struct GitSSHRemote(pub String);
 
     #[derive(cynic::Scalar, Debug)]
-    pub struct GitTimestamp(String);
+    pub struct GitTimestamp(pub String);
 
     #[derive(cynic::Scalar, Debug)]
-    pub struct Html(String);
+    pub struct Html(pub String);
 
     #[derive(cynic::Scalar, Debug)]
-    pub struct PreciseDateTime(String);
+    pub struct PreciseDateTime(pub String);
 
     #[derive(cynic::Scalar, Debug)]
-    pub struct Uri(String);
+    pub struct Uri(pub String);
 
     #[derive(cynic::Scalar, Debug)]
-    pub struct X509Certificate(String);
+    pub struct X509Certificate(pub String);
 
 }
 

--- a/cynic-querygen/tests/snapshots/github_tests__literal_enums.snap
+++ b/cynic-querygen/tests/snapshots/github_tests__literal_enums.snap
@@ -53,34 +53,34 @@ mod queries {
 )]
 mod types {
     #[derive(cynic::Scalar, Debug)]
-    pub struct Date(String);
+    pub struct Date(pub String);
 
     #[derive(cynic::Scalar, Debug)]
-    pub struct DateTime(String);
+    pub struct DateTime(pub String);
 
     #[derive(cynic::Scalar, Debug)]
-    pub struct GitObjectID(String);
+    pub struct GitObjectID(pub String);
 
     #[derive(cynic::Scalar, Debug)]
-    pub struct GitRefname(String);
+    pub struct GitRefname(pub String);
 
     #[derive(cynic::Scalar, Debug)]
-    pub struct GitSSHRemote(String);
+    pub struct GitSSHRemote(pub String);
 
     #[derive(cynic::Scalar, Debug)]
-    pub struct GitTimestamp(String);
+    pub struct GitTimestamp(pub String);
 
     #[derive(cynic::Scalar, Debug)]
-    pub struct Html(String);
+    pub struct Html(pub String);
 
     #[derive(cynic::Scalar, Debug)]
-    pub struct PreciseDateTime(String);
+    pub struct PreciseDateTime(pub String);
 
     #[derive(cynic::Scalar, Debug)]
-    pub struct Uri(String);
+    pub struct Uri(pub String);
 
     #[derive(cynic::Scalar, Debug)]
-    pub struct X509Certificate(String);
+    pub struct X509Certificate(pub String);
 
 }
 


### PR DESCRIPTION
#### Why are we making this change?

I'm working on fixing #157, which is going to involve putting some more logic
around the output of field names in the generator.  At the moment all the
output code happens in a single big function that interpolates strings and puts
them in a Vec of lines.  I threw the code together in a hurry at some point and
it could do with a tidy.

#### What effects does this change have?

This starts the process of tidying this code:

1. Adds a new output module for this code to live in, mostly moved from the
   query_parsing module of the same name.
2. Adds Display impls of most of the Output structs
3. Updates the output function to use std::fmt::Write & these Display impls
4. Provides an indent std::fmt::Write wrapper that handles indentation a bit
   better.
5. Refactors the ArgumentStruct code a little so the _actual_ name of the
   struct is contained within the output struct.