### PR TITLE
Fix enum typesafety issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,13 @@ all APIs might be changed.
 
 - Support for building and decoding subscription queries.
 
+### Bug Fixes
+
+- Cynic will now fail to compile you when you use an incorrect enum type for a
+  field in a QueryFragment.
+- Field type mismatch errors in QueryFragments are now reported on the span of
+  the field type.
+
 ## v0.12.2 - 2020-02-22
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ all APIs might be changed.
 
 ## Unreleased - xxxx-xx-xx
 
+### Breaking Changes
+
+- The return type of `cynic::Enum::select` now includes the `TypeLock` of the
+  enum.  This should only affect users that were implementing `cynic::Enum`
+  directly.  Users of the derive should be unaffected.
+
 ### New Features
 
 - Support for building and decoding subscription queries.

--- a/cynic-codegen/src/enum_derive/mod.rs
+++ b/cynic-codegen/src/enum_derive/mod.rs
@@ -95,8 +95,8 @@ pub fn enum_derive_impl(
         Ok(quote! {
             #[automatically_derived]
             impl ::cynic::Enum<#query_module::#enum_marker_ident> for #ident {
-                fn select() -> cynic::SelectionSet<'static, Self, ()> {
-                    ::cynic::selection_set::string().and_then(|s| {
+                fn select() -> cynic::SelectionSet<'static, Self, #query_module::#enum_marker_ident> {
+                    ::cynic::selection_set::enum_with(|s| {
                         match s.as_ref() {
                             #(
                                 #string_literals => ::cynic::selection_set::succeed(#ident::#variants),

--- a/cynic-codegen/src/field_type.rs
+++ b/cynic-codegen/src/field_type.rs
@@ -128,7 +128,7 @@ impl FieldType {
             FieldType::List(inner, _) => inner.as_type_lock(path_to_types),
             // TODO: I think this is wrong for scalars, but whatever.
             FieldType::Scalar(path, _) => TypePath::concat(&[path_to_types, path.clone()]),
-            FieldType::Enum(_, _) => TypePath::void(),
+            FieldType::Enum(ident, _) => TypePath::concat(&[path_to_types, ident.clone().into()]),
             FieldType::InputObject(ident, _) => {
                 TypePath::concat(&[path_to_types, ident.clone().into()])
             }

--- a/cynic-codegen/src/fragment_derive/mod.rs
+++ b/cynic-codegen/src/fragment_derive/mod.rs
@@ -1,6 +1,7 @@
 use std::collections::{HashMap, HashSet};
 
 use proc_macro2::{Span, TokenStream};
+use syn::spanned::Spanned;
 
 use crate::{
     load_schema, type_validation::check_types_are_compatible, Errors, FieldType, Ident, TypePath,
@@ -262,21 +263,24 @@ struct FieldSelectorCall {
     required_arguments: Vec<FieldArgument>,
     optional_arguments: Vec<FieldArgument>,
     recurse_limit: Option<u8>,
+    span: proc_macro2::Span,
 }
 
 impl quote::ToTokens for FieldSelectorCall {
     fn to_tokens(&self, tokens: &mut TokenStream) {
-        use quote::{quote, TokenStreamExt};
+        use quote::{quote, quote_spanned, TokenStreamExt};
+
+        let span = self.span;
 
         let inner_selection_tokens = match (&self.style, self.recurse_limit) {
-            (NamedTypeSelectorStyle::Scalar, _) => quote! {},
-            (NamedTypeSelectorStyle::Enum(enum_type), _) => quote! {
+            (NamedTypeSelectorStyle::Scalar, _) => quote_spanned! {span => },
+            (NamedTypeSelectorStyle::Enum(enum_type), _) => quote_spanned! {span =>
                 #enum_type::select()
             },
-            (NamedTypeSelectorStyle::QueryFragment(field_type), None) => quote! {
+            (NamedTypeSelectorStyle::QueryFragment(field_type), None) => quote_spanned! {span =>
                 #field_type::fragment(context.with_args(FromArguments::from_arguments(args)))
             },
-            (NamedTypeSelectorStyle::QueryFragment(field_type), Some(_)) => quote! {
+            (NamedTypeSelectorStyle::QueryFragment(field_type), Some(_)) => quote_spanned! {span =>
                 #field_type::fragment(context.recurse().with_args(FromArguments::from_arguments(args)))
             },
         };
@@ -384,6 +388,7 @@ impl FragmentImpl {
                         required_arguments,
                         optional_arguments,
                         recurse_limit: field.recurse.as_ref().map(|limit| **limit),
+                        span: field.ty.span(),
                     })
                 } else {
                     let candidates = object.fields.keys().map(|k| k.graphql_name());

--- a/cynic-codegen/tests/snapshots/query_dsl__schema_file_2.snap
+++ b/cynic-codegen/tests/snapshots/query_dsl__schema_file_2.snap
@@ -120,7 +120,7 @@ pub mod book_changed {
         }
         pub fn select<'a, T: 'a + Send + Sync>(
             self,
-            fields: ::cynic::selection_set::SelectionSet<'a, T, ()>,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::MutationType>,
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::BookChanged> {
             ::cynic::selection_set::field("mutationType", self.args, fields)
         }

--- a/cynic/src/lib.rs
+++ b/cynic/src/lib.rs
@@ -215,7 +215,7 @@ pub type SerializeError = Box<dyn std::error::Error + Send + Sync>;
 /// definition back into it's GraphQL enum.  Generally this will be some
 /// type generated in the GQL code.
 pub trait Enum<TypeLock>: Sized {
-    fn select() -> SelectionSet<'static, Self, ()>;
+    fn select() -> SelectionSet<'static, Self, TypeLock>;
 }
 
 /// A trait for GraphQL input objects.

--- a/cynic/src/selection_set/mod.rs
+++ b/cynic/src/selection_set/mod.rs
@@ -160,6 +160,18 @@ pub fn boolean() -> SelectionSet<'static, bool, ()> {
     SelectionSet::new(vec![], json_decode::boolean())
 }
 
+/// Creates a `SelectionSet` for decoding a GQL enum with a function.
+///
+/// Will decode a string and pass it to the given closure to convert
+/// into the actual enum.
+pub fn enum_with<E, TypeLock, F>(f: F) -> SelectionSet<'static, E, TypeLock>
+where
+    E: crate::Enum<TypeLock> + 'static,
+    F: (Fn(String) -> SelectionSet<'static, E, TypeLock>) + 'static + Sync + Send,
+{
+    SelectionSet::new(vec![], json_decode::string()).and_then(f)
+}
+
 /// Creates a `SelectionSet` that will decode a type that implements `serde::Deserialize`
 pub fn serde<T>() -> SelectionSet<'static, T, ()>
 where
@@ -595,7 +607,7 @@ where
 ///
 /// See the [`SelectionSet::and_then`](cynic::selection_set::SelectionSet::and_then)
 /// docs for an example.
-pub fn fail<V>(err: impl Into<String>) -> SelectionSet<'static, V, ()> {
+pub fn fail<V, TypeLock>(err: impl Into<String>) -> SelectionSet<'static, V, TypeLock> {
     SelectionSet::new(vec![], json_decode::fail(err))
 }
 

--- a/tests/ui-tests/tests/cases/wrong-enum-type.rs
+++ b/tests/ui-tests/tests/cases/wrong-enum-type.rs
@@ -1,0 +1,74 @@
+#![allow(unused_imports)]
+
+fn main() {}
+
+#[cynic::query_module(
+    schema_path = r#"./../../../schemas/github.graphql"#,
+    query_module = "query_dsl"
+)]
+mod queries {
+    use super::{query_dsl, types::*};
+
+    #[derive(cynic::QueryFragment, Debug)]
+    #[cynic(graphql_type = "CheckSuite")]
+    pub struct CheckSuite {
+        // Note: this is the wrong underlying enum type
+        // Should be CheckStatusState
+        pub status: CheckConclusionState,
+        pub conclusion: Option<CheckConclusionState>,
+    }
+
+    #[derive(cynic::Enum, Clone, Copy, Debug)]
+    #[cynic(graphql_type = "CheckConclusionState")]
+    pub enum CheckConclusionState {
+        ActionRequired,
+        Cancelled,
+        Failure,
+        Neutral,
+        Skipped,
+        Stale,
+        Success,
+        TimedOut,
+    }
+}
+
+#[cynic::query_module(
+    schema_path = r#"./../../../schemas/github.graphql"#,
+    query_module = "query_dsl"
+)]
+mod types {
+    #[derive(cynic::Scalar, Debug, Clone)]
+    pub struct Date(pub String);
+
+    #[derive(cynic::Scalar, Debug, Clone)]
+    pub struct DateTime(pub String);
+
+    #[derive(cynic::Scalar, Debug, Clone)]
+    pub struct GitObjectID(pub String);
+
+    #[derive(cynic::Scalar, Debug, Clone)]
+    pub struct GitRefname(pub String);
+
+    #[derive(cynic::Scalar, Debug, Clone)]
+    pub struct GitSSHRemote(pub String);
+
+    #[derive(cynic::Scalar, Debug, Clone)]
+    pub struct GitTimestamp(pub String);
+
+    #[derive(cynic::Scalar, Debug, Clone)]
+    pub struct Html(pub String);
+
+    #[derive(cynic::Scalar, Debug, Clone)]
+    pub struct PreciseDateTime(pub String);
+
+    #[derive(cynic::Scalar, Debug, Clone)]
+    pub struct Uri(pub String);
+
+    #[derive(cynic::Scalar, Debug, Clone)]
+    pub struct X509Certificate(pub String);
+}
+
+mod query_dsl {
+    use super::types::*;
+    cynic::query_dsl!(r#"./../../../schemas/github.graphql"#);
+}

--- a/tests/ui-tests/tests/cases/wrong-enum-type.stderr
+++ b/tests/ui-tests/tests/cases/wrong-enum-type.stderr
@@ -1,0 +1,8 @@
+error[E0308]: mismatched types
+  --> $DIR/wrong-enum-type.rs:17:21
+   |
+17 |         pub status: CheckConclusionState,
+   |                     ^^^^^^^^^^^^^^^^^^^^ expected struct `CheckStatusState`, found struct `query_dsl::CheckConclusionState`
+   |
+   = note: expected struct `SelectionSet<'_, _, CheckStatusState>`
+              found struct `SelectionSet<'static, _, query_dsl::CheckConclusionState>`

--- a/tests/ui-tests/tests/ui-tests.rs
+++ b/tests/ui-tests/tests/ui-tests.rs
@@ -1,9 +1,10 @@
 #[test]
 fn ui_test_inlinefragments() {
     let t = trybuild::TestCases::new();
-    t.compile_fail("tests/cases/inline-fragment-exhaustiveness.rs");
-    t.compile_fail("tests/cases/inline-fragment-fallback-validation.rs");
     t.compile_fail("tests/cases/enum-guess-validation.rs");
     t.compile_fail("tests/cases/fragment-guess-validation.rs");
+    t.compile_fail("tests/cases/inline-fragment-exhaustiveness.rs");
+    t.compile_fail("tests/cases/inline-fragment-fallback-validation.rs");
     t.compile_fail("tests/cases/inputobject-guess-validation.rs");
+    t.compile_fail("tests/cases/wrong-enum-type.rs");
 }


### PR DESCRIPTION
#### Why are we making this change?

Noticed today that cynics enums are not typesafe - when you select an enum
field in a QueryFragment it will accept any old enum, regardless of whether
that enum is valid for that field.

Enums have a TypeLock parameter but this wasn't actually being used to enforce
anything.

#### What effects does this change have?

Updates the enum code to use the TypeLock to enforce that the enum represents
the correct type in the schema.

Also fixed the spans on QueryFragment type mismatches.

Fixes #81
Fixes #209