### PR TITLE
Use the correct module name in SelectionBuilder paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ all APIs might be changed.
 
 ## Unreleased - xxxx-xx-xx
 
+### Bug Fixes
+
+- Fixes an issue where cynic would incorrectly case module certain names in the
+  `use_schema` output
+
 ## v0.13.0 - 2021-04-04
 
 ### Breaking Changes

--- a/cynic-codegen/src/use_schema/selector_struct.rs
+++ b/cynic-codegen/src/use_schema/selector_struct.rs
@@ -50,7 +50,7 @@ impl SelectorStruct {
                 Ident::for_module(graphql_name),
                 field.required_arguments(),
                 TypePath::new(vec![
-                    Ident::for_module(&name.rust_name()),
+                    Ident::for_module(graphql_name),
                     selection_builder.name.clone(),
                 ]),
                 type_index,


### PR DESCRIPTION
#### Why are we making this change?

Cynics `use_schema` macro does a bunch of case transforms on field names.  One
of these was incorrectly being done on a string that had already been
transformed, leading to output that disagreed with elsewhere.

#### What effects does this change have?

Fixes the transform.

Fixes #240 
