### PR TITLE
Make ValueType::to_literal context aware.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ all APIs might be changed.
   attribute on fields that recurse.
 - The generator now understands query fragments, spreads and inline fragment
   spreads. Inline fragments for interface/union types are not yet supported.
-- Interfaces can be queried via `#[derive(InlineFragments)]` on an enum.  
+- Interfaces can be queried via `#[derive(InlineFragments)]` on an enum.
 
 ### Bug Fixes
 
@@ -43,6 +43,8 @@ all APIs might be changed.
   default `rename_all` doesn't work for them.
 - The `InputObject` derive no longer looks up scalars inside `query_dsl` (which
   required them to be `pub use`d in `query_dsl`).
+- The generator is now context aware with argument values, and does a better job
+  of figuring out whether to clone or take by reference.
 
 ### Changes
 
@@ -58,6 +60,8 @@ all APIs might be changed.
     arguments is used in multiple queries. Though the correct IntoArgument impl
     is not yet generated.
 - The generator now generates scalars with public fields
+- The generator now derives `Clone` on scalars as certain positions they can
+  appear in require cloning
 
 ## v0.10.1 - 2020-11-04
 

--- a/cynic-querygen/src/lib.rs
+++ b/cynic-querygen/src/lib.rs
@@ -135,7 +135,7 @@ pub fn document_to_fragment_structs(
     // so we're parsing this out from schema.definitons rather than output.scalars
     for def in &schema.definitions {
         if let schema::Definition::TypeDefinition(schema::TypeDefinition::Scalar(scalar)) = def {
-            writeln!(output, "    #[derive(cynic::Scalar, Debug)]").unwrap();
+            writeln!(output, "    #[derive(cynic::Scalar, Debug, Clone)]").unwrap();
             writeln!(
                 output,
                 "    pub struct {}(pub String);\n",

--- a/cynic-querygen/src/output/query_fragment.rs
+++ b/cynic-querygen/src/output/query_fragment.rs
@@ -148,6 +148,8 @@ impl<'query, 'schema> FieldArgument<'query, 'schema> {
     }
 
     pub fn to_literal(&self) -> Result<String, Error> {
-        self.value.to_literal()
+        use crate::query_parsing::LiteralContext;
+
+        self.value.to_literal(LiteralContext::Argument)
     }
 }

--- a/cynic-querygen/src/query_parsing/mod.rs
+++ b/cynic-querygen/src/query_parsing/mod.rs
@@ -12,7 +12,7 @@ use arguments::ArgumentStructDetails;
 use parser::Document;
 
 pub use normalisation::Variable;
-pub use value::TypedValue;
+pub use value::{LiteralContext, TypedValue};
 
 use crate::{naming::Namer, output::Output, Error, TypeIndex};
 

--- a/cynic-querygen/src/schema/mod.rs
+++ b/cynic-querygen/src/schema/mod.rs
@@ -138,6 +138,24 @@ impl<'schema> OutputType<'schema> {
     }
 }
 
+impl<'schema> InputType<'schema> {
+    /// Checks whether it's safe to assume an InputType is Copy
+    ///
+    /// This might give false negatives for user defined scalars,
+    /// but not much that can be done about that...
+    pub fn is_definitely_copy(&self) -> bool {
+        match self {
+            InputType::InputObject(_) => false,
+            InputType::Enum(_) => true,
+            InputType::Scalar(details) => details.name == "Int" || details.name == "Boolean",
+        }
+    }
+
+    pub fn is_input_object(&self) -> bool {
+        matches!(self, InputType::InputObject(_))
+    }
+}
+
 impl<'schema> TryFrom<Type<'schema>> for InputType<'schema> {
     type Error = Error;
 

--- a/cynic-querygen/tests/snapshots/github_tests__add_comment_mutation.snap
+++ b/cynic-querygen/tests/snapshots/github_tests__add_comment_mutation.snap
@@ -53,34 +53,34 @@ mod queries {
     query_module = "query_dsl",
 )]
 mod types {
-    #[derive(cynic::Scalar, Debug)]
+    #[derive(cynic::Scalar, Debug, Clone)]
     pub struct Date(pub String);
 
-    #[derive(cynic::Scalar, Debug)]
+    #[derive(cynic::Scalar, Debug, Clone)]
     pub struct DateTime(pub String);
 
-    #[derive(cynic::Scalar, Debug)]
+    #[derive(cynic::Scalar, Debug, Clone)]
     pub struct GitObjectID(pub String);
 
-    #[derive(cynic::Scalar, Debug)]
+    #[derive(cynic::Scalar, Debug, Clone)]
     pub struct GitRefname(pub String);
 
-    #[derive(cynic::Scalar, Debug)]
+    #[derive(cynic::Scalar, Debug, Clone)]
     pub struct GitSSHRemote(pub String);
 
-    #[derive(cynic::Scalar, Debug)]
+    #[derive(cynic::Scalar, Debug, Clone)]
     pub struct GitTimestamp(pub String);
 
-    #[derive(cynic::Scalar, Debug)]
+    #[derive(cynic::Scalar, Debug, Clone)]
     pub struct Html(pub String);
 
-    #[derive(cynic::Scalar, Debug)]
+    #[derive(cynic::Scalar, Debug, Clone)]
     pub struct PreciseDateTime(pub String);
 
-    #[derive(cynic::Scalar, Debug)]
+    #[derive(cynic::Scalar, Debug, Clone)]
     pub struct Uri(pub String);
 
-    #[derive(cynic::Scalar, Debug)]
+    #[derive(cynic::Scalar, Debug, Clone)]
     pub struct X509Certificate(pub String);
 
 }
@@ -89,4 +89,5 @@ mod query_dsl{
     use super::types::*;
     cynic::query_dsl!(r#"schema.graphql"#);
 }
+
 

--- a/cynic-querygen/tests/snapshots/github_tests__input_object_arguments.snap
+++ b/cynic-querygen/tests/snapshots/github_tests__input_object_arguments.snap
@@ -75,34 +75,34 @@ mod queries {
     query_module = "query_dsl",
 )]
 mod types {
-    #[derive(cynic::Scalar, Debug)]
+    #[derive(cynic::Scalar, Debug, Clone)]
     pub struct Date(pub String);
 
-    #[derive(cynic::Scalar, Debug)]
+    #[derive(cynic::Scalar, Debug, Clone)]
     pub struct DateTime(pub String);
 
-    #[derive(cynic::Scalar, Debug)]
+    #[derive(cynic::Scalar, Debug, Clone)]
     pub struct GitObjectID(pub String);
 
-    #[derive(cynic::Scalar, Debug)]
+    #[derive(cynic::Scalar, Debug, Clone)]
     pub struct GitRefname(pub String);
 
-    #[derive(cynic::Scalar, Debug)]
+    #[derive(cynic::Scalar, Debug, Clone)]
     pub struct GitSSHRemote(pub String);
 
-    #[derive(cynic::Scalar, Debug)]
+    #[derive(cynic::Scalar, Debug, Clone)]
     pub struct GitTimestamp(pub String);
 
-    #[derive(cynic::Scalar, Debug)]
+    #[derive(cynic::Scalar, Debug, Clone)]
     pub struct Html(pub String);
 
-    #[derive(cynic::Scalar, Debug)]
+    #[derive(cynic::Scalar, Debug, Clone)]
     pub struct PreciseDateTime(pub String);
 
-    #[derive(cynic::Scalar, Debug)]
+    #[derive(cynic::Scalar, Debug, Clone)]
     pub struct Uri(pub String);
 
-    #[derive(cynic::Scalar, Debug)]
+    #[derive(cynic::Scalar, Debug, Clone)]
     pub struct X509Certificate(pub String);
 
 }
@@ -111,4 +111,5 @@ mod query_dsl{
     use super::types::*;
     cynic::query_dsl!(r#"schema.graphql"#);
 }
+
 

--- a/cynic-querygen/tests/snapshots/github_tests__input_object_literals.snap
+++ b/cynic-querygen/tests/snapshots/github_tests__input_object_literals.snap
@@ -70,34 +70,34 @@ mod queries {
     query_module = "query_dsl",
 )]
 mod types {
-    #[derive(cynic::Scalar, Debug)]
+    #[derive(cynic::Scalar, Debug, Clone)]
     pub struct Date(pub String);
 
-    #[derive(cynic::Scalar, Debug)]
+    #[derive(cynic::Scalar, Debug, Clone)]
     pub struct DateTime(pub String);
 
-    #[derive(cynic::Scalar, Debug)]
+    #[derive(cynic::Scalar, Debug, Clone)]
     pub struct GitObjectID(pub String);
 
-    #[derive(cynic::Scalar, Debug)]
+    #[derive(cynic::Scalar, Debug, Clone)]
     pub struct GitRefname(pub String);
 
-    #[derive(cynic::Scalar, Debug)]
+    #[derive(cynic::Scalar, Debug, Clone)]
     pub struct GitSSHRemote(pub String);
 
-    #[derive(cynic::Scalar, Debug)]
+    #[derive(cynic::Scalar, Debug, Clone)]
     pub struct GitTimestamp(pub String);
 
-    #[derive(cynic::Scalar, Debug)]
+    #[derive(cynic::Scalar, Debug, Clone)]
     pub struct Html(pub String);
 
-    #[derive(cynic::Scalar, Debug)]
+    #[derive(cynic::Scalar, Debug, Clone)]
     pub struct PreciseDateTime(pub String);
 
-    #[derive(cynic::Scalar, Debug)]
+    #[derive(cynic::Scalar, Debug, Clone)]
     pub struct Uri(pub String);
 
-    #[derive(cynic::Scalar, Debug)]
+    #[derive(cynic::Scalar, Debug, Clone)]
     pub struct X509Certificate(pub String);
 
 }
@@ -106,4 +106,5 @@ mod query_dsl{
     use super::types::*;
     cynic::query_dsl!(r#"schema.graphql"#);
 }
+
 

--- a/cynic-querygen/tests/snapshots/github_tests__literal_enums.snap
+++ b/cynic-querygen/tests/snapshots/github_tests__literal_enums.snap
@@ -53,34 +53,34 @@ mod queries {
     query_module = "query_dsl",
 )]
 mod types {
-    #[derive(cynic::Scalar, Debug)]
+    #[derive(cynic::Scalar, Debug, Clone)]
     pub struct Date(pub String);
 
-    #[derive(cynic::Scalar, Debug)]
+    #[derive(cynic::Scalar, Debug, Clone)]
     pub struct DateTime(pub String);
 
-    #[derive(cynic::Scalar, Debug)]
+    #[derive(cynic::Scalar, Debug, Clone)]
     pub struct GitObjectID(pub String);
 
-    #[derive(cynic::Scalar, Debug)]
+    #[derive(cynic::Scalar, Debug, Clone)]
     pub struct GitRefname(pub String);
 
-    #[derive(cynic::Scalar, Debug)]
+    #[derive(cynic::Scalar, Debug, Clone)]
     pub struct GitSSHRemote(pub String);
 
-    #[derive(cynic::Scalar, Debug)]
+    #[derive(cynic::Scalar, Debug, Clone)]
     pub struct GitTimestamp(pub String);
 
-    #[derive(cynic::Scalar, Debug)]
+    #[derive(cynic::Scalar, Debug, Clone)]
     pub struct Html(pub String);
 
-    #[derive(cynic::Scalar, Debug)]
+    #[derive(cynic::Scalar, Debug, Clone)]
     pub struct PreciseDateTime(pub String);
 
-    #[derive(cynic::Scalar, Debug)]
+    #[derive(cynic::Scalar, Debug, Clone)]
     pub struct Uri(pub String);
 
-    #[derive(cynic::Scalar, Debug)]
+    #[derive(cynic::Scalar, Debug, Clone)]
     pub struct X509Certificate(pub String);
 
 }

--- a/tests/querygen-compile-run/build.rs
+++ b/tests/querygen-compile-run/build.rs
@@ -108,6 +108,16 @@ fn main() {
             "../../cynic-querygen/tests/queries/github/input-object-literals.graphql",
             r#"queries::PullRequestTitles::fragment(FragmentContext::empty())"#,
         ),
+        TestCase::mutation(
+            &github_schema,
+            "tests/queries/github/scalar-inside-input-object.graphql",
+            r#"queries::AddPRComment::fragment(FragmentContext::new(
+                &queries::AddPRCommentArguments{
+                    body: "hello!".into(),
+                    commit: crate::types::GitObjectID("abcd".into())
+                }
+            ))"#,
+        ),
         /*
         TestCase::query_norun(
             &github_schema,

--- a/tests/querygen-compile-run/tests/queries/github/scalar-inside-input-object.graphql
+++ b/tests/querygen-compile-run/tests/queries/github/scalar-inside-input-object.graphql
@@ -1,0 +1,7 @@
+mutation AddPRComment($body: String!, $commit: GitObjectID!) {
+  addPullRequestReviewComment(input: { body: $body, commitOID: $commit }) {
+    comment {
+      bodyText
+    }
+  }
+}


### PR DESCRIPTION
#### Why are we making this change?

The generator was previously unware of the context in which it was printling
literal values.  This is an issue, because the correct thing to do depends
heavily on context: required arguments usually need cloned, optional arguments
are safe to be referenced but not if they're inside an object literal etc.

#### What effects does this change have?

This updates the `TypedValue::to_literal` function with a concept of the
context the literal is being printed in, and does a much more thorough job of
printing variables correctly within these contexts.

There was no issue that tracked this specifically.

This fixes #140 as we now have a test that includes a scalar inside an
InputObject (and are deriving Clone on scalars). This test also covers the
fixes in #160 #161, #162.