### PR TITLE
Add QueryBuilder & MutationBuilder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,10 @@ all APIs might be changed.
 ### Breaking Changes
 
 - `QueryFragment::fragment` now accepts a `FragmentContext` rather than
-  arguments. This can be constructed with `FragmentContext::new` if you have
-  arguments or `FragmentContext::empty` if not. This change was neccesary to
-  support recursive queries.
+  arguments. This change was neccesary to support recursive queries.
+- It is no longer recommended to use `QueryFragment::fragment` directly -
+  instead an Operation should be constructed with `QueryBuilder::build` or
+  `MutationBuilder::build`.
 - GraphQL fields with names that match rust keywords will no longer be
   postfixed with a `_` - you should now use a raw identifier (or rename) for
   these fields.
@@ -37,6 +38,8 @@ all APIs might be changed.
 - Added support for using chrono::NaiveDate as scalars. The decode/encode
   functions will convert to/from dates in the ISO 8601 format, that is
   `YYYY-MM-DD`
+- Added `QueryBuilder` & `MutationBuilder` traits for constructing Operations
+  from QueryFragments.
 
 ### Bug Fixes
 

--- a/cynic-book/src/derives/query-fragments.md
+++ b/cynic-book/src/derives/query-fragments.md
@@ -76,20 +76,17 @@ struct AllFilmsQuery {
 An `Operation` can be created from this `QueryFragment`:
 
 ```
-use cynic::FragmentContext;
+use cynic::QueryBuilder;
 
-let query = cynic::Operation::query(
-    AllFilmsQuery::fragment(FragmentContext::empty())
-);
+let operation = AllFilmsQuery::build(());
 ```
+
+This particular query has no arguments so we provide the unit type `()` in place
+of actual arguments.
 
 This `Operation` can be converted into JSON using `serde`, sent to a server, and
 then then it's `decode_response` function can be used to decode the response
 itself. An example of this is in the [Quickstart][quickstart].
-
-We pass a `FragmentContext` in here, which can be used to provide arguments to
-a query. In this case we have no arguments, so we use the
-`FragmentContext::empty()` constructor.
 
 ### Passing Arguments
 
@@ -121,18 +118,16 @@ struct FilmQuery {
 ```
 
 This can be converted into a query in a similar way we just need to provide
-a `FragmentContext` that contains the arguments:
+some `FilmArguments`:
 
 ```rust
-use cynic::FragmentContext;
+use cynic::QueryBuilder;
 
-let query = cynic::Operation::query(FilmQuery::fragment(
-    FragmentContext::new(
-        &FilmArguments{
-            id: Some("ZmlsbXM6MQ==".into()),
-        }
-    )
-));
+let operation = FilmQuery::build(
+    FilmArguments{
+        id: Some("ZmlsbXM6MQ==".into()),
+    }
+);
 ```
 
 #### Nested Arguments
@@ -150,9 +145,16 @@ If no nested QueryFragments require arguments, you can omit the
 
 Mutations are also constructed using QueryFragments in a very similar way to
 queries. Instead of selecting query fields you select a mutation, and pass in
-any arguments in exactly the same way. Instead of calling the
-`Operation::query` function to construct an `Operation` you call the
-`Operation::mutation` function.
+any arguments in exactly the same way. Mutations use the `MutationBuilder` 
+rather than `QueryBulder`:
+
+```rust
+use cynic::MutationBuilder;
+
+let operation = SomeMutation::build(SomeArguments { ... });
+```
+
+This `operation` can then be used in exactly the same way as with queries.
 
 <!-- TODO: An example of doing mutations -->
 
@@ -174,13 +176,13 @@ A QueryFragment can be configured with several attributes on the struct itself:
 Each field can also have it's own attributes:
 
 - `recurse = "5"` tells cynic that this field is recursive and should be
-  fetched to a maximum depth of 5.  See [Recursive Queries][recursive-queries]
+  fetched to a maximum depth of 5. See [Recursive Queries][recursive-queries]
   for more info.
-- The `flatten` attr can be used to "flatten" out excessive Options.  As
+- The `flatten` attr can be used to "flatten" out excessive Options. As
   GraphQL is used in languages with implicit nulls, it's not uncommon to see a
-  type `[Int]` - which in Rust maps to `Option<Vec<Option<i32>>`.  This isn't a
+  type `[Int]` - which in Rust maps to `Option<Vec<Option<i32>>`. This isn't a
   very nice type to work with - applying the `flatten` attribute lets you
-  represent this as a `Vec<i32>` in your QueryFragment.  Any outer nulls become
+  represent this as a `Vec<i32>` in your QueryFragment. Any outer nulls become
   an empty list and inner nulls are dropped.
 
 ### Related

--- a/cynic-book/src/manual-http-requests.md
+++ b/cynic-book/src/manual-http-requests.md
@@ -17,15 +17,13 @@ It's simple to make an HTTP query manually with `cynic`:
 For instance, to make a request with the `reqwest::blocking` client:
 
 ```rust
-use cynic::{QueryFragment, FragmentContext};
+use cynic::QueryBuilder;
 
-let query = cynic::Operation::query(
-    AllFilmsQuery::fragment(FragmentContext::empty())
-);
+let operation = AllFilmsQuery::build(());
 
 let response = reqwest::blocking::Client::new()
     .post("https://swapi-graphql.netlify.com/.netlify/functions/index")
-    .json(&query)
+    .json(&operation)
     .send()
     .unwrap();
 

--- a/cynic-book/src/quickstart.md
+++ b/cynic-book/src/quickstart.md
@@ -99,11 +99,9 @@ mod tests {
 
     #[test]
     fn all_films_query_gql_output() {
-        use cynic::QueryFragment;
-        let query = cynic::Operation::query(
-            AllFilmsQuery::fragment(FragmentContext::empty())
-        );
-        insta::assert_snapshot!(query.query);
+        use cynic::QueryBuilder;
+        let operation = AllFilmsQuery::build(());
+        insta::assert_snapshot!(operation.query);
     }
 }
 ```
@@ -122,26 +120,24 @@ Now, you're ready to make a query against a server. Cynic doesn't provide any
 HTTP code for you, so you'll need to reach for your HTTP library of choice for
 this one. We'll use reqwest here, but it should be similar for any others.
 
-First, you'll want to build a `Query` similar to how we did it in the snapshot
-test above (again, swapping `AllFilmsQuery` for the name of your root query
-struct):
+First, you'll want to build an `Operation` similar to how we did it in the
+snapshot test above (again, swapping `AllFilmsQuery` for the name of your root
+query struct):
 
 ```rust
-use cynic::{QueryFragment, FragmentContext};
+use cynic::QueryBuilder;
 
-let query = cynic::Operation::query(
-    AllFilmsQuery::fragment(FragmentContext::empty())
-);
+let operation = AllFilmsQuery::build(());
 ```
 
-This `Query` struct is serializable using `serde::Serialize`, so you should
-pass it in as the HTTP body using your HTTP client and then make a request.
-For example, to use surf to talk to the StarWars API (see the docs for
-`cynic::http` if you're using another client):
+This builds an `Operation` struct with is serializable using
+`serde::Serialize`. You should pass it in as the HTTP body using your HTTP
+client and then make a request. For example, to use surf to talk to the
+StarWars API (see the docs for `cynic::http` if you're using another client):
 
 ```rust
 let response = surf::post("https://swapi-graphql.netlify.com/.netlify/functions/index")
-    .run_graphql(&query)
+    .run_graphql(&operation)
     .await
     .unwrap();
 ```

--- a/cynic/src/bin/simple.rs
+++ b/cynic/src/bin/simple.rs
@@ -1,10 +1,7 @@
 fn main() {
-    use cynic::{FragmentContext, QueryFragment};
+    use cynic::QueryBuilder;
 
-    println!(
-        "{}",
-        cynic::Operation::query(TestStruct::fragment(FragmentContext::new(&TestArgs {}))).query
-    );
+    println!("{}", TestStruct::build(&TestArgs {}).query);
 }
 
 mod query_dsl {

--- a/cynic/src/builders.rs
+++ b/cynic/src/builders.rs
@@ -1,0 +1,51 @@
+use super::{FragmentContext, MutationRoot, Operation, QueryFragment, QueryRoot, SelectionSet};
+
+use std::borrow::Borrow;
+
+/// Provides a `build` function on `QueryFragment`s that represent a query
+pub trait QueryBuilder<'a> {
+    type Arguments;
+    type ResponseData;
+
+    /// Constructs a query operation for this QueryFragment.
+    fn build(args: impl Borrow<Self::Arguments>) -> Operation<'a, Self::ResponseData>;
+}
+
+impl<'a, T, R, Q> QueryBuilder<'a> for T
+where
+    T: QueryFragment<SelectionSet = SelectionSet<'a, R, Q>>,
+    Q: QueryRoot,
+    R: 'a,
+{
+    type Arguments = T::Arguments;
+
+    type ResponseData = R;
+
+    fn build(args: impl Borrow<Self::Arguments>) -> Operation<'a, Self::ResponseData> {
+        Operation::query(Self::fragment(FragmentContext::new(args.borrow())))
+    }
+}
+
+/// Provides a `build` function on `QueryFragment`s that represent a mutation
+pub trait MutationBuilder<'a> {
+    type Arguments;
+    type ResponseData;
+
+    /// Constructs a mutation operation for this QueryFragment.
+    fn build(args: impl Borrow<Self::Arguments>) -> Operation<'a, Self::ResponseData>;
+}
+
+impl<'a, T, R, Q> MutationBuilder<'a> for T
+where
+    T: QueryFragment<SelectionSet = SelectionSet<'a, R, Q>>,
+    Q: MutationRoot,
+    R: 'a,
+{
+    type Arguments = T::Arguments;
+
+    type ResponseData = R;
+
+    fn build(args: impl Borrow<Self::Arguments>) -> Operation<'a, Self::ResponseData> {
+        Operation::mutation(Self::fragment(FragmentContext::new(args.borrow())))
+    }
+}

--- a/cynic/src/http.rs
+++ b/cynic/src/http.rs
@@ -49,12 +49,10 @@ mod surf_ext {
     /// #     #[arguments(id = cynic::Id::new("ZmlsbXM6MQ=="))]
     /// #     film: Option<Film>,
     /// # }
-    /// use cynic::{http::SurfExt, QueryFragment, FragmentContext, Operation};
+    /// use cynic::{http::SurfExt, QueryBuilder};
     ///
     /// # async move {
-    /// let operation = Operation::query(
-    ///     FilmDirectorQuery::fragment(FragmentContext::empty())
-    /// );
+    /// let operation = FilmDirectorQuery::build(());
     ///
     /// let response = surf::post("https://swapi-graphql.netlify.com/.netlify/functions/index")
     ///     .run_graphql(operation)
@@ -143,12 +141,10 @@ mod reqwest_ext {
     /// #     #[arguments(id = cynic::Id::new("ZmlsbXM6MQ=="))]
     /// #     film: Option<Film>,
     /// # }
-    /// use cynic::{http::ReqwestExt, QueryFragment, FragmentContext, Operation};
+    /// use cynic::{http::ReqwestExt, QueryBuilder};
     ///
     /// # async move {
-    /// let operation = cynic::Operation::query(
-    ///     FilmDirectorQuery::fragment(FragmentContext::empty())
-    /// );
+    /// let operation = FilmDirectorQuery::build(());
     ///
     /// let client = reqwest::Client::new();
     /// let response = client.post("https://swapi-graphql.netlify.com/.netlify/functions/index")
@@ -239,11 +235,9 @@ mod reqwest_blocking_ext {
     /// #     #[arguments(id = cynic::Id::new("ZmlsbXM6MQ=="))]
     /// #     film: Option<Film>,
     /// # }
-    /// use cynic::{http::ReqwestBlockingExt, QueryFragment, FragmentContext, Operation};
+    /// use cynic::{http::ReqwestBlockingExt, QueryBuilder};
     ///
-    /// let operation = cynic::Operation::query(
-    ///     FilmDirectorQuery::fragment(FragmentContext::empty())
-    /// );
+    /// let operation = FilmDirectorQuery::build(());
     ///
     /// let client = reqwest::blocking::Client::new();
     /// let response = client.post("https://swapi-graphql.netlify.com/.netlify/functions/index")

--- a/cynic/src/lib.rs
+++ b/cynic/src/lib.rs
@@ -82,10 +82,8 @@
 //! }
 //!
 //! // You can then build a `cynic::Operation` from this fragment
-//! use cynic::{QueryFragment, FragmentContext};
-//! let operation = cynic::Operation::query(
-//!     FilmDirectorQuery::fragment(FragmentContext::empty())
-//! );
+//! use cynic::{QueryBuilder};
+//! let operation = FilmDirectorQuery::build(());
 //!
 //! ```
 //!
@@ -150,13 +148,9 @@
 //! }
 //!
 //! // Then we can build a query using this new struct;
-//! use cynic::QueryFragment;
-//! let operation = cynic::Operation::query(
-//!     FilmDirectorQueryWithArgs::fragment(
-//!         cynic::FragmentContext::new(
-//!             &FilmArguments{ id: Some("ZmlsbXM6MQ==".into()) }
-//!         )
-//!     )
+//! use cynic::QueryBuilder;
+//! let operation = FilmDirectorQueryWithArgs::build(
+//!     FilmArguments{ id: Some("ZmlsbXM6MQ==".into()) }
 //! );
 //! ```
 //!
@@ -178,6 +172,7 @@
 //! targetting web assembly.
 
 mod arguments;
+mod builders;
 mod fragments;
 mod id;
 mod integrations;
@@ -192,6 +187,7 @@ pub mod utils;
 pub use json_decode::DecodeError;
 
 pub use arguments::{Argument, FromArguments, IntoArgument, SerializableArgument};
+pub use builders::{MutationBuilder, QueryBuilder};
 pub use fragments::{FragmentArguments, FragmentContext, InlineFragments, QueryFragment};
 pub use id::Id;
 pub use operation::Operation;

--- a/examples/examples/github-mutation.rs
+++ b/examples/examples/github-mutation.rs
@@ -35,14 +35,12 @@ fn run_query() -> cynic::GraphQLResponse<queries::CommentOnMutationSupportIssue>
 
 #[cfg(feature = "github")]
 fn build_query() -> cynic::Operation<'static, queries::CommentOnMutationSupportIssue> {
-    use cynic::{FragmentContext, QueryFragment};
+    use cynic::QueryBuilder;
     use queries::{CommentOnMutationSupportIssue, CommentOnMutationSupportIssueArguments};
 
-    cynic::Operation::mutation(CommentOnMutationSupportIssue::fragment(
-        FragmentContext::new(&CommentOnMutationSupportIssueArguments {
-            comment_body: "Testing".into(),
-        }),
-    ))
+    CommentOnMutationSupportIssue::build(&CommentOnMutationSupportIssueArguments {
+        comment_body: "Testing".into(),
+    })
 }
 
 #[cfg(feature = "github")]

--- a/examples/examples/github-mutation.rs
+++ b/examples/examples/github-mutation.rs
@@ -35,7 +35,7 @@ fn run_query() -> cynic::GraphQLResponse<queries::CommentOnMutationSupportIssue>
 
 #[cfg(feature = "github")]
 fn build_query() -> cynic::Operation<'static, queries::CommentOnMutationSupportIssue> {
-    use cynic::QueryBuilder;
+    use cynic::MutationBuilder;
     use queries::{CommentOnMutationSupportIssue, CommentOnMutationSupportIssueArguments};
 
     CommentOnMutationSupportIssue::build(&CommentOnMutationSupportIssueArguments {

--- a/examples/examples/github.rs
+++ b/examples/examples/github.rs
@@ -35,19 +35,17 @@ fn run_query() -> cynic::GraphQLResponse<queries::PullRequestTitles> {
 
 #[cfg(feature = "github")]
 fn build_query() -> cynic::Operation<'static, queries::PullRequestTitles> {
-    use cynic::{FragmentContext, QueryFragment};
+    use cynic::QueryBuilder;
     use queries::{
         IssueOrder, IssueOrderField, OrderDirection, PullRequestTitles, PullRequestTitlesArguments,
     };
 
-    cynic::Operation::query(PullRequestTitles::fragment(FragmentContext::new(
-        &PullRequestTitlesArguments {
-            pr_order: IssueOrder {
-                direction: OrderDirection::Asc,
-                field: IssueOrderField::CreatedAt,
-            },
+    PullRequestTitles::build(&PullRequestTitlesArguments {
+        pr_order: IssueOrder {
+            direction: OrderDirection::Asc,
+            field: IssueOrderField::CreatedAt,
         },
-    )))
+    })
 }
 
 #[cfg(feature = "github")]

--- a/examples/examples/manual-reqwest.rs
+++ b/examples/examples/manual-reqwest.rs
@@ -53,12 +53,11 @@ fn run_query() -> cynic::GraphQLResponse<FilmDirectorQuery> {
 }
 
 fn build_query() -> cynic::Operation<'static, FilmDirectorQuery> {
-    use cynic::{FragmentContext, QueryFragment};
-    cynic::Operation::query(FilmDirectorQuery::fragment(FragmentContext::new(
-        &FilmArguments {
-            id: Some("ZmlsbXM6MQ==".into()),
-        },
-    )))
+    use cynic::QueryBuilder;
+
+    FilmDirectorQuery::build(&FilmArguments {
+        id: Some("ZmlsbXM6MQ==".into()),
+    })
 }
 
 #[cfg(test)]

--- a/examples/examples/reqwest-async.rs
+++ b/examples/examples/reqwest-async.rs
@@ -54,13 +54,11 @@ async fn run_query() -> cynic::GraphQLResponse<FilmDirectorQuery> {
 }
 
 fn build_query() -> cynic::Operation<'static, FilmDirectorQuery> {
-    use cynic::{FragmentContext, QueryFragment};
+    use cynic::QueryBuilder;
 
-    cynic::Operation::query(FilmDirectorQuery::fragment(FragmentContext::new(
-        &FilmArguments {
-            id: Some("ZmlsbXM6MQ==".into()),
-        },
-    )))
+    FilmDirectorQuery::build(&FilmArguments {
+        id: Some("ZmlsbXM6MQ==".into()),
+    })
 }
 
 #[cfg(test)]

--- a/examples/examples/starwars.rs
+++ b/examples/examples/starwars.rs
@@ -49,13 +49,11 @@ fn run_query() -> cynic::GraphQLResponse<FilmDirectorQuery> {
 }
 
 fn build_query() -> cynic::Operation<'static, FilmDirectorQuery> {
-    use cynic::{FragmentContext, QueryFragment};
+    use cynic::QueryBuilder;
 
-    cynic::Operation::query(FilmDirectorQuery::fragment(FragmentContext::new(
-        &FilmArguments {
-            id: Some("ZmlsbXM6MQ==".into()),
-        },
-    )))
+    FilmDirectorQuery::build(&FilmArguments {
+        id: Some("ZmlsbXM6MQ==".into()),
+    })
 }
 
 #[cfg(test)]

--- a/examples/examples/surf-client.rs
+++ b/examples/examples/surf-client.rs
@@ -54,13 +54,11 @@ async fn run_query() -> cynic::GraphQLResponse<FilmDirectorQuery> {
 }
 
 fn build_query() -> cynic::Operation<'static, FilmDirectorQuery> {
-    use cynic::{FragmentContext, QueryFragment};
+    use cynic::QueryBuilder;
 
-    cynic::Operation::query(FilmDirectorQuery::fragment(FragmentContext::new(
-        &FilmArguments {
-            id: Some("ZmlsbXM6MQ==".into()),
-        },
-    )))
+    FilmDirectorQuery::build(&FilmArguments {
+        id: Some("ZmlsbXM6MQ==".into()),
+    })
 }
 
 #[cfg(test)]

--- a/tests/querygen-compile-run/build.rs
+++ b/tests/querygen-compile-run/build.rs
@@ -19,81 +19,81 @@ fn main() {
         TestCase::query(
             &starwars_schema,
             "../../cynic-querygen/tests/queries/starwars/sanity.graphql",
-            r#"queries::SanityCheckQuery::fragment(FragmentContext::new(
+            r#"queries::SanityCheckQuery::build(
                 &queries::SanityCheckQueryArguments {
                     film_id: Some("ZmlsbXM6MQ==".into())
                 }
-            ))"#,
+            )"#,
         ),
         TestCase::query(
             &starwars_schema,
             "../../cynic-querygen/tests/queries/starwars/nested-arguments.graphql",
-            r#"queries::NestedArgsQuery::fragment(FragmentContext::new(
+            r#"queries::NestedArgsQuery::build(
                 &queries::NestedArgsQueryArguments {
                     film_id: "ZmlsbXM6MQ==".into(),
                     planet_cursor: None,
                     resident_connection: None
                 }
-            ))"#,
+            )"#,
         ),
         TestCase::query(
             &starwars_schema,
             "../../cynic-querygen/tests/queries/starwars/bare-selection-set.graphql",
-            r#"queries::UnnamedQuery::fragment(FragmentContext::empty())"#,
+            r#"queries::UnnamedQuery::build(())"#,
         ),
         TestCase::query(
             &starwars_schema,
             "../../cynic-querygen/tests/queries/starwars/multiple-queries.graphql",
-            r#"queries::AllFilms::fragment(FragmentContext::empty())"#,
+            r#"queries::AllFilms::build(())"#,
         ),
         TestCase::query(
             &starwars_schema,
             "../../cynic-querygen/tests/queries/starwars/fragment-spreads.graphql",
-            r#"queries::AllFilms::fragment(FragmentContext::empty())"#,
+            r#"queries::AllFilms::build(())"#,
         ),
         TestCase::query(
             &jobs_schema,
             "tests/queries/graphql.jobs/london-jobs.graphql",
-            r#"queries::Jobs::fragment(FragmentContext::empty())"#,
+            r#"queries::Jobs::build(())"#,
         ),
         TestCase::query(
             &jobs_schema,
             "tests/queries/graphql.jobs/jobs.graphql",
-            r#"queries::Jobs::fragment(FragmentContext::new(
+            r#"queries::Jobs::build(
                 &queries::JobsArguments {
                     input: queries::LocationInput {
                         slug: "london".into()
                     }
                 }
-            ))"#,
+            )"#,
         ),
         TestCase::mutation(
             &github_schema,
             "../../cynic-querygen/tests/queries/github/add-comment-mutation.graphql",
-            r#"queries::CommentOnMutationSupportIssue::fragment(FragmentContext::new(
-                &queries::CommentOnMutationSupportIssueArguments {
+            r#"queries::CommentOnMutationSupportIssue::build(
+                queries::CommentOnMutationSupportIssueArguments {
                     comment_body: "This is a test comment, posted by the new cynic mutation support"
                         .into(),
                 },
-            ))"#,
+            )"#,
         ),
         TestCase::query_norun(
             &github_schema,
             "../../cynic-querygen/tests/queries/github/input-object-arguments.graphql",
-            r#"queries::PullRequestTitles::fragment(FragmentContext::new(
-                &queries::PullRequestTitlesArguments {
+            r#"queries::PullRequestTitles::build(
+                queries::PullRequestTitlesArguments {
                     pr_order: queries::IssueOrder {
                         direction: queries::OrderDirection::Asc,
                         field: queries::IssueOrderField::CreatedAt,
                     }
                 },
-            ))"#,
+            )"#,
         ),
         TestCase::query_norun(
             &github_schema,
             "tests/queries/github/nested-arguments.graphql",
-            r#"queries::PullRequestTitles::fragment(FragmentContext::new(
-                &queries::PullRequestTitlesArguments {
+            r#"queries::PullRequestTitles::build(
+                queries::PullRequestTitlesArguments {
                     owner: "obmarg".into(),
                     repo: "cynic".into(),
                     pr_order: queries::IssueOrder {
@@ -101,27 +101,27 @@ fn main() {
                         field: queries::IssueOrderField::CreatedAt,
                     }
                 },
-            ))"#,
+            )"#,
         ),
         TestCase::query_norun(
             &github_schema,
             "../../cynic-querygen/tests/queries/github/input-object-literals.graphql",
-            r#"queries::PullRequestTitles::fragment(FragmentContext::empty())"#,
+            r#"queries::PullRequestTitles::build(())"#,
         ),
         TestCase::mutation(
             &github_schema,
             "tests/queries/github/scalar-inside-input-object.graphql",
-            r#"queries::AddPRComment::fragment(FragmentContext::new(
+            r#"queries::AddPRComment::build(
                 &queries::AddPRCommentArguments{
                     body: "hello!".into(),
                     commit: crate::types::GitObjectID("abcd".into())
                 }
-            ))"#,
+            )"#,
         ),
         TestCase::query_norun(
             &github_schema,
             "../../cynic-querygen/tests/queries/github/literal-enums.graphql",
-            r#"queries::RepoIssues::fragment(FragmentContext::empty())"#,
+            r#"queries::RepoIssues::build(())"#,
         ),
     ];
 
@@ -133,52 +133,48 @@ fn main() {
 struct TestCase {
     schema: Schema,
     query_path: PathBuf,
-    fragment_construct: String,
+    operation_construct: String,
     should_run: bool,
-    mutation: bool,
 }
 
 impl TestCase {
     fn query(
         schema: &Schema,
         query_path: impl Into<PathBuf>,
-        fragment_construct: impl Into<String>,
+        operation_construct: impl Into<String>,
     ) -> Self {
         TestCase {
             query_path: query_path.into(),
             schema: schema.clone(),
-            fragment_construct: fragment_construct.into(),
+            operation_construct: operation_construct.into(),
             should_run: true,
-            mutation: false,
         }
     }
 
     fn query_norun(
         schema: &Schema,
         query_path: impl Into<PathBuf>,
-        fragment_construct: impl Into<String>,
+        operation_construct: impl Into<String>,
     ) -> Self {
         TestCase {
             query_path: query_path.into(),
             schema: schema.clone(),
-            fragment_construct: fragment_construct.into(),
+            operation_construct: operation_construct.into(),
             should_run: false,
-            mutation: false,
         }
     }
 
     fn mutation(
         schema: &Schema,
         query_path: impl Into<PathBuf>,
-        fragment_construct: impl Into<String>,
+        operation_construct: impl Into<String>,
     ) -> Self {
         TestCase {
             query_path: query_path.into(),
             schema: schema.clone(),
-            fragment_construct: fragment_construct.into(),
+            operation_construct: operation_construct.into(),
             // We don't run mutations by default
             should_run: false,
-            mutation: true,
         }
     }
 
@@ -191,15 +187,6 @@ impl TestCase {
             ..QueryGenOptions::default()
         };
         let query_code = document_to_fragment_structs(&query, &schema, &options).unwrap();
-
-        // TODO: Now need to output query_code inside some sort of viable template.rs file.
-        // Could use proc_macro & quote to do this _if_ I ran cargo fmt after...
-        //
-        // Ideally I have a func that does the build-a-query & run it through HTTP stuff
-        // somewhere that the examples can pull in.
-        //
-        // Then I just need to output fragment_structs & a main function that ties the two
-        // together...
 
         let test_filename = {
             let mut path = self.query_path.clone();
@@ -215,14 +202,6 @@ impl TestCase {
             "#![allow(unreachable_code)] return;"
         };
 
-        let operation_function = if self.mutation {
-            "send_mutation"
-        } else {
-            "send_query"
-        };
-
-        // TODO: So, need a way to know the query struct name here.
-        // Also need to be able to construct any variable structs...
         write!(
             &mut file,
             r#"
@@ -230,17 +209,16 @@ impl TestCase {
 
             fn main() {{
                 {norun_code}
-                use cynic::{{QueryFragment, FragmentContext}};
-                querygen_compile_run::{operation_function}("{url}", {fragment_construct}).unwrap();
+                use cynic::{{QueryBuilder, MutationBuilder}};
+                querygen_compile_run::send("{url}", {operation_construct}).unwrap();
             }}
 
             {query_code}
             "#,
             norun_code = norun_code,
-            operation_function = operation_function,
             url = self.schema.query_url,
             query_code = query_code,
-            fragment_construct = self.fragment_construct
+            operation_construct = self.operation_construct
         )
         .unwrap();
     }

--- a/tests/querygen-compile-run/src/lib.rs
+++ b/tests/querygen-compile-run/src/lib.rs
@@ -1,41 +1,15 @@
-pub fn send_query<'a, ResponseData: 'a, Root: cynic::QueryRoot>(
+pub fn send<'a, ResponseData: 'a>(
     url: &str,
-    selection_set: cynic::SelectionSet<'a, ResponseData, Root>,
+    operation: cynic::Operation<'a, ResponseData>,
 ) -> Result<ResponseData, Box<dyn std::error::Error>> {
-    let query = cynic::Operation::query(selection_set);
-
     let response = reqwest::blocking::Client::new()
         .post(url)
         .header("User-Agent", "obmarg/cynic")
-        .json(&query)
+        .json(&operation)
         .send()
         .unwrap();
 
-    let response_data = query.decode_response(response.json()?)?;
-    if let Some(_errors) = response_data.errors {
-        println!("{:?}", _errors);
-        return Err("GraphQL server returned errors".into());
-        // TODO: Better errors here
-        //Err(errors)?
-    }
-
-    Ok(response_data.data.expect("response data"))
-}
-
-pub fn send_mutation<'a, ResponseData: 'a, Root: cynic::MutationRoot>(
-    url: &str,
-    selection_set: cynic::SelectionSet<'a, ResponseData, Root>,
-) -> Result<ResponseData, Box<dyn std::error::Error>> {
-    let query = cynic::Operation::mutation(selection_set);
-
-    let response = reqwest::blocking::Client::new()
-        .post(url)
-        .header("User-Agent", "obmarg/cynic")
-        .json(&query)
-        .send()
-        .unwrap();
-
-    let response_data = query.decode_response(response.json()?)?;
+    let response_data = operation.decode_response(response.json()?)?;
     if let Some(_errors) = response_data.errors {
         println!("{:?}", _errors);
         return Err("GraphQL server returned errors".into());


### PR DESCRIPTION
#### Why are we making this change?

#132 added support for recursive queries.  As part of this I had to change the
signature of `QueryFragment::fragment` to take a `FragmentContext` that
contains the arguments.  Prior to this change `QueryFragment::fragment` just
took some arguments.  As `QueryFragment::fragment` is also the primary way to
construct a query, this made the cynic interface more verbose than I'd like.

#### What effects does this change have?

This adds two extension traits named `QueryBuilder` & `MutationBuilder`.  These
are implemented for any `QueryFragment` at the `QueryRoot` or `MutationRoot`.
This gives us a nicer API to construct `Operations` than we had before (and way
better than what we had temporarily after #132)

Fixes #134 