### PR TITLE
Pull in json-decode 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ all APIs might be changed.
 
 ## Unreleased - xxxx-xx-xx
 
+### Bug Fixes
+
+- This fixes a problem with JSON decoding that made it extremely inefficient
+  (particularly on larger responses).  In my benchmarking this improves
+  decoding performance 10x.
+
 ## v0.13.1 - 2021-04-26
 
 ### Bug Fixes

--- a/cynic/Cargo.toml
+++ b/cynic/Cargo.toml
@@ -26,7 +26,7 @@ surf-encoding = ["surf/encoding"]
 [dependencies]
 chrono = { version = "0.4.11", optional = true }
 cynic-proc-macros = { path = "../cynic-proc-macros", version = "0.13.1" }
-json-decode = "0.5.0"
+json-decode = "0.6.0"
 serde = { version = "1.0.104", features = [ "derive" ] }
 serde_json = "1.0"
 thiserror = "1.0.20"


### PR DESCRIPTION
#### Why are we making this change?

I noticed that cynic decoding was waaaaay slower than it should have been.                                                                               After some profiling I noticed this was because json-decode errors contained a
stringified version of the JSON, and those errors were behind `ok_or` and not
`ok_or_else` - so the JSON string was always built even if no error occurred.

#### What effects does this change have?

Pulls in json-decode 0.6 which fixes this.

Fixes #198 