### PR TITLE
Allow optional InputObject arguments to be passed by reference.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ all APIs might be changed.
 
 ## Unreleased - xxxx-xx-xx
 
+### Bug Fixes
+
+- Optional InputObject arguments can now be provided by reference.  Previously
+  this required a clone.
+
 ## v0.11.0 - 2020-12-31
 
 ### Breaking Changes

--- a/cynic/src/arguments/into_argument.rs
+++ b/cynic/src/arguments/into_argument.rs
@@ -27,6 +27,28 @@ where
     }
 }
 
+impl<'a, T> IntoArgument<Option<T>> for Option<&'a T>
+where
+    T: SerializableArgument,
+{
+    type Output = Option<&'a T>;
+
+    fn into_argument(self) -> Self::Output {
+        self
+    }
+}
+
+impl<'a, T> IntoArgument<Option<T>> for &'a Option<T>
+where
+    T: SerializableArgument,
+{
+    type Output = Option<&'a T>;
+
+    fn into_argument(self) -> Self::Output {
+        self.as_ref()
+    }
+}
+
 /// Defines useful argument conversions for scalar-like types
 ///
 /// Mostly just converts references to owned via cloning and
@@ -52,37 +74,11 @@ macro_rules! impl_into_argument_for_options {
     };
 }
 
-macro_rules! impl_into_argument_for_option_refs {
-    ($inner:ty) => {
-        impl<'a> $crate::IntoArgument<Option<$inner>> for Option<&'a $inner> {
-            type Output = Option<&'a $inner>;
-
-            fn into_argument(self) -> Option<&'a $inner> {
-                self
-            }
-        }
-
-        impl<'a> $crate::IntoArgument<Option<$inner>> for &'a Option<$inner> {
-            type Output = Option<&'a $inner>;
-
-            fn into_argument(self) -> Option<&'a $inner> {
-                self.as_ref()
-            }
-        }
-    };
-}
-
 impl_into_argument_for_options!(i32);
 impl_into_argument_for_options!(f64);
 impl_into_argument_for_options!(String);
 impl_into_argument_for_options!(bool);
 impl_into_argument_for_options!(Id);
-
-impl_into_argument_for_option_refs!(i32);
-impl_into_argument_for_option_refs!(f64);
-impl_into_argument_for_option_refs!(String);
-impl_into_argument_for_option_refs!(bool);
-impl_into_argument_for_option_refs!(Id);
 
 impl<'a> IntoArgument<String> for &'a str {
     type Output = &'a str;

--- a/tests/querygen-compile-run/build.rs
+++ b/tests/querygen-compile-run/build.rs
@@ -124,6 +124,15 @@ fn main() {
             "../../cynic-querygen/tests/queries/github/literal-enums.graphql",
             r#"queries::RepoIssues::build(())"#,
         ),
+        TestCase::query_norun(
+            &github_schema,
+            "tests/queries/github/optional-input-object-argument.graphql",
+            r#"queries::PullRequestTitles::build(
+                queries::PullRequestTitlesArguments {
+                    pr_order: None
+                },
+            )"#,
+        ),
     ];
 
     for case in cases {

--- a/tests/querygen-compile-run/tests/queries/github/optional-input-object-argument.graphql
+++ b/tests/querygen-compile-run/tests/queries/github/optional-input-object-argument.graphql
@@ -1,0 +1,10 @@
+# Tests passing an optional InputObject as an argument
+query PullRequestTitles($prOrder: IssueOrder) {
+  repository(name: "cynic", owner: "obmarg") {
+    pullRequests(orderBy: $prOrder) {
+      nodes {
+        title
+      }
+    }
+  }
+}


### PR DESCRIPTION
#### Why are we making this change?

`IntoArgument` provides argument conversion for cynic to allow a bit of
flexibility in the types that can be accepted for any given argument.  Prior to
this change there was no `IntoArgument` definition for optional references to
`InputObjects` - all `Option<InputObject>` arguments had to be passed as owned
objects.  This meant you needed to clone the entire InputObject.  This also
meant that the generator output didn't work, as it assumed references should
work.

#### What effects does this change have?

We had a macro for dealing with these conversions internally, but it defined a
trait on `Option<&T>` so was not suitable for use outside of the crate.  This
moves the definitions in that macro into generic defintions for _any_
`Option<T>`.  This seems to solve the problem, and importantly doesn't any
existing functionality.

Fixes #185 