### PR TITLE
Fix docs.rs build (hopefully)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ all APIs might be changed.
 
 ## Unreleased - xxxx-xx-xx
 
+## v0.12.2 - 2020-02-22
+
+### Bug Fixes
+
+- Hopefully fixed the build of documentation for docs.rs
+
 ## v0.12.1 - 2020-02-12
 
 ### Bug Fixes

--- a/cynic/src/lib.rs
+++ b/cynic/src/lib.rs
@@ -171,6 +171,8 @@
 //! [known issues](https://github.com/servo/rust-url/issues/557) when
 //! targetting web assembly.
 
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
 mod arguments;
 mod builders;
 mod fragments;


### PR DESCRIPTION
#### Why are we making this change?

Just noticed that the docs.rs build for 0.12 is failing with:

```
[INFO] [stderr] error[E0658]: `#[doc(cfg)]` is experimental
[INFO] [stderr]  --> src/http.rs:7:20
[INFO] [stderr]   |
[INFO] [stderr] 7 | #[cfg_attr(docsrs, doc(cfg(feature = "surf")))]
[INFO] [stderr]   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^
[INFO] [stderr]   |
[INFO] [stderr]   = note: see issue #43781 <https://github.com/rust-lang/rust/issues/43781> for more information
[INFO] [stderr]   = help: add `#![feature(doc_cfg)]` to the crate attributes to enable
```

#### What effects does this change have?

This adds the `doc_cfg` feature when building on docs.rs
