### PR TITLE
Update docs & codegen after #213

### DIFF
--- a/cynic-book/src/derives/enums.md
+++ b/cynic-book/src/derives/enums.md
@@ -6,7 +6,6 @@ an enum, and the easiest way to define that trait is to derive it:
 
 ```rust
 #[derive(cynic::Enum, Clone, Copy, Debug)]
-#[cynic(graphql_type = "Market")]
 pub enum Market {
     Uk,
     Ie,
@@ -19,9 +18,9 @@ variants, the derive will emit errors.
 
 #### Variant Naming
 
-The GraphQL spec [recommends that enums are "all caps"][1].  To handle this
+The GraphQL spec [recommends that enums are "all caps"][1]. To handle this
 smoothly, Cynic matches rust variants up to their equivalent
-`SCREAMING_SNAKE_CASE` GraphQL variants.  This behaviour can be disabled by
+`SCREAMING_SNAKE_CASE` GraphQL variants. This behaviour can be disabled by
 specifying a `rename_all = "None"` attribute, or customised alternative
 `rename_all` values or individual `rename` attributes on the variants.
 
@@ -29,8 +28,8 @@ specifying a `rename_all = "None"` attribute, or customised alternative
 
 An Enum can be configured with several attributes on the enum itself:
 
-- `graphql_type = "AType"` is required and tells cynic which type in the
-  GraphQL schema to map this enum to
+- `graphql_type = "AType"` tells cynic which enum in the GraphQL schema this
+  enum represents. The name of the enum is used if it is omitted.
 - `rename_all="camelCase"` tells cynic to rename all the rust field names with
   a particular rule to match their GraphQL counterparts. If not provided this
   defaults to `SCREAMING_SNAKE_CASE` to be consistent with GraphQL conventions.

--- a/cynic-book/src/derives/inline-fragments.md
+++ b/cynic-book/src/derives/inline-fragments.md
@@ -16,7 +16,6 @@ For example, the GitHub API has an `Assignee` union type which could be queried 
 #[cynic(
     schema_path = "github.graphql",
     query_module = "query_dsl",
-    graphql_type = "Assignee"
 )]
 enum Assignee {
     Bot(Bot),
@@ -32,8 +31,8 @@ implement `QueryFragment` for the respective GraphQL types.
 #### Fallbacks
 
 By default cynic will error you if you leave out any possible type for a given
-union type of interface.  If you don't want to provide cases for each of the
-possible types you can provide the `fallback` attribute on a variant.  That
+union type of interface. If you don't want to provide cases for each of the
+possible types you can provide the `fallback` attribute on a variant. That
 variant will be output whenever an unhandled type is returned.
 
 ```rust
@@ -41,7 +40,6 @@ variant will be output whenever an unhandled type is returned.
 #[cynic(
     schema_path = "github.graphql",
     query_module = "query_dsl",
-    graphql_type = "Assignee"
 )]
 enum Assignee {
     Bot(Bot),
@@ -65,7 +63,6 @@ also select some fields from the interface:
 #[cynic(
     schema_path = "github.graphql",
     query_module = "query_dsl",
-    graphql_type = "Actor"
 )]
 pub enum Actor {
     User(User),
@@ -78,7 +75,6 @@ pub enum Actor {
 #[cynic(
     schema_path = "github.graphql",
     query_module = "query_dsl",
-    graphql_type = "Actor"
 )]
 enum ActorFallback {
     pub login: String
@@ -93,8 +89,9 @@ concept of shared fields.
 An `InlineFragments` can be configured with several attributes on the
 enum itself:
 
-- `graphql_type = "AType"` is required and tells cynic which interface
-  or union type in the GraphQL schema to map this struct to
+- `graphql_type = "AType"` tells cynic which interface or union type
+  in the GraphQL schema this enum represents. The name of the enum is
+  used if it is omitted.
 - `schema_path` sets the path to the GraphQL schema. This is required,
   but
   can be provided by nesting the InlineFragments inside a query module
@@ -110,6 +107,6 @@ Each variant can also have it's own attributes:
 
 - `fallback` can be applied on a single variant to indicate that it
   should be used whenver cynic encounters a `__typename` that doesn't
-  match one of the other variants.  For interfaces this can contain a
-  `QueryFragment` type.  For union types it must be applied on a unit
+  match one of the other variants. For interfaces this can contain a
+  `QueryFragment` type. For union types it must be applied on a unit
   variant.

--- a/cynic-book/src/derives/input-objects.md
+++ b/cynic-book/src/derives/input-objects.md
@@ -6,7 +6,6 @@ input object and the easiest way to define that trait is to derive it:
 
 ```rust
 #[derive(cynic::InputObject, Clone, Debug)]
-#[cynic(graphql_type = "IssueOrder")]
 pub struct IssueOrder {
     pub direction: OrderDirection,
     pub field: IssueOrderField,
@@ -14,7 +13,7 @@ pub struct IssueOrder {
 ```
 
 The derive will work on any struct that matches the format of the input object
-and it may contain scalar values or other `InputObject`s.  See `Field Naming`
+and it may contain scalar values or other `InputObject`s. See `Field Naming`
 below for how names are matched between GraphQL & Rust.
 
 By default the field names are expected to match the GraphQL variants
@@ -34,11 +33,11 @@ sent as `null`.
 
 <!-- TODO: example of the above?  Better wording. -->
 
-### Field Naming 
+### Field Naming
 
-It's a common GraphQL convention for fields to be named in `camelCase`.  To
+It's a common GraphQL convention for fields to be named in `camelCase`. To
 handle this smoothly, Cynic matches rust fields up to their equivalent
-`SCREAMING_SNAKE_CASE` GraphQL fields.  This behaviour can be disabled by
+`SCREAMING_SNAKE_CASE` GraphQL fields. This behaviour can be disabled by
 specifying a `rename_all = "None"` attribute, or customised alternative
 `rename_all` values or individual `rename` attributes on the fields.
 
@@ -46,8 +45,8 @@ specifying a `rename_all = "None"` attribute, or customised alternative
 
 An InputObject can be configured with several attributes on the struct itself:
 
-- `graphql_type = "AType"` is required and tells cynic which type in the
-  GraphQL schema to map this struct to
+- `graphql_type = "AType"` tells cynic which input object in the GraphQL
+  schema this struct represents. The name of the struct is used if it is omitted.
 - `require_all_fields` can be provided when you want cynic to make sure your
   struct has all of the fields defined in the GraphQL schema.
 - `rename_all="camelCase"` tells cynic to rename all the rust field names with

--- a/cynic-book/src/derives/query-fragments.md
+++ b/cynic-book/src/derives/query-fragments.md
@@ -11,7 +11,6 @@ Generally you'll use a derive to create query fragments, like this:
 #[cynic(
     schema_path = "examples/starwars.schema.graphql",
     query_module = "query_dsl",
-    graphql_type = "Film"
 )]
 struct Film {
     title: Option<String>,
@@ -145,7 +144,7 @@ If no nested QueryFragments require arguments, you can omit the
 
 Mutations are also constructed using QueryFragments in a very similar way to
 queries. Instead of selecting query fields you select a mutation, and pass in
-any arguments in exactly the same way. Mutations use the `MutationBuilder` 
+any arguments in exactly the same way. Mutations use the `MutationBuilder`
 rather than `QueryBulder`:
 
 ```rust
@@ -162,8 +161,8 @@ This `operation` can then be used in exactly the same way as with queries.
 
 A QueryFragment can be configured with several attributes on the struct itself:
 
-- `graphql_type = "AType"` is required and tells cynic which type in the
-  GraphQL schema to map this struct to
+- `graphql_type = "AType"` tells cynic which object in the GraphQL schema this
+  struct represents. The name of the struct is used if it is omitted.
 - `schema_path` sets the path to the GraphQL schema. This is required, but
   can be provided by nesting the QueryFragment inside a query module with this
   attr.

--- a/cynic-book/src/derives/recursive-queries.md
+++ b/cynic-book/src/derives/recursive-queries.md
@@ -9,7 +9,6 @@ the other films that they were in (and so on) we could do:
 
 ```rust
 #[derive(cynic::QueryFragment, Debug)]
-#[cynic(graphql_type = "Film")]
 struct Film {
     title: Option<String>,
     character_connection: Option<CharacterConnection>,

--- a/cynic-book/src/derives/scalars.md
+++ b/cynic-book/src/derives/scalars.md
@@ -17,7 +17,7 @@ GraphQL allows a schema to define it's own scalars - cynic also supports these.
 
 If you have an existing type (including 3rd party types) that has a
 `serde::Serialize` impl and want to use it as a Scalar, you can use
-`impl_scalar!` to register it as a `Scalar`.  For example to register
+`impl_scalar!` to register it as a `Scalar`. For example to register
 `chrono::DateTime<chrono::Utc>` as a `DateTime` scalar:
 
 ```rust
@@ -26,7 +26,7 @@ impl_scalar!(DateTime, query_dsl::DateTime);
 ```
 
 This `DateTime` type alias can now be used anywhere that the schema expects a
-`DateTime`.  Note that the type alias is currently required due to limitations
+`DateTime`. Note that the type alias is currently required due to limitations
 in some of the cynic macros (though this may not always be the case).
 
 ### `#[derive(Scalar)]`
@@ -42,7 +42,7 @@ struct MyScalar(String);
 This `MyScalar` type can now be used anywhere the schema expects a `MyScalar`.
 
 Any types that derive `cynic::Scalar` must also derive (or otherwise implement)
-`serde::Serialize`.  You can change the inner type that's used to deserialize
+`serde::Serialize`. You can change the inner type that's used to deserialize
 the scalar by changing the type inside the struct.
 
 Note that this derive only works on newtype structs - for any more complex
@@ -53,9 +53,8 @@ datatype you'll have to implement cynic::Scalar yourself.
 A Scalar derive can be configured with several attributes on the struct itself:
 
 - `graphql_type = "AType"` can be provided if the type of the struct differs
-  from the type of and tells cynic the name of the Scalar in the schema.  This
+  from the type of and tells cynic the name of the Scalar in the schema. This
   defaults to the name of the struct if not provided.
-  GraphQL schema to map this struct to
 - `query_module` tells cynic where to find the query module - that is a module
   that has called the `query_dsl!` macro. This is required but can also be
   provided by nesting the QueryFragment inside a query module.

--- a/cynic-querygen/src/output/enums.rs
+++ b/cynic-querygen/src/output/enums.rs
@@ -9,7 +9,9 @@ impl std::fmt::Display for EnumDetails<'_> {
         let type_name = self.name;
 
         writeln!(f, "#[derive(cynic::Enum, Clone, Copy, Debug)]")?;
-        writeln!(f, "#[cynic(graphql_type = \"{}\")]", type_name)?;
+        if type_name != type_name.to_pascal_case() {
+            writeln!(f, "#[cynic(graphql_type = \"{}\")]", type_name)?;
+        }
         writeln!(f, "pub enum {} {{", type_name.to_pascal_case())?;
 
         for variant in &self.values {

--- a/cynic-querygen/src/output/input_object.rs
+++ b/cynic-querygen/src/output/input_object.rs
@@ -14,8 +14,10 @@ pub struct InputObject<'schema> {
 impl std::fmt::Display for InputObject<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         writeln!(f, "#[derive(cynic::InputObject, Debug)]")?;
-        writeln!(f, "#[cynic(graphql_type = \"{}\")]", self.name)?;
-        writeln!(f, "pub struct {} {{", self.name)?;
+        if self.name != self.name.to_pascal_case() {
+            writeln!(f, "#[cynic(graphql_type = \"{}\")]", self.name)?;
+        }
+        writeln!(f, "pub struct {} {{", self.name.to_pascal_case())?;
 
         for field in &self.fields {
             let mut f = indented(f, 4);

--- a/cynic-querygen/src/output/query_fragment.rs
+++ b/cynic-querygen/src/output/query_fragment.rs
@@ -16,18 +16,23 @@ pub struct QueryFragment<'query, 'schema> {
 
 impl std::fmt::Display for QueryFragment<'_, '_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let argument_struct_param = if let Some(name) = &self.argument_struct_name {
-            format!(", argument_struct = \"{}\"", name)
-        } else {
-            "".to_string()
-        };
-
         writeln!(f, "#[derive(cynic::QueryFragment, Debug)]")?;
-        writeln!(
-            f,
-            "#[cynic(graphql_type = \"{}\"{})]",
-            self.target_type, argument_struct_param
-        )?;
+
+        if self.target_type != self.name || self.argument_struct_name.is_some() {
+            write!(f, "#[cynic(")?;
+            if self.target_type != self.name {
+                write!(f, "graphql_type = \"{}\"", self.target_type)?;
+            }
+
+            if let Some(name) = &self.argument_struct_name {
+                if self.target_type != self.name {
+                    write!(f, ", ")?;
+                }
+                write!(f, "argument_struct = \"{}\"", name)?;
+            }
+            writeln!(f, ")]",)?;
+        }
+
         writeln!(f, "pub struct {} {{", self.name)?;
         for field in &self.fields {
             write!(indented(f, 4), "{}", field)?;

--- a/cynic-querygen/tests/snapshots/github_tests__add_comment_mutation.snap
+++ b/cynic-querygen/tests/snapshots/github_tests__add_comment_mutation.snap
@@ -22,25 +22,21 @@ mod queries {
     }
 
     #[derive(cynic::QueryFragment, Debug)]
-    #[cynic(graphql_type = "AddCommentPayload")]
     pub struct AddCommentPayload {
         pub comment_edge: Option<IssueCommentEdge>,
     }
 
     #[derive(cynic::QueryFragment, Debug)]
-    #[cynic(graphql_type = "IssueCommentEdge")]
     pub struct IssueCommentEdge {
         pub node: Option<IssueComment>,
     }
 
     #[derive(cynic::QueryFragment, Debug)]
-    #[cynic(graphql_type = "IssueComment")]
     pub struct IssueComment {
         pub id: cynic::Id,
     }
 
     #[derive(cynic::InputObject, Debug)]
-    #[cynic(graphql_type = "AddCommentInput")]
     pub struct AddCommentInput {
         pub body: String,
         pub subject_id: cynic::Id,

--- a/cynic-querygen/tests/snapshots/github_tests__input_object_arguments.snap
+++ b/cynic-querygen/tests/snapshots/github_tests__input_object_arguments.snap
@@ -22,26 +22,23 @@ mod queries {
     }
 
     #[derive(cynic::QueryFragment, Debug)]
-    #[cynic(graphql_type = "Repository", argument_struct = "PullRequestTitlesArguments")]
+    #[cynic(argument_struct = "PullRequestTitlesArguments")]
     pub struct Repository {
         #[arguments(order_by = &args.pr_order)]
         pub pull_requests: PullRequestConnection,
     }
 
     #[derive(cynic::QueryFragment, Debug)]
-    #[cynic(graphql_type = "PullRequestConnection")]
     pub struct PullRequestConnection {
         pub nodes: Option<Vec<Option<PullRequest>>>,
     }
 
     #[derive(cynic::QueryFragment, Debug)]
-    #[cynic(graphql_type = "PullRequest")]
     pub struct PullRequest {
         pub title: String,
     }
 
     #[derive(cynic::Enum, Clone, Copy, Debug)]
-    #[cynic(graphql_type = "IssueOrderField")]
     pub enum IssueOrderField {
         Comments,
         CreatedAt,
@@ -49,14 +46,12 @@ mod queries {
     }
 
     #[derive(cynic::Enum, Clone, Copy, Debug)]
-    #[cynic(graphql_type = "OrderDirection")]
     pub enum OrderDirection {
         Asc,
         Desc,
     }
 
     #[derive(cynic::InputObject, Debug)]
-    #[cynic(graphql_type = "IssueOrder")]
     pub struct IssueOrder {
         pub direction: OrderDirection,
         pub field: IssueOrderField,

--- a/cynic-querygen/tests/snapshots/github_tests__input_object_literals.snap
+++ b/cynic-querygen/tests/snapshots/github_tests__input_object_literals.snap
@@ -17,26 +17,22 @@ mod queries {
     }
 
     #[derive(cynic::QueryFragment, Debug)]
-    #[cynic(graphql_type = "Repository")]
     pub struct Repository {
         #[arguments(order_by = IssueOrder { direction: OrderDirection::Asc, field: IssueOrderField::CreatedAt })]
         pub pull_requests: PullRequestConnection,
     }
 
     #[derive(cynic::QueryFragment, Debug)]
-    #[cynic(graphql_type = "PullRequestConnection")]
     pub struct PullRequestConnection {
         pub nodes: Option<Vec<Option<PullRequest>>>,
     }
 
     #[derive(cynic::QueryFragment, Debug)]
-    #[cynic(graphql_type = "PullRequest")]
     pub struct PullRequest {
         pub title: String,
     }
 
     #[derive(cynic::Enum, Clone, Copy, Debug)]
-    #[cynic(graphql_type = "IssueOrderField")]
     pub enum IssueOrderField {
         Comments,
         CreatedAt,
@@ -44,14 +40,12 @@ mod queries {
     }
 
     #[derive(cynic::Enum, Clone, Copy, Debug)]
-    #[cynic(graphql_type = "OrderDirection")]
     pub enum OrderDirection {
         Asc,
         Desc,
     }
 
     #[derive(cynic::InputObject, Debug)]
-    #[cynic(graphql_type = "IssueOrder")]
     pub struct IssueOrder {
         pub direction: OrderDirection,
         pub field: IssueOrderField,

--- a/cynic-querygen/tests/snapshots/github_tests__literal_enums.snap
+++ b/cynic-querygen/tests/snapshots/github_tests__literal_enums.snap
@@ -17,27 +17,23 @@ mod queries {
     }
 
     #[derive(cynic::QueryFragment, Debug)]
-    #[cynic(graphql_type = "Repository")]
     pub struct Repository {
         #[arguments(states = Some(vec![IssueState::Open]), first = 10)]
         pub issues: IssueConnection,
     }
 
     #[derive(cynic::QueryFragment, Debug)]
-    #[cynic(graphql_type = "IssueConnection")]
     pub struct IssueConnection {
         pub nodes: Option<Vec<Option<Issue>>>,
     }
 
     #[derive(cynic::QueryFragment, Debug)]
-    #[cynic(graphql_type = "Issue")]
     pub struct Issue {
         pub title: String,
         pub state: IssueState,
     }
 
     #[derive(cynic::Enum, Clone, Copy, Debug)]
-    #[cynic(graphql_type = "IssueState")]
     pub enum IssueState {
         Closed,
         Open,

--- a/cynic-querygen/tests/snapshots/starwars_tests__bare_selection_sets.snap
+++ b/cynic-querygen/tests/snapshots/starwars_tests__bare_selection_sets.snap
@@ -16,13 +16,11 @@ mod queries {
     }
 
     #[derive(cynic::QueryFragment, Debug)]
-    #[cynic(graphql_type = "FilmsConnection")]
     pub struct FilmsConnection {
         pub films: Option<Vec<Option<Film>>>,
     }
 
     #[derive(cynic::QueryFragment, Debug)]
-    #[cynic(graphql_type = "Film")]
     pub struct Film {
         pub id: cynic::Id,
         pub title: Option<String>,
@@ -33,4 +31,5 @@ mod queries {
 mod query_dsl{
     cynic::query_dsl!(r#"schema.graphql"#);
 }
+
 

--- a/cynic-querygen/tests/snapshots/starwars_tests__fragment_spreads.snap
+++ b/cynic-querygen/tests/snapshots/starwars_tests__fragment_spreads.snap
@@ -18,13 +18,11 @@ mod queries {
     }
 
     #[derive(cynic::QueryFragment, Debug)]
-    #[cynic(graphql_type = "FilmsConnection")]
     pub struct FilmsConnection {
         pub films: Option<Vec<Option<Film>>>,
     }
 
     #[derive(cynic::QueryFragment, Debug)]
-    #[cynic(graphql_type = "Film")]
     pub struct Film {
         pub id: cynic::Id,
         pub title: Option<String>,
@@ -35,4 +33,5 @@ mod queries {
 mod query_dsl{
     cynic::query_dsl!(r#"schema.graphql"#);
 }
+
 

--- a/cynic-querygen/tests/snapshots/starwars_tests__multiple_queries.snap
+++ b/cynic-querygen/tests/snapshots/starwars_tests__multiple_queries.snap
@@ -28,13 +28,11 @@ mod queries {
     }
 
     #[derive(cynic::QueryFragment, Debug)]
-    #[cynic(graphql_type = "StarshipsConnection")]
     pub struct StarshipsConnection {
         pub starships: Option<Vec<Option<Starship>>>,
     }
 
     #[derive(cynic::QueryFragment, Debug)]
-    #[cynic(graphql_type = "Starship")]
     pub struct Starship {
         pub id: cynic::Id,
         pub starship_class: Option<String>,
@@ -42,7 +40,6 @@ mod queries {
     }
 
     #[derive(cynic::QueryFragment, Debug)]
-    #[cynic(graphql_type = "StarshipFilmsConnection")]
     pub struct StarshipFilmsConnection {
         pub films: Option<Vec<Option<Film>>>,
     }
@@ -60,25 +57,21 @@ mod queries {
     }
 
     #[derive(cynic::QueryFragment, Debug)]
-    #[cynic(graphql_type = "PlanetsConnection")]
     pub struct PlanetsConnection {
         pub planets: Option<Vec<Option<Planet>>>,
     }
 
     #[derive(cynic::QueryFragment, Debug)]
-    #[cynic(graphql_type = "Planet")]
     pub struct Planet {
         pub film_connection: Option<PlanetFilmsConnection>,
     }
 
     #[derive(cynic::QueryFragment, Debug)]
-    #[cynic(graphql_type = "PlanetFilmsConnection")]
     pub struct PlanetFilmsConnection {
         pub films: Option<Vec<Option<Film2>>>,
     }
 
     #[derive(cynic::QueryFragment, Debug)]
-    #[cynic(graphql_type = "FilmsConnection")]
     pub struct FilmsConnection {
         pub films: Option<Vec<Option<Film>>>,
     }
@@ -92,7 +85,6 @@ mod queries {
     }
 
     #[derive(cynic::QueryFragment, Debug)]
-    #[cynic(graphql_type = "Film")]
     pub struct Film {
         pub id: cynic::Id,
         pub title: Option<String>,
@@ -103,4 +95,5 @@ mod queries {
 mod query_dsl{
     cynic::query_dsl!(r#"schema.graphql"#);
 }
+
 

--- a/cynic-querygen/tests/snapshots/starwars_tests__nested_arguments.snap
+++ b/cynic-querygen/tests/snapshots/starwars_tests__nested_arguments.snap
@@ -24,7 +24,7 @@ mod queries {
     }
 
     #[derive(cynic::QueryFragment, Debug)]
-    #[cynic(graphql_type = "Film", argument_struct = "NestedArgsQueryArguments")]
+    #[cynic(argument_struct = "NestedArgsQueryArguments")]
     pub struct Film {
         pub title: Option<String>,
         pub director: Option<String>,
@@ -33,26 +33,24 @@ mod queries {
     }
 
     #[derive(cynic::QueryFragment, Debug)]
-    #[cynic(graphql_type = "FilmPlanetsConnection", argument_struct = "NestedArgsQueryArguments")]
+    #[cynic(argument_struct = "NestedArgsQueryArguments")]
     pub struct FilmPlanetsConnection {
         pub planets: Option<Vec<Option<Planet>>>,
     }
 
     #[derive(cynic::QueryFragment, Debug)]
-    #[cynic(graphql_type = "Planet", argument_struct = "NestedArgsQueryArguments")]
+    #[cynic(argument_struct = "NestedArgsQueryArguments")]
     pub struct Planet {
         #[arguments(after = &args.resident_connection)]
         pub resident_connection: Option<PlanetResidentsConnection>,
     }
 
     #[derive(cynic::QueryFragment, Debug)]
-    #[cynic(graphql_type = "PlanetResidentsConnection")]
     pub struct PlanetResidentsConnection {
         pub residents: Option<Vec<Option<Person>>>,
     }
 
     #[derive(cynic::QueryFragment, Debug)]
-    #[cynic(graphql_type = "Person")]
     pub struct Person {
         pub name: Option<String>,
     }
@@ -62,4 +60,5 @@ mod queries {
 mod query_dsl{
     cynic::query_dsl!(r#"schema.graphql"#);
 }
+
 

--- a/cynic-querygen/tests/snapshots/starwars_tests__sanity_test_starwars_query.snap
+++ b/cynic-querygen/tests/snapshots/starwars_tests__sanity_test_starwars_query.snap
@@ -22,7 +22,6 @@ mod queries {
     }
 
     #[derive(cynic::QueryFragment, Debug)]
-    #[cynic(graphql_type = "Film")]
     pub struct Film {
         pub title: Option<String>,
         pub director: Option<String>,
@@ -33,4 +32,5 @@ mod queries {
 mod query_dsl{
     cynic::query_dsl!(r#"schema.graphql"#);
 }
+
 

--- a/cynic/src/bin/simple.rs
+++ b/cynic/src/bin/simple.rs
@@ -15,7 +15,6 @@ struct TestArgs {}
 #[cynic(
     schema_path = "src/bin/simple.graphql",
     query_module = "query_dsl",
-    graphql_type = "TestStruct",
     argument_struct = "TestArgs"
 )]
 struct TestStruct {
@@ -29,11 +28,7 @@ struct TestStruct {
 }
 
 #[derive(cynic::QueryFragment)]
-#[cynic(
-    schema_path = "src/bin/simple.graphql",
-    query_module = "query_dsl",
-    graphql_type = "Nested"
-)]
+#[cynic(schema_path = "src/bin/simple.graphql", query_module = "query_dsl")]
 struct Nested {
     pub a_string: String,
     pub opt_string: Option<String>,
@@ -56,7 +51,6 @@ struct Test {
 #[cynic(
     schema_path = "src/bin/simple.graphql",
     query_module = "query_dsl",
-    graphql_type = "AnInputType",
     rename_all = "camelCase"
 )]
 struct AnInputType {
@@ -67,7 +61,6 @@ struct AnInputType {
 #[cynic(
     schema_path = "src/bin/simple.graphql",
     query_module = "query_dsl",
-    graphql_type = "Dessert",
     rename_all = "SCREAMING_SNAKE_CASE"
 )]
 enum Dessert {
@@ -76,11 +69,7 @@ enum Dessert {
 }
 
 #[derive(cynic::InlineFragments)]
-#[cynic(
-    schema_path = "src/bin/simple.graphql",
-    query_module = "query_dsl",
-    graphql_type = "MyUnionType"
-)]
+#[cynic(schema_path = "src/bin/simple.graphql", query_module = "query_dsl")]
 enum MyUnionType {
     TestStruct(Test),
     Nested(Nested),

--- a/cynic/src/bin/simple_v2.rs
+++ b/cynic/src/bin/simple_v2.rs
@@ -22,7 +22,7 @@ mod queries {
     pub struct TestArgs {}
 
     #[derive(cynic::QueryFragment)]
-    #[cynic(graphql_type = "TestStruct", argument_struct = "TestArgs")]
+    #[cynic(argument_struct = "TestArgs")]
     pub struct TestStruct {
         #[arguments(x = 1, y = "1")]
         pub field_one: String,
@@ -32,7 +32,6 @@ mod queries {
     }
 
     #[derive(cynic::QueryFragment)]
-    #[cynic(graphql_type = "Nested")]
     pub struct Nested {
         pub a_string: String,
         pub opt_string: Option<String>,
@@ -46,14 +45,13 @@ mod queries {
     }
 
     #[derive(cynic::Enum, Clone, Copy)]
-    #[cynic(graphql_type = "Dessert", rename_all = "SCREAMING_SNAKE_CASE")]
+    #[cynic(rename_all = "SCREAMING_SNAKE_CASE")]
     pub enum Dessert {
         Cheesecake,
         IceCream,
     }
 
     #[derive(cynic::InlineFragments)]
-    #[cynic(graphql_type = "MyUnionType")]
     pub enum MyUnionType {
         TestStruct(Test),
         Nested(Nested),

--- a/cynic/src/http.rs
+++ b/cynic/src/http.rs
@@ -35,7 +35,6 @@ mod surf_ext {
     /// # #[cynic(
     /// #    schema_path = "../schemas/starwars.schema.graphql",
     /// #    query_module = "query_dsl",
-    /// #    graphql_type = "Film"
     /// # )]
     /// # struct Film {
     /// #    title: Option<String>,
@@ -128,7 +127,6 @@ mod reqwest_ext {
     /// # #[cynic(
     /// #    schema_path = "../schemas/starwars.schema.graphql",
     /// #    query_module = "query_dsl",
-    /// #    graphql_type = "Film"
     /// # )]
     /// # struct Film {
     /// #    title: Option<String>,
@@ -223,7 +221,6 @@ mod reqwest_blocking_ext {
     /// # #[cynic(
     /// #    schema_path = "../schemas/starwars.schema.graphql",
     /// #    query_module = "query_dsl",
-    /// #    graphql_type = "Film"
     /// # )]
     /// # struct Film {
     /// #    title: Option<String>,

--- a/cynic/src/lib.rs
+++ b/cynic/src/lib.rs
@@ -53,7 +53,6 @@
 //! #[cynic(
 //!     schema_path = "../schemas/starwars.schema.graphql",
 //!     query_module = "query_dsl",
-//!     graphql_type = "Film"
 //! )]
 //! struct Film {
 //!     title: Option<String>,
@@ -115,9 +114,8 @@
 //!
 //! # #[derive(cynic::QueryFragment)]
 //! # #[cynic(
-//! #     schema_path = "../schemas/starwars.schema.graphql",
+//! #    schema_path = "../schemas/starwars.schema.graphql",
 //! #    query_module = "query_dsl",
-//! #    graphql_type = "Film"
 //! # )]
 //! # struct Film {
 //! #    title: Option<String>,

--- a/cynic/tests/recursive-queries.rs
+++ b/cynic/tests/recursive-queries.rs
@@ -29,21 +29,13 @@ mod recursive_lists {
     }
 
     #[derive(QueryFragment, Serialize)]
-    #[cynic(
-        graphql_type = "Comment",
-        schema_path = "tests/test-schema.graphql",
-        query_module = "query_dsl"
-    )]
+    #[cynic(schema_path = "tests/test-schema.graphql", query_module = "query_dsl")]
     struct Comment {
         author: Author,
     }
 
     #[derive(QueryFragment, Serialize)]
-    #[cynic(
-        graphql_type = "Author",
-        schema_path = "tests/test-schema.graphql",
-        query_module = "query_dsl"
-    )]
+    #[cynic(schema_path = "tests/test-schema.graphql", query_module = "query_dsl")]
     struct Author {
         #[cynic(recurse = "2")]
         posts: Option<Vec<Post>>,
@@ -115,11 +107,7 @@ mod optional_recursive_types {
     }
 
     #[derive(QueryFragment, Serialize)]
-    #[cynic(
-        graphql_type = "Author",
-        schema_path = "tests/test-schema.graphql",
-        query_module = "query_dsl"
-    )]
+    #[cynic(schema_path = "tests/test-schema.graphql", query_module = "query_dsl")]
     struct Author {
         #[cynic(recurse = "2")]
         friends: Option<Vec<Author>>,
@@ -227,11 +215,7 @@ mod required_recursive_types {
     }
 
     #[derive(QueryFragment, Serialize)]
-    #[cynic(
-        graphql_type = "Author",
-        schema_path = "tests/test-schema.graphql",
-        query_module = "query_dsl"
-    )]
+    #[cynic(schema_path = "tests/test-schema.graphql", query_module = "query_dsl")]
     struct Author {
         #[cynic(recurse = "2")]
         me: Option<Box<Author>>,

--- a/cynic/tests/simple_schema_tests.rs
+++ b/cynic/tests/simple_schema_tests.rs
@@ -9,7 +9,6 @@ struct TestArgs {}
 #[cynic(
     schema_path = "src/bin/simple.graphql",
     query_module = "query_dsl",
-    graphql_type = "TestStruct",
     //argument_struct = "TestArgs"
 )]
 struct TestStruct {
@@ -24,11 +23,7 @@ struct TestStruct {
 }
 
 #[derive(cynic::QueryFragment, PartialEq, Debug)]
-#[cynic(
-    schema_path = "src/bin/simple.graphql",
-    query_module = "query_dsl",
-    graphql_type = "Nested"
-)]
+#[cynic(schema_path = "src/bin/simple.graphql", query_module = "query_dsl")]
 struct Nested {
     a_string: String,
     opt_string: Option<String>,
@@ -48,7 +43,6 @@ struct TestQuery {
 #[derive(cynic::Enum, Clone, Debug, PartialEq)]
 #[cynic(
     schema_path = "src/bin/simple.graphql",
-    graphql_type = "Dessert",
     query_module = "query_dsl",
     rename_all = "SCREAMING_SNAKE_CASE"
 )]

--- a/examples/examples/chrono-scalars.rs
+++ b/examples/examples/chrono-scalars.rs
@@ -11,8 +11,7 @@ cynic::impl_scalar!(DateTime, query_dsl::DateTime);
 #[derive(cynic::QueryFragment, Debug)]
 #[cynic(
     schema_path = "../schemas/graphql.jobs.graphql",
-    query_module = "query_dsl",
-    graphql_type = "Job"
+    query_module = "query_dsl"
 )]
 struct Job {
     created_at: DateTime,

--- a/examples/examples/github-mutation.rs
+++ b/examples/examples/github-mutation.rs
@@ -68,25 +68,22 @@ mod queries {
     }
 
     #[derive(cynic::QueryFragment, Debug)]
-    #[cynic(graphql_type = "AddCommentPayload")]
     pub struct AddCommentPayload {
         pub comment_edge: Option<IssueCommentEdge>,
     }
 
     #[derive(cynic::QueryFragment, Debug)]
-    #[cynic(graphql_type = "IssueCommentEdge")]
     pub struct IssueCommentEdge {
         pub node: Option<IssueComment>,
     }
 
     #[derive(cynic::QueryFragment, Debug)]
-    #[cynic(graphql_type = "IssueComment")]
     pub struct IssueComment {
         pub id: cynic::Id,
     }
 
     #[derive(cynic::InputObject, Clone, Debug)]
-    #[cynic(graphql_type = "AddCommentInput", rename_all = "camelCase")]
+    #[cynic(rename_all = "camelCase")]
     pub struct AddCommentInput {
         pub body: String,
         pub client_mutation_id: Option<String>,

--- a/examples/examples/github.rs
+++ b/examples/examples/github.rs
@@ -63,21 +63,21 @@ mod queries {
     }
 
     #[derive(cynic::InputObject, Clone, Debug)]
-    #[cynic(graphql_type = "IssueOrder", rename_all = "camelCase")]
+    #[cynic(rename_all = "camelCase")]
     pub struct IssueOrder {
         pub direction: OrderDirection,
         pub field: IssueOrderField,
     }
 
     #[derive(cynic::Enum, Clone, Copy, Debug)]
-    #[cynic(graphql_type = "OrderDirection", rename_all = "SCREAMING_SNAKE_CASE")]
+    #[cynic(rename_all = "SCREAMING_SNAKE_CASE")]
     pub enum OrderDirection {
         Asc,
         Desc,
     }
 
     #[derive(cynic::Enum, Clone, Copy, Debug)]
-    #[cynic(graphql_type = "IssueOrderField", rename_all = "SCREAMING_SNAKE_CASE")]
+    #[cynic(rename_all = "SCREAMING_SNAKE_CASE")]
     pub enum IssueOrderField {
         Comments,
         CreatedAt,
@@ -92,24 +92,19 @@ mod queries {
     }
 
     #[derive(cynic::QueryFragment, Debug)]
-    #[cynic(
-        graphql_type = "Repository",
-        argument_struct = "PullRequestTitlesArguments"
-    )]
+    #[cynic(argument_struct = "PullRequestTitlesArguments")]
     pub struct Repository {
         #[arguments(order_by = &args.pr_order, first = 10)]
         pub pull_requests: PullRequestConnection,
     }
 
     #[derive(cynic::QueryFragment, Debug)]
-    #[cynic(graphql_type = "PullRequestConnection")]
     pub struct PullRequestConnection {
         #[cynic(flatten)]
         pub nodes: Vec<PullRequest>,
     }
 
     #[derive(cynic::QueryFragment, Debug)]
-    #[cynic(graphql_type = "PullRequest")]
     pub struct PullRequest {
         pub title: String,
         pub created_at: DateTime,

--- a/examples/examples/manual-reqwest.rs
+++ b/examples/examples/manual-reqwest.rs
@@ -8,8 +8,7 @@ mod query_dsl {
 #[derive(cynic::QueryFragment, Debug)]
 #[cynic(
     schema_path = "../schemas/starwars.schema.graphql",
-    query_module = "query_dsl",
-    // graphql_type = "Film" Same name, no longer needed
+    query_module = "query_dsl"
 )]
 struct Film {
     title: Option<String>,

--- a/examples/examples/querying-interfaces.rs
+++ b/examples/examples/querying-interfaces.rs
@@ -7,8 +7,7 @@ mod query_dsl {
 #[derive(cynic::InlineFragments, Debug)]
 #[cynic(
     schema_path = "../schemas/starwars.schema.graphql",
-    query_module = "query_dsl",
-    graphql_type = "Node"
+    query_module = "query_dsl"
 )]
 enum Node {
     Film(Film),
@@ -21,8 +20,7 @@ enum Node {
 #[derive(cynic::QueryFragment, Debug)]
 #[cynic(
     schema_path = "../schemas/starwars.schema.graphql",
-    query_module = "query_dsl",
-    graphql_type = "Film"
+    query_module = "query_dsl"
 )]
 struct Film {
     title: Option<String>,
@@ -32,8 +30,7 @@ struct Film {
 #[derive(cynic::QueryFragment, Debug)]
 #[cynic(
     schema_path = "../schemas/starwars.schema.graphql",
-    query_module = "query_dsl",
-    graphql_type = "Planet"
+    query_module = "query_dsl"
 )]
 struct Planet {
     name: Option<String>,

--- a/examples/examples/reqwest-async.rs
+++ b/examples/examples/reqwest-async.rs
@@ -10,8 +10,7 @@ mod query_dsl {
 #[derive(cynic::QueryFragment, Debug)]
 #[cynic(
     schema_path = "../schemas/starwars.schema.graphql",
-    query_module = "query_dsl",
-    graphql_type = "Film"
+    query_module = "query_dsl"
 )]
 struct Film {
     title: Option<String>,

--- a/examples/examples/starwars.rs
+++ b/examples/examples/starwars.rs
@@ -7,8 +7,7 @@ mod query_dsl {
 #[derive(cynic::QueryFragment, Debug)]
 #[cynic(
     schema_path = "../schemas/starwars.schema.graphql",
-    query_module = "query_dsl",
-    graphql_type = "Film"
+    query_module = "query_dsl"
 )]
 struct Film {
     title: Option<String>,

--- a/examples/examples/surf-client.rs
+++ b/examples/examples/surf-client.rs
@@ -10,8 +10,7 @@ mod query_dsl {
 #[derive(cynic::QueryFragment, Debug)]
 #[cynic(
     schema_path = "../schemas/starwars.schema.graphql",
-    query_module = "query_dsl",
-    graphql_type = "Film"
+    query_module = "query_dsl"
 )]
 struct Film {
     title: Option<String>,

--- a/tests/ui-tests/tests/cases/fragment-guess-validation.rs
+++ b/tests/ui-tests/tests/cases/fragment-guess-validation.rs
@@ -16,13 +16,11 @@ mod queries {
     }
 
     #[derive(cynic::QueryFragment, Debug)]
-    #[cynic(graphql_type = "FilmsConnection")]
     pub struct FilmsConnection {
         pub films: Option<Vec<Option<Film>>>,
     }
 
     #[derive(cynic::QueryFragment, Debug)]
-    #[cynic(graphql_type = "Film")]
     pub struct Film {
         pub id: cynic::Id,
         pub title: Option<String>,

--- a/tests/ui-tests/tests/cases/inline-fragment-exhaustiveness.rs
+++ b/tests/ui-tests/tests/cases/inline-fragment-exhaustiveness.rs
@@ -7,8 +7,7 @@ mod query_dsl {
 #[derive(cynic::InlineFragments)]
 #[cynic(
     schema_path = "../../../cynic/src/bin/simple.graphql",
-    query_module = "query_dsl",
-    graphql_type = "MyUnionType"
+    query_module = "query_dsl"
 )]
 enum MyUnionType {
     TestStruct(Test),
@@ -18,8 +17,7 @@ enum MyUnionType {
 #[derive(cynic::QueryFragment)]
 #[cynic(
     schema_path = "../../../cynic/src/bin/simple.graphql",
-    query_module = "query_dsl",
-    graphql_type = "Nested"
+    query_module = "query_dsl"
 )]
 struct Nested {
     pub a_string: String,

--- a/tests/ui-tests/tests/cases/inline-fragment-exhaustiveness.stderr
+++ b/tests/ui-tests/tests/cases/inline-fragment-exhaustiveness.stderr
@@ -1,7 +1,7 @@
 error: Could not find a match for Nestde in MyUnionType. Did you mean Nested?
-  --> $DIR/inline-fragment-exhaustiveness.rs:15:5
+  --> $DIR/inline-fragment-exhaustiveness.rs:14:5
    |
-15 |     Nestde(Nested),
+14 |     Nestde(Nested),
    |     ^^^^^^
 
 error: This InlineFragment is missing a variant for Nested.  Either provide a variant for this type or add a fallback variant.

--- a/tests/ui-tests/tests/cases/inline-fragment-fallback-validation.rs
+++ b/tests/ui-tests/tests/cases/inline-fragment-fallback-validation.rs
@@ -20,8 +20,7 @@ enum MyFailingUnionType {
 #[derive(cynic::QueryFragment)]
 #[cynic(
     schema_path = "../../../cynic/src/bin/simple.graphql",
-    query_module = "query_dsl",
-    graphql_type = "Nested"
+    query_module = "query_dsl"
 )]
 struct Nested {
     pub a_string: String,

--- a/tests/ui-tests/tests/cases/inputobject-guess-validation.rs
+++ b/tests/ui-tests/tests/cases/inputobject-guess-validation.rs
@@ -10,7 +10,6 @@ mod queries {
     use super::{query_dsl, types::*};
 
     #[derive(cynic::Enum, Clone, Copy, Debug)]
-    #[cynic(graphql_type = "IssueOrderField")]
     pub enum IssueOrderField {
         Comments,
         CreatedAt,
@@ -18,14 +17,12 @@ mod queries {
     }
 
     #[derive(cynic::Enum, Clone, Copy, Debug)]
-    #[cynic(graphql_type = "OrderDirection")]
     pub enum OrderDirection {
         Asc,
         Desc,
     }
 
     #[derive(cynic::InputObject, Debug)]
-    #[cynic(graphql_type = "IssueOrder")]
     pub struct IssueOrder {
         pub direction: OrderDirection,
         pub fieid: IssueOrderField,

--- a/tests/ui-tests/tests/cases/inputobject-guess-validation.stderr
+++ b/tests/ui-tests/tests/cases/inputobject-guess-validation.stderr
@@ -1,11 +1,16 @@
 error: Could not find a field fieid in the GraphQL InputObject IssueOrder. Did you mean field?
-  --> $DIR/inputobject-guess-validation.rs:31:13
+  --> $DIR/inputobject-guess-validation.rs:28:13
    |
-31 |         pub fieid: IssueOrderField,
+28 |         pub fieid: IssueOrderField,
    |             ^^^^^
 
 error: This InputObject is missing these required fields: field
-  --> $DIR/inputobject-guess-validation.rs:28:5
-   |
-28 |     #[cynic(graphql_type = "IssueOrder")]
-   |     ^
+ --> $DIR/inputobject-guess-validation.rs:5:1
+  |
+5 | / #[cynic::query_module(
+6 | |     schema_path = r#"./../../../schemas/github.graphql"#,
+7 | |     query_module = "query_dsl"
+8 | | )]
+  | |__^
+  |
+  = note: this error originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-tests/tests/cases/wrong-enum-type.rs
+++ b/tests/ui-tests/tests/cases/wrong-enum-type.rs
@@ -10,7 +10,6 @@ mod queries {
     use super::{query_dsl, types::*};
 
     #[derive(cynic::QueryFragment, Debug)]
-    #[cynic(graphql_type = "CheckSuite")]
     pub struct CheckSuite {
         // Note: this is the wrong underlying enum type
         // Should be CheckStatusState
@@ -19,7 +18,6 @@ mod queries {
     }
 
     #[derive(cynic::Enum, Clone, Copy, Debug)]
-    #[cynic(graphql_type = "CheckConclusionState")]
     pub enum CheckConclusionState {
         ActionRequired,
         Cancelled,

--- a/tests/ui-tests/tests/cases/wrong-enum-type.stderr
+++ b/tests/ui-tests/tests/cases/wrong-enum-type.stderr
@@ -1,7 +1,7 @@
 error[E0308]: mismatched types
-  --> $DIR/wrong-enum-type.rs:17:21
+  --> $DIR/wrong-enum-type.rs:16:21
    |
-17 |         pub status: CheckConclusionState,
+16 |         pub status: CheckConclusionState,
    |                     ^^^^^^^^^^^^^^^^^^^^ expected enum `CheckStatusState`, found enum `query_dsl::CheckConclusionState`
    |
    = note: expected struct `SelectionSet<'_, _, CheckStatusState>`


### PR DESCRIPTION
#### Why are we making this change?

PR #213 updated the `graphql_type` parameters to be optional.

#### What effects does this change have?

This commit updates:

1. The documentation to indicate this
2. All the examples to omit this where not required
3. Querygen to not provide this unless required.

Fixes #217 
