### PR TITLE
v0.12.3 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ all APIs might be changed.
 
 ## Unreleased - xxxx-xx-xx
 
+## v0.12.3 - 2020-04-01
+
 ## Bug Fixes
 
 - The `cynic::Scalar` derive output no longer contains a spurious `?` that

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ all APIs might be changed.
 
 ## Unreleased - xxxx-xx-xx
 
+## Bug Fixes
+
+- The `cynic::Scalar` derive output no longer contains a spurious `?` that
+  clippy warns about in Rust 1.51.
+
 ## v0.12.2 - 2020-02-22
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2722,9 +2722,9 @@ checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
 name = "trybuild"
-version = "1.0.35"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7d30fe369fd650072b352b1a9cb9587669de6b89be3b8225544012c1c45292d"
+checksum = "99471a206425fba51842a9186315f32d91c56eadc21ea4c21f847b59cf778f8b"
 dependencies = [
  "glob",
  "lazy_static",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -598,7 +598,7 @@ dependencies = [
 
 [[package]]
 name = "cynic"
-version = "0.12.2"
+version = "0.12.3"
 dependencies = [
  "assert_matches",
  "bson",
@@ -618,7 +618,7 @@ dependencies = [
 
 [[package]]
 name = "cynic-codegen"
-version = "0.12.2"
+version = "0.12.3"
 dependencies = [
  "Inflector",
  "assert_matches",
@@ -636,7 +636,7 @@ dependencies = [
 
 [[package]]
 name = "cynic-examples"
-version = "0.12.2"
+version = "0.12.3"
 dependencies = [
  "async-std",
  "cynic",
@@ -650,7 +650,7 @@ dependencies = [
 
 [[package]]
 name = "cynic-proc-macros"
-version = "0.12.2"
+version = "0.12.3"
 dependencies = [
  "cynic-codegen",
  "syn",
@@ -658,7 +658,7 @@ dependencies = [
 
 [[package]]
 name = "cynic-querygen"
-version = "0.12.2"
+version = "0.12.3"
 dependencies = [
  "Inflector",
  "assert_matches",
@@ -672,7 +672,7 @@ dependencies = [
 
 [[package]]
 name = "cynic-querygen-web"
-version = "0.12.2"
+version = "0.12.3"
 dependencies = [
  "cynic-querygen",
  "seed",

--- a/cynic-codegen/Cargo.toml
+++ b/cynic-codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cynic-codegen"
-version = "0.12.2"
+version = "0.12.3"
 authors = ["Graeme Coupar <graeme@polyandglot.dev>"]
 edition = "2018"
 homepage = "https://cynic-rs.dev"

--- a/cynic-codegen/src/ident.rs
+++ b/cynic-codegen/src/ident.rs
@@ -103,9 +103,9 @@ impl From<proc_macro2::Ident> for Ident {
     }
 }
 
-impl Into<proc_macro2::Ident> for &Ident {
-    fn into(self) -> proc_macro2::Ident {
-        self.rust.clone()
+impl From<&Ident> for proc_macro2::Ident {
+    fn from(ident: &Ident) -> proc_macro2::Ident {
+        ident.rust.clone()
     }
 }
 

--- a/cynic-codegen/src/scalar_derive/mod.rs
+++ b/cynic-codegen/src/scalar_derive/mod.rs
@@ -35,7 +35,7 @@ pub fn scalar_derive_impl(input: ScalarDeriveInput) -> Result<TokenStream, syn::
                 Ok(#ident(<#inner_type as ::cynic::Scalar>::decode(value)?))
             }
             fn encode(&self) -> Result<::cynic::serde_json::Value, ::cynic::SerializeError> {
-                Ok(self.0.encode()?)
+                self.0.encode()
             }
         }
 

--- a/cynic-proc-macros/Cargo.toml
+++ b/cynic-proc-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cynic-proc-macros"
-version = "0.12.2"
+version = "0.12.3"
 authors = ["Graeme Coupar <graeme@polyandglot.dev>"]
 edition = "2018"
 homepage = "https://cynic-rs.dev"
@@ -15,5 +15,5 @@ documentation = "https://docs.rs/cynic-proc-macros"
 proc-macro = true
 
 [dependencies]
-cynic-codegen = { path = "../cynic-codegen", version = "0.12.2" }
+cynic-codegen = { path = "../cynic-codegen", version = "0.12.3" }
 syn = "1.0.13"

--- a/cynic-querygen-web/Cargo.toml
+++ b/cynic-querygen-web/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-version = "0.12.2"
+version = "0.12.3"
 name = "cynic-querygen-web"
 repository = "https://github.com/obmarg/cynic"
 authors = ["Graeme Coupar<graeme@polyandglot.dev>"]

--- a/cynic-querygen-web/src/graphiql_page.rs
+++ b/cynic-querygen-web/src/graphiql_page.rs
@@ -24,7 +24,7 @@ impl Model {
     }
 
     fn generate_code(&mut self) {
-        if self.query != "" && self.schema_data.is_some() {
+        if !self.query.is_empty() && self.schema_data.is_some() {
             self.generated_code = cynic_querygen::document_to_fragment_structs(
                 &self.query,
                 self.schema_data.as_ref().unwrap(),

--- a/cynic-querygen/Cargo.toml
+++ b/cynic-querygen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cynic-querygen"
-version = "0.12.2"
+version = "0.12.3"
 authors = ["Graeme Coupar <grambo@grambo.me.uk>"]
 edition = "2018"
 homepage = "https://cynic-rs.dev"

--- a/cynic-querygen/src/query_parsing/value.rs
+++ b/cynic-querygen/src/query_parsing/value.rs
@@ -63,11 +63,11 @@ impl<'query, 'schema> TypedValue<'query, 'schema> {
                     values
                         .iter()
                         .map(|val| {
-                            Ok(TypedValue::from_query_value(
+                            TypedValue::from_query_value(
                                 val,
                                 inner_type.clone(),
                                 variable_definitions,
-                            )?)
+                            )
                         })
                         .collect::<Result<_, Error>>()?,
                     field_type,
@@ -120,7 +120,7 @@ impl<'query, 'schema> TypedValue<'query, 'schema> {
     }
 
     pub fn is_variable(&self) -> bool {
-        matches!(self, TypedValue::Variable{ ..})
+        matches!(self, TypedValue::Variable { .. })
     }
 
     pub fn variables(&self) -> Vec<Variable<'query, 'schema>> {
@@ -199,7 +199,7 @@ impl<'query, 'schema> TypedValue<'query, 'schema> {
             TypedValue::List(values, _) => {
                 let inner = values
                     .iter()
-                    .map(|v| Ok(v.to_literal(LiteralContext::ListItem)?))
+                    .map(|v| v.to_literal(LiteralContext::ListItem))
                     .collect::<Result<Vec<_>, Error>>()?
                     .join(", ");
 

--- a/cynic-querygen/src/schema/type_refs.rs
+++ b/cynic-querygen/src/schema/type_refs.rs
@@ -63,7 +63,7 @@ macro_rules! impl_type_ref {
                 }
             }
 
-            #[allow(dead_code)]
+            #[allow(dead_code, clippy::needless_question_mark)]
             pub fn lookup(&self) -> Result<$lookup_type<'schema>, Error> {
                 Ok(self.type_index.lookup_type(&self.type_name)?.try_into()?)
             }

--- a/cynic/Cargo.toml
+++ b/cynic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cynic"
-version = "0.12.2"
+version = "0.12.3"
 authors = ["Graeme Coupar <graeme@polyandglot.dev>"]
 edition = "2018"
 homepage = "https://cynic-rs.dev"
@@ -27,7 +27,7 @@ json-decode = "0.5.0"
 serde = { version = "1.0.104", features = [ "derive" ] }
 serde_json = "1.0"
 thiserror = "1.0.20"
-cynic-proc-macros = { path = "../cynic-proc-macros", version = "0.12.2" }
+cynic-proc-macros = { path = "../cynic-proc-macros", version = "0.12.3" }
 chrono = { version = "0.4.11", optional = true }
 
 # Scalar feature deps

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cynic-examples"
-version = "0.12.2"
+version = "0.12.3"
 authors = ["Graeme Coupar <grambo@grambo.me.uk>"]
 edition = "2018"
 


### PR DESCRIPTION
#### Why are we making this change?

Rust 1.51 has added a bunch of clippy lints, one of which is triggered by the codegen output.

#### What effects does this change have?

Fixes that clippy lint, so users don't have to see a whole ton of warnings in their codebases.

This branch will be released as v0.12.3 when CI passes.