### PR TITLE
Update querygen to only output requried scalars.

### DIFF
--- a/cynic-querygen/src/output/mod.rs
+++ b/cynic-querygen/src/output/mod.rs
@@ -8,6 +8,7 @@ pub mod query_fragment;
 
 pub use argument_struct::{ArgumentStruct, ArgumentStructField};
 pub use indent::indented;
+use inflector::Inflector;
 pub use input_object::InputObject;
 pub use query_fragment::QueryFragment;
 
@@ -20,3 +21,10 @@ pub struct Output<'query, 'schema> {
 }
 
 pub struct Scalar<'schema>(pub &'schema str);
+
+impl std::fmt::Display for Scalar<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "#[derive(cynic::Scalar, Debug, Clone)]")?;
+        writeln!(f, "pub struct {}(pub String);", self.0.to_pascal_case())
+    }
+}

--- a/cynic-querygen/src/schema/parser.rs
+++ b/cynic-querygen/src/schema/parser.rs
@@ -3,7 +3,6 @@
 pub type Document<'a> = graphql_parser::schema::Document<'a, &'a str>;
 pub type Type<'a> = graphql_parser::schema::Type<'a, &'a str>;
 pub type Field<'a> = graphql_parser::schema::Field<'a, &'a str>;
-pub type Definition<'a> = graphql_parser::schema::Definition<'a, &'a str>;
 pub type TypeDefinition<'a> = graphql_parser::schema::TypeDefinition<'a, &'a str>;
 pub type ScalarType<'a> = graphql_parser::schema::ScalarType<'a, &'a str>;
 pub type InputValue<'a> = graphql_parser::schema::InputValue<'a, &'a str>;

--- a/cynic-querygen/tests/snapshots/github_tests__add_comment_mutation.snap
+++ b/cynic-querygen/tests/snapshots/github_tests__add_comment_mutation.snap
@@ -7,7 +7,7 @@ expression: "document_to_fragment_structs(query, schema,\n                      
     query_module = "schema",
 )]
 mod queries {
-    use super::{schema, types::*};
+    use super::schema;
 
     #[derive(cynic::FragmentArguments, Debug)]
     pub struct CommentOnMutationSupportIssueArguments {
@@ -44,47 +44,7 @@ mod queries {
 
 }
 
-#[cynic::query_module(
-    schema_path = r#"schema.graphql"#,
-    query_module = "schema",
-)]
-mod types {
-    use super::schema;
-
-    #[derive(cynic::Scalar, Debug, Clone)]
-    pub struct Date(pub String);
-
-    #[derive(cynic::Scalar, Debug, Clone)]
-    pub struct DateTime(pub String);
-
-    #[derive(cynic::Scalar, Debug, Clone)]
-    pub struct GitObjectID(pub String);
-
-    #[derive(cynic::Scalar, Debug, Clone)]
-    pub struct GitRefname(pub String);
-
-    #[derive(cynic::Scalar, Debug, Clone)]
-    pub struct GitSSHRemote(pub String);
-
-    #[derive(cynic::Scalar, Debug, Clone)]
-    pub struct GitTimestamp(pub String);
-
-    #[derive(cynic::Scalar, Debug, Clone)]
-    pub struct Html(pub String);
-
-    #[derive(cynic::Scalar, Debug, Clone)]
-    pub struct PreciseDateTime(pub String);
-
-    #[derive(cynic::Scalar, Debug, Clone)]
-    pub struct Uri(pub String);
-
-    #[derive(cynic::Scalar, Debug, Clone)]
-    pub struct X509Certificate(pub String);
-
-}
-
 mod schema {
-    use super::types::*;
     cynic::use_schema!(r#"schema.graphql"#);
 }
 

--- a/cynic-querygen/tests/snapshots/github_tests__input_object_arguments.snap
+++ b/cynic-querygen/tests/snapshots/github_tests__input_object_arguments.snap
@@ -7,7 +7,7 @@ expression: "document_to_fragment_structs(query, schema,\n                      
     query_module = "schema",
 )]
 mod queries {
-    use super::{schema, types::*};
+    use super::schema;
 
     #[derive(cynic::FragmentArguments, Debug)]
     pub struct PullRequestTitlesArguments {
@@ -59,47 +59,7 @@ mod queries {
 
 }
 
-#[cynic::query_module(
-    schema_path = r#"schema.graphql"#,
-    query_module = "schema",
-)]
-mod types {
-    use super::schema;
-
-    #[derive(cynic::Scalar, Debug, Clone)]
-    pub struct Date(pub String);
-
-    #[derive(cynic::Scalar, Debug, Clone)]
-    pub struct DateTime(pub String);
-
-    #[derive(cynic::Scalar, Debug, Clone)]
-    pub struct GitObjectID(pub String);
-
-    #[derive(cynic::Scalar, Debug, Clone)]
-    pub struct GitRefname(pub String);
-
-    #[derive(cynic::Scalar, Debug, Clone)]
-    pub struct GitSSHRemote(pub String);
-
-    #[derive(cynic::Scalar, Debug, Clone)]
-    pub struct GitTimestamp(pub String);
-
-    #[derive(cynic::Scalar, Debug, Clone)]
-    pub struct Html(pub String);
-
-    #[derive(cynic::Scalar, Debug, Clone)]
-    pub struct PreciseDateTime(pub String);
-
-    #[derive(cynic::Scalar, Debug, Clone)]
-    pub struct Uri(pub String);
-
-    #[derive(cynic::Scalar, Debug, Clone)]
-    pub struct X509Certificate(pub String);
-
-}
-
 mod schema {
-    use super::types::*;
     cynic::use_schema!(r#"schema.graphql"#);
 }
 

--- a/cynic-querygen/tests/snapshots/github_tests__input_object_literals.snap
+++ b/cynic-querygen/tests/snapshots/github_tests__input_object_literals.snap
@@ -7,7 +7,7 @@ expression: "document_to_fragment_structs(query, schema,\n                      
     query_module = "schema",
 )]
 mod queries {
-    use super::{schema, types::*};
+    use super::schema;
 
     #[derive(cynic::QueryFragment, Debug)]
     #[cynic(graphql_type = "Query")]
@@ -53,47 +53,7 @@ mod queries {
 
 }
 
-#[cynic::query_module(
-    schema_path = r#"schema.graphql"#,
-    query_module = "schema",
-)]
-mod types {
-    use super::schema;
-
-    #[derive(cynic::Scalar, Debug, Clone)]
-    pub struct Date(pub String);
-
-    #[derive(cynic::Scalar, Debug, Clone)]
-    pub struct DateTime(pub String);
-
-    #[derive(cynic::Scalar, Debug, Clone)]
-    pub struct GitObjectID(pub String);
-
-    #[derive(cynic::Scalar, Debug, Clone)]
-    pub struct GitRefname(pub String);
-
-    #[derive(cynic::Scalar, Debug, Clone)]
-    pub struct GitSSHRemote(pub String);
-
-    #[derive(cynic::Scalar, Debug, Clone)]
-    pub struct GitTimestamp(pub String);
-
-    #[derive(cynic::Scalar, Debug, Clone)]
-    pub struct Html(pub String);
-
-    #[derive(cynic::Scalar, Debug, Clone)]
-    pub struct PreciseDateTime(pub String);
-
-    #[derive(cynic::Scalar, Debug, Clone)]
-    pub struct Uri(pub String);
-
-    #[derive(cynic::Scalar, Debug, Clone)]
-    pub struct X509Certificate(pub String);
-
-}
-
 mod schema {
-    use super::types::*;
     cynic::use_schema!(r#"schema.graphql"#);
 }
 

--- a/cynic-querygen/tests/snapshots/github_tests__literal_enums.snap
+++ b/cynic-querygen/tests/snapshots/github_tests__literal_enums.snap
@@ -7,7 +7,7 @@ expression: "document_to_fragment_structs(query, schema,\n                      
     query_module = "schema",
 )]
 mod queries {
-    use super::{schema, types::*};
+    use super::schema;
 
     #[derive(cynic::QueryFragment, Debug)]
     #[cynic(graphql_type = "Query")]
@@ -41,47 +41,7 @@ mod queries {
 
 }
 
-#[cynic::query_module(
-    schema_path = r#"schema.graphql"#,
-    query_module = "schema",
-)]
-mod types {
-    use super::schema;
-
-    #[derive(cynic::Scalar, Debug, Clone)]
-    pub struct Date(pub String);
-
-    #[derive(cynic::Scalar, Debug, Clone)]
-    pub struct DateTime(pub String);
-
-    #[derive(cynic::Scalar, Debug, Clone)]
-    pub struct GitObjectID(pub String);
-
-    #[derive(cynic::Scalar, Debug, Clone)]
-    pub struct GitRefname(pub String);
-
-    #[derive(cynic::Scalar, Debug, Clone)]
-    pub struct GitSSHRemote(pub String);
-
-    #[derive(cynic::Scalar, Debug, Clone)]
-    pub struct GitTimestamp(pub String);
-
-    #[derive(cynic::Scalar, Debug, Clone)]
-    pub struct Html(pub String);
-
-    #[derive(cynic::Scalar, Debug, Clone)]
-    pub struct PreciseDateTime(pub String);
-
-    #[derive(cynic::Scalar, Debug, Clone)]
-    pub struct Uri(pub String);
-
-    #[derive(cynic::Scalar, Debug, Clone)]
-    pub struct X509Certificate(pub String);
-
-}
-
 mod schema {
-    use super::types::*;
     cynic::use_schema!(r#"schema.graphql"#);
 }
 

--- a/tests/querygen-compile-run/build.rs
+++ b/tests/querygen-compile-run/build.rs
@@ -115,7 +115,7 @@ fn main() {
             r#"queries::AddPRComment::build(
                 &queries::AddPRCommentArguments{
                     body: "hello!".into(),
-                    commit: crate::types::GitObjectID("abcd".into())
+                    commit: queries::GitObjectID("abcd".into())
                 }
             )"#,
         ),


### PR DESCRIPTION
#### Why are we making this change?

#218 updated cynic to no longer require definitions of scalars that aren't used
in a query.

#### What effects does this change have?

This updates querygen to only output scalars that are actually used in a query.
They're also no longer output in a types module - this was only there because
previously both the query_dsl _and_ query modules needed access to these.  Now
it's only the query module that needs them so I've moved them into there.

Fixes #221