### PR TITLE
Deprecate `query_module` derive in favour of `schema_module`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,19 @@ all APIs might be changed.
 
 ### Breaking Changes
 
-- The return type of `cynic::Enum::select` now includes the `TypeLock` of the
-  enum. This should only affect users that were implementing `cynic::Enum`
-  directly. Users of the derive should be unaffected.
-- `IntoArgument` has been removed in favour of the new `InputType` trait.
+There are a number of breaking changes here, though they shouldn't require too
+much work for users to update. An example of an upgrade can be found
+[here](https://github.com/obmarg/git-lead-time/pull/1).
+
+- The `cynic::Scalar` derive has some new requirements:
+  - You should now derive (or otherwise implement) `serde::Serialize` for your
+    Scalar types.
+  - The derive now requires a `schema_module` parameter. The
+    `schema_for_derives` macro will automatically insert this (if you're using
+    it) but you may need to add `use super::schema;` to ensure it's
+    in-scope.
+  - The derive now has an optional `graphql_type` parameter. This is required
+    if the name of your type and the name of the scalar in the schema differ.
 - Scalars have been revamped:
   - The scalar trait now has a typelock. This means that a Scalar impl is now
     directly tied to the scalar definition in a given `query_dsl`.
@@ -30,16 +39,6 @@ all APIs might be changed.
     around scalar types.
   - `query_dsl` now defines markers for all the scalar types. As such you
     should not import any custom scalars into your query_dsl module.
-- `SerializableArgument` has been retired in favour of just using
-  `serde::Serialize`.
-- The `cynic::Scalar` derive has some new requirements:
-  - You should now derive (or otherwise implement) `serde::Serialize` for your
-    Scalar types.
-  - The derive now requires a `query_dsl` parameter. The `query_module` macro
-    will automatically insert this (if you're using it) but you may need to add
-    `use super::query_dsl;` to ensure it's in-scope.
-  - The derive now has an optional `graphql_type` parameter. This is required
-    if the name of your type and the name of the scalar in the schema differ.
 - Required scalar arguments no longer have concrete types, so anything
   that relied on type inference (i.e. `arg = "hello".into()`) will no longer
   work. You should either call an explicit function, or rely on a `InputType`
@@ -47,6 +46,12 @@ all APIs might be changed.
 - The `uuid`, `chrono`, `bson`, and `url` features have been retired. If you
   were using these you should register them as `Scalar` with the `impl_scalar!`
   macro.
+- `SerializableArgument` has been retired in favour of just using
+  `serde::Serialize`.
+- The return type of `cynic::Enum::select` now includes the `TypeLock` of the
+  enum. This should only affect users that were implementing `cynic::Enum`
+  directly. Users of the derive should be unaffected.
+- `IntoArgument` has been removed in favour of the new `InputType` trait.
 - `cynic::SerializeError` no longer exists.
 
 ### New Features
@@ -63,6 +68,8 @@ all APIs might be changed.
 - `cynic_codegen::output_query_dsl` is now named `cynic_codegen::output_schema_module`.
 - The `query_module` attribute macro has been deprecated in favour of
   `schema_for_derives`
+- The `query_module` parameter to the derives has been deprecated in favour of
+  `schema_module`.
 
 ### Bug Fixes
 

--- a/cynic-book/src/derives/enums.md
+++ b/cynic-book/src/derives/enums.md
@@ -33,6 +33,10 @@ An Enum can be configured with several attributes on the enum itself:
 - `rename_all="camelCase"` tells cynic to rename all the rust field names with
   a particular rule to match their GraphQL counterparts. If not provided this
   defaults to `SCREAMING_SNAKE_CASE` to be consistent with GraphQL conventions.
+- `schema_module` tells cynic where to find the schema module - that is a
+  module that has called the `use_schema!` macro. This will default to
+  `schema` if not provided. An override can also be provided by nesting the
+  Enum inside a module with the `schema_for_derives` attribute macro.
 
 <!-- TODO: list of the rename rules, possibly pulled from codegen docs -->
 

--- a/cynic-book/src/derives/inline-fragments.md
+++ b/cynic-book/src/derives/inline-fragments.md
@@ -13,10 +13,7 @@ For example, the GitHub API has an `Assignee` union type which could be queried 
 
 ```rust
 #[derive(cynic::InlineFragments)]
-#[cynic(
-    schema_path = "github.graphql",
-    query_module = "schema",
-)]
+#[cynic(schema_path = "github.graphql")]
 enum Assignee {
     Bot(Bot),
     Mannequin(Mannequin)
@@ -37,10 +34,7 @@ variant will be output whenever an unhandled type is returned.
 
 ```rust
 #[derive(cynic::InlineFragments)]
-#[cynic(
-    schema_path = "github.graphql",
-    query_module = "schema",
-)]
+#[cynic(schema_path = "github.graphql")]
 enum Assignee {
     Bot(Bot),
     User(User)
@@ -60,10 +54,7 @@ also select some fields from the interface:
 
 ```rust
 #[derive(cynic::InlineFragments, Debug)]
-#[cynic(
-    schema_path = "github.graphql",
-    query_module = "schema",
-)]
+#[cynic(schema_path = "github.graphql")]
 pub enum Actor {
     User(User),
 
@@ -72,10 +63,7 @@ pub enum Actor {
 }
 
 #[derive(cynic::QueryFragment)]
-#[cynic(
-    schema_path = "github.graphql",
-    query_module = "schema",
-)]
+#[cynic(schema_path = "github.graphql")]
 enum ActorFallback {
     pub login: String
 }
@@ -96,10 +84,11 @@ enum itself:
   but
   can be provided by nesting the InlineFragments inside a query module
   with this attr.
-- `query_module` tells cynic where to find the query module - that is a
-  module that has called the `schema!` macro. This is required but
-  can also be provided by nesting the QueryFragment inside a query
-  module.
+- `schema_module` tells cynic where to find the schema module - that is a
+  module that has called the `use_schema!` macro. This will default to
+  `schema` if not provided. An override can also be provided by nesting the
+  InlineFragments inside a module with the `schema_for_derives` attribute
+  macro.
 
 #### Variant Attributes
 

--- a/cynic-book/src/derives/input-objects.md
+++ b/cynic-book/src/derives/input-objects.md
@@ -52,6 +52,11 @@ An InputObject can be configured with several attributes on the struct itself:
 - `rename_all="camelCase"` tells cynic to rename all the rust field names with
   a particular rule to match their GraphQL counterparts. If not provided this
   defaults to camelCase to be consistent with GraphQL conventions.
+- `schema_module` tells cynic where to find the schema module - that is a
+  module that has called the `use_schema!` macro. This will default to
+  `schema` if not provided. An override can also be provided by nesting the
+  InputObject inside a module with the `schema_for_derives` attribute
+  macro.
 
 <!-- TODO: list of the rename rules, possibly pulled from codegen docs -->
 

--- a/cynic-book/src/derives/query-arguments.md
+++ b/cynic-book/src/derives/query-arguments.md
@@ -25,7 +25,6 @@ attribute on the fields where you wish to pass them.
 #[derive(cynic::QueryFragment, Debug)]
 #[cynic(
     schema_path = "examples/starwars.schema.graphql",
-    query_module = "schema",
     graphql_type = "Root",
     argument_struct = "FilmArguments"
 )]

--- a/cynic-book/src/derives/query-fragments.md
+++ b/cynic-book/src/derives/query-fragments.md
@@ -10,7 +10,7 @@ Generally you'll use a derive to create query fragments, like this:
 #[derive(cynic::QueryFragment, Debug)]
 #[cynic(
     schema_path = "examples/starwars.schema.graphql",
-    query_module = "schema",
+    schema_module = "schema",
 )]
 struct Film {
     title: Option<String>,
@@ -26,7 +26,7 @@ be nested inside each other, like so:
 #[derive(cynic::QueryFragment, Debug)]
 #[cynic(
     schema_path = "examples/starwars.schema.graphql",
-    query_module = "schema",
+    schema_module = "schema",
     graphql_type = "Root",
 )]
 struct FilmsConnection {
@@ -64,7 +64,7 @@ API we need a QueryFragment like this:
 #[derive(cynic::QueryFragment, Debug)]
 #[cynic(
     schema_path = "examples/starwars.schema.graphql",
-    query_module = "schema",
+    schema_module = "schema",
     graphql_type = "Root",
 )]
 struct AllFilmsQuery {
@@ -106,7 +106,7 @@ struct FilmArguments {
 #[derive(cynic::QueryFragment, Debug)]
 #[cynic(
     schema_path = "examples/starwars.schema.graphql",
-    query_module = "schema",
+    schema_module = "schema",
     graphql_type = "Root",
     argument_struct = "FilmArguments"
 )]
@@ -166,9 +166,10 @@ A QueryFragment can be configured with several attributes on the struct itself:
 - `schema_path` sets the path to the GraphQL schema. This is required, but
   can be provided by nesting the QueryFragment inside a query module with this
   attr.
-- `query_module` tells cynic where to find the query module - that is a module
-  that has called the `schema!` macro. This is required but can also be
-  provided by nesting the QueryFragment inside a query module.
+- `schema_module` tells cynic where to find the schema module - that is a module
+  module that has called the `use_schema!` macro. This will default to
+  `schema` if not provided. An override can also be provided by nesting the
+  QueryFragment inside a module with the `schema_for_derives` attribute macro.
 
 #### Field Attributes
 

--- a/cynic-book/src/derives/scalars.md
+++ b/cynic-book/src/derives/scalars.md
@@ -35,7 +35,7 @@ You can also derive `Scalar` on any newtype structs:
 
 ```rust
 #[derive(cynic::Scalar, serde::Serialize)]
-#[cynic(query_module = "schema")]
+#[cynic(schema_module = "schema")]
 struct MyScalar(String);
 ```
 
@@ -55,6 +55,6 @@ A Scalar derive can be configured with several attributes on the struct itself:
 - `graphql_type = "AType"` can be provided if the type of the struct differs
   from the type of and tells cynic the name of the Scalar in the schema. This
   defaults to the name of the struct if not provided.
-- `query_module` tells cynic where to find the query module - that is a module
+- `schema_module` tells cynic where to find the query module - that is a module
   that has called the `use_schema!` macro. This is required but can also be
   provided by nesting the QueryFragment inside a query module.

--- a/cynic-codegen/src/enum_derive/input.rs
+++ b/cynic-codegen/src/enum_derive/input.rs
@@ -10,13 +10,31 @@ pub struct EnumDeriveInput {
     pub(super) data: darling::ast::Data<EnumDeriveVariant, ()>,
 
     pub schema_path: SpannedValue<String>,
-    pub query_module: SpannedValue<String>,
+
+    // query_module is deprecated, remove eventually.
+    #[darling(default)]
+    query_module: Option<SpannedValue<String>>,
+    #[darling(default, rename = "schema_module")]
+    schema_module_: Option<SpannedValue<String>>,
 
     #[darling(default)]
     pub graphql_type: Option<SpannedValue<String>>,
 
     #[darling(default)]
     pub(super) rename_all: Option<RenameAll>,
+}
+
+impl EnumDeriveInput {
+    pub fn schema_module(&self) -> SpannedValue<String> {
+        if let Some(schema_module) = &self.schema_module_ {
+            return schema_module.clone();
+        }
+        if let Some(query_module) = &self.query_module {
+            return query_module.clone();
+        }
+
+        SpannedValue::new("schema".into(), Span::call_site())
+    }
 }
 
 #[derive(Debug, darling::FromVariant)]

--- a/cynic-codegen/src/enum_derive/mod.rs
+++ b/cynic-codegen/src/enum_derive/mod.rs
@@ -80,7 +80,6 @@ pub fn enum_derive_impl(
         };
 
         let enum_marker_ident = Ident::for_type(&input.graphql_type_name());
-        let ident = input.ident;
 
         let string_literals: Vec<_> = pairs
             .iter()
@@ -89,12 +88,13 @@ pub fn enum_derive_impl(
 
         let variants: Vec<_> = pairs.iter().map(|(variant, _)| &variant.ident).collect();
 
-        let query_module = Ident::for_module(&input.query_module);
+        let schema_module = Ident::for_module(&input.schema_module());
+        let ident = input.ident;
 
         Ok(quote! {
             #[automatically_derived]
-            impl ::cynic::Enum<#query_module::#enum_marker_ident> for #ident {
-                fn select() -> cynic::SelectionSet<'static, Self, #query_module::#enum_marker_ident> {
+            impl ::cynic::Enum<#schema_module::#enum_marker_ident> for #ident {
+                fn select() -> cynic::SelectionSet<'static, Self, #schema_module::#enum_marker_ident> {
                     ::cynic::selection_set::enum_with(|s| {
                         match s.as_ref() {
                             #(
@@ -119,7 +119,7 @@ pub fn enum_derive_impl(
                     }
             }
 
-            ::cynic::impl_input_type!(#ident, #query_module::#enum_marker_ident);
+            ::cynic::impl_input_type!(#ident, #schema_module::#enum_marker_ident);
         })
     } else {
         Err(syn::Error::new(

--- a/cynic-codegen/src/fragment_derive/input.rs
+++ b/cynic-codegen/src/fragment_derive/input.rs
@@ -10,7 +10,12 @@ pub struct FragmentDeriveInput {
     pub(super) data: darling::ast::Data<(), FragmentDeriveField>,
 
     pub schema_path: SpannedValue<String>,
-    pub query_module: SpannedValue<String>,
+
+    // query_module is deprecated, remove eventually.
+    #[darling(default)]
+    query_module: Option<SpannedValue<String>>,
+    #[darling(default, rename = "schema_module")]
+    schema_module_: Option<SpannedValue<String>>,
 
     #[darling(default)]
     pub graphql_type: Option<SpannedValue<String>>,
@@ -19,6 +24,17 @@ pub struct FragmentDeriveInput {
 }
 
 impl FragmentDeriveInput {
+    pub fn schema_module(&self) -> SpannedValue<String> {
+        if let Some(schema_module) = &self.schema_module_ {
+            return schema_module.clone();
+        }
+        if let Some(query_module) = &self.query_module {
+            return query_module.clone();
+        }
+
+        SpannedValue::new("schema".into(), Span::call_site())
+    }
+
     pub fn graphql_type_name(&self) -> String {
         self.graphql_type
             .as_ref()
@@ -141,7 +157,8 @@ mod tests {
                 ],
             )),
             schema_path: "abcd".to_string().into(),
-            query_module: "abcd".to_string().into(),
+            query_module: None,
+            schema_module_: None,
             graphql_type: Some("abcd".to_string().into()),
             argument_struct: None,
         };
@@ -180,7 +197,8 @@ mod tests {
                 ],
             )),
             schema_path: "abcd".to_string().into(),
-            query_module: "abcd".to_string().into(),
+            query_module: None,
+            schema_module_: Some("abcd".to_string().into()),
             graphql_type: Some("abcd".to_string().into()),
             argument_struct: None,
         };
@@ -198,7 +216,8 @@ mod tests {
                 vec![],
             )),
             schema_path: "abcd".to_string().into(),
-            query_module: "abcd".to_string().into(),
+            query_module: None,
+            schema_module_: Some("abcd".to_string().into()),
             graphql_type: Some("abcd".to_string().into()),
             argument_struct: None,
         };
@@ -241,7 +260,8 @@ mod tests {
                 ],
             )),
             schema_path: "abcd".to_string().into(),
-            query_module: "abcd".to_string().into(),
+            query_module: None,
+            schema_module_: Some("abcd".to_string().into()),
             graphql_type: None,
             argument_struct: None,
         };

--- a/cynic-codegen/src/fragment_derive/mod.rs
+++ b/cynic-codegen/src/fragment_derive/mod.rs
@@ -72,12 +72,12 @@ pub fn fragment_derive_impl(
 
     if let darling::ast::Data::Struct(fields) = &input.data {
         let graphql_name = &(input.graphql_type_name());
-        let query_module = input.query_module;
+        let schema_module = input.schema_module();
         let fragment_impl = FragmentImpl::new_for(
             &fields,
             &input.ident,
             &object,
-            Ident::new_spanned(&*query_module, query_module.span()).into(),
+            Ident::new_spanned(&*schema_module, schema_module.span()).into(),
             graphql_name,
             argument_struct,
         )?;

--- a/cynic-codegen/src/inline_fragments_derive/input.rs
+++ b/cynic-codegen/src/inline_fragments_derive/input.rs
@@ -8,7 +8,12 @@ pub struct InlineFragmentsDeriveInput {
     pub(super) data: darling::ast::Data<SpannedValue<InlineFragmentsDeriveVariant>, ()>,
 
     pub schema_path: SpannedValue<String>,
-    pub query_module: SpannedValue<String>,
+
+    // query_module is deprecated, remove eventually.
+    #[darling(default)]
+    query_module: Option<SpannedValue<String>>,
+    #[darling(default, rename = "schema_module")]
+    schema_module_: Option<SpannedValue<String>>,
 
     #[darling(default)]
     pub graphql_type: Option<SpannedValue<String>>,
@@ -17,6 +22,17 @@ pub struct InlineFragmentsDeriveInput {
 }
 
 impl InlineFragmentsDeriveInput {
+    pub fn schema_module(&self) -> SpannedValue<String> {
+        if let Some(schema_module) = &self.schema_module_ {
+            return schema_module.clone();
+        }
+        if let Some(query_module) = &self.query_module {
+            return query_module.clone();
+        }
+
+        SpannedValue::new("schema".into(), Span::call_site())
+    }
+
     pub fn graphql_type_name(&self) -> String {
         self.graphql_type
             .as_ref()

--- a/cynic-codegen/src/inline_fragments_derive/mod.rs
+++ b/cynic-codegen/src/inline_fragments_derive/mod.rs
@@ -65,11 +65,12 @@ pub(crate) fn inline_fragments_derive_impl(
         exhaustiveness_check(variants, &target_type, &schema)?;
 
         let fallback = check_fallback(variants, &target_type)?;
+        let schema_module = input.schema_module();
 
         let inline_fragments_impl = InlineFragmentsImpl {
             target_struct: input.ident.clone(),
             type_lock: TypePath::concat(&[
-                Ident::new_spanned(&*input.query_module, input.query_module.span()).into(),
+                Ident::new_spanned(&*schema_module, schema_module.span()).into(),
                 Ident::for_type(&input.graphql_type_name()).into(),
             ]),
             argument_struct,

--- a/cynic-codegen/src/input_object_derive/input.rs
+++ b/cynic-codegen/src/input_object_derive/input.rs
@@ -10,7 +10,12 @@ pub struct InputObjectDeriveInput {
     pub(super) data: darling::ast::Data<(), InputObjectDeriveField>,
 
     pub schema_path: SpannedValue<String>,
-    pub query_module: SpannedValue<String>,
+
+    // query_module is deprecated, remove eventually.
+    #[darling(default)]
+    query_module: Option<SpannedValue<String>>,
+    #[darling(default, rename = "schema_module")]
+    schema_module_: Option<SpannedValue<String>>,
 
     #[darling(default)]
     pub graphql_type: Option<SpannedValue<String>>,
@@ -36,6 +41,17 @@ pub struct InputObjectDeriveField {
 }
 
 impl InputObjectDeriveInput {
+    pub fn schema_module(&self) -> SpannedValue<String> {
+        if let Some(schema_module) = &self.schema_module_ {
+            return schema_module.clone();
+        }
+        if let Some(query_module) = &self.query_module {
+            return query_module.clone();
+        }
+
+        SpannedValue::new("schema".into(), Span::call_site())
+    }
+
     pub fn graphql_type_name(&self) -> String {
         self.graphql_type
             .as_ref()

--- a/cynic-codegen/src/input_object_derive/mod.rs
+++ b/cynic-codegen/src/input_object_derive/mod.rs
@@ -75,7 +75,7 @@ pub fn input_object_derive_impl(
     if let darling::ast::Data::Struct(fields) = &input.data {
         let ident = &input.ident;
         let input_marker_ident = Ident::for_type(&input.graphql_type_name());
-        let query_module = Ident::for_module(&input.query_module);
+        let query_module = Ident::for_module(&input.schema_module());
         let input_object_name = ident.to_string();
 
         let pairs = match join_fields(

--- a/cynic-codegen/src/scalar_derive/input.rs
+++ b/cynic-codegen/src/scalar_derive/input.rs
@@ -1,4 +1,5 @@
 use darling::util::SpannedValue;
+use proc_macro2::Span;
 
 #[derive(darling::FromDeriveInput)]
 #[darling(attributes(cynic), supports(struct_newtype))]
@@ -6,7 +7,8 @@ pub struct ScalarDeriveInput {
     pub(super) ident: proc_macro2::Ident,
     pub(super) data: darling::ast::Data<(), ScalarDeriveField>,
 
-    pub(super) query_module: SpannedValue<String>,
+    #[darling(default, rename = "schema_module")]
+    schema_module_: Option<SpannedValue<String>>,
 
     #[darling(default)]
     pub(super) graphql_type: Option<SpannedValue<String>>,
@@ -16,4 +18,14 @@ pub struct ScalarDeriveInput {
 #[darling(forward_attrs(arguments))]
 pub struct ScalarDeriveField {
     pub(super) ty: syn::Type,
+}
+
+impl ScalarDeriveInput {
+    pub fn schema_module(&self) -> SpannedValue<String> {
+        if let Some(schema_module) = &self.schema_module_ {
+            return schema_module.clone();
+        }
+
+        SpannedValue::new("schema".into(), Span::call_site())
+    }
 }

--- a/cynic-codegen/src/scalar_derive/mod.rs
+++ b/cynic-codegen/src/scalar_derive/mod.rs
@@ -18,6 +18,8 @@ pub fn scalar_derive(ast: &syn::DeriveInput) -> Result<TokenStream, syn::Error> 
 pub fn scalar_derive_impl(input: ScalarDeriveInput) -> Result<TokenStream, syn::Error> {
     use quote::quote;
 
+    let schema_module = input.schema_module();
+
     // We're assuming that Darling has already validated this as a newtype enum,
     // so we can get away with panicing here.
     let field = input
@@ -36,7 +38,7 @@ pub fn scalar_derive_impl(input: ScalarDeriveInput) -> Result<TokenStream, syn::
         ident.clone().into()
     };
     let type_lock = TypePath::concat(&[
-        Ident::new(input.query_module.as_ref()).into(),
+        Ident::new(schema_module.as_ref()).into(),
         type_lock_ident.into(),
     ]);
 

--- a/cynic/src/bin/simple.rs
+++ b/cynic/src/bin/simple.rs
@@ -12,11 +12,7 @@ mod schema {
 struct TestArgs {}
 
 #[derive(cynic::QueryFragment)]
-#[cynic(
-    schema_path = "src/bin/simple.graphql",
-    query_module = "schema",
-    argument_struct = "TestArgs"
-)]
+#[cynic(schema_path = "src/bin/simple.graphql", argument_struct = "TestArgs")]
 struct TestStruct {
     #[arguments(x = Some(1), y = "1")]
     pub field_one: String,
@@ -28,18 +24,14 @@ struct TestStruct {
 }
 
 #[derive(cynic::QueryFragment)]
-#[cynic(schema_path = "src/bin/simple.graphql", query_module = "schema")]
+#[cynic(schema_path = "src/bin/simple.graphql")]
 struct Nested {
     pub a_string: String,
     pub opt_string: Option<String>,
 }
 
 #[derive(cynic::QueryFragment)]
-#[cynic(
-    schema_path = "src/bin/simple.graphql",
-    query_module = "schema",
-    graphql_type = "TestStruct"
-)]
+#[cynic(schema_path = "src/bin/simple.graphql", graphql_type = "TestStruct")]
 struct Test {
     #[arguments(x = Some(1), y = Some("1".to_string()))]
     pub field_one: String,
@@ -48,11 +40,7 @@ struct Test {
 }
 
 #[derive(cynic::InputObject, Clone)]
-#[cynic(
-    schema_path = "src/bin/simple.graphql",
-    query_module = "schema",
-    rename_all = "camelCase"
-)]
+#[cynic(schema_path = "src/bin/simple.graphql", rename_all = "camelCase")]
 struct AnInputType {
     favourite_dessert: Option<Dessert>,
 }
@@ -60,7 +48,6 @@ struct AnInputType {
 #[derive(cynic::Enum, Clone)]
 #[cynic(
     schema_path = "src/bin/simple.graphql",
-    query_module = "schema",
     rename_all = "SCREAMING_SNAKE_CASE"
 )]
 enum Dessert {
@@ -69,7 +56,7 @@ enum Dessert {
 }
 
 #[derive(cynic::InlineFragments)]
-#[cynic(schema_path = "src/bin/simple.graphql", query_module = "schema")]
+#[cynic(schema_path = "src/bin/simple.graphql")]
 enum MyUnionType {
     TestStruct(Test),
     Nested(Nested),

--- a/cynic/src/http.rs
+++ b/cynic/src/http.rs
@@ -34,7 +34,7 @@ mod surf_ext {
     /// # #[derive(cynic::QueryFragment)]
     /// # #[cynic(
     /// #    schema_path = "../schemas/starwars.schema.graphql",
-    /// #    query_module = "schema",
+    /// #    schema_module = "schema",
     /// # )]
     /// # struct Film {
     /// #    title: Option<String>,
@@ -44,7 +44,7 @@ mod surf_ext {
     /// # #[derive(cynic::QueryFragment)]
     /// # #[cynic(
     /// #     schema_path = "../schemas/starwars.schema.graphql",
-    /// #     query_module = "schema",
+    /// #     schema_module = "schema",
     /// #     graphql_type = "Root"
     /// # )]
     /// # struct FilmDirectorQuery {
@@ -126,7 +126,7 @@ mod reqwest_ext {
     /// # #[derive(cynic::QueryFragment)]
     /// # #[cynic(
     /// #    schema_path = "../schemas/starwars.schema.graphql",
-    /// #    query_module = "schema",
+    /// #    schema_module = "schema",
     /// # )]
     /// # struct Film {
     /// #    title: Option<String>,
@@ -136,7 +136,7 @@ mod reqwest_ext {
     /// # #[derive(cynic::QueryFragment)]
     /// # #[cynic(
     /// #     schema_path = "../schemas/starwars.schema.graphql",
-    /// #     query_module = "schema",
+    /// #     schema_module = "schema",
     /// #     graphql_type = "Root"
     /// # )]
     /// # struct FilmDirectorQuery {
@@ -220,7 +220,7 @@ mod reqwest_blocking_ext {
     /// # #[derive(cynic::QueryFragment)]
     /// # #[cynic(
     /// #    schema_path = "../schemas/starwars.schema.graphql",
-    /// #    query_module = "schema",
+    /// #    schema_module = "schema",
     /// # )]
     /// # struct Film {
     /// #    title: Option<String>,
@@ -230,7 +230,7 @@ mod reqwest_blocking_ext {
     /// # #[derive(cynic::QueryFragment)]
     /// # #[cynic(
     /// #     schema_path = "../schemas/starwars.schema.graphql",
-    /// #     query_module = "schema",
+    /// #     schema_module = "schema",
     /// #     graphql_type = "Root"
     /// # )]
     /// # struct FilmDirectorQuery {

--- a/cynic/src/lib.rs
+++ b/cynic/src/lib.rs
@@ -50,10 +50,7 @@
 //! # }
 //!
 //! #[derive(cynic::QueryFragment)]
-//! #[cynic(
-//!     schema_path = "../schemas/starwars.schema.graphql",
-//!     query_module = "schema",
-//! )]
+//! #[cynic(schema_path = "../schemas/starwars.schema.graphql")]
 //! struct Film {
 //!     title: Option<String>,
 //!     director: Option<String>
@@ -68,7 +65,6 @@
 //! #[derive(cynic::QueryFragment)]
 //! #[cynic(
 //!     schema_path = "../schemas/starwars.schema.graphql",
-//!     query_module = "schema",
 //!     graphql_type = "Root"
 //! )]
 //! struct FilmDirectorQuery {
@@ -115,7 +111,6 @@
 //! # #[derive(cynic::QueryFragment)]
 //! # #[cynic(
 //! #    schema_path = "../schemas/starwars.schema.graphql",
-//! #    query_module = "schema",
 //! # )]
 //! # struct Film {
 //! #    title: Option<String>,
@@ -133,7 +128,6 @@
 //! #[derive(cynic::QueryFragment)]
 //! #[cynic(
 //!     schema_path = "../schemas/starwars.schema.graphql",
-//!     query_module = "schema",
 //!     graphql_type = "Root",
 //!     // By adding the `argument_struct` parameter to our `QueryFragment` we've made a variable
 //!     // named `args` avaiable for use in the `arguments` attribute.

--- a/cynic/tests/input-object-tests.rs
+++ b/cynic/tests/input-object-tests.rs
@@ -14,7 +14,6 @@ fn test_input_object_renames() {
     #[cynic(
         graphql_type = "BlogPostInput",
         schema_path = "tests/test-schema.graphql",
-        query_module = "schema",
         rename_all = "lowercase"
     )]
     struct BlogPost {

--- a/cynic/tests/simple_schema_tests.rs
+++ b/cynic/tests/simple_schema_tests.rs
@@ -8,7 +8,7 @@ struct TestArgs {}
 #[derive(cynic::QueryFragment, PartialEq, Debug)]
 #[cynic(
     schema_path = "src/bin/simple.graphql",
-    query_module = "schema",
+
     //argument_struct = "TestArgs"
 )]
 struct TestStruct {
@@ -32,7 +32,6 @@ struct Nested {
 #[derive(cynic::QueryFragment, PartialEq, Debug)]
 #[cynic(
     schema_path = "src/bin/simple.graphql",
-    query_module = "schema",
     graphql_type = "Query",
     argument_struct = "TestArgs"
 )]
@@ -43,7 +42,6 @@ struct TestQuery {
 #[derive(cynic::Enum, Clone, Debug, PartialEq)]
 #[cynic(
     schema_path = "src/bin/simple.graphql",
-    query_module = "schema",
     rename_all = "SCREAMING_SNAKE_CASE"
 )]
 pub enum Dessert {

--- a/examples/examples/chrono-scalars.rs
+++ b/examples/examples/chrono-scalars.rs
@@ -20,7 +20,6 @@ struct Job {
 #[derive(cynic::QueryFragment, Debug)]
 #[cynic(
     schema_path = "../schemas/graphql.jobs.graphql",
-    query_module = "schema",
     graphql_type = "Query"
 )]
 struct JobsQuery {

--- a/examples/examples/manual-reqwest.rs
+++ b/examples/examples/manual-reqwest.rs
@@ -23,7 +23,6 @@ struct FilmArguments {
 #[derive(cynic::QueryFragment, Debug)]
 #[cynic(
     schema_path = "../schemas/starwars.schema.graphql",
-    query_module = "schema",
     graphql_type = "Root",
     argument_struct = "FilmArguments"
 )]

--- a/examples/examples/querying-interfaces.rs
+++ b/examples/examples/querying-interfaces.rs
@@ -39,7 +39,6 @@ struct Planet {
 #[derive(cynic::QueryFragment, Debug)]
 #[cynic(
     schema_path = "../schemas/starwars.schema.graphql",
-    query_module = "schema",
     graphql_type = "Node"
 )]
 struct OtherNode {
@@ -54,7 +53,6 @@ struct Arguments {
 #[derive(cynic::QueryFragment, Debug)]
 #[cynic(
     schema_path = "../schemas/starwars.schema.graphql",
-    query_module = "schema",
     graphql_type = "Root",
     argument_struct = "Arguments"
 )]

--- a/examples/examples/reqwest-async.rs
+++ b/examples/examples/reqwest-async.rs
@@ -25,7 +25,6 @@ struct FilmArguments {
 #[derive(cynic::QueryFragment, Debug)]
 #[cynic(
     schema_path = "../schemas/starwars.schema.graphql",
-    query_module = "schema",
     graphql_type = "Root",
     argument_struct = "FilmArguments"
 )]

--- a/examples/examples/starwars.rs
+++ b/examples/examples/starwars.rs
@@ -22,7 +22,6 @@ struct FilmArguments {
 #[derive(cynic::QueryFragment, Debug)]
 #[cynic(
     schema_path = "../schemas/starwars.schema.graphql",
-    query_module = "schema",
     graphql_type = "Root",
     argument_struct = "FilmArguments"
 )]

--- a/examples/examples/surf-client.rs
+++ b/examples/examples/surf-client.rs
@@ -25,7 +25,6 @@ struct FilmArguments {
 #[derive(cynic::QueryFragment, Debug)]
 #[cynic(
     schema_path = "../schemas/starwars.schema.graphql",
-    query_module = "schema",
     graphql_type = "Root",
     argument_struct = "FilmArguments"
 )]

--- a/tests/ui-tests/tests/cases/enum-guess-validation.rs
+++ b/tests/ui-tests/tests/cases/enum-guess-validation.rs
@@ -7,7 +7,6 @@ mod schema {
 #[derive(cynic::Enum, Clone, Copy, Debug)]
 #[cynic(
     schema_path = "../../../cynic/src/bin/simple.graphql",
-    query_module = "schema",
     graphql_type = "Desseqt"
 )]
 enum Dessert {

--- a/tests/ui-tests/tests/cases/enum-guess-validation.stderr
+++ b/tests/ui-tests/tests/cases/enum-guess-validation.stderr
@@ -1,13 +1,13 @@
 error: Could not find an enum named Desseqt in ../../../cynic/src/bin/simple.graphql. Did you mean Dessert?
-  --> $DIR/enum-guess-validation.rs:11:5
+  --> $DIR/enum-guess-validation.rs:10:5
    |
-11 |     graphql_type = "Desseqt"
+10 |     graphql_type = "Desseqt"
    |     ^^^^^^^^^^^^
 
 warning: variant `ICE_CREAM` should have an upper camel case name
-  --> $DIR/enum-guess-validation.rs:15:5
+  --> $DIR/enum-guess-validation.rs:14:5
    |
-15 |     ICE_CREAM,
+14 |     ICE_CREAM,
    |     ^^^^^^^^^ help: convert the identifier to upper camel case: `IceCream`
    |
    = note: `#[warn(non_camel_case_types)]` on by default

--- a/tests/ui-tests/tests/cases/inline-fragment-exhaustiveness.rs
+++ b/tests/ui-tests/tests/cases/inline-fragment-exhaustiveness.rs
@@ -27,7 +27,6 @@ struct Nested {
 #[derive(cynic::QueryFragment)]
 #[cynic(
     schema_path = "../../../cynic/src/bin/simple.graphql",
-    query_module = "schema",
     graphql_type = "TestStruct"
 )]
 struct Test {

--- a/tests/ui-tests/tests/cases/inline-fragment-fallback-validation.rs
+++ b/tests/ui-tests/tests/cases/inline-fragment-fallback-validation.rs
@@ -7,7 +7,6 @@ mod schema {
 #[derive(cynic::InlineFragments)]
 #[cynic(
     schema_path = "../../../cynic/src/bin/simple.graphql",
-    query_module = "schema",
     graphql_type = "MyUnionType"
 )]
 enum MyFailingUnionType {
@@ -30,7 +29,6 @@ struct Nested {
 #[derive(cynic::InlineFragments)]
 #[cynic(
     schema_path = "../../../cynic/src/bin/simple.graphql",
-    query_module = "schema",
     graphql_type = "MyUnionType"
 )]
 enum MyOkUnionTYpe {

--- a/tests/ui-tests/tests/cases/inline-fragment-fallback-validation.stderr
+++ b/tests/ui-tests/tests/cases/inline-fragment-fallback-validation.stderr
@@ -1,5 +1,5 @@
 error: The fallback for a union type must be a unit variant
-  --> $DIR/inline-fragment-fallback-validation.rs:16:5
+  --> $DIR/inline-fragment-fallback-validation.rs:15:5
    |
-16 |     #[cynic(fallback)]
+15 |     #[cynic(fallback)]
    |     ^


### PR DESCRIPTION
#### Why are we making this change?

I'm renaming the `query_dsl` to `schema module` in this release.  So it no
longer makes sense for the derives to have a `query_module` parameter.

#### What effects does this change have?

Adds a `schema_module` parameter to the derives that replaces `query_module` -
defaults to `schema` if not provided.

Fixes #234 

Also added a link to an example upgrade PR, Fixes #227