### PR TITLE
Make InputObject look scalars up in the correct place

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ all APIs might be changed.
   named `type` or similar.
 - The generator now correctly renames InputObject fields & Enum variants if the
   default `rename_all` doesn't work for them.
+- The `InputObject` derive no longer looks up scalars inside `query_dsl` (which
+  required them to be `pub use`d in `query_dsl`).
 
 ### Changes
 

--- a/cynic-codegen/src/input_object_derive/field_serializer.rs
+++ b/cynic-codegen/src/input_object_derive/field_serializer.rs
@@ -6,7 +6,7 @@ use super::InputObjectDeriveField;
 use crate::{
     schema::InputValue,
     type_validation::{check_types_are_compatible, CheckMode},
-    FieldType, Ident, TypeIndex,
+    FieldType, Ident, TypeIndex, TypePath,
 };
 
 pub struct FieldSerializer<'a> {
@@ -63,7 +63,7 @@ impl<'a> FieldSerializer<'a> {
         let generic_param = self.graphql_field_type.generic_parameter(Ident::new("T"));
         let arg_type = self.graphql_field_type.to_tokens(
             generic_param.as_ref().map(|p| p.name.clone()),
-            self.query_module.clone().into(),
+            TypePath::empty(),
         );
 
         let rust_field_name = &self.rust_field.ident;


### PR DESCRIPTION
#### Why are we making this change?

The InputObject derive outputs some type checking functions. As part of this
it needs to use parameter types in two ways. First it needs to use the field
type taken from the InputObject itself. Second it needs to use the typelock
type defined in the `query_dsl` to provide generic bounds.

The typelock needs to be taken from `query_dsl`, but the literal field type
does not.  I messed up writing this code though and the literal field type was
pulled from the query_dsl.

#### What effects does this change have?

Updates the InputObject derive to only pull the typelock from the query_dsl.

No test as I have a test locally that still doesn't work - will commit it once
I finish fixing issues.

Fixes #139