### PR TITLE
Fix the URL to the starwars API.

### DIFF
--- a/cynic-book/src/manual-http-requests.md
+++ b/cynic-book/src/manual-http-requests.md
@@ -22,7 +22,7 @@ use cynic::QueryBuilder;
 let operation = AllFilmsQuery::build(());
 
 let response = reqwest::blocking::Client::new()
-    .post("https://swapi-graphql.netlify.com/.netlify/functions/index")
+    .post("https://swapi-graphql.netlify.app/.netlify/functions/index")
     .json(&operation)
     .send()
     .unwrap();

--- a/cynic-book/src/quickstart.md
+++ b/cynic-book/src/quickstart.md
@@ -136,7 +136,7 @@ client and then make a request. For example, to use surf to talk to the
 StarWars API (see the docs for `cynic::http` if you're using another client):
 
 ```rust
-let response = surf::post("https://swapi-graphql.netlify.com/.netlify/functions/index")
+let response = surf::post("https://swapi-graphql.netlify.app/.netlify/functions/index")
     .run_graphql(&operation)
     .await
     .unwrap();

--- a/cynic/src/http.rs
+++ b/cynic/src/http.rs
@@ -57,7 +57,7 @@ mod surf_ext {
     /// # async move {
     /// let operation = FilmDirectorQuery::build(());
     ///
-    /// let response = surf::post("https://swapi-graphql.netlify.com/.netlify/functions/index")
+    /// let response = surf::post("https://swapi-graphql.netlify.app/.netlify/functions/index")
     ///     .run_graphql(operation)
     ///     .await
     ///     .unwrap();
@@ -151,7 +151,7 @@ mod reqwest_ext {
     /// let operation = FilmDirectorQuery::build(());
     ///
     /// let client = reqwest::Client::new();
-    /// let response = client.post("https://swapi-graphql.netlify.com/.netlify/functions/index")
+    /// let response = client.post("https://swapi-graphql.netlify.app/.netlify/functions/index")
     ///     .run_graphql(operation)
     ///     .await
     ///     .unwrap();
@@ -245,7 +245,7 @@ mod reqwest_blocking_ext {
     /// let operation = FilmDirectorQuery::build(());
     ///
     /// let client = reqwest::blocking::Client::new();
-    /// let response = client.post("https://swapi-graphql.netlify.com/.netlify/functions/index")
+    /// let response = client.post("https://swapi-graphql.netlify.app/.netlify/functions/index")
     ///     .run_graphql(operation)
     ///     .unwrap();
     ///

--- a/examples/examples/manual-reqwest.rs
+++ b/examples/examples/manual-reqwest.rs
@@ -42,7 +42,7 @@ fn run_query() -> cynic::GraphQLResponse<FilmDirectorQuery> {
     let query = build_query();
 
     let response = reqwest::blocking::Client::new()
-        .post("https://swapi-graphql.netlify.com/.netlify/functions/index")
+        .post("https://swapi-graphql.netlify.app/.netlify/functions/index")
         .json(&query)
         .send()
         .unwrap();

--- a/examples/examples/querying-interfaces.rs
+++ b/examples/examples/querying-interfaces.rs
@@ -77,7 +77,7 @@ fn run_query(id: cynic::Id) -> cynic::GraphQLResponse<FilmDirectorQuery> {
     let query = build_query(id);
 
     reqwest::blocking::Client::new()
-        .post("https://swapi-graphql.netlify.com/.netlify/functions/index")
+        .post("https://swapi-graphql.netlify.app/.netlify/functions/index")
         .run_graphql(query)
         .unwrap()
 }

--- a/examples/examples/reqwest-async.rs
+++ b/examples/examples/reqwest-async.rs
@@ -47,7 +47,7 @@ async fn run_query() -> cynic::GraphQLResponse<FilmDirectorQuery> {
     let query = build_query();
 
     reqwest::Client::new()
-        .post("https://swapi-graphql.netlify.com/.netlify/functions/index")
+        .post("https://swapi-graphql.netlify.app/.netlify/functions/index")
         .run_graphql(query)
         .await
         .unwrap()

--- a/examples/examples/starwars.rs
+++ b/examples/examples/starwars.rs
@@ -43,7 +43,7 @@ fn run_query() -> cynic::GraphQLResponse<FilmDirectorQuery> {
     let query = build_query();
 
     reqwest::blocking::Client::new()
-        .post("https://swapi-graphql.netlify.com/.netlify/functions/index")
+        .post("https://swapi-graphql.netlify.app/.netlify/functions/index")
         .run_graphql(query)
         .unwrap()
 }

--- a/examples/examples/surf-client.rs
+++ b/examples/examples/surf-client.rs
@@ -47,7 +47,7 @@ async fn run_query() -> cynic::GraphQLResponse<FilmDirectorQuery> {
 
     let operation = build_query();
 
-    surf::post("http://swapi-graphql.netlify.com/.netlify/functions/index")
+    surf::post("http://swapi-graphql.netlify.app/.netlify/functions/index")
         .run_graphql(operation)
         .await
         .unwrap()

--- a/tests/querygen-compile-run/build.rs
+++ b/tests/querygen-compile-run/build.rs
@@ -8,7 +8,7 @@ use cynic_querygen::{document_to_fragment_structs, QueryGenOptions};
 
 fn main() {
     let starwars_schema = Schema::from_repo_schemas(
-        "https://swapi-graphql.netlify.com/.netlify/functions/index",
+        "https://swapi-graphql.netlify.app/.netlify/functions/index",
         "starwars.schema.graphql",
     );
     let jobs_schema =


### PR DESCRIPTION
Apparently netlify have changed their domain name - the old domain is
now returning redirects.

This is breaking the surf examples as they don't follow redirects.