### PR TITLE
Support subscription operations

### DIFF
--- a/cynic-codegen/src/query_dsl/mod.rs
+++ b/cynic-codegen/src/query_dsl/mod.rs
@@ -87,7 +87,7 @@ impl From<schema::Document> for QueryDsl {
                         interfaces_implementations.push(impls);
                     }
 
-                    // Ok, so would be nice to restructure this so that the argument structs
+                    // Would be nice to restructure this so that the argument structs
                     // are visible at the point we're generating the field_selectors...
                     let selector = SelectorStruct::from_object(&object, &type_index);
                     if !selector.selection_builders.is_empty() {

--- a/cynic-codegen/tests/snapshots/query_dsl__schema_file_2.snap
+++ b/cynic-codegen/tests/snapshots/query_dsl__schema_file_2.snap
@@ -256,4 +256,5 @@ pub mod subscription_root {
 pub struct MutationType {}
 impl ::cynic::MutationRoot for MutationRoot {}
 impl ::cynic::QueryRoot for QueryRoot {}
+impl ::cynic::SubscriptionRoot for SubscriptionRoot {}
 

--- a/cynic/src/lib.rs
+++ b/cynic/src/lib.rs
@@ -190,7 +190,7 @@ pub use arguments::{Argument, FromArguments, IntoArgument, SerializableArgument}
 pub use builders::{MutationBuilder, QueryBuilder};
 pub use fragments::{FragmentArguments, FragmentContext, InlineFragments, QueryFragment};
 pub use id::Id;
-pub use operation::Operation;
+pub use operation::{Operation, StreamingOperation};
 pub use result::{GraphQLError, GraphQLResponse, GraphQLResult, PossiblyParsedData};
 pub use scalar::Scalar;
 pub use selection_set::SelectionSet;
@@ -237,3 +237,7 @@ pub trait QueryRoot {}
 /// A marker trait that indicates a particular type is at the root of a GraphQL schemas
 /// mutation hierarchy.
 pub trait MutationRoot {}
+
+/// A marker trait that indicates a particular type is at the root of a GraphQL schemas
+/// subscription hierarchy.
+pub trait SubscriptionRoot {}

--- a/cynic/src/selection_set/field.rs
+++ b/cynic/src/selection_set/field.rs
@@ -3,6 +3,7 @@ use crate::Argument;
 pub enum OperationType {
     Query,
     Mutation,
+    Subscription,
 }
 
 pub enum Field {
@@ -71,6 +72,7 @@ impl Field {
                 let operation_def = match operation_type {
                     OperationType::Query => "query Query",
                     OperationType::Mutation => "mutation Mutation",
+                    OperationType::Subscription => "subscription Subscription",
                 };
 
                 format!(

--- a/cynic/src/selection_set/mod.rs
+++ b/cynic/src/selection_set/mod.rs
@@ -24,7 +24,7 @@ use json_decode::{BoxDecoder, DecodeError};
 use std::collections::HashMap;
 use std::marker::PhantomData;
 
-use crate::{scalar, Argument, MutationRoot, QueryRoot};
+use crate::{scalar, Argument, MutationRoot, QueryRoot, SubscriptionRoot};
 
 use field::{Field, OperationType};
 
@@ -305,6 +305,21 @@ where
 {
     SelectionSet::new(
         vec![Field::Root(selection_set.fields, OperationType::Mutation)],
+        selection_set.decoder,
+    )
+}
+
+pub(crate) fn subscription_root<'a, DecodesTo, InnerTypeLock: SubscriptionRoot>(
+    selection_set: SelectionSet<'a, DecodesTo, InnerTypeLock>,
+) -> SelectionSet<'a, DecodesTo, ()>
+where
+    DecodesTo: 'a,
+{
+    SelectionSet::new(
+        vec![Field::Root(
+            selection_set.fields,
+            OperationType::Subscription,
+        )],
         selection_set.decoder,
     )
 }


### PR DESCRIPTION
#### Why are we making this change?

I want to add support for subscriptions to cynic.

#### What effects does this change have?

Adds support for building subscription operations to cynic:

- Added a new SubscriptionRoot marker trait, equivalent to the existing
  QueryRoot & MutationRoot.
- Added a SubscriptionBuilder, equivalent to QueryBuilder & MutationBuilder.
- Added a new StreamingOperation, similar to Operation but for operations that
  stream responses (i.e. subscriptions)

This is mostly untested currently as I haven't yet added support for any 
streaming transports.  That will be coming soon.

Part of #148 