### PR TITLE
Make sure HTTP clients are documented on docs.rs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ all APIs might be changed.
 
 - Optional InputObject arguments can now be provided by reference.  Previously
   this required a clone.
+- Makes sure docs.rs builds documentation for the HTTP client code.
 
 ## v0.11.0 - 2020-12-31
 

--- a/cynic/Cargo.toml
+++ b/cynic/Cargo.toml
@@ -39,9 +39,13 @@ url = { version = "2.1.1", optional = true }
 surf = { version = "2.0.0", default-features = false, optional = true }
 
 # Reqwest feature deps
-reqwest = { version = "0.10", optional = true }
+reqwest = { version = "0.10", optional = true, features = ["json"] }
 
 [dev-dependencies]
 maplit = "1.0.2"
 assert_matches = "1.3.0"
 insta = "1.1"
+
+[package.metadata.docs.rs]
+features = ["all"]
+rustdoc-args = ["--cfg", "docsrs"]

--- a/cynic/src/http.rs
+++ b/cynic/src/http.rs
@@ -4,12 +4,15 @@
 //! heavy dependencies, and there's several options to choose from.
 
 #[cfg(feature = "surf")]
+#[cfg_attr(docsrs, doc(cfg(feature = "surf")))]
 pub use self::surf_ext::SurfExt;
 
 #[cfg(feature = "reqwest")]
+#[cfg_attr(docsrs, doc(cfg(feature = "reqwest")))]
 pub use reqwest_ext::ReqwestExt;
 
 #[cfg(feature = "reqwest-blocking")]
+#[cfg_attr(docsrs, doc(cfg(feature = "reqwest-blocking")))]
 pub use reqwest_blocking_ext::ReqwestBlockingExt;
 
 #[cfg(feature = "surf")]
@@ -68,6 +71,7 @@ mod surf_ext {
     /// );
     /// # };
     /// ```
+    #[cfg_attr(docsrs, doc(cfg(feature = "surf")))]
     pub trait SurfExt {
         /// Runs a GraphQL query with the parameters in RequestBuilder, decodes
         /// the and returns the result.
@@ -161,6 +165,7 @@ mod reqwest_ext {
     /// );
     /// # };
     /// ```
+    #[cfg_attr(docsrs, doc(cfg(feature = "reqwest")))]
     pub trait ReqwestExt {
         /// Runs a GraphQL query with the parameters in RequestBuilder, decodes
         /// the and returns the result.
@@ -252,6 +257,7 @@ mod reqwest_blocking_ext {
     ///         .unwrap()
     /// );
     /// ```
+    #[cfg_attr(docsrs, doc(cfg(feature = "reqwest-blocking")))]
     pub trait ReqwestBlockingExt {
         /// Runs a GraphQL query with the parameters in RequestBuilder, decodes
         /// the and returns the result.


### PR DESCRIPTION
#### Why are we making this change?

Some of our code is behind feature flags, which meant it wasn't getting built
on docs.rs

#### What effects does this change have?

This provides annotations in `Cargo.toml` that tell docs.rs to build with all
the features enabled.  It also adds feature annotations to these types which
I'm hoping docs.rs will pick up.  Though I've been unable to get that to work
locally.

Fixes #179 