### PR TITLE
Explicitly rename InputObject fields in generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ all APIs might be changed.
 - Cynic derives (and cynic itself) no longer emit clippy warnings (on 1.48 at least)
 - We now support raw identifiers in QueryFragment derives, useful for fields
   named `type` or similar.
+- The generator now correctly renames InputObject fields & Enum variants if the
+  default `rename_all` doesn't work for them.
 
 ### Changes
 

--- a/cynic-querygen/src/output/enums.rs
+++ b/cynic-querygen/src/output/enums.rs
@@ -1,5 +1,7 @@
 use inflector::Inflector;
+use std::fmt::Write;
 
+use super::indented;
 use crate::schema::EnumDetails;
 
 impl std::fmt::Display for EnumDetails<'_> {
@@ -14,7 +16,15 @@ impl std::fmt::Display for EnumDetails<'_> {
         writeln!(f, "pub enum {} {{", type_name.to_pascal_case())?;
 
         for variant in &self.values {
-            writeln!(f, "    {},", variant.to_pascal_case())?;
+            let mut f = indented(f, 4);
+
+            if variant.to_pascal_case().to_screaming_snake_case() != *variant {
+                // If a pascal -> screaming snake casing roundtrip is not lossless
+                // we need to explicitly rename this variant
+                writeln!(f, "#[cynic(rename = \"{}\")]", variant)?;
+            }
+
+            writeln!(f, "{},", variant.to_pascal_case())?;
         }
         writeln!(f, "}}")
     }

--- a/cynic-querygen/src/output/input_object.rs
+++ b/cynic-querygen/src/output/input_object.rs
@@ -22,8 +22,16 @@ impl std::fmt::Display for InputObject<'_> {
         writeln!(f, "pub struct {} {{", self.name)?;
 
         for field in &self.fields {
+            let mut f = indented(f, 4);
+
+            if field.name.to_snake_case().to_camel_case() != field.name {
+                // If a snake -> camel casing roundtrip is not lossless
+                // we need to explicitly rename this field
+                writeln!(f, "#[cynic(rename = \"{}\")]", field.name)?;
+            }
+
             writeln!(
-                indented(f, 4),
+                f,
                 "pub {}: {},",
                 field.name.to_snake_case(),
                 field.type_spec()


### PR DESCRIPTION
#### Why are we making this change?

The generator defaults to putting a rename_all="camelCase" on InputObjects and then providing the field names in snake_case.  However some fields don't have an lossless snake_case -> camelCase conversion so this doesn't work.

#### What effects does this change have?

This updates the generator to put a rename on fields for which this is the case.

This PR doesn't include a test, but one will come in a future test when other issues are fixed.

Fixes #157 

#### Still to do

- [x] Update CHANGELOG
- [x] Probably need to check if this applies to enums (or QueryFragments) as well 