### PR TITLE
Add support for fields with an underscore name.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ all APIs might be changed.
 
 ## Unreleased - xxxx-xx-xx
 
+### New Features
+
+- The `QueryFragment` derive now supports renaming fields.
+
+### Bug Fixes
+
+- Underscore field names are now supported in schemas and for querying.
+
 ## v0.13.2 - 2021-05-16
 
 This release is only of the `cynic` crate - other crates remain at 0.13.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ all APIs might be changed.
 ### Bug Fixes
 
 - Underscore field names are now supported in schemas and for querying.
+- Field names with leading underscores will no longer have those leading
+  underscores removed.
 
 ## v0.13.2 - 2021-05-16
 

--- a/cynic-book/src/derives/query-fragments.md
+++ b/cynic-book/src/derives/query-fragments.md
@@ -175,6 +175,10 @@ A QueryFragment can be configured with several attributes on the struct itself:
 
 Each field can also have it's own attributes:
 
+- `rename = "someGraphqlName"` can be provided if you want the rust field name
+  to differ from the GraphQL field name.  You should provide the name as it is
+  in the GraphQL schema (although due to implementation details a snake case
+  form of the name may work as well)
 - `recurse = "5"` tells cynic that this field is recursive and should be
   fetched to a maximum depth of 5. See [Recursive Queries][recursive-queries]
   for more info.

--- a/cynic-codegen/src/fragment_derive/input.rs
+++ b/cynic-codegen/src/fragment_derive/input.rs
@@ -93,6 +93,9 @@ pub struct FragmentDeriveField {
 
     #[darling(default)]
     pub(super) recurse: Option<SpannedValue<u8>>,
+
+    #[darling(default)]
+    rename: Option<SpannedValue<String>>,
 }
 
 impl FragmentDeriveField {
@@ -117,6 +120,14 @@ impl FragmentDeriveField {
             CheckMode::Normal
         }
     }
+
+    pub fn graphql_ident(&self) -> Option<crate::Ident> {
+        match (&self.rename, &self.ident) {
+            (Some(rename), _) => Some(crate::Ident::for_field(&**rename).with_span(rename.span())),
+            (_, Some(ident)) => Some(crate::Ident::from_proc_macro2(ident, None)),
+            _ => None,
+        }
+    }
 }
 
 #[cfg(test)]
@@ -139,6 +150,7 @@ mod tests {
                         attrs: vec![],
                         flatten: false,
                         recurse: None,
+                        rename: None,
                     },
                     FragmentDeriveField {
                         ident: Some(format_ident!("field_two")),
@@ -146,6 +158,7 @@ mod tests {
                         attrs: vec![],
                         flatten: true,
                         recurse: None,
+                        rename: None,
                     },
                     FragmentDeriveField {
                         ident: Some(format_ident!("field_three")),
@@ -153,6 +166,7 @@ mod tests {
                         attrs: vec![],
                         flatten: false,
                         recurse: Some(8.into()),
+                        rename: Some("fieldThree".to_string().into()),
                     },
                 ],
             )),
@@ -179,6 +193,7 @@ mod tests {
                         attrs: vec![],
                         flatten: false,
                         recurse: None,
+                        rename: None,
                     },
                     FragmentDeriveField {
                         ident: Some(format_ident!("field_two")),
@@ -186,6 +201,7 @@ mod tests {
                         attrs: vec![],
                         flatten: true,
                         recurse: Some(8.into()),
+                        rename: None,
                     },
                     FragmentDeriveField {
                         ident: Some(format_ident!("field_three")),
@@ -193,6 +209,7 @@ mod tests {
                         attrs: vec![],
                         flatten: true,
                         recurse: Some(8.into()),
+                        rename: None,
                     },
                 ],
             )),
@@ -242,6 +259,7 @@ mod tests {
                         attrs: vec![],
                         flatten: false,
                         recurse: None,
+                        rename: None,
                     },
                     FragmentDeriveField {
                         ident: Some(format_ident!("field_two")),
@@ -249,6 +267,7 @@ mod tests {
                         attrs: vec![],
                         flatten: true,
                         recurse: None,
+                        rename: None,
                     },
                     FragmentDeriveField {
                         ident: Some(format_ident!("field_three")),
@@ -256,6 +275,7 @@ mod tests {
                         attrs: vec![],
                         flatten: false,
                         recurse: Some(8.into()),
+                        rename: None,
                     },
                 ],
             )),

--- a/cynic-codegen/tests/snapshots/use_schema__schema_file_4.snap
+++ b/cynic-codegen/tests/snapshots/use_schema__schema_file_4.snap
@@ -1,0 +1,31 @@
+---
+source: cynic-codegen/tests/use-schema.rs
+expression: "format_code(format!(\"{}\", tokens))"
+
+---
+#[allow(dead_code)]
+pub struct Foo;
+#[allow(dead_code)]
+impl Foo {
+    pub fn __underscore() -> foo::SelectionBuilder {
+        foo::SelectionBuilder::new(vec![])
+    }
+}
+#[allow(dead_code)]
+pub mod foo {
+    pub struct SelectionBuilder {
+        args: Vec<::cynic::Argument>,
+    }
+    impl SelectionBuilder {
+        pub(super) fn new(args: Vec<::cynic::Argument>) -> Self {
+            SelectionBuilder { args }
+        }
+        pub fn select<'a, T: 'a + Send + Sync>(
+            self,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, bool>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Foo> {
+            ::cynic::selection_set::field("_", self.args, ::cynic::selection_set::option(inner))
+        }
+    }
+}
+

--- a/cynic-codegen/tests/use-schema.rs
+++ b/cynic-codegen/tests/use-schema.rs
@@ -10,7 +10,8 @@ use cynic_codegen::use_schema::{use_schema, QueryDslParams};
 #[rstest(schema_file => [
     "graphql.jobs.graphql",
     "books.graphql",
-    "starwars.schema.graphql"
+    "starwars.schema.graphql",
+    "test_cases.graphql"
 ])]
 fn snapshot_use_schema(schema_file: &str) {
     let schema_path = PathBuf::from("../schemas/").join(schema_file);

--- a/cynic/tests/renames.rs
+++ b/cynic/tests/renames.rs
@@ -1,0 +1,71 @@
+use cynic::QueryFragment;
+use serde::Serialize;
+use serde_json::json;
+
+mod schema {
+    cynic::use_schema!("tests/test-schema.graphql");
+}
+
+#[derive(QueryFragment, Serialize)]
+#[cynic(
+    graphql_type = "Query",
+    schema_path = "tests/test-schema.graphql",
+    query_module = "schema"
+)]
+struct AllPostsQuery {
+    all_posts: Vec<Post>,
+}
+
+#[derive(QueryFragment, Serialize)]
+#[cynic(
+    graphql_type = "BlogPost",
+    schema_path = "tests/test-schema.graphql",
+    query_module = "schema"
+)]
+struct Post {
+    // TODO: UI tests of failure on renames
+    #[cynic(rename = "hasMetadata")]
+    metadata_present: Option<bool>,
+    metadata: Option<EmptyType>,
+}
+
+#[derive(QueryFragment, Serialize)]
+#[cynic(schema_path = "tests/test-schema.graphql")]
+struct EmptyType {
+    #[cynic(rename = "_")]
+    underscore: Option<bool>,
+}
+
+#[test]
+fn test_all_posts_query_output() {
+    use cynic::{FragmentContext, Operation};
+
+    let query = Operation::query(AllPostsQuery::fragment(FragmentContext::empty()));
+
+    insta::assert_display_snapshot!(query.query);
+}
+
+#[test]
+fn test_decoding() {
+    use cynic::{FragmentContext, GraphQlResponse, Operation};
+
+    let data = GraphQlResponse {
+        data: Some(json!({ "allPosts": posts() })),
+        errors: None,
+    };
+
+    let query = Operation::query(AllPostsQuery::fragment(FragmentContext::empty()));
+
+    insta::assert_yaml_snapshot!(query.decode_response(data).unwrap().data)
+}
+
+fn posts() -> serde_json::Value {
+    json!([
+        {
+            "hasMetadata": true,
+            "metadata": {
+                "_": null
+            }
+        }
+    ])
+}

--- a/cynic/tests/snapshots/renames__all_posts_query_output.snap
+++ b/cynic/tests/snapshots/renames__all_posts_query_output.snap
@@ -1,0 +1,14 @@
+---
+source: cynic/tests/renames.rs
+expression: query.query
+
+---
+query Query {
+  allPosts {
+    hasMetadata
+    metadata {
+      _
+    }
+  }
+}
+

--- a/cynic/tests/snapshots/renames__decoding.snap
+++ b/cynic/tests/snapshots/renames__decoding.snap
@@ -1,0 +1,10 @@
+---
+source: cynic/tests/renames.rs
+expression: query.decode_response(data).unwrap().data
+
+---
+all_posts:
+  - metadata_present: true
+    metadata:
+      underscore: ~
+

--- a/cynic/tests/test-schema.graphql
+++ b/cynic/tests/test-schema.graphql
@@ -6,6 +6,8 @@ input BlogPostInput {
 type BlogPost {
   author: Author!
   comments: [Comment!]!
+  hasMetadata: Boolean
+  metadata: EmptyType
 }
 
 type Comment {
@@ -22,6 +24,10 @@ type Author {
   # A nonsense self referential field
   # Don't think this would make sense usually, but it's useful for testing.
   me: Author!
+}
+
+type EmptyType {
+  _: Boolean
 }
 
 type Query {

--- a/schemas/test_cases.graphql
+++ b/schemas/test_cases.graphql
@@ -1,0 +1,3 @@
+type Foo {
+  _: Boolean
+}

--- a/tests/ui-tests/tests/cases/rename-failures.rs
+++ b/tests/ui-tests/tests/cases/rename-failures.rs
@@ -1,0 +1,12 @@
+fn main() {}
+
+mod schema {
+    cynic::use_schema!("../../../schemas/starwars.schema.graphql");
+}
+
+#[derive(cynic::QueryFragment, Debug)]
+#[cynic(schema_path = "../../../schemas/starwars.schema.graphql")]
+struct Film {
+    #[cynic(rename = "episode")]
+    episode_id: Option<i32>,
+}

--- a/tests/ui-tests/tests/cases/rename-failures.stderr
+++ b/tests/ui-tests/tests/cases/rename-failures.stderr
@@ -1,0 +1,5 @@
+error: Field episode does not exist on the GraphQL type Film. Did you mean created?
+  --> $DIR/rename-failures.rs:10:13
+   |
+10 |     #[cynic(rename = "episode")]
+   |             ^^^^^^

--- a/tests/ui-tests/tests/ui-tests.rs
+++ b/tests/ui-tests/tests/ui-tests.rs
@@ -5,6 +5,7 @@ fn ui_test_inlinefragments() {
     t.compile_fail("tests/cases/fragment-guess-validation.rs");
     t.compile_fail("tests/cases/inline-fragment-exhaustiveness.rs");
     t.compile_fail("tests/cases/inline-fragment-fallback-validation.rs");
+    t.compile_fail("tests/cases/rename-failures.rs");
     t.compile_fail("tests/cases/inputobject-guess-validation.rs");
     t.compile_fail("tests/cases/wrong-enum-type.rs");
     t.pass("tests/cases/input-fragment-no-graphql-type.rs");


### PR DESCRIPTION
#### Why are we making this change?

As reported in #252 - it's a common pattern to name a field with an underscore
when you have an otherwise empty type (as empty types are not supported in
graphql).  Cynic does not support this (nor does rust).

#### What effects does this change have?

Adds support for underscore fields in schemas, and adds renames to the query
fragment derive so that you can work around rusts lack of support for `_`
fields.

Fixes #252 
Does part of #151 