### PR TITLE
Add StreamingOperation::decode_response.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ all APIs might be changed.
 
 ## Unreleased - xxxx-xx-xx
 
+### New Features
+
+- Support for building and decoding subscription queries.
+
 ## v0.12.1 - 2020-02-12
 
 ### Bug Fixes

--- a/cynic/Cargo.toml
+++ b/cynic/Cargo.toml
@@ -23,12 +23,12 @@ surf-middleware-logger = ["surf/middleware-logger"]
 surf-encoding = ["surf/encoding"]
 
 [dependencies]
+chrono = { version = "0.4.11", optional = true }
+cynic-proc-macros = { path = "../cynic-proc-macros", version = "0.12.1" }
 json-decode = "0.5.0"
 serde = { version = "1.0.104", features = [ "derive" ] }
 serde_json = "1.0"
 thiserror = "1.0.20"
-cynic-proc-macros = { path = "../cynic-proc-macros", version = "0.12.1" }
-chrono = { version = "0.4.11", optional = true }
 
 # Scalar feature deps
 bson = { version = "1.1.0", optional = true }

--- a/cynic/src/lib.rs
+++ b/cynic/src/lib.rs
@@ -187,7 +187,7 @@ pub mod utils;
 pub use json_decode::DecodeError;
 
 pub use arguments::{Argument, FromArguments, IntoArgument, SerializableArgument};
-pub use builders::{MutationBuilder, QueryBuilder};
+pub use builders::{MutationBuilder, QueryBuilder, SubscriptionBuilder};
 pub use fragments::{FragmentArguments, FragmentContext, InlineFragments, QueryFragment};
 pub use id::Id;
 pub use operation::{Operation, StreamingOperation};

--- a/cynic/src/operation.rs
+++ b/cynic/src/operation.rs
@@ -106,6 +106,13 @@ impl<'a, ResponseData: 'a> StreamingOperation<'a, ResponseData> {
             },
         }
     }
+
+    pub fn decode_response(
+        &self,
+        response: GraphQLResponse<serde_json::Value>,
+    ) -> Result<GraphQLResponse<ResponseData>, json_decode::DecodeError> {
+        self.inner.decode_response(response)
+    }
 }
 
 impl<ResponseData> serde::Serialize for StreamingOperation<'_, ResponseData> {


### PR DESCRIPTION
#### Why are we making this change?

PR #177 added a `StreamingOperation` type - exactly equivalent to
`Operation` but for subscriptions where we expect to stream > 1 response
to the given operation.

It didn't expose a `decode_response` function though so was effectively
useless.

#### What effects does this change have?

Adds `StreamingOperation::decode_response` which means cynic can
now be used for subscriptions (although it does not currently do any protocol
stuff - that will be coming soon).