### PR TITLE
Implement list & option coercion in generator.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,8 @@ all APIs might be changed.
 - The generator now generates scalars with public fields
 - The generator now derives `Clone` on scalars as certain positions they can
   appear in require cloning
+- The generator now outputs correct Rust code when faced with queries that rely
+  on list coercion.
 
 ## v0.10.1 - 2020-11-04
 

--- a/cynic-querygen/src/schema/fields.rs
+++ b/cynic-querygen/src/schema/fields.rs
@@ -120,6 +120,14 @@ impl<'schema> InputFieldType<'schema> {
         }
     }
 
+    pub fn contains_list(&self) -> bool {
+        match self {
+            InputFieldType::NonNullType(inner) => inner.contains_list(),
+            InputFieldType::NamedType(_) => false,
+            InputFieldType::ListType(_) => true,
+        }
+    }
+
     pub fn is_required(&self) -> bool {
         matches!(self, InputFieldType::NonNullType(_))
     }

--- a/cynic-querygen/src/schema/type_refs.rs
+++ b/cynic-querygen/src/schema/type_refs.rs
@@ -54,6 +54,15 @@ macro_rules! impl_type_ref {
                 }
             }
 
+            #[cfg(test)]
+            #[allow(dead_code)]
+            pub fn test_ref(type_name: String, type_index: &Rc<TypeIndex<'schema>>) -> Self {
+                Self {
+                    type_name: Cow::Owned(type_name),
+                    type_index: Rc::clone(type_index),
+                }
+            }
+
             #[allow(dead_code)]
             pub fn lookup(&self) -> Result<$lookup_type<'schema>, Error> {
                 Ok(self.type_index.lookup_type(&self.type_name)?.try_into()?)

--- a/cynic-querygen/tests/queries/github/literal-enums.graphql
+++ b/cynic-querygen/tests/queries/github/literal-enums.graphql
@@ -1,4 +1,4 @@
-query {
+query RepoIssues {
   repository(owner: "obmarg", name: "cynic") {
     issues(states: OPEN, first: 10) {
       nodes {

--- a/cynic-querygen/tests/snapshots/github_tests__literal_enums.snap
+++ b/cynic-querygen/tests/snapshots/github_tests__literal_enums.snap
@@ -11,7 +11,7 @@ mod queries {
 
     #[derive(cynic::QueryFragment, Debug)]
     #[cynic(graphql_type = "Query")]
-    pub struct UnnamedQuery {
+    pub struct RepoIssues {
         #[arguments(owner = "obmarg".into(), name = "cynic".into())]
         pub repository: Option<Repository>,
     }
@@ -19,7 +19,7 @@ mod queries {
     #[derive(cynic::QueryFragment, Debug)]
     #[cynic(graphql_type = "Repository")]
     pub struct Repository {
-        #[arguments(states = IssueState::Open, first = 10)]
+        #[arguments(states = Some(vec![IssueState::Open]), first = 10)]
         pub issues: IssueConnection,
     }
 

--- a/tests/querygen-compile-run/build.rs
+++ b/tests/querygen-compile-run/build.rs
@@ -118,13 +118,11 @@ fn main() {
                 }
             ))"#,
         ),
-        /*
         TestCase::query_norun(
             &github_schema,
             "../../cynic-querygen/tests/queries/github/literal-enums.graphql",
-            r#"queries::Query::fragment(())"#,
+            r#"queries::RepoIssues::fragment(FragmentContext::empty())"#,
         ),
-        */
     ];
 
     for case in cases {


### PR DESCRIPTION
#### Why are we making this change?

GraphQL has the concept of coercion for list inputs: if a type expects a list
you can provide a single element of that list and the GraphQL server should
treat it like a list with a single element.  Similarly, GraphQL doesn't have
explicit option types so any Option<T> field in GraphQL is happy to accept a
literal T.

For option coercion I've implemented the `IntoArguments` trait: any field that
expects an Option<T> is happy to accept a `T` because there's often an
`IntoArguments<Option<T>> for T`.  I'd have liked to extend this to lists, but
unfortunately rust starts running into type inference problems when I do this.

#### What effects does this change have?

Updates the generator to correctly wrap variables & list types in lists when
required and also to cover for a couple of other places where option coercion
doesn't quite work.  This should mean that users can provide queries that rely
on list coercion to the generator and it will still output working rust.

Fixes #106 