### PR TITLE
Make NaiveTime support times without seconds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ all APIs might be changed.
 
 ## Unreleased - xxxx-xx-xx
 
+### Bug Fixes
+
+- `chrono::NaiveTime` now supports times without seconds (e.g. `10:30`)
+- Failures to parse chrono types now provide error messages that mention
+  chrono: these were fairly hard to diagnose before.
+
 ## v0.12.0 - 2020-02-08
 
 ### Breaking Changes

--- a/cynic-querygen/src/lib.rs
+++ b/cynic-querygen/src/lib.rs
@@ -161,11 +161,3 @@ pub fn document_to_fragment_structs(
 
     Ok(output)
 }
-
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn it_works() {
-        assert_eq!(2 + 2, 4);
-    }
-}

--- a/cynic/src/integrations/chrono.rs
+++ b/cynic/src/integrations/chrono.rs
@@ -6,9 +6,8 @@ use crate::{scalar::Scalar, SerializeError};
 impl Scalar for NaiveDate {
     fn decode(value: &serde_json::Value) -> Result<Self, DecodeError> {
         match value {
-            serde_json::Value::String(s) => {
-                Ok(NaiveDate::parse_from_str(s, "%Y-%m-%d").map_err(chrono_decode_error)?)
-            }
+            serde_json::Value::String(s) => Ok(NaiveDate::parse_from_str(s, "%Y-%m-%d")
+                .map_err(|e| chrono_parse_error(e, "NaiveDate"))?),
             _ => Err(DecodeError::IncorrectType(
                 "String".to_string(),
                 value.to_string(),
@@ -28,7 +27,18 @@ crate::impl_serializable_argument_for_scalar!(NaiveDate);
 impl Scalar for NaiveTime {
     fn decode(value: &serde_json::Value) -> Result<Self, DecodeError> {
         match value {
-            serde_json::Value::String(s) => Ok(s.parse().map_err(chrono_decode_error)?),
+            serde_json::Value::String(s) => {
+                match s.parse() {
+                    Ok(s) => Ok(s),
+                    Err(e) => {
+                        // Attempt to fall back to times without a second component.
+                        match NaiveTime::parse_from_str(s, "%H:%M") {
+                            Ok(s) => Ok(s),
+                            _ => Err(chrono_parse_error(e, "NaiveTime")),
+                        }
+                    }
+                }
+            }
             _ => Err(DecodeError::IncorrectType(
                 "String".to_string(),
                 value.to_string(),
@@ -46,9 +56,8 @@ crate::impl_serializable_argument_for_scalar!(NaiveTime);
 impl Scalar for DateTime<FixedOffset> {
     fn decode(value: &serde_json::Value) -> Result<Self, DecodeError> {
         match value {
-            serde_json::Value::String(s) => {
-                Ok(DateTime::parse_from_rfc3339(s).map_err(chrono_decode_error)?)
-            }
+            serde_json::Value::String(s) => Ok(DateTime::parse_from_rfc3339(s)
+                .map_err(|e| chrono_parse_error(e, "DateTime<FixedOffset>"))?),
             _ => Err(DecodeError::IncorrectType(
                 "String".to_string(),
                 value.to_string(),
@@ -67,7 +76,7 @@ impl Scalar for DateTime<Utc> {
     fn decode(value: &serde_json::Value) -> Result<Self, DecodeError> {
         match value {
             serde_json::Value::String(s) => Ok(DateTime::parse_from_rfc3339(s)
-                .map_err(chrono_decode_error)?
+                .map_err(|e| chrono_parse_error(e, "DateTime<Utc>"))?
                 .with_timezone(&Utc)),
             _ => Err(DecodeError::IncorrectType(
                 "String".to_string(),
@@ -83,13 +92,14 @@ impl Scalar for DateTime<Utc> {
 
 crate::impl_serializable_argument_for_scalar!(DateTime<Utc>);
 
-fn chrono_decode_error(err: chrono::ParseError) -> DecodeError {
-    DecodeError::Other(err.to_string())
+fn chrono_parse_error(err: chrono::ParseError, kind: &'static str) -> DecodeError {
+    DecodeError::Other(format!("{} parse error: {}", kind, err.to_string()))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::json;
 
     #[test]
     fn test_naive_date_scalar() {
@@ -104,13 +114,29 @@ mod tests {
     fn test_naive_time_scalar() {
         use chrono::NaiveTime;
 
-        let time: NaiveTime = NaiveTime::from_hms(15, 03, 19);
+        let time: NaiveTime = NaiveTime::from_hms(15, 3, 19);
         assert_eq!(NaiveTime::decode(&time.encode().unwrap()), Ok(time));
 
-        let time_with_millis: NaiveTime = NaiveTime::from_hms_milli(15, 03, 10, 234);
+        let time_with_millis: NaiveTime = NaiveTime::from_hms_milli(15, 3, 10, 234);
         assert_eq!(
             NaiveTime::decode(&time_with_millis.encode().unwrap()),
             Ok(time_with_millis)
+        );
+    }
+
+    #[test]
+    fn test_naive_time_decode_supports_short_forms() {
+        assert_eq!(
+            NaiveTime::decode(&json!("10:00:43.123")),
+            Ok(NaiveTime::from_hms_milli(10, 0, 43, 123))
+        );
+        assert_eq!(
+            NaiveTime::decode(&json!("10:00:43")),
+            Ok(NaiveTime::from_hms(10, 0, 43))
+        );
+        assert_eq!(
+            NaiveTime::decode(&json!("10:05")),
+            Ok(NaiveTime::from_hms(10, 5, 0))
         );
     }
 
@@ -119,7 +145,7 @@ mod tests {
         use chrono::TimeZone;
 
         let datetime: DateTime<FixedOffset> = FixedOffset::east(3600 * 5)
-            .ymd(2016, 11, 08)
+            .ymd(2016, 11, 8)
             .and_hms(10, 15, 20);
 
         assert_eq!(DateTime::decode(&datetime.encode().unwrap()), Ok(datetime));


### PR DESCRIPTION
#### Why are we making this change?

PR #197 added support for NaiveTime.  It was expected that this would also
support `10:30` as a time, but it does not.

#### What effects does this change have?

Adds a fallback that attempts to decode 10:30 if the first attempt fails.

Also updates the chrono error messages to be a bit more self explanitory.