### PR TITLE
Disable GraphiQL fetches if no schema URL provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ all APIs might be changed.
 
 ## Unreleased - xxxx-xx-xx
 
+### Bug Fixes
+
+- The generator no longer tries (and fails) to run queries when it has no URL
+  to work with.
+
 ## v0.11.0 - 2020-12-31
 
 ### Breaking Changes

--- a/cynic-querygen-web/js/src/index.tsx
+++ b/cynic-querygen-web/js/src/index.tsx
@@ -121,24 +121,27 @@ const GraphQLEditor = (props: EditorProps) => {
 
 ReactiveElements("gql-editor", GraphQLEditor, { useShadowDom: true });
 
-const makeFetcher = (schemaUrl) => {
-  return (graphQLParams: FetcherParams, opts: FetcherOpts) =>
-    fetch(schemaUrl, {
+const makeFetcher = (schemaUrl: string) => {
+  return async (graphQLParams: FetcherParams, opts: FetcherOpts) => {
+    if (schemaUrl.length === 0) {
+      return "Can't run queries - you pasted a schema so we don't have a URL";
+    }
+
+    const response = await fetch(schemaUrl, {
       method: "post",
       headers: {
         "Content-Type": "application/json",
         ...opts.headers,
       },
       body: JSON.stringify(graphQLParams),
-    })
-      .then(function (response) {
-        return response.text();
-      })
-      .then(function (responseBody) {
-        try {
-          return JSON.parse(responseBody);
-        } catch (e) {
-          return responseBody;
-        }
-      });
+    });
+
+    const responseBody = await response.text();
+
+    try {
+      return JSON.parse(responseBody);
+    } catch (e) {
+      return responseBody;
+    }
+  };
 };


### PR DESCRIPTION
#### Why are we making this change?

The generator has two ways of provided a schema: via a URL or by pasting
GraphQL SDL into a text box.  When pasting the SDL we have no server to run
queries against, but GraphiQL tries to query `/` anyway.  On production this
leads to a netlify 404 appearing in the results pane, and periodic failed
fetches in the browsers dev tools as GraphiQL tries to run the introspection
query.

#### What effects does this change have?

Updates our fetcher to not run fetches if we have no schema, fixing this
behaviour.

Fixes #184