### PR TITLE
Set defaults for rename_all

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@ all APIs might be changed.
 - GraphQL fields with names that match rust keywords will no longer be
   postfixed with a `_` - you should now use a raw identifier (or rename) for
   these fields.
+- Derived `Enums` now default to `rename_all = "SCREAMING_SNAKE_CASE"` if not
+  provided. To revert to the old behaviour you should explicitly provide "None"
+- Derived `InputObjects` now default to `rename_all = "camelCase" if not
+  provided. To revert to the old behaviour you should explicitly provide "None"
+- Removed the `kebab-case` & `SCREAMING-KEBAB-CASE` rename_all rules - fairly
+  sure kebab case is not valid in GraphQL so this shouldn't affect much.
 
 ### New Features
 
@@ -67,6 +73,7 @@ all APIs might be changed.
   appear in require cloning
 - The generator now outputs correct Rust code when faced with queries that rely
   on list coercion.
+- "rename_all" attribute is no longer case sensitive.
 
 ## v0.10.1 - 2020-11-04
 

--- a/cynic-book/src/derives/enums.md
+++ b/cynic-book/src/derives/enums.md
@@ -17,7 +17,7 @@ The derive will work on any enum that only has unit variants that match up with
 the variants on the enum in the schema. If there are any extra or missing
 variants, the derive will emit errors.
 
-#### Struct Attributes
+#### Enum Attributes
 
 An Enum can be configured with several attributes on the enum itself:
 

--- a/cynic-book/src/derives/enums.md
+++ b/cynic-book/src/derives/enums.md
@@ -8,8 +8,8 @@ an enum, and the easiest way to define that trait is to derive it:
 #[derive(cynic::Enum, Clone, Copy, Debug)]
 #[cynic(graphql_type = "Market")]
 pub enum Market {
-    UK,
-    IE,
+    Uk,
+    Ie,
 }
 ```
 
@@ -17,8 +17,23 @@ The derive will work on any enum that only has unit variants that match up with
 the variants on the enum in the schema. If there are any extra or missing
 variants, the derive will emit errors.
 
-By default the variant names are expected to match the GraphQL variants
-exactly, but this can be controlled with either the `rename_all` top level
-parametr or the rename variant parameter.
+#### Struct Attributes
+
+An Enum can be configured with several attributes on the enum itself:
+
+- `graphql_type = "AType"` is required and tells cynic which type in the
+  GraphQL schema to map this enum to
+- `rename_all="camelCase"` tells cynic to rename all the rust field names with
+  a particular rule to match their GraphQL counterparts. If not provided this
+  defaults to `SCREAMING_SNAKE_CASE` to be consistent with GraphQL conventions.
+
+<!-- TODO: list of the rename rules, possibly pulled from codegen docs -->
+
+#### Field Attributes
+
+Each field can also have it's own attributes:
+
+- `rename="SOME_VARIANT"` can be used to map a variant to a completely
+  different GraphQL variant name.
 
 <!-- TODO: example of the above?  Better wording -->

--- a/cynic-book/src/derives/input-objects.md
+++ b/cynic-book/src/derives/input-objects.md
@@ -6,7 +6,7 @@ input object and the easiest way to define that trait is to derive it:
 
 ```rust
 #[derive(cynic::InputObject, Clone, Debug)]
-#[cynic(graphql_type = "IssueOrder", rename_all = "camelCase")]
+#[cynic(graphql_type = "IssueOrder")]
 pub struct IssueOrder {
     pub direction: OrderDirection,
     pub field: IssueOrderField,
@@ -39,19 +39,21 @@ An InputObject can be configured with several attributes on the struct itself:
 
 - `graphql_type = "AType"` is required and tells cynic which type in the
   GraphQL schema to map this struct to
-- `rename_all="camelCase"` tells cynic to rename all the rust field names with a particular
-  rule to match their GraphQL counterparts. Typically this would be set to
-  `camelCase` but others are supported.
 - `require_all_fields` can be provided when you want cynic to make sure your
   struct has all of the fields defined in the GraphQL schema.
+- `rename_all="camelCase"` tells cynic to rename all the rust field names with
+  a particular rule to match their GraphQL counterparts. If not provided this
+  defaults to camelCase to be consistent with GraphQL conventions.
+
+<!-- TODO: list of the rename rules, possibly pulled from codegen docs -->
 
 #### Field Attributes
 
 Each field can also have it's own attributes:
 
-- `rename="someFieldName"` can be used to map a field to a completely different
-  GraphQL field name.
+- `rename="someFieldName"` can be used to map a field to a completely
+  different GraphQL field name.
 - `skip_serializing_if="path"` can be used on optional fields to skip
-  serializing them.  By default an `Option` field will be sent as `null` to
+  serializing them. By default an `Option` field will be sent as `null` to
   servers, but if you provide `skip_serializing_if="Option::is_none"` then the
   field will not be provided at all.

--- a/cynic-codegen/src/input_object_derive/mod.rs
+++ b/cynic-codegen/src/input_object_derive/mod.rs
@@ -59,6 +59,8 @@ pub fn input_object_derive_impl(
 
     let type_index = TypeIndex::for_schema(&schema);
 
+    let rename_all = input.rename_all.unwrap_or(RenameAll::CamelCase);
+
     if let darling::ast::Data::Struct(fields) = &input.data {
         let ident = &input.ident;
         let input_marker_ident = Ident::for_type(&*input.graphql_type);
@@ -69,7 +71,7 @@ pub fn input_object_derive_impl(
             &fields.fields,
             input_object_def,
             &input_object_name,
-            input.rename_all,
+            rename_all,
             input.require_all_fields,
             &struct_span,
         ) {
@@ -142,7 +144,7 @@ fn join_fields<'a>(
     fields: &'a [InputObjectDeriveField],
     input_object_def: &'a InputObjectType,
     input_object_name: &str,
-    rename_all: Option<RenameAll>,
+    rename_all: RenameAll,
     require_all_fields: bool,
     struct_span: &Span,
 ) -> Result<Vec<(&'a InputObjectDeriveField, &'a InputValue)>, TokenStream> {
@@ -271,7 +273,7 @@ mod test {
             &fields,
             &input_object,
             "MyInputObject",
-            None,
+            RenameAll::None,
             true,
             &Span::call_site(),
         );
@@ -293,7 +295,7 @@ mod test {
             &fields,
             &input_object,
             "MyInputObject",
-            None,
+            RenameAll::None,
             false,
             &Span::call_site(),
         );
@@ -315,7 +317,7 @@ mod test {
             &fields,
             &input_object,
             "MyInputObject",
-            None,
+            RenameAll::None,
             false,
             &Span::call_site(),
         );

--- a/cynic-codegen/src/lib.rs
+++ b/cynic-codegen/src/lib.rs
@@ -18,6 +18,8 @@ mod type_index;
 mod type_path;
 mod type_validation;
 
+pub use ident::RenameAll;
+
 use error::Errors;
 use field_argument::FieldArgument;
 use field_type::FieldType;

--- a/cynic-querygen/src/output/enums.rs
+++ b/cynic-querygen/src/output/enums.rs
@@ -9,10 +9,7 @@ impl std::fmt::Display for EnumDetails<'_> {
         let type_name = self.name;
 
         writeln!(f, "#[derive(cynic::Enum, Clone, Copy, Debug)]")?;
-        writeln!(f, "#[cynic(")?;
-        writeln!(f, "    graphql_type = \"{}\",", type_name)?;
-        writeln!(f, "    rename_all = \"SCREAMING_SNAKE_CASE\"")?;
-        writeln!(f, ")]")?;
+        writeln!(f, "#[cynic(graphql_type = \"{}\")]", type_name)?;
         writeln!(f, "pub enum {} {{", type_name.to_pascal_case())?;
 
         for variant in &self.values {

--- a/cynic-querygen/src/output/input_object.rs
+++ b/cynic-querygen/src/output/input_object.rs
@@ -14,11 +14,7 @@ pub struct InputObject<'schema> {
 impl std::fmt::Display for InputObject<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         writeln!(f, "#[derive(cynic::InputObject, Debug)]")?;
-        writeln!(
-            f,
-            "#[cynic(graphql_type = \"{}\", rename_all=\"camelCase\")]",
-            self.name
-        )?;
+        writeln!(f, "#[cynic(graphql_type = \"{}\")]", self.name)?;
         writeln!(f, "pub struct {} {{", self.name)?;
 
         for field in &self.fields {

--- a/cynic-querygen/tests/snapshots/github_tests__add_comment_mutation.snap
+++ b/cynic-querygen/tests/snapshots/github_tests__add_comment_mutation.snap
@@ -40,7 +40,7 @@ mod queries {
     }
 
     #[derive(cynic::InputObject, Debug)]
-    #[cynic(graphql_type = "AddCommentInput", rename_all="camelCase")]
+    #[cynic(graphql_type = "AddCommentInput")]
     pub struct AddCommentInput {
         pub body: String,
         pub subject_id: cynic::Id,

--- a/cynic-querygen/tests/snapshots/github_tests__input_object_arguments.snap
+++ b/cynic-querygen/tests/snapshots/github_tests__input_object_arguments.snap
@@ -41,10 +41,7 @@ mod queries {
     }
 
     #[derive(cynic::Enum, Clone, Copy, Debug)]
-    #[cynic(
-        graphql_type = "IssueOrderField",
-        rename_all = "SCREAMING_SNAKE_CASE"
-    )]
+    #[cynic(graphql_type = "IssueOrderField")]
     pub enum IssueOrderField {
         Comments,
         CreatedAt,
@@ -52,17 +49,14 @@ mod queries {
     }
 
     #[derive(cynic::Enum, Clone, Copy, Debug)]
-    #[cynic(
-        graphql_type = "OrderDirection",
-        rename_all = "SCREAMING_SNAKE_CASE"
-    )]
+    #[cynic(graphql_type = "OrderDirection")]
     pub enum OrderDirection {
         Asc,
         Desc,
     }
 
     #[derive(cynic::InputObject, Debug)]
-    #[cynic(graphql_type = "IssueOrder", rename_all="camelCase")]
+    #[cynic(graphql_type = "IssueOrder")]
     pub struct IssueOrder {
         pub direction: OrderDirection,
         pub field: IssueOrderField,

--- a/cynic-querygen/tests/snapshots/github_tests__input_object_literals.snap
+++ b/cynic-querygen/tests/snapshots/github_tests__input_object_literals.snap
@@ -36,10 +36,7 @@ mod queries {
     }
 
     #[derive(cynic::Enum, Clone, Copy, Debug)]
-    #[cynic(
-        graphql_type = "IssueOrderField",
-        rename_all = "SCREAMING_SNAKE_CASE"
-    )]
+    #[cynic(graphql_type = "IssueOrderField")]
     pub enum IssueOrderField {
         Comments,
         CreatedAt,
@@ -47,17 +44,14 @@ mod queries {
     }
 
     #[derive(cynic::Enum, Clone, Copy, Debug)]
-    #[cynic(
-        graphql_type = "OrderDirection",
-        rename_all = "SCREAMING_SNAKE_CASE"
-    )]
+    #[cynic(graphql_type = "OrderDirection")]
     pub enum OrderDirection {
         Asc,
         Desc,
     }
 
     #[derive(cynic::InputObject, Debug)]
-    #[cynic(graphql_type = "IssueOrder", rename_all="camelCase")]
+    #[cynic(graphql_type = "IssueOrder")]
     pub struct IssueOrder {
         pub direction: OrderDirection,
         pub field: IssueOrderField,

--- a/cynic-querygen/tests/snapshots/github_tests__literal_enums.snap
+++ b/cynic-querygen/tests/snapshots/github_tests__literal_enums.snap
@@ -37,10 +37,7 @@ mod queries {
     }
 
     #[derive(cynic::Enum, Clone, Copy, Debug)]
-    #[cynic(
-        graphql_type = "IssueState",
-        rename_all = "SCREAMING_SNAKE_CASE"
-    )]
+    #[cynic(graphql_type = "IssueState")]
     pub enum IssueState {
         Closed,
         Open,


### PR DESCRIPTION
#### Why are we making this change?

The `InputObject` & `Enum` derives have a top-level `rename_all` attribute.
This exists because Rust naming conventions and GraphQL naming conventions tend
to differ: rust uses camel_case for fields and PascalCase for variants, whereas
GraphQL uses pascalCase for fields and SCREAMING_SNAKE_CASE for variants.

Prior to this change it was expected that users would provide this field
themselves.  However, this is inconsistent with `QueryFragment` derives where
you don't need to provide anything.

#### What effects does this change have?

Updates the rename_all attribute to default to the appropriate value for
standard GraphQL conventions, bringing the `InputObject` & `Enum` derives in
line with the `QueryFragment` derives.  If users want to override it (or
disable it) they can.

Fixes #99 