### PR TITLE
Better interface & union type support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,21 @@ all APIs might be changed.
 
 ## Unreleased - xxxx-xx-xx
 
+### Breaking Changes
+
+- `selection_set::inline_fragments` now takes a backup selection set parameter
+  for when we get an unexpected `__typename`.
+- The `InlineFragments` derive now performs exhaustiveness checking and
+  validates the provided variants.
+- `InlineFragments` has a new required function `fallback`
+
+### New Features
+
+- `InlineFragments` are now validated for exhaustiveness & correctness.
+- `InlineFragments` now support a fallback variant for the case where users
+  only care about some of the possibilities.
+- `QueryFragment` can now be derived for interfaces
+
 ### Changes
 
 - Updated reqwest dependency to 0.11

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -604,7 +604,7 @@ dependencies = [
  "bson",
  "chrono",
  "cynic-proc-macros",
- "insta 1.4.0",
+ "insta 1.5.3",
  "json-decode",
  "maplit",
  "reqwest 0.11.0",
@@ -624,7 +624,7 @@ dependencies = [
  "assert_matches",
  "darling",
  "graphql-parser",
- "insta 1.4.0",
+ "insta 1.5.3",
  "lazy_static",
  "maplit",
  "proc-macro2",
@@ -662,7 +662,7 @@ dependencies = [
  "Inflector",
  "assert_matches",
  "graphql-parser",
- "insta 1.4.0",
+ "insta 1.5.3",
  "rstest",
  "rust_decimal",
  "thiserror",
@@ -1346,16 +1346,16 @@ dependencies = [
 
 [[package]]
 name = "insta"
-version = "1.4.0"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ad34c5249910ef48fc32e776b6609b98e4601f2fea5b5dcd0ac01e296b62f87"
+checksum = "f62fca340815e6190f0ab60fd2729d297a55bcf9863025e5a8a4ce68f50066c4"
 dependencies = [
  "console 0.14.0",
- "difference",
  "lazy_static",
  "serde",
  "serde_json",
  "serde_yaml",
+ "similar",
  "uuid",
 ]
 
@@ -2269,6 +2269,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "similar"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c2c5334976f6000d0c36cf95a0b70ff4daa310b935aa4ce190d02f1012c81d0"
+
+[[package]]
 name = "slab"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2726,6 +2732,15 @@ name = "typenum"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
+
+[[package]]
+name = "ui-tests"
+version = "0.1.0"
+dependencies = [
+ "cynic",
+ "serde_json",
+ "trybuild",
+]
 
 [[package]]
 name = "unicase"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,8 @@ members = [
     "examples",
     "cynic-querygen",
     "cynic-querygen-web",
-    "tests/querygen-compile-run"
+    "tests/querygen-compile-run",
+    "tests/ui-tests"
 ]
 
 [profile.release]

--- a/README.md
+++ b/README.md
@@ -60,11 +60,7 @@ supported:
 - Defining custom scalars.
 - Building dynamic (but still type checked) queries at run time.
 - Query arguments including input objects
-
-The following features are not well supported or tested and may not work well,
-or at all:
-
-- Fetching union and interface types via inline fragments
+- Interfaces & union types
 
 The following features are not yet supported, though should be soon (if you
 want to help out with the project I'd be happy for someone else to try and

--- a/cynic-book/src/derives/inline-fragments.md
+++ b/cynic-book/src/derives/inline-fragments.md
@@ -5,7 +5,7 @@ which of the sub-types the query returned and to get at the fields inside that
 type.
 
 `InlineFragments` can be derived on any enum that's variants contain a single
-type that implements `QueryFragment`.  Each of the `QueryFragment`s should have
+type that implements `QueryFragment`. Each of the `QueryFragment`s should have
 a `graphql_type` that maps to one of the sub-types of the `graphql_type` type
 for the `InlineFragment`.
 
@@ -28,3 +28,88 @@ enum Assignee {
 
 Where each of `Bot`, `Mannequin`, `Organization` & `User` are all structs that
 implement `QueryFragment` for the respective GraphQL types.
+
+#### Fallbacks
+
+By default cynic will error you if you leave out any possible type for a given
+union type of interface.  If you don't want to provide cases for each of the
+possible types you can provide the `fallback` attribute on a variant.  That
+variant will be output whenever an unhandled type is returned.
+
+```rust
+#[derive(cynic::InlineFragments)]
+#[cynic(
+    schema_path = "github.graphql",
+    query_module = "query_dsl",
+    graphql_type = "Assignee"
+)]
+enum Assignee {
+    Bot(Bot),
+    User(User)
+
+    #[cynic(fallback)]
+    Other
+}
+```
+
+A fallback can also be provided when you have handled all cases - this will
+allow your code to continue to compile even in the face of server changes.
+
+##### Fallbacks for interfaces
+
+If your `InlineFragments` is querying an interface your fallback variant can
+also select some fields from the interface:
+
+```rust
+#[derive(cynic::InlineFragments, Debug)]
+#[cynic(
+    schema_path = "github.graphql",
+    query_module = "query_dsl",
+    graphql_type = "Actor"
+)]
+pub enum Actor {
+    User(User),
+
+    #[cynic(fallback)]
+    Other(ActorFallback),
+}
+
+#[derive(cynic::QueryFragment)]
+#[cynic(
+    schema_path = "github.graphql",
+    query_module = "query_dsl",
+    graphql_type = "Actor"
+)]
+enum ActorFallback {
+    pub login: String
+}
+```
+
+This functionality is only available for interfaces as union types have no
+concept of shared fields.
+
+#### Struct Attributes
+
+An `InlineFragments` can be configured with several attributes on the
+enum itself:
+
+- `graphql_type = "AType"` is required and tells cynic which interface
+  or union type in the GraphQL schema to map this struct to
+- `schema_path` sets the path to the GraphQL schema. This is required,
+  but
+  can be provided by nesting the InlineFragments inside a query module
+  with this attr.
+- `query_module` tells cynic where to find the query module - that is a
+  module that has called the `query_dsl!` macro. This is required but
+  can also be provided by nesting the QueryFragment inside a query
+  module.
+
+#### Variant Attributes
+
+Each variant can also have it's own attributes:
+
+- `fallback` can be applied on a single variant to indicate that it
+  should be used whenver cynic encounters a `__typename` that doesn't
+  match one of the other variants.  For interfaces this can contain a
+  `QueryFragment` type.  For union types it must be applied on a unit
+  variant.

--- a/cynic-codegen/src/error.rs
+++ b/cynic-codegen/src/error.rs
@@ -1,4 +1,4 @@
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct Errors {
     errors: Vec<syn::Error>,
 }

--- a/cynic-codegen/src/inline_fragments_derive/input.rs
+++ b/cynic-codegen/src/inline_fragments_derive/input.rs
@@ -1,7 +1,7 @@
 use darling::util::SpannedValue;
 
 #[derive(darling::FromDeriveInput)]
-#[darling(attributes(cynic), supports(enum_newtype))]
+#[darling(attributes(cynic), supports(enum_newtype, enum_unit))]
 pub struct InlineFragmentsDeriveInput {
     pub(super) ident: proc_macro2::Ident,
     pub(super) data: darling::ast::Data<SpannedValue<InlineFragmentsDeriveVariant>, ()>,
@@ -18,6 +18,9 @@ pub struct InlineFragmentsDeriveInput {
 pub(super) struct InlineFragmentsDeriveVariant {
     pub ident: proc_macro2::Ident,
     pub fields: darling::ast::Fields<InlineFragmentsDeriveField>,
+
+    #[darling(default)]
+    pub(super) fallback: SpannedValue<bool>,
 }
 
 #[derive(darling::FromField)]

--- a/cynic-codegen/src/inline_fragments_derive/mod.rs
+++ b/cynic-codegen/src/inline_fragments_derive/mod.rs
@@ -1,15 +1,16 @@
 use darling::util::SpannedValue;
 use proc_macro2::{Span, TokenStream};
 
-use crate::{load_schema, schema, Ident, TypePath};
+use crate::{load_schema, schema, Errors, Ident, TypePath};
 
 pub mod input;
 
 pub use input::InlineFragmentsDeriveInput;
 
 use input::InlineFragmentsDeriveVariant;
+use std::collections::HashSet;
 
-pub fn inline_fragments_derive(ast: &syn::DeriveInput) -> Result<TokenStream, syn::Error> {
+pub fn inline_fragments_derive(ast: &syn::DeriveInput) -> Result<TokenStream, Errors> {
     use darling::FromDeriveInput;
 
     match InlineFragmentsDeriveInput::from_derive_input(ast) {
@@ -20,21 +21,24 @@ pub fn inline_fragments_derive(ast: &syn::DeriveInput) -> Result<TokenStream, sy
 
 pub(crate) fn inline_fragments_derive_impl(
     input: InlineFragmentsDeriveInput,
-) -> Result<TokenStream, syn::Error> {
+) -> Result<TokenStream, Errors> {
     use quote::{quote, quote_spanned};
 
     let schema =
         load_schema(&*input.schema_path).map_err(|e| e.into_syn_error(input.schema_path.span()))?;
 
-    if !find_union_or_interface_type(&input.graphql_type, &schema) {
+    let target_type = find_union_or_interface_type(&input.graphql_type, &schema);
+    if target_type.is_none() {
         return Err(syn::Error::new(
             input.graphql_type.span(),
             format!(
                 "Could not find a Union type or Interface named {}",
                 &*input.graphql_type
             ),
-        ));
+        )
+        .into());
     }
+    let target_type = target_type.unwrap();
 
     let argument_struct = if let Some(arg_struct) = input.argument_struct {
         let span = arg_struct.span();
@@ -46,6 +50,10 @@ pub(crate) fn inline_fragments_derive_impl(
     };
 
     if let darling::ast::Data::Enum(variants) = &input.data {
+        exhaustiveness_check(variants, &target_type, &schema)?;
+
+        let fallback = check_fallback(variants, &target_type)?;
+
         let inline_fragments_impl = InlineFragmentsImpl {
             target_struct: input.ident.clone(),
             type_lock: TypePath::concat(&[
@@ -55,6 +63,7 @@ pub(crate) fn inline_fragments_derive_impl(
             argument_struct,
             possible_types: possible_types_from_variants(variants)?,
             graphql_type_name: (*input.graphql_type).clone(),
+            fallback,
         };
 
         Ok(quote! { #inline_fragments_impl })
@@ -62,8 +71,99 @@ pub(crate) fn inline_fragments_derive_impl(
         Err(syn::Error::new(
             Span::call_site(),
             "InlineFragments can only be derived from an enum".to_string(),
-        ))
+        )
+        .into())
     }
+}
+
+fn exhaustiveness_check(
+    variants: &[SpannedValue<InlineFragmentsDeriveVariant>],
+    target_type: &InlineFragmentType,
+    schema: &schema::Document,
+) -> Result<(), Errors> {
+    use schema::{Definition, TypeDefinition};
+
+    let variant_names = variants
+        .iter()
+        .filter(|v| !*v.fallback)
+        .map(|v| v.ident.to_string())
+        .collect::<HashSet<_>>();
+
+    let required_variants = match target_type {
+        InlineFragmentType::Interface(iface) => schema
+            .definitions
+            .iter()
+            .map(|d| match d {
+                Definition::TypeDefinition(TypeDefinition::Object(obj)) => {
+                    if obj.implements_interfaces.contains(&iface.name) {
+                        Some(&obj.name)
+                    } else {
+                        None
+                    }
+                }
+                _ => None,
+            })
+            .flatten()
+            .cloned()
+            .collect::<HashSet<_>>(),
+        InlineFragmentType::Union(union) => union.types.iter().cloned().collect::<HashSet<_>>(),
+    };
+
+    let has_fallback = variants.iter().any(|v| *v.fallback);
+
+    if has_fallback && !variant_names.is_subset(&required_variants) {
+        let mut errors = Errors::default();
+
+        for unexpected_variant_name in variant_names.difference(&required_variants) {
+            let variant = variants
+                .iter()
+                .find(|v| v.ident == *unexpected_variant_name)
+                .unwrap();
+
+            errors.push(syn::Error::new(
+                variant.span(),
+                format!(
+                    "Could not find a match for {} in {}",
+                    variant.ident,
+                    target_type.name()
+                ),
+            ))
+        }
+
+        return Err(errors);
+    } else if !has_fallback && variant_names != required_variants {
+        let mut errors = Errors::default();
+
+        for unexpected_variant_name in variant_names.difference(&required_variants) {
+            let variant = variants
+                .iter()
+                .find(|v| v.ident == *unexpected_variant_name)
+                .unwrap();
+
+            errors.push(syn::Error::new(
+                variant.span(),
+                format!(
+                    "Could not find a match for {} in {}",
+                    variant.ident,
+                    target_type.name()
+                ),
+            ));
+        }
+
+        for missing_variant_name in required_variants.difference(&variant_names) {
+            errors.push(syn::Error::new(
+                Span::call_site(),
+                format!(
+                    "This InlineFragment is missing a variant for {}.  Either provide a variant for this type or add a fallback variant.",
+                    missing_variant_name
+                ),
+            ));
+        }
+
+        return Err(errors);
+    }
+
+    Ok(())
 }
 
 fn possible_types_from_variants(
@@ -71,6 +171,10 @@ fn possible_types_from_variants(
 ) -> Result<Vec<(syn::Ident, syn::Type)>, syn::Error> {
     let mut result = vec![];
     for variant in variants {
+        if *variant.fallback {
+            continue;
+        }
+
         if variant.fields.style != darling::ast::Style::Tuple || variant.fields.fields.len() != 1 {
             return Err(syn::Error::new(
                 variant.span(),
@@ -83,12 +187,71 @@ fn possible_types_from_variants(
     Ok(result)
 }
 
+fn check_fallback(
+    variants: &[SpannedValue<InlineFragmentsDeriveVariant>],
+    target_type: &InlineFragmentType,
+) -> Result<Option<(syn::Ident, Option<syn::Type>)>, Errors> {
+    let fallbacks = variants.iter().filter(|v| *v.fallback).collect::<Vec<_>>();
+
+    if fallbacks.is_empty() {
+        return Ok(None);
+    }
+
+    if fallbacks.len() > 1 {
+        let mut errors = Errors::default();
+        for fallback in &fallbacks[1..] {
+            errors.push(syn::Error::new(
+                fallback.span(),
+                "InlineFragments can't have more than one fallback",
+            ))
+        }
+
+        return Err(errors);
+    }
+
+    let fallback = fallbacks[0];
+    match target_type {
+        InlineFragmentType::Interface(_) => match fallback.fields.style {
+            darling::ast::Style::Struct => Err(syn::Error::new(
+                fallback.span(),
+                "InlineFragment fallbacks don't currently support struct variants",
+            )
+            .into()),
+            darling::ast::Style::Tuple => {
+                if fallback.fields.len() != 1 {
+                    return Err(syn::Error::new(
+                        fallback.span(),
+                        "InlineFragments require variants to have one unnamed field",
+                    )
+                    .into());
+                }
+                Ok(Some((
+                    fallback.ident.clone(),
+                    Some(fallback.fields.fields[0].ty.clone()),
+                )))
+            }
+            darling::ast::Style::Unit => Ok(Some((fallback.ident.clone(), None))),
+        },
+        InlineFragmentType::Union(_) => {
+            if fallback.fields.style != darling::ast::Style::Unit {
+                return Err(syn::Error::new(
+                    fallback.span(),
+                    "The fallback for a union type must be a unit variant",
+                )
+                .into());
+            }
+            Ok(Some((fallback.ident.clone(), None)))
+        }
+    }
+}
+
 struct InlineFragmentsImpl {
     target_struct: syn::Ident,
     type_lock: TypePath,
     argument_struct: syn::Type,
     possible_types: Vec<(syn::Ident, syn::Type)>,
     graphql_type_name: String,
+    fallback: Option<(syn::Ident, Option<syn::Type>)>,
 }
 
 impl quote::ToTokens for InlineFragmentsImpl {
@@ -101,6 +264,34 @@ impl quote::ToTokens for InlineFragmentsImpl {
         let internal_types: Vec<_> = self.possible_types.iter().map(|(_, ty)| ty).collect();
         let variants: Vec<_> = self.possible_types.iter().map(|(v, _)| v).collect();
         let graphql_type = proc_macro2::Literal::string(&self.graphql_type_name);
+
+        let fallback_selection = if let Some((fallback_variant, fallback_type)) = &self.fallback {
+            if let Some(fallback_type) = fallback_type {
+                quote! {
+                    use ::cynic::QueryFragment;
+                    Some(
+                        #fallback_type
+                            ::fragment(
+                                context.with_args(
+                                    ::cynic::FromArguments::from_arguments(context.args)
+                                )
+                            )
+                            .map(#target_struct::#fallback_variant)
+                            .transform_typelock()
+                    )
+                }
+            } else {
+                quote! {
+                    Some(
+                        ::cynic::selection_set::succeed_using(
+                            || #target_struct::#fallback_variant
+                        )
+                    )
+                }
+            }
+        } else {
+            quote! { None }
+        };
 
         tokens.append_all(quote! {
             #[automatically_derived]
@@ -131,28 +322,51 @@ impl quote::ToTokens for InlineFragmentsImpl {
                 fn graphql_type() -> String {
                     #graphql_type.to_string()
                 }
+
+                fn fallback(context: ::cynic::FragmentContext<'_, Self::Arguments>) ->
+                  Option<::cynic::SelectionSet<'static, Self, Self::TypeLock>>
+                {
+                    #fallback_selection
+                }
             }
         });
     }
 }
 
-fn find_union_or_interface_type(name: &str, schema: &schema::Document) -> bool {
+fn find_union_or_interface_type<'a>(
+    name: &str,
+    schema: &'a schema::Document,
+) -> Option<InlineFragmentType<'a>> {
     for definition in &schema.definitions {
         use graphql_parser::schema::{Definition, TypeDefinition};
         match definition {
             Definition::TypeDefinition(TypeDefinition::Union(union)) => {
                 if union.name == name {
-                    return true;
+                    return Some(InlineFragmentType::Union(union));
                 }
             }
             Definition::TypeDefinition(TypeDefinition::Interface(interface)) => {
                 if interface.name == name {
-                    return true;
+                    return Some(InlineFragmentType::Interface(interface));
                 }
             }
             _ => {}
         }
     }
 
-    false
+    None
+}
+
+enum InlineFragmentType<'a> {
+    Union(&'a schema::UnionType),
+    Interface(&'a schema::InterfaceType),
+}
+
+impl<'a> InlineFragmentType<'a> {
+    pub fn name(&self) -> &str {
+        match self {
+            InlineFragmentType::Interface(iface) => &iface.name,
+            InlineFragmentType::Union(union) => &union.name,
+        }
+    }
 }

--- a/cynic-codegen/src/query_dsl/interface_struct.rs
+++ b/cynic-codegen/src/query_dsl/interface_struct.rs
@@ -1,6 +1,8 @@
 use proc_macro2::TokenStream;
 
-use crate::{schema, Ident};
+use crate::{schema, type_index::TypeIndex, Ident};
+
+use super::SelectorStruct;
 
 /// We generate an InterfaceStruct for each interface in the schema.
 ///
@@ -9,12 +11,14 @@ use crate::{schema, Ident};
 #[derive(Debug)]
 pub struct InterfaceStruct {
     pub name: Ident,
+    pub selector_struct: SelectorStruct,
 }
 
 impl InterfaceStruct {
-    pub fn from_interface(interface: &schema::InterfaceType) -> Self {
+    pub fn from_interface(interface: &schema::InterfaceType, type_index: &TypeIndex) -> Self {
         InterfaceStruct {
             name: Ident::for_type(&interface.name),
+            selector_struct: SelectorStruct::new(&interface.name, &interface.fields, type_index),
         }
     }
 }
@@ -23,11 +27,8 @@ impl quote::ToTokens for InterfaceStruct {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         use quote::{quote, TokenStreamExt};
 
-        let name = &self.name;
+        let selector = &self.selector_struct;
 
-        tokens.append_all(quote! {
-            #[allow(dead_code)]
-            pub struct #name {}
-        });
+        tokens.append_all(quote! { #selector });
     }
 }

--- a/cynic-codegen/src/query_dsl/interfaces_implementations.rs
+++ b/cynic-codegen/src/query_dsl/interfaces_implementations.rs
@@ -12,6 +12,15 @@ pub struct InterfacesImplementations {
 }
 
 impl InterfacesImplementations {
+    pub fn from_interface(iface: &schema::InterfaceType) -> Self {
+        let ident = Ident::for_type(&iface.name);
+
+        Self {
+            implementor: ident.clone(),
+            interfaces: vec![ident],
+        }
+    }
+
     pub fn from_object(obj: &schema::ObjectType) -> Option<Self> {
         if obj.implements_interfaces.is_empty() {
             return None;

--- a/cynic-codegen/src/query_dsl/mod.rs
+++ b/cynic-codegen/src/query_dsl/mod.rs
@@ -107,8 +107,22 @@ impl From<schema::Document> for QueryDsl {
                 Definition::TypeDefinition(TypeDefinition::Union(union)) => {
                     unions.push(UnionStruct::from_union(&union));
                 }
-                Definition::TypeDefinition(TypeDefinition::Interface(interface)) => {
-                    interfaces.push(InterfaceStruct::from_interface(&interface));
+                Definition::TypeDefinition(TypeDefinition::Interface(interface_def)) => {
+                    interfaces_implementations
+                        .push(InterfacesImplementations::from_interface(interface_def));
+
+                    let interface = InterfaceStruct::from_interface(&interface_def, &type_index);
+
+                    // Could be nice to restructure this so that the argument structs
+                    // just live inside the selector_struct or similar?
+                    if !interface.selector_struct.selection_builders.is_empty() {
+                        argument_struct_modules.push(Module::new(
+                            &interface_def.name,
+                            interface.selector_struct.selection_builders.clone(),
+                        ));
+                    }
+
+                    interfaces.push(interface);
                 }
                 Definition::TypeDefinition(TypeDefinition::Enum(en)) => {
                     enums.push(EnumMarker::from_enum(&en));

--- a/cynic-codegen/src/query_dsl/selector_struct.rs
+++ b/cynic-codegen/src/query_dsl/selector_struct.rs
@@ -23,12 +23,16 @@ pub struct SelectorStruct {
 
 impl SelectorStruct {
     pub fn from_object(obj: &schema::ObjectType, type_index: &TypeIndex) -> Self {
-        let name = Ident::for_type(&obj.name);
+        SelectorStruct::new(&obj.name, &obj.fields, type_index)
+    }
 
-        let mut processed_fields = Vec::with_capacity(obj.fields.len());
-        let mut selection_builders = Vec::with_capacity(obj.fields.len());
+    pub fn new(graphql_name: &str, fields: &[schema::Field], type_index: &TypeIndex) -> Self {
+        let name = Ident::for_type(graphql_name);
 
-        for field in &obj.fields {
+        let mut processed_fields = Vec::with_capacity(fields.len());
+        let mut selection_builders = Vec::with_capacity(fields.len());
+
+        for field in fields {
             let field_type = FieldType::from_schema_type(&field.field_type, type_index);
 
             let selection_builder = FieldSelectionBuilder::for_field(
@@ -43,7 +47,7 @@ impl SelectorStruct {
                 &field.name,
                 field_type,
                 name.clone(),
-                Ident::for_module(&obj.name),
+                Ident::for_module(graphql_name),
                 field.required_arguments(),
                 TypePath::new(vec![
                     Ident::for_module(&name.rust_name()),
@@ -57,7 +61,7 @@ impl SelectorStruct {
 
         SelectorStruct {
             name,
-            graphql_name: obj.name.clone(),
+            graphql_name: graphql_name.to_owned(),
             fields: processed_fields,
             selection_builders,
         }

--- a/cynic-proc-macros/src/lib.rs
+++ b/cynic-proc-macros/src/lib.rs
@@ -52,7 +52,7 @@ pub fn inline_fragments_derive(input: TokenStream) -> TokenStream {
 
     let rv = match inline_fragments_derive::inline_fragments_derive(&ast) {
         Ok(tokens) => tokens.into(),
-        Err(e) => e.to_compile_error().into(),
+        Err(e) => e.to_compile_errors().into(),
     };
 
     //eprintln!("{}", rv);

--- a/cynic/Cargo.toml
+++ b/cynic/Cargo.toml
@@ -44,7 +44,7 @@ reqwest = { version = "0.11", optional = true, features = ["json"] }
 [dev-dependencies]
 maplit = "1.0.2"
 assert_matches = "1.3.0"
-insta = "1.1"
+insta = "1.5"
 
 [package.metadata.docs.rs]
 features = ["all"]

--- a/cynic/src/bin/simple.rs
+++ b/cynic/src/bin/simple.rs
@@ -84,7 +84,7 @@ enum Dessert {
     graphql_type = "MyUnionType"
 )]
 enum MyUnionType {
-    Test(Test),
+    TestStruct(Test),
     Nested(Nested),
 }
 

--- a/cynic/src/bin/simple_v2.rs
+++ b/cynic/src/bin/simple_v2.rs
@@ -58,7 +58,7 @@ mod queries {
     #[derive(cynic::InlineFragments)]
     #[cynic(graphql_type = "MyUnionType")]
     pub enum MyUnionType {
-        Test(Test),
+        TestStruct(Test),
         Nested(Nested),
     }
 }

--- a/examples/examples/querying-interfaces.rs
+++ b/examples/examples/querying-interfaces.rs
@@ -1,0 +1,132 @@
+//! An example of querying for interfaces with an InlineFragment
+
+mod query_dsl {
+    cynic::query_dsl!("../schemas/starwars.schema.graphql");
+}
+
+#[derive(cynic::InlineFragments, Debug)]
+#[cynic(
+    schema_path = "../schemas/starwars.schema.graphql",
+    query_module = "query_dsl",
+    graphql_type = "Node"
+)]
+enum Node {
+    Film(Film),
+    Planet(Planet),
+
+    #[cynic(fallback)]
+    Other(OtherNode),
+}
+
+#[derive(cynic::QueryFragment, Debug)]
+#[cynic(
+    schema_path = "../schemas/starwars.schema.graphql",
+    query_module = "query_dsl",
+    graphql_type = "Film"
+)]
+struct Film {
+    title: Option<String>,
+    director: Option<String>,
+}
+
+#[derive(cynic::QueryFragment, Debug)]
+#[cynic(
+    schema_path = "../schemas/starwars.schema.graphql",
+    query_module = "query_dsl",
+    graphql_type = "Planet"
+)]
+struct Planet {
+    name: Option<String>,
+}
+
+#[derive(cynic::QueryFragment, Debug)]
+#[cynic(
+    schema_path = "../schemas/starwars.schema.graphql",
+    query_module = "query_dsl",
+    graphql_type = "Node"
+)]
+struct OtherNode {
+    id: cynic::Id,
+}
+
+#[derive(cynic::FragmentArguments)]
+struct Arguments {
+    id: cynic::Id,
+}
+
+#[derive(cynic::QueryFragment, Debug)]
+#[cynic(
+    schema_path = "../schemas/starwars.schema.graphql",
+    query_module = "query_dsl",
+    graphql_type = "Root",
+    argument_struct = "Arguments"
+)]
+struct FilmDirectorQuery {
+    #[arguments(id = args.id.clone())]
+    node: Option<Node>,
+}
+
+fn main() {
+    let result = run_query("ZmlsbXM6MQ==".into());
+    println!("{:?}", result);
+}
+
+fn run_query(id: cynic::Id) -> cynic::GraphQLResponse<FilmDirectorQuery> {
+    use cynic::http::ReqwestBlockingExt;
+
+    let query = build_query(id);
+
+    reqwest::blocking::Client::new()
+        .post("https://swapi-graphql.netlify.com/.netlify/functions/index")
+        .run_graphql(query)
+        .unwrap()
+}
+
+fn build_query(id: cynic::Id) -> cynic::Operation<'static, FilmDirectorQuery> {
+    use cynic::QueryBuilder;
+
+    FilmDirectorQuery::build(&Arguments { id })
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn snapshot_test_menu_query() {
+        // Running a snapshot test of the query building functionality as that gives us
+        // a place to copy and paste the actual GQL we're using for running elsewhere,
+        // and also helps ensure we don't change queries by mistake
+
+        let query = build_query("ZmlsbXM6MQ==".into());
+
+        insta::assert_snapshot!(query.query);
+    }
+
+    #[test]
+    fn test_running_query_with_film() {
+        let result = run_query("ZmlsbXM6MQ==".into());
+        if result.errors.is_some() {
+            assert_eq!(result.errors.unwrap().len(), 0);
+        }
+        insta::assert_debug_snapshot!(result.data);
+    }
+
+    #[test]
+    fn test_running_query_with_planet() {
+        let result = run_query("cGxhbmV0czo0OQ==".into());
+        if result.errors.is_some() {
+            assert_eq!(result.errors.unwrap().len(), 0);
+        }
+        insta::assert_debug_snapshot!(result.data);
+    }
+
+    #[test]
+    fn test_running_query_with_starship() {
+        let result = run_query("c3RhcnNoaXBzOjY1".into());
+        if result.errors.is_some() {
+            assert_eq!(result.errors.unwrap().len(), 0);
+        }
+        insta::assert_debug_snapshot!(result.data);
+    }
+}

--- a/examples/examples/snapshots/querying_interfaces__test__running_query_with_film.snap
+++ b/examples/examples/snapshots/querying_interfaces__test__running_query_with_film.snap
@@ -1,0 +1,20 @@
+---
+source: examples/examples/querying-interfaces.rs
+expression: result.data
+---
+Some(
+    FilmDirectorQuery {
+        node: Some(
+            Film(
+                Film {
+                    title: Some(
+                        "A New Hope",
+                    ),
+                    director: Some(
+                        "George Lucas",
+                    ),
+                },
+            ),
+        ),
+    },
+)

--- a/examples/examples/snapshots/querying_interfaces__test__running_query_with_planet.snap
+++ b/examples/examples/snapshots/querying_interfaces__test__running_query_with_planet.snap
@@ -1,0 +1,17 @@
+---
+source: examples/examples/querying-interfaces.rs
+expression: result.data
+---
+Some(
+    FilmDirectorQuery {
+        node: Some(
+            Planet(
+                Planet {
+                    name: Some(
+                        "Dorin",
+                    ),
+                },
+            ),
+        ),
+    },
+)

--- a/examples/examples/snapshots/querying_interfaces__test__running_query_with_starship.snap
+++ b/examples/examples/snapshots/querying_interfaces__test__running_query_with_starship.snap
@@ -1,0 +1,17 @@
+---
+source: examples/examples/querying-interfaces.rs
+expression: result.data
+---
+Some(
+    FilmDirectorQuery {
+        node: Some(
+            Other(
+                OtherNode {
+                    id: Id(
+                        "c3RhcnNoaXBzOjY1",
+                    ),
+                },
+            ),
+        ),
+    },
+)

--- a/examples/examples/snapshots/querying_interfaces__test__snapshot_test_menu_query.snap
+++ b/examples/examples/snapshots/querying_interfaces__test__snapshot_test_menu_query.snap
@@ -1,0 +1,18 @@
+---
+source: examples/examples/querying-interfaces.rs
+expression: query.query
+---
+query Query($_0: ID!) {
+  node(id: $_0) {
+    __typename
+    ... on Film {
+      title
+      director
+    }
+    ... on Planet {
+      name
+    }
+    id
+  }
+}
+

--- a/tests/ui-tests/Cargo.toml
+++ b/tests/ui-tests/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "ui-tests"
+version = "0.1.0"
+authors = ["Graeme Coupar <grambo@grambo.me.uk>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dev-dependencies]
+cynic = { path = "../../cynic" }
+serde_json = "1.0"
+trybuild = "1.0"

--- a/tests/ui-tests/src/main.rs
+++ b/tests/ui-tests/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello, world!");
+}

--- a/tests/ui-tests/tests/cases/inline-fragment-exhaustiveness.rs
+++ b/tests/ui-tests/tests/cases/inline-fragment-exhaustiveness.rs
@@ -1,0 +1,39 @@
+fn main() {}
+
+mod query_dsl {
+    type Json = serde_json::Value;
+
+    cynic::query_dsl!("../../../cynic/src/bin/simple.graphql");
+}
+
+#[derive(cynic::InlineFragments)]
+#[cynic(
+    schema_path = "../../../cynic/src/bin/simple.graphql",
+    query_module = "query_dsl",
+    graphql_type = "MyUnionType"
+)]
+enum MyUnionType {
+    Test(Test),
+    Nested(Nested),
+}
+
+#[derive(cynic::QueryFragment)]
+#[cynic(
+    schema_path = "../../../cynic/src/bin/simple.graphql",
+    query_module = "query_dsl",
+    graphql_type = "Nested"
+)]
+struct Nested {
+    pub a_string: String,
+    pub opt_string: Option<String>,
+}
+
+#[derive(cynic::QueryFragment)]
+#[cynic(
+    schema_path = "../../../cynic/src/bin/simple.graphql",
+    query_module = "query_dsl",
+    graphql_type = "TestStruct"
+)]
+struct Test {
+    pub field_one: String,
+}

--- a/tests/ui-tests/tests/cases/inline-fragment-exhaustiveness.stderr
+++ b/tests/ui-tests/tests/cases/inline-fragment-exhaustiveness.stderr
@@ -1,0 +1,13 @@
+error: Could not find a match for Test in MyUnionType
+  --> $DIR/inline-fragment-exhaustiveness.rs:16:5
+   |
+16 |     Test(Test),
+   |     ^^^^
+
+error: This InlineFragment is missing a variant for TestStruct.  Either provide a variant for this type or add a fallback variant.
+ --> $DIR/inline-fragment-exhaustiveness.rs:9:10
+  |
+9 | #[derive(cynic::InlineFragments)]
+  |          ^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-tests/tests/cases/inline-fragment-fallback-validation.rs
+++ b/tests/ui-tests/tests/cases/inline-fragment-fallback-validation.rs
@@ -1,0 +1,44 @@
+fn main() {}
+
+mod query_dsl {
+    type Json = serde_json::Value;
+
+    cynic::query_dsl!("../../../cynic/src/bin/simple.graphql");
+}
+
+#[derive(cynic::InlineFragments)]
+#[cynic(
+    schema_path = "../../../cynic/src/bin/simple.graphql",
+    query_module = "query_dsl",
+    graphql_type = "MyUnionType"
+)]
+enum MyFailingUnionType {
+    Nested(Nested),
+
+    #[cynic(fallback)]
+    Other(Nested),
+}
+
+#[derive(cynic::QueryFragment)]
+#[cynic(
+    schema_path = "../../../cynic/src/bin/simple.graphql",
+    query_module = "query_dsl",
+    graphql_type = "Nested"
+)]
+struct Nested {
+    pub a_string: String,
+    pub opt_string: Option<String>,
+}
+
+#[derive(cynic::InlineFragments)]
+#[cynic(
+    schema_path = "../../../cynic/src/bin/simple.graphql",
+    query_module = "query_dsl",
+    graphql_type = "MyUnionType"
+)]
+enum MyOkUnionTYpe {
+    Nested(Nested),
+
+    #[cynic(fallback)]
+    Other,
+}

--- a/tests/ui-tests/tests/ui-tests.rs
+++ b/tests/ui-tests/tests/ui-tests.rs
@@ -1,0 +1,6 @@
+#[test]
+fn ui_test_inlinefragments() {
+    let t = trybuild::TestCases::new();
+    t.compile_fail("tests/cases/inline-fragment-exhaustiveness.rs");
+    t.compile_fail("tests/cases/inline-fragment-fallback-validation.rs");
+}


### PR DESCRIPTION
#### Why are we making this change?

Cynic has had rough support for union types via InlineFragments for a while.
#158 added support for using `InlineFragments` on interfaces.  However there
were a few limitations in this:

1. Little validation was done on InlineFragments - if you named a variant wrong
   or left off a variant you wouldn't be warned.
2. You needed to manually specify all types of a union or subtypes of an
   interface or you would get decode errors if you ran a query that encountered
   one you hadn't specified.

#### What effects does this change have?

This PR adds better support for interfaces & union types:

1. The variants are now validated - any incorrect variants will cause a compile
   error, and exhaustiveness checking is now done by default.
2. It adds a `#[cynic(fallback)]` annotation for `InlineFragment` variants -
   this branch will be decoded if the `__typename` does not match one of the
   provided types.  It can be either a unit variant or in the case of
   interfaces an `interface` type.
3. QueryFragment can now be derived on interface types directly, to support the
   above (and also for the case where you just want to query an interface type
   directly without using inline fragments to select more fields)

#### Still To Do

- [x] Update Book
- [x] Fix tests