### PR TITLE
Deduplicate leaf types in generator.

### DIFF
--- a/cynic-querygen/src/query_parsing/leaf_types.rs
+++ b/cynic-querygen/src/query_parsing/leaf_types.rs
@@ -1,4 +1,5 @@
 //! Handles "leaf types" - i.e. enums & scalars that don't have any nested fields.
+use std::collections::HashSet;
 
 use super::{inputs::InputObjectSet, normalisation::NormalisedDocument};
 use crate::{
@@ -16,7 +17,7 @@ pub fn extract_leaf_types<'query, 'schema>(
         .iter()
         .flat_map(|selection_set| selection_set.leaf_output_types())
         .map(TypeRef::from)
-        .collect::<Vec<_>>();
+        .collect::<HashSet<_>>();
 
     leaf_types.extend(
         doc.selection_sets

--- a/cynic-querygen/tests/queries/github/literal-enums.graphql
+++ b/cynic-querygen/tests/queries/github/literal-enums.graphql
@@ -3,6 +3,7 @@ query {
     issues(states: OPEN, first: 10) {
       nodes {
         title
+        state
       }
     }
   }

--- a/cynic-querygen/tests/snapshots/github_tests__literal_enums.snap
+++ b/cynic-querygen/tests/snapshots/github_tests__literal_enums.snap
@@ -33,6 +33,7 @@ mod queries {
     #[cynic(graphql_type = "Issue")]
     pub struct Issue {
         pub title: String,
+        pub state: IssueState,
     }
 
     #[derive(cynic::Enum, Clone, Copy, Debug)]
@@ -88,4 +89,5 @@ mod query_dsl{
     use super::types::*;
     cynic::query_dsl!(r#"schema.graphql"#);
 }
+
 


### PR DESCRIPTION
#### Why are we making this change?

PR #141 rewrote a lot of the generator code, and was meant to put an end
to duplicate types being output.  However I forgot to dedupe leaf types
(enums & scalars) before writing them out.

#### What effects does this change have?

Puts the leaf TypeRefs into a HashSet before outputting them and makes
sure we have a test for this case.

Fixes #152 
