### PR TITLE
Added support for chrono::NaiveDate scalars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ all APIs might be changed.
 - The generator now understands query fragments, spreads and inline fragment
   spreads. Inline fragments for interface/union types are not yet supported.
 - Interfaces can be queried via `#[derive(InlineFragments)]` on an enum.
+- Added support for using chrono::NaiveDate as scalars. The decode/encode
+  functions will convert to/from dates in the ISO 8601 format, that is
+  `YYYY-MM-DD`
 
 ### Bug Fixes
 

--- a/cynic/src/integrations/chrono.rs
+++ b/cynic/src/integrations/chrono.rs
@@ -1,7 +1,24 @@
-use chrono::{DateTime, FixedOffset, Utc};
+use chrono::{DateTime, FixedOffset, Utc, NaiveDate};
 use json_decode::DecodeError;
 
 use crate::{scalar::Scalar, SerializeError};
+
+impl Scalar for NaiveDate {
+    fn decode(value: &serde_json::Value) -> Result<Self, DecodeError> {
+        match value {
+            serde_json::Value::String(s) => Ok(NaiveDate::parse_from_str(s, "%Y-%m-%d")
+                .map_err(chrono_decode_error)?),
+            _ => Err(DecodeError::IncorrectType(
+                "String".to_string(),
+                value.to_string(),
+            )),
+        }
+    }
+
+    fn encode(&self) -> Result<serde_json::Value, SerializeError> {
+        Ok(serde_json::Value::String(self.format("%Y-%m-%d").to_string()))
+    }
+}
 
 impl Scalar for DateTime<FixedOffset> {
     fn decode(value: &serde_json::Value) -> Result<Self, DecodeError> {
@@ -67,5 +84,14 @@ mod tests {
             .and_hms(10, 15, 20);
 
         assert_eq!(DateTime::decode(&datetime.encode().unwrap()), Ok(datetime));
+    }
+
+    #[test]
+    fn test_naive_date_scalar() {
+        use chrono::NaiveDate;
+
+        let date: NaiveDate = NaiveDate::from_ymd(2020, 12, 29);
+
+        assert_eq!(NaiveDate::decode(&date.encode().unwrap()), Ok(date));
     }
 }

--- a/cynic/src/integrations/chrono.rs
+++ b/cynic/src/integrations/chrono.rs
@@ -1,4 +1,4 @@
-use chrono::{DateTime, FixedOffset, Utc, NaiveDate};
+use chrono::{DateTime, FixedOffset, NaiveDate, Utc};
 use json_decode::DecodeError;
 
 use crate::{scalar::Scalar, SerializeError};
@@ -6,8 +6,9 @@ use crate::{scalar::Scalar, SerializeError};
 impl Scalar for NaiveDate {
     fn decode(value: &serde_json::Value) -> Result<Self, DecodeError> {
         match value {
-            serde_json::Value::String(s) => Ok(NaiveDate::parse_from_str(s, "%Y-%m-%d")
-                .map_err(chrono_decode_error)?),
+            serde_json::Value::String(s) => {
+                Ok(NaiveDate::parse_from_str(s, "%Y-%m-%d").map_err(chrono_decode_error)?)
+            }
             _ => Err(DecodeError::IncorrectType(
                 "String".to_string(),
                 value.to_string(),
@@ -16,7 +17,9 @@ impl Scalar for NaiveDate {
     }
 
     fn encode(&self) -> Result<serde_json::Value, SerializeError> {
-        Ok(serde_json::Value::String(self.format("%Y-%m-%d").to_string()))
+        Ok(serde_json::Value::String(
+            self.format("%Y-%m-%d").to_string(),
+        ))
     }
 }
 


### PR DESCRIPTION
#### Why are we making this change?

Added a scalar implementation for chrono::NaiveDate which is a date with no timezone info. There was no date scalars yet only datetime.

#### What effects does this change have?

Its a pretty minor change. It takes care of converting you ISO 8601 formatted dates into chrono::NaiveDate type instead of having to convert them from strings yourself. 
