### PR TITLE
Add support for field aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ all APIs might be changed.
 
 ## Unreleased - xxxx-xx-xx
 
+### New Features
+
+- Cynic now supports GraphQL field aliases.  These can be requested, but will
+  also automatically be added to queries if any QueryFragment requests the same
+  field twice.
+- The generator also now supports field aliases.
+
 ## v0.14.0 - 2021-06-06
 
 ### New Features

--- a/cynic-book/src/derives/query-fragments.md
+++ b/cynic-book/src/derives/query-fragments.md
@@ -179,6 +179,8 @@ Each field can also have it's own attributes:
   to differ from the GraphQL field name.  You should provide the name as it is
   in the GraphQL schema (although due to implementation details a snake case
   form of the name may work as well)
+- `alias` can be provided if you have a renamed field and want to explicitly
+  request a GraphQL alias in the resulting query output.
 - `recurse = "5"` tells cynic that this field is recursive and should be
   fetched to a maximum depth of 5. See [Recursive Queries][recursive-queries]
   for more info.

--- a/cynic-codegen/src/use_schema/selection_builder.rs
+++ b/cynic-codegen/src/use_schema/selection_builder.rs
@@ -64,6 +64,20 @@ impl FieldSelectionBuilder {
                         #selector
                     )
                 }
+
+            pub fn select_aliased<'a, T: 'a + Send + Sync>(
+                self,
+                alias: &str,
+                #arg_name: ::cynic::selection_set::SelectionSet<'a, T, #argument_type_lock>
+            ) -> ::cynic::selection_set::SelectionSet<'a, #decodes_to, super::#type_lock>
+                {
+                    ::cynic::selection_set::field_alias(
+                        #query_field_name,
+                        alias,
+                        self.args,
+                        #selector
+                    )
+                }
         }
     }
 }

--- a/cynic-codegen/tests/snapshots/use_schema__schema_file_1.snap
+++ b/cynic-codegen/tests/snapshots/use_schema__schema_file_1.snap
@@ -1,6 +1,7 @@
 ---
-source: cynic-codegen/tests/query-dsl.rs
+source: cynic-codegen/tests/use-schema.rs
 expression: "format_code(format!(\"{}\", tokens))"
+
 ---
 #[allow(dead_code)]
 pub struct City;
@@ -409,6 +410,13 @@ pub mod city {
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::City> {
             ::cynic::selection_set::field("id", self.args, inner)
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, ::cynic::Id>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::City> {
+            ::cynic::selection_set::field_alias("id", alias, self.args, inner)
+        }
     }
     pub struct NameSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -422,6 +430,13 @@ pub mod city {
             inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::City> {
             ::cynic::selection_set::field("name", self.args, inner)
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::City> {
+            ::cynic::selection_set::field_alias("name", alias, self.args, inner)
         }
     }
     pub struct SlugSelectionBuilder {
@@ -437,6 +452,13 @@ pub mod city {
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::City> {
             ::cynic::selection_set::field("slug", self.args, inner)
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::City> {
+            ::cynic::selection_set::field_alias("slug", alias, self.args, inner)
+        }
     }
     pub struct CountrySelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -451,6 +473,13 @@ pub mod city {
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::City> {
             ::cynic::selection_set::field("country", self.args, fields)
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::Country>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::City> {
+            ::cynic::selection_set::field_alias("country", alias, self.args, fields)
+        }
     }
     pub struct TypeSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -464,6 +493,13 @@ pub mod city {
             inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::City> {
             ::cynic::selection_set::field("type", self.args, inner)
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::City> {
+            ::cynic::selection_set::field_alias("type", alias, self.args, inner)
         }
     }
     pub struct JobsSelectionBuilder {
@@ -572,6 +608,18 @@ pub mod city {
                 ::cynic::selection_set::option(::cynic::selection_set::vec(fields)),
             )
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::Job>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<Vec<T>>, super::City> {
+            ::cynic::selection_set::field_alias(
+                "jobs",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(::cynic::selection_set::vec(fields)),
+            )
+        }
     }
     pub struct CreatedAtSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -586,6 +634,13 @@ pub mod city {
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::City> {
             ::cynic::selection_set::field("createdAt", self.args, inner)
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, super::DateTime>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::City> {
+            ::cynic::selection_set::field_alias("createdAt", alias, self.args, inner)
+        }
     }
     pub struct UpdatedAtSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -599,6 +654,13 @@ pub mod city {
             inner: ::cynic::selection_set::SelectionSet<'a, T, super::DateTime>,
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::City> {
             ::cynic::selection_set::field("updatedAt", self.args, inner)
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, super::DateTime>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::City> {
+            ::cynic::selection_set::field_alias("updatedAt", alias, self.args, inner)
         }
     }
 }
@@ -617,6 +679,13 @@ pub mod commitment {
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::Commitment> {
             ::cynic::selection_set::field("id", self.args, inner)
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, ::cynic::Id>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::Commitment> {
+            ::cynic::selection_set::field_alias("id", alias, self.args, inner)
+        }
     }
     pub struct TitleSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -631,6 +700,13 @@ pub mod commitment {
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::Commitment> {
             ::cynic::selection_set::field("title", self.args, inner)
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::Commitment> {
+            ::cynic::selection_set::field_alias("title", alias, self.args, inner)
+        }
     }
     pub struct SlugSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -644,6 +720,13 @@ pub mod commitment {
             inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::Commitment> {
             ::cynic::selection_set::field("slug", self.args, inner)
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::Commitment> {
+            ::cynic::selection_set::field_alias("slug", alias, self.args, inner)
         }
     }
     pub struct JobsSelectionBuilder {
@@ -752,6 +835,18 @@ pub mod commitment {
                 ::cynic::selection_set::option(::cynic::selection_set::vec(fields)),
             )
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::Job>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<Vec<T>>, super::Commitment> {
+            ::cynic::selection_set::field_alias(
+                "jobs",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(::cynic::selection_set::vec(fields)),
+            )
+        }
     }
     pub struct CreatedAtSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -766,6 +861,13 @@ pub mod commitment {
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::Commitment> {
             ::cynic::selection_set::field("createdAt", self.args, inner)
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, super::DateTime>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::Commitment> {
+            ::cynic::selection_set::field_alias("createdAt", alias, self.args, inner)
+        }
     }
     pub struct UpdatedAtSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -779,6 +881,13 @@ pub mod commitment {
             inner: ::cynic::selection_set::SelectionSet<'a, T, super::DateTime>,
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::Commitment> {
             ::cynic::selection_set::field("updatedAt", self.args, inner)
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, super::DateTime>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::Commitment> {
+            ::cynic::selection_set::field_alias("updatedAt", alias, self.args, inner)
         }
     }
 }
@@ -797,6 +906,13 @@ pub mod company {
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::Company> {
             ::cynic::selection_set::field("id", self.args, inner)
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, ::cynic::Id>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::Company> {
+            ::cynic::selection_set::field_alias("id", alias, self.args, inner)
+        }
     }
     pub struct NameSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -810,6 +926,13 @@ pub mod company {
             inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::Company> {
             ::cynic::selection_set::field("name", self.args, inner)
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::Company> {
+            ::cynic::selection_set::field_alias("name", alias, self.args, inner)
         }
     }
     pub struct SlugSelectionBuilder {
@@ -825,6 +948,13 @@ pub mod company {
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::Company> {
             ::cynic::selection_set::field("slug", self.args, inner)
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::Company> {
+            ::cynic::selection_set::field_alias("slug", alias, self.args, inner)
+        }
     }
     pub struct WebsiteUrlSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -838,6 +968,13 @@ pub mod company {
             inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::Company> {
             ::cynic::selection_set::field("websiteUrl", self.args, inner)
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::Company> {
+            ::cynic::selection_set::field_alias("websiteUrl", alias, self.args, inner)
         }
     }
     pub struct LogoUrlSelectionBuilder {
@@ -853,6 +990,18 @@ pub mod company {
         ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Company> {
             ::cynic::selection_set::field(
                 "logoUrl",
+                self.args,
+                ::cynic::selection_set::option(inner),
+            )
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Company> {
+            ::cynic::selection_set::field_alias(
+                "logoUrl",
+                alias,
                 self.args,
                 ::cynic::selection_set::option(inner),
             )
@@ -964,6 +1113,18 @@ pub mod company {
                 ::cynic::selection_set::option(::cynic::selection_set::vec(fields)),
             )
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::Job>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<Vec<T>>, super::Company> {
+            ::cynic::selection_set::field_alias(
+                "jobs",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(::cynic::selection_set::vec(fields)),
+            )
+        }
     }
     pub struct TwitterSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -978,6 +1139,18 @@ pub mod company {
         ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Company> {
             ::cynic::selection_set::field(
                 "twitter",
+                self.args,
+                ::cynic::selection_set::option(inner),
+            )
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Company> {
+            ::cynic::selection_set::field_alias(
+                "twitter",
+                alias,
                 self.args,
                 ::cynic::selection_set::option(inner),
             )
@@ -1000,6 +1173,18 @@ pub mod company {
                 ::cynic::selection_set::option(inner),
             )
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, bool>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Company> {
+            ::cynic::selection_set::field_alias(
+                "emailed",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(inner),
+            )
+        }
     }
     pub struct CreatedAtSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -1014,6 +1199,13 @@ pub mod company {
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::Company> {
             ::cynic::selection_set::field("createdAt", self.args, inner)
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, super::DateTime>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::Company> {
+            ::cynic::selection_set::field_alias("createdAt", alias, self.args, inner)
+        }
     }
     pub struct UpdatedAtSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -1027,6 +1219,13 @@ pub mod company {
             inner: ::cynic::selection_set::SelectionSet<'a, T, super::DateTime>,
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::Company> {
             ::cynic::selection_set::field("updatedAt", self.args, inner)
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, super::DateTime>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::Company> {
+            ::cynic::selection_set::field_alias("updatedAt", alias, self.args, inner)
         }
     }
 }
@@ -1045,6 +1244,13 @@ pub mod country {
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::Country> {
             ::cynic::selection_set::field("id", self.args, inner)
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, ::cynic::Id>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::Country> {
+            ::cynic::selection_set::field_alias("id", alias, self.args, inner)
+        }
     }
     pub struct NameSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -1058,6 +1264,13 @@ pub mod country {
             inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::Country> {
             ::cynic::selection_set::field("name", self.args, inner)
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::Country> {
+            ::cynic::selection_set::field_alias("name", alias, self.args, inner)
         }
     }
     pub struct SlugSelectionBuilder {
@@ -1073,6 +1286,13 @@ pub mod country {
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::Country> {
             ::cynic::selection_set::field("slug", self.args, inner)
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::Country> {
+            ::cynic::selection_set::field_alias("slug", alias, self.args, inner)
+        }
     }
     pub struct TypeSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -1086,6 +1306,13 @@ pub mod country {
             inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::Country> {
             ::cynic::selection_set::field("type", self.args, inner)
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::Country> {
+            ::cynic::selection_set::field_alias("type", alias, self.args, inner)
         }
     }
     pub struct IsoCodeSelectionBuilder {
@@ -1101,6 +1328,18 @@ pub mod country {
         ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Country> {
             ::cynic::selection_set::field(
                 "isoCode",
+                self.args,
+                ::cynic::selection_set::option(inner),
+            )
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Country> {
+            ::cynic::selection_set::field_alias(
+                "isoCode",
+                alias,
                 self.args,
                 ::cynic::selection_set::option(inner),
             )
@@ -1208,6 +1447,18 @@ pub mod country {
         ) -> ::cynic::selection_set::SelectionSet<'a, Option<Vec<T>>, super::Country> {
             ::cynic::selection_set::field(
                 "cities",
+                self.args,
+                ::cynic::selection_set::option(::cynic::selection_set::vec(fields)),
+            )
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::City>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<Vec<T>>, super::Country> {
+            ::cynic::selection_set::field_alias(
+                "cities",
+                alias,
                 self.args,
                 ::cynic::selection_set::option(::cynic::selection_set::vec(fields)),
             )
@@ -1319,6 +1570,18 @@ pub mod country {
                 ::cynic::selection_set::option(::cynic::selection_set::vec(fields)),
             )
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::Job>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<Vec<T>>, super::Country> {
+            ::cynic::selection_set::field_alias(
+                "jobs",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(::cynic::selection_set::vec(fields)),
+            )
+        }
     }
     pub struct CreatedAtSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -1333,6 +1596,13 @@ pub mod country {
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::Country> {
             ::cynic::selection_set::field("createdAt", self.args, inner)
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, super::DateTime>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::Country> {
+            ::cynic::selection_set::field_alias("createdAt", alias, self.args, inner)
+        }
     }
     pub struct UpdatedAtSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -1346,6 +1616,13 @@ pub mod country {
             inner: ::cynic::selection_set::SelectionSet<'a, T, super::DateTime>,
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::Country> {
             ::cynic::selection_set::field("updatedAt", self.args, inner)
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, super::DateTime>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::Country> {
+            ::cynic::selection_set::field_alias("updatedAt", alias, self.args, inner)
         }
     }
 }
@@ -1364,6 +1641,13 @@ pub mod job {
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::Job> {
             ::cynic::selection_set::field("id", self.args, inner)
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, ::cynic::Id>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::Job> {
+            ::cynic::selection_set::field_alias("id", alias, self.args, inner)
+        }
     }
     pub struct TitleSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -1377,6 +1661,13 @@ pub mod job {
             inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::Job> {
             ::cynic::selection_set::field("title", self.args, inner)
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::Job> {
+            ::cynic::selection_set::field_alias("title", alias, self.args, inner)
         }
     }
     pub struct SlugSelectionBuilder {
@@ -1392,6 +1683,13 @@ pub mod job {
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::Job> {
             ::cynic::selection_set::field("slug", self.args, inner)
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::Job> {
+            ::cynic::selection_set::field_alias("slug", alias, self.args, inner)
+        }
     }
     pub struct CommitmentSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -1405,6 +1703,13 @@ pub mod job {
             fields: ::cynic::selection_set::SelectionSet<'a, T, super::Commitment>,
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::Job> {
             ::cynic::selection_set::field("commitment", self.args, fields)
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::Commitment>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::Job> {
+            ::cynic::selection_set::field_alias("commitment", alias, self.args, fields)
         }
     }
     pub struct CitiesSelectionBuilder {
@@ -1509,6 +1814,18 @@ pub mod job {
         ) -> ::cynic::selection_set::SelectionSet<'a, Option<Vec<T>>, super::Job> {
             ::cynic::selection_set::field(
                 "cities",
+                self.args,
+                ::cynic::selection_set::option(::cynic::selection_set::vec(fields)),
+            )
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::City>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<Vec<T>>, super::Job> {
+            ::cynic::selection_set::field_alias(
+                "cities",
+                alias,
                 self.args,
                 ::cynic::selection_set::option(::cynic::selection_set::vec(fields)),
             )
@@ -1620,6 +1937,18 @@ pub mod job {
                 ::cynic::selection_set::option(::cynic::selection_set::vec(fields)),
             )
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::Country>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<Vec<T>>, super::Job> {
+            ::cynic::selection_set::field_alias(
+                "countries",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(::cynic::selection_set::vec(fields)),
+            )
+        }
     }
     pub struct RemotesSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -1727,6 +2056,18 @@ pub mod job {
                 ::cynic::selection_set::option(::cynic::selection_set::vec(fields)),
             )
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::Remote>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<Vec<T>>, super::Job> {
+            ::cynic::selection_set::field_alias(
+                "remotes",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(::cynic::selection_set::vec(fields)),
+            )
+        }
     }
     pub struct DescriptionSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -1741,6 +2082,18 @@ pub mod job {
         ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Job> {
             ::cynic::selection_set::field(
                 "description",
+                self.args,
+                ::cynic::selection_set::option(inner),
+            )
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Job> {
+            ::cynic::selection_set::field_alias(
+                "description",
+                alias,
                 self.args,
                 ::cynic::selection_set::option(inner),
             )
@@ -1763,6 +2116,18 @@ pub mod job {
                 ::cynic::selection_set::option(inner),
             )
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Job> {
+            ::cynic::selection_set::field_alias(
+                "applyUrl",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(inner),
+            )
+        }
     }
     pub struct CompanySelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -1777,6 +2142,18 @@ pub mod job {
         ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Job> {
             ::cynic::selection_set::field(
                 "company",
+                self.args,
+                ::cynic::selection_set::option(fields),
+            )
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::Company>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Job> {
+            ::cynic::selection_set::field_alias(
+                "company",
+                alias,
                 self.args,
                 ::cynic::selection_set::option(fields),
             )
@@ -1888,6 +2265,18 @@ pub mod job {
                 ::cynic::selection_set::option(::cynic::selection_set::vec(fields)),
             )
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::Tag>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<Vec<T>>, super::Job> {
+            ::cynic::selection_set::field_alias(
+                "tags",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(::cynic::selection_set::vec(fields)),
+            )
+        }
     }
     pub struct IsPublishedSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -1902,6 +2291,18 @@ pub mod job {
         ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Job> {
             ::cynic::selection_set::field(
                 "isPublished",
+                self.args,
+                ::cynic::selection_set::option(inner),
+            )
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, bool>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Job> {
+            ::cynic::selection_set::field_alias(
+                "isPublished",
+                alias,
                 self.args,
                 ::cynic::selection_set::option(inner),
             )
@@ -1924,6 +2325,18 @@ pub mod job {
                 ::cynic::selection_set::option(inner),
             )
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, bool>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Job> {
+            ::cynic::selection_set::field_alias(
+                "isFeatured",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(inner),
+            )
+        }
     }
     pub struct LocationNamesSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -1938,6 +2351,18 @@ pub mod job {
         ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Job> {
             ::cynic::selection_set::field(
                 "locationNames",
+                self.args,
+                ::cynic::selection_set::option(inner),
+            )
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Job> {
+            ::cynic::selection_set::field_alias(
+                "locationNames",
+                alias,
                 self.args,
                 ::cynic::selection_set::option(inner),
             )
@@ -1960,6 +2385,18 @@ pub mod job {
                 ::cynic::selection_set::option(inner),
             )
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Job> {
+            ::cynic::selection_set::field_alias(
+                "userEmail",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(inner),
+            )
+        }
     }
     pub struct PostedAtSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -1973,6 +2410,13 @@ pub mod job {
             inner: ::cynic::selection_set::SelectionSet<'a, T, super::DateTime>,
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::Job> {
             ::cynic::selection_set::field("postedAt", self.args, inner)
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, super::DateTime>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::Job> {
+            ::cynic::selection_set::field_alias("postedAt", alias, self.args, inner)
         }
     }
     pub struct CreatedAtSelectionBuilder {
@@ -1988,6 +2432,13 @@ pub mod job {
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::Job> {
             ::cynic::selection_set::field("createdAt", self.args, inner)
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, super::DateTime>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::Job> {
+            ::cynic::selection_set::field_alias("createdAt", alias, self.args, inner)
+        }
     }
     pub struct UpdatedAtSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -2001,6 +2452,13 @@ pub mod job {
             inner: ::cynic::selection_set::SelectionSet<'a, T, super::DateTime>,
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::Job> {
             ::cynic::selection_set::field("updatedAt", self.args, inner)
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, super::DateTime>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::Job> {
+            ::cynic::selection_set::field_alias("updatedAt", alias, self.args, inner)
         }
     }
 }
@@ -2019,6 +2477,13 @@ pub mod location {
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::Location> {
             ::cynic::selection_set::field("id", self.args, inner)
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, ::cynic::Id>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::Location> {
+            ::cynic::selection_set::field_alias("id", alias, self.args, inner)
+        }
     }
     pub struct SlugSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -2032,6 +2497,13 @@ pub mod location {
             inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::Location> {
             ::cynic::selection_set::field("slug", self.args, inner)
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::Location> {
+            ::cynic::selection_set::field_alias("slug", alias, self.args, inner)
         }
     }
     pub struct NameSelectionBuilder {
@@ -2047,6 +2519,13 @@ pub mod location {
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::Location> {
             ::cynic::selection_set::field("name", self.args, inner)
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::Location> {
+            ::cynic::selection_set::field_alias("name", alias, self.args, inner)
+        }
     }
     pub struct TypeSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -2060,6 +2539,13 @@ pub mod location {
             inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::Location> {
             ::cynic::selection_set::field("type", self.args, inner)
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::Location> {
+            ::cynic::selection_set::field_alias("type", alias, self.args, inner)
         }
     }
 }
@@ -2078,6 +2564,13 @@ pub mod mutation {
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::Mutation> {
             ::cynic::selection_set::field("subscribe", self.args, fields)
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::User>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::Mutation> {
+            ::cynic::selection_set::field_alias("subscribe", alias, self.args, fields)
+        }
     }
     pub struct PostJobSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -2091,6 +2584,13 @@ pub mod mutation {
             fields: ::cynic::selection_set::SelectionSet<'a, T, super::Job>,
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::Mutation> {
             ::cynic::selection_set::field("postJob", self.args, fields)
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::Job>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::Mutation> {
+            ::cynic::selection_set::field_alias("postJob", alias, self.args, fields)
         }
     }
     pub struct UpdateJobSelectionBuilder {
@@ -2106,6 +2606,13 @@ pub mod mutation {
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::Mutation> {
             ::cynic::selection_set::field("updateJob", self.args, fields)
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::Job>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::Mutation> {
+            ::cynic::selection_set::field_alias("updateJob", alias, self.args, fields)
+        }
     }
     pub struct UpdateCompanySelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -2119,6 +2626,13 @@ pub mod mutation {
             fields: ::cynic::selection_set::SelectionSet<'a, T, super::Company>,
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::Mutation> {
             ::cynic::selection_set::field("updateCompany", self.args, fields)
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::Company>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::Mutation> {
+            ::cynic::selection_set::field_alias("updateCompany", alias, self.args, fields)
         }
     }
 }
@@ -2151,6 +2665,18 @@ pub mod query {
         ) -> ::cynic::selection_set::SelectionSet<'a, Vec<T>, super::Query> {
             ::cynic::selection_set::field("jobs", self.args, ::cynic::selection_set::vec(fields))
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::Job>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Vec<T>, super::Query> {
+            ::cynic::selection_set::field_alias(
+                "jobs",
+                alias,
+                self.args,
+                ::cynic::selection_set::vec(fields),
+            )
+        }
     }
     pub struct JobSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -2164,6 +2690,13 @@ pub mod query {
             fields: ::cynic::selection_set::SelectionSet<'a, T, super::Job>,
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::Query> {
             ::cynic::selection_set::field("job", self.args, fields)
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::Job>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::Query> {
+            ::cynic::selection_set::field_alias("job", alias, self.args, fields)
         }
     }
     pub struct LocationsSelectionBuilder {
@@ -2183,6 +2716,18 @@ pub mod query {
                 ::cynic::selection_set::vec(fields),
             )
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::Location>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Vec<T>, super::Query> {
+            ::cynic::selection_set::field_alias(
+                "locations",
+                alias,
+                self.args,
+                ::cynic::selection_set::vec(fields),
+            )
+        }
     }
     pub struct CitySelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -2196,6 +2741,13 @@ pub mod query {
             fields: ::cynic::selection_set::SelectionSet<'a, T, super::City>,
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::Query> {
             ::cynic::selection_set::field("city", self.args, fields)
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::City>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::Query> {
+            ::cynic::selection_set::field_alias("city", alias, self.args, fields)
         }
     }
     pub struct CountrySelectionBuilder {
@@ -2211,6 +2763,13 @@ pub mod query {
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::Query> {
             ::cynic::selection_set::field("country", self.args, fields)
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::Country>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::Query> {
+            ::cynic::selection_set::field_alias("country", alias, self.args, fields)
+        }
     }
     pub struct RemoteSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -2224,6 +2783,13 @@ pub mod query {
             fields: ::cynic::selection_set::SelectionSet<'a, T, super::Remote>,
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::Query> {
             ::cynic::selection_set::field("remote", self.args, fields)
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::Remote>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::Query> {
+            ::cynic::selection_set::field_alias("remote", alias, self.args, fields)
         }
     }
     pub struct CommitmentsSelectionBuilder {
@@ -2243,6 +2809,18 @@ pub mod query {
                 ::cynic::selection_set::vec(fields),
             )
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::Commitment>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Vec<T>, super::Query> {
+            ::cynic::selection_set::field_alias(
+                "commitments",
+                alias,
+                self.args,
+                ::cynic::selection_set::vec(fields),
+            )
+        }
     }
     pub struct CitiesSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -2256,6 +2834,18 @@ pub mod query {
             fields: ::cynic::selection_set::SelectionSet<'a, T, super::City>,
         ) -> ::cynic::selection_set::SelectionSet<'a, Vec<T>, super::Query> {
             ::cynic::selection_set::field("cities", self.args, ::cynic::selection_set::vec(fields))
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::City>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Vec<T>, super::Query> {
+            ::cynic::selection_set::field_alias(
+                "cities",
+                alias,
+                self.args,
+                ::cynic::selection_set::vec(fields),
+            )
         }
     }
     pub struct CountriesSelectionBuilder {
@@ -2275,6 +2865,18 @@ pub mod query {
                 ::cynic::selection_set::vec(fields),
             )
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::Country>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Vec<T>, super::Query> {
+            ::cynic::selection_set::field_alias(
+                "countries",
+                alias,
+                self.args,
+                ::cynic::selection_set::vec(fields),
+            )
+        }
     }
     pub struct RemotesSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -2288,6 +2890,18 @@ pub mod query {
             fields: ::cynic::selection_set::SelectionSet<'a, T, super::Remote>,
         ) -> ::cynic::selection_set::SelectionSet<'a, Vec<T>, super::Query> {
             ::cynic::selection_set::field("remotes", self.args, ::cynic::selection_set::vec(fields))
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::Remote>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Vec<T>, super::Query> {
+            ::cynic::selection_set::field_alias(
+                "remotes",
+                alias,
+                self.args,
+                ::cynic::selection_set::vec(fields),
+            )
         }
     }
     pub struct CompaniesSelectionBuilder {
@@ -2303,6 +2917,18 @@ pub mod query {
         ) -> ::cynic::selection_set::SelectionSet<'a, Vec<T>, super::Query> {
             ::cynic::selection_set::field(
                 "companies",
+                self.args,
+                ::cynic::selection_set::vec(fields),
+            )
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::Company>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Vec<T>, super::Query> {
+            ::cynic::selection_set::field_alias(
+                "companies",
+                alias,
                 self.args,
                 ::cynic::selection_set::vec(fields),
             )
@@ -2324,6 +2950,13 @@ pub mod remote {
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::Remote> {
             ::cynic::selection_set::field("id", self.args, inner)
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, ::cynic::Id>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::Remote> {
+            ::cynic::selection_set::field_alias("id", alias, self.args, inner)
+        }
     }
     pub struct NameSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -2337,6 +2970,13 @@ pub mod remote {
             inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::Remote> {
             ::cynic::selection_set::field("name", self.args, inner)
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::Remote> {
+            ::cynic::selection_set::field_alias("name", alias, self.args, inner)
         }
     }
     pub struct SlugSelectionBuilder {
@@ -2352,6 +2992,13 @@ pub mod remote {
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::Remote> {
             ::cynic::selection_set::field("slug", self.args, inner)
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::Remote> {
+            ::cynic::selection_set::field_alias("slug", alias, self.args, inner)
+        }
     }
     pub struct TypeSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -2365,6 +3012,13 @@ pub mod remote {
             inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::Remote> {
             ::cynic::selection_set::field("type", self.args, inner)
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::Remote> {
+            ::cynic::selection_set::field_alias("type", alias, self.args, inner)
         }
     }
     pub struct JobsSelectionBuilder {
@@ -2473,6 +3127,18 @@ pub mod remote {
                 ::cynic::selection_set::option(::cynic::selection_set::vec(fields)),
             )
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::Job>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<Vec<T>>, super::Remote> {
+            ::cynic::selection_set::field_alias(
+                "jobs",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(::cynic::selection_set::vec(fields)),
+            )
+        }
     }
     pub struct CreatedAtSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -2487,6 +3153,13 @@ pub mod remote {
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::Remote> {
             ::cynic::selection_set::field("createdAt", self.args, inner)
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, super::DateTime>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::Remote> {
+            ::cynic::selection_set::field_alias("createdAt", alias, self.args, inner)
+        }
     }
     pub struct UpdatedAtSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -2500,6 +3173,13 @@ pub mod remote {
             inner: ::cynic::selection_set::SelectionSet<'a, T, super::DateTime>,
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::Remote> {
             ::cynic::selection_set::field("updatedAt", self.args, inner)
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, super::DateTime>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::Remote> {
+            ::cynic::selection_set::field_alias("updatedAt", alias, self.args, inner)
         }
     }
 }
@@ -2518,6 +3198,13 @@ pub mod tag {
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::Tag> {
             ::cynic::selection_set::field("id", self.args, inner)
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, ::cynic::Id>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::Tag> {
+            ::cynic::selection_set::field_alias("id", alias, self.args, inner)
+        }
     }
     pub struct NameSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -2532,6 +3219,13 @@ pub mod tag {
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::Tag> {
             ::cynic::selection_set::field("name", self.args, inner)
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::Tag> {
+            ::cynic::selection_set::field_alias("name", alias, self.args, inner)
+        }
     }
     pub struct SlugSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -2545,6 +3239,13 @@ pub mod tag {
             inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::Tag> {
             ::cynic::selection_set::field("slug", self.args, inner)
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::Tag> {
+            ::cynic::selection_set::field_alias("slug", alias, self.args, inner)
         }
     }
     pub struct JobsSelectionBuilder {
@@ -2653,6 +3354,18 @@ pub mod tag {
                 ::cynic::selection_set::option(::cynic::selection_set::vec(fields)),
             )
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::Job>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<Vec<T>>, super::Tag> {
+            ::cynic::selection_set::field_alias(
+                "jobs",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(::cynic::selection_set::vec(fields)),
+            )
+        }
     }
     pub struct CreatedAtSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -2667,6 +3380,13 @@ pub mod tag {
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::Tag> {
             ::cynic::selection_set::field("createdAt", self.args, inner)
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, super::DateTime>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::Tag> {
+            ::cynic::selection_set::field_alias("createdAt", alias, self.args, inner)
+        }
     }
     pub struct UpdatedAtSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -2680,6 +3400,13 @@ pub mod tag {
             inner: ::cynic::selection_set::SelectionSet<'a, T, super::DateTime>,
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::Tag> {
             ::cynic::selection_set::field("updatedAt", self.args, inner)
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, super::DateTime>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::Tag> {
+            ::cynic::selection_set::field_alias("updatedAt", alias, self.args, inner)
         }
     }
 }
@@ -2698,6 +3425,13 @@ pub mod user {
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::User> {
             ::cynic::selection_set::field("id", self.args, inner)
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, ::cynic::Id>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::User> {
+            ::cynic::selection_set::field_alias("id", alias, self.args, inner)
+        }
     }
     pub struct NameSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -2711,6 +3445,18 @@ pub mod user {
             inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
         ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::User> {
             ::cynic::selection_set::field("name", self.args, ::cynic::selection_set::option(inner))
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::User> {
+            ::cynic::selection_set::field_alias(
+                "name",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(inner),
+            )
         }
     }
     pub struct EmailSelectionBuilder {
@@ -2726,6 +3472,13 @@ pub mod user {
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::User> {
             ::cynic::selection_set::field("email", self.args, inner)
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::User> {
+            ::cynic::selection_set::field_alias("email", alias, self.args, inner)
+        }
     }
     pub struct SubscribeSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -2739,6 +3492,13 @@ pub mod user {
             inner: ::cynic::selection_set::SelectionSet<'a, T, bool>,
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::User> {
             ::cynic::selection_set::field("subscribe", self.args, inner)
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, bool>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::User> {
+            ::cynic::selection_set::field_alias("subscribe", alias, self.args, inner)
         }
     }
     pub struct CreatedAtSelectionBuilder {
@@ -2754,6 +3514,13 @@ pub mod user {
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::User> {
             ::cynic::selection_set::field("createdAt", self.args, inner)
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, super::DateTime>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::User> {
+            ::cynic::selection_set::field_alias("createdAt", alias, self.args, inner)
+        }
     }
     pub struct UpdatedAtSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -2767,6 +3534,13 @@ pub mod user {
             inner: ::cynic::selection_set::SelectionSet<'a, T, super::DateTime>,
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::User> {
             ::cynic::selection_set::field("updatedAt", self.args, inner)
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, super::DateTime>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::User> {
+            ::cynic::selection_set::field_alias("updatedAt", alias, self.args, inner)
         }
     }
 }

--- a/cynic-codegen/tests/snapshots/use_schema__schema_file_2.snap
+++ b/cynic-codegen/tests/snapshots/use_schema__schema_file_2.snap
@@ -1,6 +1,7 @@
 ---
-source: cynic-codegen/tests/query-dsl.rs
+source: cynic-codegen/tests/use-schema.rs
 expression: "format_code(format!(\"{}\", tokens))"
+
 ---
 #[allow(dead_code)]
 pub struct Book;
@@ -93,6 +94,13 @@ pub mod book {
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::Book> {
             ::cynic::selection_set::field("id", self.args, inner)
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::Book> {
+            ::cynic::selection_set::field_alias("id", alias, self.args, inner)
+        }
     }
     pub struct NameSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -107,6 +115,13 @@ pub mod book {
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::Book> {
             ::cynic::selection_set::field("name", self.args, inner)
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::Book> {
+            ::cynic::selection_set::field_alias("name", alias, self.args, inner)
+        }
     }
     pub struct AuthorSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -120,6 +135,13 @@ pub mod book {
             inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::Book> {
             ::cynic::selection_set::field("author", self.args, inner)
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::Book> {
+            ::cynic::selection_set::field_alias("author", alias, self.args, inner)
         }
     }
 }
@@ -138,6 +160,13 @@ pub mod book_changed {
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::BookChanged> {
             ::cynic::selection_set::field("mutationType", self.args, inner)
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, super::MutationType>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::BookChanged> {
+            ::cynic::selection_set::field_alias("mutationType", alias, self.args, inner)
+        }
     }
     pub struct IdSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -152,6 +181,13 @@ pub mod book_changed {
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::BookChanged> {
             ::cynic::selection_set::field("id", self.args, inner)
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, ::cynic::Id>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::BookChanged> {
+            ::cynic::selection_set::field_alias("id", alias, self.args, inner)
+        }
     }
     pub struct BookSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -165,6 +201,18 @@ pub mod book_changed {
             fields: ::cynic::selection_set::SelectionSet<'a, T, super::Book>,
         ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::BookChanged> {
             ::cynic::selection_set::field("book", self.args, ::cynic::selection_set::option(fields))
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::Book>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::BookChanged> {
+            ::cynic::selection_set::field_alias(
+                "book",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(fields),
+            )
         }
     }
 }
@@ -183,6 +231,13 @@ pub mod mutation_root {
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::MutationRoot> {
             ::cynic::selection_set::field("createBook", self.args, inner)
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, ::cynic::Id>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::MutationRoot> {
+            ::cynic::selection_set::field_alias("createBook", alias, self.args, inner)
+        }
     }
     pub struct DeleteBookSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -196,6 +251,13 @@ pub mod mutation_root {
             inner: ::cynic::selection_set::SelectionSet<'a, T, bool>,
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::MutationRoot> {
             ::cynic::selection_set::field("deleteBook", self.args, inner)
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, bool>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::MutationRoot> {
+            ::cynic::selection_set::field_alias("deleteBook", alias, self.args, inner)
         }
     }
 }
@@ -214,6 +276,18 @@ pub mod query_root {
         ) -> ::cynic::selection_set::SelectionSet<'a, Vec<T>, super::QueryRoot> {
             ::cynic::selection_set::field("books", self.args, ::cynic::selection_set::vec(fields))
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::Book>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Vec<T>, super::QueryRoot> {
+            ::cynic::selection_set::field_alias(
+                "books",
+                alias,
+                self.args,
+                ::cynic::selection_set::vec(fields),
+            )
+        }
     }
 }
 #[allow(dead_code)]
@@ -230,6 +304,13 @@ pub mod subscription_root {
             inner: ::cynic::selection_set::SelectionSet<'a, T, i32>,
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::SubscriptionRoot> {
             ::cynic::selection_set::field("interval", self.args, inner)
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, i32>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::SubscriptionRoot> {
+            ::cynic::selection_set::field_alias("interval", alias, self.args, inner)
         }
     }
     pub struct BooksSelectionBuilder {
@@ -258,6 +339,13 @@ pub mod subscription_root {
             fields: ::cynic::selection_set::SelectionSet<'a, T, super::BookChanged>,
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::SubscriptionRoot> {
             ::cynic::selection_set::field("books", self.args, fields)
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::BookChanged>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::SubscriptionRoot> {
+            ::cynic::selection_set::field_alias("books", alias, self.args, fields)
         }
     }
 }

--- a/cynic-codegen/tests/snapshots/use_schema__schema_file_3.snap
+++ b/cynic-codegen/tests/snapshots/use_schema__schema_file_3.snap
@@ -1,6 +1,7 @@
 ---
-source: cynic-codegen/tests/query-dsl.rs
+source: cynic-codegen/tests/use-schema.rs
 expression: "format_code(format!(\"{}\", tokens))"
+
 ---
 #[allow(dead_code)]
 pub struct Node;
@@ -1017,6 +1018,18 @@ pub mod film {
         ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Film> {
             ::cynic::selection_set::field("title", self.args, ::cynic::selection_set::option(inner))
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Film> {
+            ::cynic::selection_set::field_alias(
+                "title",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(inner),
+            )
+        }
     }
     pub struct EpisodeIDSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -1031,6 +1044,18 @@ pub mod film {
         ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Film> {
             ::cynic::selection_set::field(
                 "episodeID",
+                self.args,
+                ::cynic::selection_set::option(inner),
+            )
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, i32>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Film> {
+            ::cynic::selection_set::field_alias(
+                "episodeID",
+                alias,
                 self.args,
                 ::cynic::selection_set::option(inner),
             )
@@ -1053,6 +1078,18 @@ pub mod film {
                 ::cynic::selection_set::option(inner),
             )
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Film> {
+            ::cynic::selection_set::field_alias(
+                "openingCrawl",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(inner),
+            )
+        }
     }
     pub struct DirectorSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -1067,6 +1104,18 @@ pub mod film {
         ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Film> {
             ::cynic::selection_set::field(
                 "director",
+                self.args,
+                ::cynic::selection_set::option(inner),
+            )
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Film> {
+            ::cynic::selection_set::field_alias(
+                "director",
+                alias,
                 self.args,
                 ::cynic::selection_set::option(inner),
             )
@@ -1091,6 +1140,20 @@ pub mod film {
                 )),
             )
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<Vec<Option<T>>>, super::Film> {
+            ::cynic::selection_set::field_alias(
+                "producers",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(::cynic::selection_set::vec(
+                    ::cynic::selection_set::option(inner),
+                )),
+            )
+        }
     }
     pub struct ReleaseDateSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -1105,6 +1168,18 @@ pub mod film {
         ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Film> {
             ::cynic::selection_set::field(
                 "releaseDate",
+                self.args,
+                ::cynic::selection_set::option(inner),
+            )
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Film> {
+            ::cynic::selection_set::field_alias(
+                "releaseDate",
+                alias,
                 self.args,
                 ::cynic::selection_set::option(inner),
             )
@@ -1177,6 +1252,18 @@ pub mod film {
                 ::cynic::selection_set::option(fields),
             )
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::FilmSpeciesConnection>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Film> {
+            ::cynic::selection_set::field_alias(
+                "speciesConnection",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(fields),
+            )
+        }
     }
     pub struct StarshipConnectionSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -1241,6 +1328,18 @@ pub mod film {
         ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Film> {
             ::cynic::selection_set::field(
                 "starshipConnection",
+                self.args,
+                ::cynic::selection_set::option(fields),
+            )
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::FilmStarshipsConnection>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Film> {
+            ::cynic::selection_set::field_alias(
+                "starshipConnection",
+                alias,
                 self.args,
                 ::cynic::selection_set::option(fields),
             )
@@ -1313,6 +1412,18 @@ pub mod film {
                 ::cynic::selection_set::option(fields),
             )
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::FilmVehiclesConnection>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Film> {
+            ::cynic::selection_set::field_alias(
+                "vehicleConnection",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(fields),
+            )
+        }
     }
     pub struct CharacterConnectionSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -1377,6 +1488,18 @@ pub mod film {
         ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Film> {
             ::cynic::selection_set::field(
                 "characterConnection",
+                self.args,
+                ::cynic::selection_set::option(fields),
+            )
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::FilmCharactersConnection>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Film> {
+            ::cynic::selection_set::field_alias(
+                "characterConnection",
+                alias,
                 self.args,
                 ::cynic::selection_set::option(fields),
             )
@@ -1449,6 +1572,18 @@ pub mod film {
                 ::cynic::selection_set::option(fields),
             )
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::FilmPlanetsConnection>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Film> {
+            ::cynic::selection_set::field_alias(
+                "planetConnection",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(fields),
+            )
+        }
     }
     pub struct CreatedSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -1463,6 +1598,18 @@ pub mod film {
         ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Film> {
             ::cynic::selection_set::field(
                 "created",
+                self.args,
+                ::cynic::selection_set::option(inner),
+            )
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Film> {
+            ::cynic::selection_set::field_alias(
+                "created",
+                alias,
                 self.args,
                 ::cynic::selection_set::option(inner),
             )
@@ -1485,6 +1632,18 @@ pub mod film {
                 ::cynic::selection_set::option(inner),
             )
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Film> {
+            ::cynic::selection_set::field_alias(
+                "edited",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(inner),
+            )
+        }
     }
     pub struct IdSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -1498,6 +1657,13 @@ pub mod film {
             inner: ::cynic::selection_set::SelectionSet<'a, T, ::cynic::Id>,
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::Film> {
             ::cynic::selection_set::field("id", self.args, inner)
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, ::cynic::Id>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::Film> {
+            ::cynic::selection_set::field_alias("id", alias, self.args, inner)
         }
     }
 }
@@ -1515,6 +1681,13 @@ pub mod film_characters_connection {
             fields: ::cynic::selection_set::SelectionSet<'a, T, super::PageInfo>,
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::FilmCharactersConnection> {
             ::cynic::selection_set::field("pageInfo", self.args, fields)
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::PageInfo>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::FilmCharactersConnection> {
+            ::cynic::selection_set::field_alias("pageInfo", alias, self.args, fields)
         }
     }
     pub struct EdgesSelectionBuilder {
@@ -1540,6 +1713,24 @@ pub mod film_characters_connection {
                 )),
             )
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::FilmCharactersEdge>,
+        ) -> ::cynic::selection_set::SelectionSet<
+            'a,
+            Option<Vec<Option<T>>>,
+            super::FilmCharactersConnection,
+        > {
+            ::cynic::selection_set::field_alias(
+                "edges",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(::cynic::selection_set::vec(
+                    ::cynic::selection_set::option(fields),
+                )),
+            )
+        }
     }
     pub struct TotalCountSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -1555,6 +1746,19 @@ pub mod film_characters_connection {
         {
             ::cynic::selection_set::field(
                 "totalCount",
+                self.args,
+                ::cynic::selection_set::option(inner),
+            )
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, i32>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::FilmCharactersConnection>
+        {
+            ::cynic::selection_set::field_alias(
+                "totalCount",
+                alias,
                 self.args,
                 ::cynic::selection_set::option(inner),
             )
@@ -1583,6 +1787,24 @@ pub mod film_characters_connection {
                 )),
             )
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::Person>,
+        ) -> ::cynic::selection_set::SelectionSet<
+            'a,
+            Option<Vec<Option<T>>>,
+            super::FilmCharactersConnection,
+        > {
+            ::cynic::selection_set::field_alias(
+                "characters",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(::cynic::selection_set::vec(
+                    ::cynic::selection_set::option(fields),
+                )),
+            )
+        }
     }
 }
 #[allow(dead_code)]
@@ -1601,6 +1823,19 @@ pub mod film_characters_edge {
         {
             ::cynic::selection_set::field("node", self.args, ::cynic::selection_set::option(fields))
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::Person>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::FilmCharactersEdge>
+        {
+            ::cynic::selection_set::field_alias(
+                "node",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(fields),
+            )
+        }
     }
     pub struct CursorSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -1614,6 +1849,13 @@ pub mod film_characters_edge {
             inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::FilmCharactersEdge> {
             ::cynic::selection_set::field("cursor", self.args, inner)
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::FilmCharactersEdge> {
+            ::cynic::selection_set::field_alias("cursor", alias, self.args, inner)
         }
     }
 }
@@ -1631,6 +1873,13 @@ pub mod film_planets_connection {
             fields: ::cynic::selection_set::SelectionSet<'a, T, super::PageInfo>,
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::FilmPlanetsConnection> {
             ::cynic::selection_set::field("pageInfo", self.args, fields)
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::PageInfo>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::FilmPlanetsConnection> {
+            ::cynic::selection_set::field_alias("pageInfo", alias, self.args, fields)
         }
     }
     pub struct EdgesSelectionBuilder {
@@ -1656,6 +1905,24 @@ pub mod film_planets_connection {
                 )),
             )
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::FilmPlanetsEdge>,
+        ) -> ::cynic::selection_set::SelectionSet<
+            'a,
+            Option<Vec<Option<T>>>,
+            super::FilmPlanetsConnection,
+        > {
+            ::cynic::selection_set::field_alias(
+                "edges",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(::cynic::selection_set::vec(
+                    ::cynic::selection_set::option(fields),
+                )),
+            )
+        }
     }
     pub struct TotalCountSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -1671,6 +1938,19 @@ pub mod film_planets_connection {
         {
             ::cynic::selection_set::field(
                 "totalCount",
+                self.args,
+                ::cynic::selection_set::option(inner),
+            )
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, i32>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::FilmPlanetsConnection>
+        {
+            ::cynic::selection_set::field_alias(
+                "totalCount",
+                alias,
                 self.args,
                 ::cynic::selection_set::option(inner),
             )
@@ -1699,6 +1979,24 @@ pub mod film_planets_connection {
                 )),
             )
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::Planet>,
+        ) -> ::cynic::selection_set::SelectionSet<
+            'a,
+            Option<Vec<Option<T>>>,
+            super::FilmPlanetsConnection,
+        > {
+            ::cynic::selection_set::field_alias(
+                "planets",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(::cynic::selection_set::vec(
+                    ::cynic::selection_set::option(fields),
+                )),
+            )
+        }
     }
 }
 #[allow(dead_code)]
@@ -1716,6 +2014,18 @@ pub mod film_planets_edge {
         ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::FilmPlanetsEdge> {
             ::cynic::selection_set::field("node", self.args, ::cynic::selection_set::option(fields))
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::Planet>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::FilmPlanetsEdge> {
+            ::cynic::selection_set::field_alias(
+                "node",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(fields),
+            )
+        }
     }
     pub struct CursorSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -1729,6 +2039,13 @@ pub mod film_planets_edge {
             inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::FilmPlanetsEdge> {
             ::cynic::selection_set::field("cursor", self.args, inner)
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::FilmPlanetsEdge> {
+            ::cynic::selection_set::field_alias("cursor", alias, self.args, inner)
         }
     }
 }
@@ -1746,6 +2063,13 @@ pub mod films_connection {
             fields: ::cynic::selection_set::SelectionSet<'a, T, super::PageInfo>,
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::FilmsConnection> {
             ::cynic::selection_set::field("pageInfo", self.args, fields)
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::PageInfo>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::FilmsConnection> {
+            ::cynic::selection_set::field_alias("pageInfo", alias, self.args, fields)
         }
     }
     pub struct EdgesSelectionBuilder {
@@ -1768,6 +2092,21 @@ pub mod films_connection {
                 )),
             )
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::FilmsEdge>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<Vec<Option<T>>>, super::FilmsConnection>
+        {
+            ::cynic::selection_set::field_alias(
+                "edges",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(::cynic::selection_set::vec(
+                    ::cynic::selection_set::option(fields),
+                )),
+            )
+        }
     }
     pub struct TotalCountSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -1782,6 +2121,18 @@ pub mod films_connection {
         ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::FilmsConnection> {
             ::cynic::selection_set::field(
                 "totalCount",
+                self.args,
+                ::cynic::selection_set::option(inner),
+            )
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, i32>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::FilmsConnection> {
+            ::cynic::selection_set::field_alias(
+                "totalCount",
+                alias,
                 self.args,
                 ::cynic::selection_set::option(inner),
             )
@@ -1807,6 +2158,21 @@ pub mod films_connection {
                 )),
             )
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::Film>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<Vec<Option<T>>>, super::FilmsConnection>
+        {
+            ::cynic::selection_set::field_alias(
+                "films",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(::cynic::selection_set::vec(
+                    ::cynic::selection_set::option(fields),
+                )),
+            )
+        }
     }
 }
 #[allow(dead_code)]
@@ -1824,6 +2190,18 @@ pub mod films_edge {
         ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::FilmsEdge> {
             ::cynic::selection_set::field("node", self.args, ::cynic::selection_set::option(fields))
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::Film>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::FilmsEdge> {
+            ::cynic::selection_set::field_alias(
+                "node",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(fields),
+            )
+        }
     }
     pub struct CursorSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -1837,6 +2215,13 @@ pub mod films_edge {
             inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::FilmsEdge> {
             ::cynic::selection_set::field("cursor", self.args, inner)
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::FilmsEdge> {
+            ::cynic::selection_set::field_alias("cursor", alias, self.args, inner)
         }
     }
 }
@@ -1854,6 +2239,13 @@ pub mod film_species_connection {
             fields: ::cynic::selection_set::SelectionSet<'a, T, super::PageInfo>,
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::FilmSpeciesConnection> {
             ::cynic::selection_set::field("pageInfo", self.args, fields)
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::PageInfo>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::FilmSpeciesConnection> {
+            ::cynic::selection_set::field_alias("pageInfo", alias, self.args, fields)
         }
     }
     pub struct EdgesSelectionBuilder {
@@ -1879,6 +2271,24 @@ pub mod film_species_connection {
                 )),
             )
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::FilmSpeciesEdge>,
+        ) -> ::cynic::selection_set::SelectionSet<
+            'a,
+            Option<Vec<Option<T>>>,
+            super::FilmSpeciesConnection,
+        > {
+            ::cynic::selection_set::field_alias(
+                "edges",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(::cynic::selection_set::vec(
+                    ::cynic::selection_set::option(fields),
+                )),
+            )
+        }
     }
     pub struct TotalCountSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -1894,6 +2304,19 @@ pub mod film_species_connection {
         {
             ::cynic::selection_set::field(
                 "totalCount",
+                self.args,
+                ::cynic::selection_set::option(inner),
+            )
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, i32>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::FilmSpeciesConnection>
+        {
+            ::cynic::selection_set::field_alias(
+                "totalCount",
+                alias,
                 self.args,
                 ::cynic::selection_set::option(inner),
             )
@@ -1922,6 +2345,24 @@ pub mod film_species_connection {
                 )),
             )
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::Species>,
+        ) -> ::cynic::selection_set::SelectionSet<
+            'a,
+            Option<Vec<Option<T>>>,
+            super::FilmSpeciesConnection,
+        > {
+            ::cynic::selection_set::field_alias(
+                "species",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(::cynic::selection_set::vec(
+                    ::cynic::selection_set::option(fields),
+                )),
+            )
+        }
     }
 }
 #[allow(dead_code)]
@@ -1939,6 +2380,18 @@ pub mod film_species_edge {
         ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::FilmSpeciesEdge> {
             ::cynic::selection_set::field("node", self.args, ::cynic::selection_set::option(fields))
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::Species>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::FilmSpeciesEdge> {
+            ::cynic::selection_set::field_alias(
+                "node",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(fields),
+            )
+        }
     }
     pub struct CursorSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -1952,6 +2405,13 @@ pub mod film_species_edge {
             inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::FilmSpeciesEdge> {
             ::cynic::selection_set::field("cursor", self.args, inner)
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::FilmSpeciesEdge> {
+            ::cynic::selection_set::field_alias("cursor", alias, self.args, inner)
         }
     }
 }
@@ -1969,6 +2429,13 @@ pub mod film_starships_connection {
             fields: ::cynic::selection_set::SelectionSet<'a, T, super::PageInfo>,
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::FilmStarshipsConnection> {
             ::cynic::selection_set::field("pageInfo", self.args, fields)
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::PageInfo>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::FilmStarshipsConnection> {
+            ::cynic::selection_set::field_alias("pageInfo", alias, self.args, fields)
         }
     }
     pub struct EdgesSelectionBuilder {
@@ -1994,6 +2461,24 @@ pub mod film_starships_connection {
                 )),
             )
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::FilmStarshipsEdge>,
+        ) -> ::cynic::selection_set::SelectionSet<
+            'a,
+            Option<Vec<Option<T>>>,
+            super::FilmStarshipsConnection,
+        > {
+            ::cynic::selection_set::field_alias(
+                "edges",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(::cynic::selection_set::vec(
+                    ::cynic::selection_set::option(fields),
+                )),
+            )
+        }
     }
     pub struct TotalCountSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -2009,6 +2494,19 @@ pub mod film_starships_connection {
         {
             ::cynic::selection_set::field(
                 "totalCount",
+                self.args,
+                ::cynic::selection_set::option(inner),
+            )
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, i32>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::FilmStarshipsConnection>
+        {
+            ::cynic::selection_set::field_alias(
+                "totalCount",
+                alias,
                 self.args,
                 ::cynic::selection_set::option(inner),
             )
@@ -2037,6 +2535,24 @@ pub mod film_starships_connection {
                 )),
             )
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::Starship>,
+        ) -> ::cynic::selection_set::SelectionSet<
+            'a,
+            Option<Vec<Option<T>>>,
+            super::FilmStarshipsConnection,
+        > {
+            ::cynic::selection_set::field_alias(
+                "starships",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(::cynic::selection_set::vec(
+                    ::cynic::selection_set::option(fields),
+                )),
+            )
+        }
     }
 }
 #[allow(dead_code)]
@@ -2054,6 +2570,18 @@ pub mod film_starships_edge {
         ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::FilmStarshipsEdge> {
             ::cynic::selection_set::field("node", self.args, ::cynic::selection_set::option(fields))
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::Starship>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::FilmStarshipsEdge> {
+            ::cynic::selection_set::field_alias(
+                "node",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(fields),
+            )
+        }
     }
     pub struct CursorSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -2067,6 +2595,13 @@ pub mod film_starships_edge {
             inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::FilmStarshipsEdge> {
             ::cynic::selection_set::field("cursor", self.args, inner)
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::FilmStarshipsEdge> {
+            ::cynic::selection_set::field_alias("cursor", alias, self.args, inner)
         }
     }
 }
@@ -2084,6 +2619,13 @@ pub mod film_vehicles_connection {
             fields: ::cynic::selection_set::SelectionSet<'a, T, super::PageInfo>,
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::FilmVehiclesConnection> {
             ::cynic::selection_set::field("pageInfo", self.args, fields)
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::PageInfo>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::FilmVehiclesConnection> {
+            ::cynic::selection_set::field_alias("pageInfo", alias, self.args, fields)
         }
     }
     pub struct EdgesSelectionBuilder {
@@ -2109,6 +2651,24 @@ pub mod film_vehicles_connection {
                 )),
             )
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::FilmVehiclesEdge>,
+        ) -> ::cynic::selection_set::SelectionSet<
+            'a,
+            Option<Vec<Option<T>>>,
+            super::FilmVehiclesConnection,
+        > {
+            ::cynic::selection_set::field_alias(
+                "edges",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(::cynic::selection_set::vec(
+                    ::cynic::selection_set::option(fields),
+                )),
+            )
+        }
     }
     pub struct TotalCountSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -2124,6 +2684,19 @@ pub mod film_vehicles_connection {
         {
             ::cynic::selection_set::field(
                 "totalCount",
+                self.args,
+                ::cynic::selection_set::option(inner),
+            )
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, i32>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::FilmVehiclesConnection>
+        {
+            ::cynic::selection_set::field_alias(
+                "totalCount",
+                alias,
                 self.args,
                 ::cynic::selection_set::option(inner),
             )
@@ -2152,6 +2725,24 @@ pub mod film_vehicles_connection {
                 )),
             )
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::Vehicle>,
+        ) -> ::cynic::selection_set::SelectionSet<
+            'a,
+            Option<Vec<Option<T>>>,
+            super::FilmVehiclesConnection,
+        > {
+            ::cynic::selection_set::field_alias(
+                "vehicles",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(::cynic::selection_set::vec(
+                    ::cynic::selection_set::option(fields),
+                )),
+            )
+        }
     }
 }
 #[allow(dead_code)]
@@ -2169,6 +2760,18 @@ pub mod film_vehicles_edge {
         ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::FilmVehiclesEdge> {
             ::cynic::selection_set::field("node", self.args, ::cynic::selection_set::option(fields))
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::Vehicle>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::FilmVehiclesEdge> {
+            ::cynic::selection_set::field_alias(
+                "node",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(fields),
+            )
+        }
     }
     pub struct CursorSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -2182,6 +2785,13 @@ pub mod film_vehicles_edge {
             inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::FilmVehiclesEdge> {
             ::cynic::selection_set::field("cursor", self.args, inner)
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::FilmVehiclesEdge> {
+            ::cynic::selection_set::field_alias("cursor", alias, self.args, inner)
         }
     }
 }
@@ -2200,6 +2810,13 @@ pub mod node {
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::Node> {
             ::cynic::selection_set::field("id", self.args, inner)
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, ::cynic::Id>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::Node> {
+            ::cynic::selection_set::field_alias("id", alias, self.args, inner)
+        }
     }
 }
 #[allow(dead_code)]
@@ -2217,6 +2834,13 @@ pub mod page_info {
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::PageInfo> {
             ::cynic::selection_set::field("hasNextPage", self.args, inner)
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, bool>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::PageInfo> {
+            ::cynic::selection_set::field_alias("hasNextPage", alias, self.args, inner)
+        }
     }
     pub struct HasPreviousPageSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -2230,6 +2854,13 @@ pub mod page_info {
             inner: ::cynic::selection_set::SelectionSet<'a, T, bool>,
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::PageInfo> {
             ::cynic::selection_set::field("hasPreviousPage", self.args, inner)
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, bool>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::PageInfo> {
+            ::cynic::selection_set::field_alias("hasPreviousPage", alias, self.args, inner)
         }
     }
     pub struct StartCursorSelectionBuilder {
@@ -2245,6 +2876,18 @@ pub mod page_info {
         ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::PageInfo> {
             ::cynic::selection_set::field(
                 "startCursor",
+                self.args,
+                ::cynic::selection_set::option(inner),
+            )
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::PageInfo> {
+            ::cynic::selection_set::field_alias(
+                "startCursor",
+                alias,
                 self.args,
                 ::cynic::selection_set::option(inner),
             )
@@ -2267,6 +2910,18 @@ pub mod page_info {
                 ::cynic::selection_set::option(inner),
             )
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::PageInfo> {
+            ::cynic::selection_set::field_alias(
+                "endCursor",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(inner),
+            )
+        }
     }
 }
 #[allow(dead_code)]
@@ -2283,6 +2938,13 @@ pub mod people_connection {
             fields: ::cynic::selection_set::SelectionSet<'a, T, super::PageInfo>,
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::PeopleConnection> {
             ::cynic::selection_set::field("pageInfo", self.args, fields)
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::PageInfo>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::PeopleConnection> {
+            ::cynic::selection_set::field_alias("pageInfo", alias, self.args, fields)
         }
     }
     pub struct EdgesSelectionBuilder {
@@ -2305,6 +2967,21 @@ pub mod people_connection {
                 )),
             )
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::PeopleEdge>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<Vec<Option<T>>>, super::PeopleConnection>
+        {
+            ::cynic::selection_set::field_alias(
+                "edges",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(::cynic::selection_set::vec(
+                    ::cynic::selection_set::option(fields),
+                )),
+            )
+        }
     }
     pub struct TotalCountSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -2319,6 +2996,18 @@ pub mod people_connection {
         ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::PeopleConnection> {
             ::cynic::selection_set::field(
                 "totalCount",
+                self.args,
+                ::cynic::selection_set::option(inner),
+            )
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, i32>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::PeopleConnection> {
+            ::cynic::selection_set::field_alias(
+                "totalCount",
+                alias,
                 self.args,
                 ::cynic::selection_set::option(inner),
             )
@@ -2344,6 +3033,21 @@ pub mod people_connection {
                 )),
             )
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::Person>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<Vec<Option<T>>>, super::PeopleConnection>
+        {
+            ::cynic::selection_set::field_alias(
+                "people",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(::cynic::selection_set::vec(
+                    ::cynic::selection_set::option(fields),
+                )),
+            )
+        }
     }
 }
 #[allow(dead_code)]
@@ -2361,6 +3065,18 @@ pub mod people_edge {
         ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::PeopleEdge> {
             ::cynic::selection_set::field("node", self.args, ::cynic::selection_set::option(fields))
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::Person>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::PeopleEdge> {
+            ::cynic::selection_set::field_alias(
+                "node",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(fields),
+            )
+        }
     }
     pub struct CursorSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -2374,6 +3090,13 @@ pub mod people_edge {
             inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::PeopleEdge> {
             ::cynic::selection_set::field("cursor", self.args, inner)
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::PeopleEdge> {
+            ::cynic::selection_set::field_alias("cursor", alias, self.args, inner)
         }
     }
 }
@@ -2392,6 +3115,18 @@ pub mod person {
         ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Person> {
             ::cynic::selection_set::field("name", self.args, ::cynic::selection_set::option(inner))
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Person> {
+            ::cynic::selection_set::field_alias(
+                "name",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(inner),
+            )
+        }
     }
     pub struct BirthYearSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -2406,6 +3141,18 @@ pub mod person {
         ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Person> {
             ::cynic::selection_set::field(
                 "birthYear",
+                self.args,
+                ::cynic::selection_set::option(inner),
+            )
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Person> {
+            ::cynic::selection_set::field_alias(
+                "birthYear",
+                alias,
                 self.args,
                 ::cynic::selection_set::option(inner),
             )
@@ -2428,6 +3175,18 @@ pub mod person {
                 ::cynic::selection_set::option(inner),
             )
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Person> {
+            ::cynic::selection_set::field_alias(
+                "eyeColor",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(inner),
+            )
+        }
     }
     pub struct GenderSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -2442,6 +3201,18 @@ pub mod person {
         ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Person> {
             ::cynic::selection_set::field(
                 "gender",
+                self.args,
+                ::cynic::selection_set::option(inner),
+            )
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Person> {
+            ::cynic::selection_set::field_alias(
+                "gender",
+                alias,
                 self.args,
                 ::cynic::selection_set::option(inner),
             )
@@ -2464,6 +3235,18 @@ pub mod person {
                 ::cynic::selection_set::option(inner),
             )
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Person> {
+            ::cynic::selection_set::field_alias(
+                "hairColor",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(inner),
+            )
+        }
     }
     pub struct HeightSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -2482,6 +3265,18 @@ pub mod person {
                 ::cynic::selection_set::option(inner),
             )
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, i32>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Person> {
+            ::cynic::selection_set::field_alias(
+                "height",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(inner),
+            )
+        }
     }
     pub struct MassSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -2495,6 +3290,18 @@ pub mod person {
             inner: ::cynic::selection_set::SelectionSet<'a, T, f64>,
         ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Person> {
             ::cynic::selection_set::field("mass", self.args, ::cynic::selection_set::option(inner))
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, f64>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Person> {
+            ::cynic::selection_set::field_alias(
+                "mass",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(inner),
+            )
         }
     }
     pub struct SkinColorSelectionBuilder {
@@ -2514,6 +3321,18 @@ pub mod person {
                 ::cynic::selection_set::option(inner),
             )
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Person> {
+            ::cynic::selection_set::field_alias(
+                "skinColor",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(inner),
+            )
+        }
     }
     pub struct HomeworldSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -2528,6 +3347,18 @@ pub mod person {
         ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Person> {
             ::cynic::selection_set::field(
                 "homeworld",
+                self.args,
+                ::cynic::selection_set::option(fields),
+            )
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::Planet>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Person> {
+            ::cynic::selection_set::field_alias(
+                "homeworld",
+                alias,
                 self.args,
                 ::cynic::selection_set::option(fields),
             )
@@ -2600,6 +3431,18 @@ pub mod person {
                 ::cynic::selection_set::option(fields),
             )
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::PersonFilmsConnection>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Person> {
+            ::cynic::selection_set::field_alias(
+                "filmConnection",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(fields),
+            )
+        }
     }
     pub struct SpeciesSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -2614,6 +3457,18 @@ pub mod person {
         ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Person> {
             ::cynic::selection_set::field(
                 "species",
+                self.args,
+                ::cynic::selection_set::option(fields),
+            )
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::Species>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Person> {
+            ::cynic::selection_set::field_alias(
+                "species",
+                alias,
                 self.args,
                 ::cynic::selection_set::option(fields),
             )
@@ -2686,6 +3541,18 @@ pub mod person {
                 ::cynic::selection_set::option(fields),
             )
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::PersonStarshipsConnection>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Person> {
+            ::cynic::selection_set::field_alias(
+                "starshipConnection",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(fields),
+            )
+        }
     }
     pub struct VehicleConnectionSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -2754,6 +3621,18 @@ pub mod person {
                 ::cynic::selection_set::option(fields),
             )
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::PersonVehiclesConnection>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Person> {
+            ::cynic::selection_set::field_alias(
+                "vehicleConnection",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(fields),
+            )
+        }
     }
     pub struct CreatedSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -2768,6 +3647,18 @@ pub mod person {
         ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Person> {
             ::cynic::selection_set::field(
                 "created",
+                self.args,
+                ::cynic::selection_set::option(inner),
+            )
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Person> {
+            ::cynic::selection_set::field_alias(
+                "created",
+                alias,
                 self.args,
                 ::cynic::selection_set::option(inner),
             )
@@ -2790,6 +3681,18 @@ pub mod person {
                 ::cynic::selection_set::option(inner),
             )
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Person> {
+            ::cynic::selection_set::field_alias(
+                "edited",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(inner),
+            )
+        }
     }
     pub struct IdSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -2803,6 +3706,13 @@ pub mod person {
             inner: ::cynic::selection_set::SelectionSet<'a, T, ::cynic::Id>,
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::Person> {
             ::cynic::selection_set::field("id", self.args, inner)
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, ::cynic::Id>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::Person> {
+            ::cynic::selection_set::field_alias("id", alias, self.args, inner)
         }
     }
 }
@@ -2820,6 +3730,13 @@ pub mod person_films_connection {
             fields: ::cynic::selection_set::SelectionSet<'a, T, super::PageInfo>,
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::PersonFilmsConnection> {
             ::cynic::selection_set::field("pageInfo", self.args, fields)
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::PageInfo>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::PersonFilmsConnection> {
+            ::cynic::selection_set::field_alias("pageInfo", alias, self.args, fields)
         }
     }
     pub struct EdgesSelectionBuilder {
@@ -2845,6 +3762,24 @@ pub mod person_films_connection {
                 )),
             )
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::PersonFilmsEdge>,
+        ) -> ::cynic::selection_set::SelectionSet<
+            'a,
+            Option<Vec<Option<T>>>,
+            super::PersonFilmsConnection,
+        > {
+            ::cynic::selection_set::field_alias(
+                "edges",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(::cynic::selection_set::vec(
+                    ::cynic::selection_set::option(fields),
+                )),
+            )
+        }
     }
     pub struct TotalCountSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -2860,6 +3795,19 @@ pub mod person_films_connection {
         {
             ::cynic::selection_set::field(
                 "totalCount",
+                self.args,
+                ::cynic::selection_set::option(inner),
+            )
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, i32>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::PersonFilmsConnection>
+        {
+            ::cynic::selection_set::field_alias(
+                "totalCount",
+                alias,
                 self.args,
                 ::cynic::selection_set::option(inner),
             )
@@ -2888,6 +3836,24 @@ pub mod person_films_connection {
                 )),
             )
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::Film>,
+        ) -> ::cynic::selection_set::SelectionSet<
+            'a,
+            Option<Vec<Option<T>>>,
+            super::PersonFilmsConnection,
+        > {
+            ::cynic::selection_set::field_alias(
+                "films",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(::cynic::selection_set::vec(
+                    ::cynic::selection_set::option(fields),
+                )),
+            )
+        }
     }
 }
 #[allow(dead_code)]
@@ -2905,6 +3871,18 @@ pub mod person_films_edge {
         ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::PersonFilmsEdge> {
             ::cynic::selection_set::field("node", self.args, ::cynic::selection_set::option(fields))
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::Film>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::PersonFilmsEdge> {
+            ::cynic::selection_set::field_alias(
+                "node",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(fields),
+            )
+        }
     }
     pub struct CursorSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -2918,6 +3896,13 @@ pub mod person_films_edge {
             inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::PersonFilmsEdge> {
             ::cynic::selection_set::field("cursor", self.args, inner)
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::PersonFilmsEdge> {
+            ::cynic::selection_set::field_alias("cursor", alias, self.args, inner)
         }
     }
 }
@@ -2935,6 +3920,13 @@ pub mod person_starships_connection {
             fields: ::cynic::selection_set::SelectionSet<'a, T, super::PageInfo>,
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::PersonStarshipsConnection> {
             ::cynic::selection_set::field("pageInfo", self.args, fields)
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::PageInfo>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::PersonStarshipsConnection> {
+            ::cynic::selection_set::field_alias("pageInfo", alias, self.args, fields)
         }
     }
     pub struct EdgesSelectionBuilder {
@@ -2960,6 +3952,24 @@ pub mod person_starships_connection {
                 )),
             )
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::PersonStarshipsEdge>,
+        ) -> ::cynic::selection_set::SelectionSet<
+            'a,
+            Option<Vec<Option<T>>>,
+            super::PersonStarshipsConnection,
+        > {
+            ::cynic::selection_set::field_alias(
+                "edges",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(::cynic::selection_set::vec(
+                    ::cynic::selection_set::option(fields),
+                )),
+            )
+        }
     }
     pub struct TotalCountSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -2975,6 +3985,19 @@ pub mod person_starships_connection {
         {
             ::cynic::selection_set::field(
                 "totalCount",
+                self.args,
+                ::cynic::selection_set::option(inner),
+            )
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, i32>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::PersonStarshipsConnection>
+        {
+            ::cynic::selection_set::field_alias(
+                "totalCount",
+                alias,
                 self.args,
                 ::cynic::selection_set::option(inner),
             )
@@ -3003,6 +4026,24 @@ pub mod person_starships_connection {
                 )),
             )
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::Starship>,
+        ) -> ::cynic::selection_set::SelectionSet<
+            'a,
+            Option<Vec<Option<T>>>,
+            super::PersonStarshipsConnection,
+        > {
+            ::cynic::selection_set::field_alias(
+                "starships",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(::cynic::selection_set::vec(
+                    ::cynic::selection_set::option(fields),
+                )),
+            )
+        }
     }
 }
 #[allow(dead_code)]
@@ -3021,6 +4062,19 @@ pub mod person_starships_edge {
         {
             ::cynic::selection_set::field("node", self.args, ::cynic::selection_set::option(fields))
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::Starship>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::PersonStarshipsEdge>
+        {
+            ::cynic::selection_set::field_alias(
+                "node",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(fields),
+            )
+        }
     }
     pub struct CursorSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -3034,6 +4088,13 @@ pub mod person_starships_edge {
             inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::PersonStarshipsEdge> {
             ::cynic::selection_set::field("cursor", self.args, inner)
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::PersonStarshipsEdge> {
+            ::cynic::selection_set::field_alias("cursor", alias, self.args, inner)
         }
     }
 }
@@ -3051,6 +4112,13 @@ pub mod person_vehicles_connection {
             fields: ::cynic::selection_set::SelectionSet<'a, T, super::PageInfo>,
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::PersonVehiclesConnection> {
             ::cynic::selection_set::field("pageInfo", self.args, fields)
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::PageInfo>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::PersonVehiclesConnection> {
+            ::cynic::selection_set::field_alias("pageInfo", alias, self.args, fields)
         }
     }
     pub struct EdgesSelectionBuilder {
@@ -3076,6 +4144,24 @@ pub mod person_vehicles_connection {
                 )),
             )
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::PersonVehiclesEdge>,
+        ) -> ::cynic::selection_set::SelectionSet<
+            'a,
+            Option<Vec<Option<T>>>,
+            super::PersonVehiclesConnection,
+        > {
+            ::cynic::selection_set::field_alias(
+                "edges",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(::cynic::selection_set::vec(
+                    ::cynic::selection_set::option(fields),
+                )),
+            )
+        }
     }
     pub struct TotalCountSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -3091,6 +4177,19 @@ pub mod person_vehicles_connection {
         {
             ::cynic::selection_set::field(
                 "totalCount",
+                self.args,
+                ::cynic::selection_set::option(inner),
+            )
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, i32>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::PersonVehiclesConnection>
+        {
+            ::cynic::selection_set::field_alias(
+                "totalCount",
+                alias,
                 self.args,
                 ::cynic::selection_set::option(inner),
             )
@@ -3119,6 +4218,24 @@ pub mod person_vehicles_connection {
                 )),
             )
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::Vehicle>,
+        ) -> ::cynic::selection_set::SelectionSet<
+            'a,
+            Option<Vec<Option<T>>>,
+            super::PersonVehiclesConnection,
+        > {
+            ::cynic::selection_set::field_alias(
+                "vehicles",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(::cynic::selection_set::vec(
+                    ::cynic::selection_set::option(fields),
+                )),
+            )
+        }
     }
 }
 #[allow(dead_code)]
@@ -3137,6 +4254,19 @@ pub mod person_vehicles_edge {
         {
             ::cynic::selection_set::field("node", self.args, ::cynic::selection_set::option(fields))
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::Vehicle>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::PersonVehiclesEdge>
+        {
+            ::cynic::selection_set::field_alias(
+                "node",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(fields),
+            )
+        }
     }
     pub struct CursorSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -3150,6 +4280,13 @@ pub mod person_vehicles_edge {
             inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::PersonVehiclesEdge> {
             ::cynic::selection_set::field("cursor", self.args, inner)
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::PersonVehiclesEdge> {
+            ::cynic::selection_set::field_alias("cursor", alias, self.args, inner)
         }
     }
 }
@@ -3168,6 +4305,18 @@ pub mod planet {
         ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Planet> {
             ::cynic::selection_set::field("name", self.args, ::cynic::selection_set::option(inner))
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Planet> {
+            ::cynic::selection_set::field_alias(
+                "name",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(inner),
+            )
+        }
     }
     pub struct DiameterSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -3182,6 +4331,18 @@ pub mod planet {
         ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Planet> {
             ::cynic::selection_set::field(
                 "diameter",
+                self.args,
+                ::cynic::selection_set::option(inner),
+            )
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, i32>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Planet> {
+            ::cynic::selection_set::field_alias(
+                "diameter",
+                alias,
                 self.args,
                 ::cynic::selection_set::option(inner),
             )
@@ -3204,6 +4365,18 @@ pub mod planet {
                 ::cynic::selection_set::option(inner),
             )
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, i32>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Planet> {
+            ::cynic::selection_set::field_alias(
+                "rotationPeriod",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(inner),
+            )
+        }
     }
     pub struct OrbitalPeriodSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -3218,6 +4391,18 @@ pub mod planet {
         ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Planet> {
             ::cynic::selection_set::field(
                 "orbitalPeriod",
+                self.args,
+                ::cynic::selection_set::option(inner),
+            )
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, i32>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Planet> {
+            ::cynic::selection_set::field_alias(
+                "orbitalPeriod",
+                alias,
                 self.args,
                 ::cynic::selection_set::option(inner),
             )
@@ -3240,6 +4425,18 @@ pub mod planet {
                 ::cynic::selection_set::option(inner),
             )
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Planet> {
+            ::cynic::selection_set::field_alias(
+                "gravity",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(inner),
+            )
+        }
     }
     pub struct PopulationSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -3254,6 +4451,18 @@ pub mod planet {
         ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Planet> {
             ::cynic::selection_set::field(
                 "population",
+                self.args,
+                ::cynic::selection_set::option(inner),
+            )
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, f64>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Planet> {
+            ::cynic::selection_set::field_alias(
+                "population",
+                alias,
                 self.args,
                 ::cynic::selection_set::option(inner),
             )
@@ -3273,6 +4482,21 @@ pub mod planet {
         {
             ::cynic::selection_set::field(
                 "climates",
+                self.args,
+                ::cynic::selection_set::option(::cynic::selection_set::vec(
+                    ::cynic::selection_set::option(inner),
+                )),
+            )
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<Vec<Option<T>>>, super::Planet>
+        {
+            ::cynic::selection_set::field_alias(
+                "climates",
+                alias,
                 self.args,
                 ::cynic::selection_set::option(::cynic::selection_set::vec(
                     ::cynic::selection_set::option(inner),
@@ -3300,6 +4524,21 @@ pub mod planet {
                 )),
             )
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<Vec<Option<T>>>, super::Planet>
+        {
+            ::cynic::selection_set::field_alias(
+                "terrains",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(::cynic::selection_set::vec(
+                    ::cynic::selection_set::option(inner),
+                )),
+            )
+        }
     }
     pub struct SurfaceWaterSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -3314,6 +4553,18 @@ pub mod planet {
         ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Planet> {
             ::cynic::selection_set::field(
                 "surfaceWater",
+                self.args,
+                ::cynic::selection_set::option(inner),
+            )
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, f64>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Planet> {
+            ::cynic::selection_set::field_alias(
+                "surfaceWater",
+                alias,
                 self.args,
                 ::cynic::selection_set::option(inner),
             )
@@ -3386,6 +4637,18 @@ pub mod planet {
                 ::cynic::selection_set::option(fields),
             )
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::PlanetResidentsConnection>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Planet> {
+            ::cynic::selection_set::field_alias(
+                "residentConnection",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(fields),
+            )
+        }
     }
     pub struct FilmConnectionSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -3454,6 +4717,18 @@ pub mod planet {
                 ::cynic::selection_set::option(fields),
             )
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::PlanetFilmsConnection>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Planet> {
+            ::cynic::selection_set::field_alias(
+                "filmConnection",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(fields),
+            )
+        }
     }
     pub struct CreatedSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -3468,6 +4743,18 @@ pub mod planet {
         ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Planet> {
             ::cynic::selection_set::field(
                 "created",
+                self.args,
+                ::cynic::selection_set::option(inner),
+            )
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Planet> {
+            ::cynic::selection_set::field_alias(
+                "created",
+                alias,
                 self.args,
                 ::cynic::selection_set::option(inner),
             )
@@ -3490,6 +4777,18 @@ pub mod planet {
                 ::cynic::selection_set::option(inner),
             )
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Planet> {
+            ::cynic::selection_set::field_alias(
+                "edited",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(inner),
+            )
+        }
     }
     pub struct IdSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -3503,6 +4802,13 @@ pub mod planet {
             inner: ::cynic::selection_set::SelectionSet<'a, T, ::cynic::Id>,
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::Planet> {
             ::cynic::selection_set::field("id", self.args, inner)
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, ::cynic::Id>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::Planet> {
+            ::cynic::selection_set::field_alias("id", alias, self.args, inner)
         }
     }
 }
@@ -3520,6 +4826,13 @@ pub mod planet_films_connection {
             fields: ::cynic::selection_set::SelectionSet<'a, T, super::PageInfo>,
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::PlanetFilmsConnection> {
             ::cynic::selection_set::field("pageInfo", self.args, fields)
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::PageInfo>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::PlanetFilmsConnection> {
+            ::cynic::selection_set::field_alias("pageInfo", alias, self.args, fields)
         }
     }
     pub struct EdgesSelectionBuilder {
@@ -3545,6 +4858,24 @@ pub mod planet_films_connection {
                 )),
             )
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::PlanetFilmsEdge>,
+        ) -> ::cynic::selection_set::SelectionSet<
+            'a,
+            Option<Vec<Option<T>>>,
+            super::PlanetFilmsConnection,
+        > {
+            ::cynic::selection_set::field_alias(
+                "edges",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(::cynic::selection_set::vec(
+                    ::cynic::selection_set::option(fields),
+                )),
+            )
+        }
     }
     pub struct TotalCountSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -3560,6 +4891,19 @@ pub mod planet_films_connection {
         {
             ::cynic::selection_set::field(
                 "totalCount",
+                self.args,
+                ::cynic::selection_set::option(inner),
+            )
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, i32>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::PlanetFilmsConnection>
+        {
+            ::cynic::selection_set::field_alias(
+                "totalCount",
+                alias,
                 self.args,
                 ::cynic::selection_set::option(inner),
             )
@@ -3588,6 +4932,24 @@ pub mod planet_films_connection {
                 )),
             )
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::Film>,
+        ) -> ::cynic::selection_set::SelectionSet<
+            'a,
+            Option<Vec<Option<T>>>,
+            super::PlanetFilmsConnection,
+        > {
+            ::cynic::selection_set::field_alias(
+                "films",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(::cynic::selection_set::vec(
+                    ::cynic::selection_set::option(fields),
+                )),
+            )
+        }
     }
 }
 #[allow(dead_code)]
@@ -3605,6 +4967,18 @@ pub mod planet_films_edge {
         ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::PlanetFilmsEdge> {
             ::cynic::selection_set::field("node", self.args, ::cynic::selection_set::option(fields))
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::Film>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::PlanetFilmsEdge> {
+            ::cynic::selection_set::field_alias(
+                "node",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(fields),
+            )
+        }
     }
     pub struct CursorSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -3618,6 +4992,13 @@ pub mod planet_films_edge {
             inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::PlanetFilmsEdge> {
             ::cynic::selection_set::field("cursor", self.args, inner)
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::PlanetFilmsEdge> {
+            ::cynic::selection_set::field_alias("cursor", alias, self.args, inner)
         }
     }
 }
@@ -3635,6 +5016,13 @@ pub mod planet_residents_connection {
             fields: ::cynic::selection_set::SelectionSet<'a, T, super::PageInfo>,
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::PlanetResidentsConnection> {
             ::cynic::selection_set::field("pageInfo", self.args, fields)
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::PageInfo>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::PlanetResidentsConnection> {
+            ::cynic::selection_set::field_alias("pageInfo", alias, self.args, fields)
         }
     }
     pub struct EdgesSelectionBuilder {
@@ -3660,6 +5048,24 @@ pub mod planet_residents_connection {
                 )),
             )
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::PlanetResidentsEdge>,
+        ) -> ::cynic::selection_set::SelectionSet<
+            'a,
+            Option<Vec<Option<T>>>,
+            super::PlanetResidentsConnection,
+        > {
+            ::cynic::selection_set::field_alias(
+                "edges",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(::cynic::selection_set::vec(
+                    ::cynic::selection_set::option(fields),
+                )),
+            )
+        }
     }
     pub struct TotalCountSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -3675,6 +5081,19 @@ pub mod planet_residents_connection {
         {
             ::cynic::selection_set::field(
                 "totalCount",
+                self.args,
+                ::cynic::selection_set::option(inner),
+            )
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, i32>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::PlanetResidentsConnection>
+        {
+            ::cynic::selection_set::field_alias(
+                "totalCount",
+                alias,
                 self.args,
                 ::cynic::selection_set::option(inner),
             )
@@ -3703,6 +5122,24 @@ pub mod planet_residents_connection {
                 )),
             )
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::Person>,
+        ) -> ::cynic::selection_set::SelectionSet<
+            'a,
+            Option<Vec<Option<T>>>,
+            super::PlanetResidentsConnection,
+        > {
+            ::cynic::selection_set::field_alias(
+                "residents",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(::cynic::selection_set::vec(
+                    ::cynic::selection_set::option(fields),
+                )),
+            )
+        }
     }
 }
 #[allow(dead_code)]
@@ -3721,6 +5158,19 @@ pub mod planet_residents_edge {
         {
             ::cynic::selection_set::field("node", self.args, ::cynic::selection_set::option(fields))
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::Person>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::PlanetResidentsEdge>
+        {
+            ::cynic::selection_set::field_alias(
+                "node",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(fields),
+            )
+        }
     }
     pub struct CursorSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -3734,6 +5184,13 @@ pub mod planet_residents_edge {
             inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::PlanetResidentsEdge> {
             ::cynic::selection_set::field("cursor", self.args, inner)
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::PlanetResidentsEdge> {
+            ::cynic::selection_set::field_alias("cursor", alias, self.args, inner)
         }
     }
 }
@@ -3751,6 +5208,13 @@ pub mod planets_connection {
             fields: ::cynic::selection_set::SelectionSet<'a, T, super::PageInfo>,
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::PlanetsConnection> {
             ::cynic::selection_set::field("pageInfo", self.args, fields)
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::PageInfo>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::PlanetsConnection> {
+            ::cynic::selection_set::field_alias("pageInfo", alias, self.args, fields)
         }
     }
     pub struct EdgesSelectionBuilder {
@@ -3776,6 +5240,24 @@ pub mod planets_connection {
                 )),
             )
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::PlanetsEdge>,
+        ) -> ::cynic::selection_set::SelectionSet<
+            'a,
+            Option<Vec<Option<T>>>,
+            super::PlanetsConnection,
+        > {
+            ::cynic::selection_set::field_alias(
+                "edges",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(::cynic::selection_set::vec(
+                    ::cynic::selection_set::option(fields),
+                )),
+            )
+        }
     }
     pub struct TotalCountSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -3790,6 +5272,18 @@ pub mod planets_connection {
         ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::PlanetsConnection> {
             ::cynic::selection_set::field(
                 "totalCount",
+                self.args,
+                ::cynic::selection_set::option(inner),
+            )
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, i32>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::PlanetsConnection> {
+            ::cynic::selection_set::field_alias(
+                "totalCount",
+                alias,
                 self.args,
                 ::cynic::selection_set::option(inner),
             )
@@ -3818,6 +5312,24 @@ pub mod planets_connection {
                 )),
             )
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::Planet>,
+        ) -> ::cynic::selection_set::SelectionSet<
+            'a,
+            Option<Vec<Option<T>>>,
+            super::PlanetsConnection,
+        > {
+            ::cynic::selection_set::field_alias(
+                "planets",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(::cynic::selection_set::vec(
+                    ::cynic::selection_set::option(fields),
+                )),
+            )
+        }
     }
 }
 #[allow(dead_code)]
@@ -3835,6 +5347,18 @@ pub mod planets_edge {
         ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::PlanetsEdge> {
             ::cynic::selection_set::field("node", self.args, ::cynic::selection_set::option(fields))
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::Planet>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::PlanetsEdge> {
+            ::cynic::selection_set::field_alias(
+                "node",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(fields),
+            )
+        }
     }
     pub struct CursorSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -3848,6 +5372,13 @@ pub mod planets_edge {
             inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::PlanetsEdge> {
             ::cynic::selection_set::field("cursor", self.args, inner)
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::PlanetsEdge> {
+            ::cynic::selection_set::field_alias("cursor", alias, self.args, inner)
         }
     }
 }
@@ -3920,6 +5451,18 @@ pub mod root {
                 ::cynic::selection_set::option(fields),
             )
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::FilmsConnection>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Root> {
+            ::cynic::selection_set::field_alias(
+                "allFilms",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(fields),
+            )
+        }
     }
     pub struct FilmSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -3961,6 +5504,18 @@ pub mod root {
             fields: ::cynic::selection_set::SelectionSet<'a, T, super::Film>,
         ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Root> {
             ::cynic::selection_set::field("film", self.args, ::cynic::selection_set::option(fields))
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::Film>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Root> {
+            ::cynic::selection_set::field_alias(
+                "film",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(fields),
+            )
         }
     }
     pub struct AllPeopleSelectionBuilder {
@@ -4030,6 +5585,18 @@ pub mod root {
                 ::cynic::selection_set::option(fields),
             )
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::PeopleConnection>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Root> {
+            ::cynic::selection_set::field_alias(
+                "allPeople",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(fields),
+            )
+        }
     }
     pub struct PersonSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -4072,6 +5639,18 @@ pub mod root {
         ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Root> {
             ::cynic::selection_set::field(
                 "person",
+                self.args,
+                ::cynic::selection_set::option(fields),
+            )
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::Person>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Root> {
+            ::cynic::selection_set::field_alias(
+                "person",
+                alias,
                 self.args,
                 ::cynic::selection_set::option(fields),
             )
@@ -4144,6 +5723,18 @@ pub mod root {
                 ::cynic::selection_set::option(fields),
             )
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::PlanetsConnection>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Root> {
+            ::cynic::selection_set::field_alias(
+                "allPlanets",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(fields),
+            )
+        }
     }
     pub struct PlanetSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -4186,6 +5777,18 @@ pub mod root {
         ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Root> {
             ::cynic::selection_set::field(
                 "planet",
+                self.args,
+                ::cynic::selection_set::option(fields),
+            )
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::Planet>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Root> {
+            ::cynic::selection_set::field_alias(
+                "planet",
+                alias,
                 self.args,
                 ::cynic::selection_set::option(fields),
             )
@@ -4258,6 +5861,18 @@ pub mod root {
                 ::cynic::selection_set::option(fields),
             )
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::SpeciesConnection>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Root> {
+            ::cynic::selection_set::field_alias(
+                "allSpecies",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(fields),
+            )
+        }
     }
     pub struct SpeciesSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -4300,6 +5915,18 @@ pub mod root {
         ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Root> {
             ::cynic::selection_set::field(
                 "species",
+                self.args,
+                ::cynic::selection_set::option(fields),
+            )
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::Species>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Root> {
+            ::cynic::selection_set::field_alias(
+                "species",
+                alias,
                 self.args,
                 ::cynic::selection_set::option(fields),
             )
@@ -4372,6 +5999,18 @@ pub mod root {
                 ::cynic::selection_set::option(fields),
             )
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::StarshipsConnection>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Root> {
+            ::cynic::selection_set::field_alias(
+                "allStarships",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(fields),
+            )
+        }
     }
     pub struct StarshipSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -4414,6 +6053,18 @@ pub mod root {
         ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Root> {
             ::cynic::selection_set::field(
                 "starship",
+                self.args,
+                ::cynic::selection_set::option(fields),
+            )
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::Starship>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Root> {
+            ::cynic::selection_set::field_alias(
+                "starship",
+                alias,
                 self.args,
                 ::cynic::selection_set::option(fields),
             )
@@ -4486,6 +6137,18 @@ pub mod root {
                 ::cynic::selection_set::option(fields),
             )
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::VehiclesConnection>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Root> {
+            ::cynic::selection_set::field_alias(
+                "allVehicles",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(fields),
+            )
+        }
     }
     pub struct VehicleSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -4532,6 +6195,18 @@ pub mod root {
                 ::cynic::selection_set::option(fields),
             )
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::Vehicle>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Root> {
+            ::cynic::selection_set::field_alias(
+                "vehicle",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(fields),
+            )
+        }
     }
     pub struct NodeSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -4545,6 +6220,18 @@ pub mod root {
             fields: ::cynic::selection_set::SelectionSet<'a, T, super::Node>,
         ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Root> {
             ::cynic::selection_set::field("node", self.args, ::cynic::selection_set::option(fields))
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::Node>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Root> {
+            ::cynic::selection_set::field_alias(
+                "node",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(fields),
+            )
         }
     }
 }
@@ -4563,6 +6250,18 @@ pub mod species {
         ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Species> {
             ::cynic::selection_set::field("name", self.args, ::cynic::selection_set::option(inner))
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Species> {
+            ::cynic::selection_set::field_alias(
+                "name",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(inner),
+            )
+        }
     }
     pub struct ClassificationSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -4577,6 +6276,18 @@ pub mod species {
         ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Species> {
             ::cynic::selection_set::field(
                 "classification",
+                self.args,
+                ::cynic::selection_set::option(inner),
+            )
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Species> {
+            ::cynic::selection_set::field_alias(
+                "classification",
+                alias,
                 self.args,
                 ::cynic::selection_set::option(inner),
             )
@@ -4599,6 +6310,18 @@ pub mod species {
                 ::cynic::selection_set::option(inner),
             )
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Species> {
+            ::cynic::selection_set::field_alias(
+                "designation",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(inner),
+            )
+        }
     }
     pub struct AverageHeightSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -4613,6 +6336,18 @@ pub mod species {
         ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Species> {
             ::cynic::selection_set::field(
                 "averageHeight",
+                self.args,
+                ::cynic::selection_set::option(inner),
+            )
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, f64>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Species> {
+            ::cynic::selection_set::field_alias(
+                "averageHeight",
+                alias,
                 self.args,
                 ::cynic::selection_set::option(inner),
             )
@@ -4635,6 +6370,18 @@ pub mod species {
                 ::cynic::selection_set::option(inner),
             )
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, i32>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Species> {
+            ::cynic::selection_set::field_alias(
+                "averageLifespan",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(inner),
+            )
+        }
     }
     pub struct EyeColorsSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -4650,6 +6397,21 @@ pub mod species {
         {
             ::cynic::selection_set::field(
                 "eyeColors",
+                self.args,
+                ::cynic::selection_set::option(::cynic::selection_set::vec(
+                    ::cynic::selection_set::option(inner),
+                )),
+            )
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<Vec<Option<T>>>, super::Species>
+        {
+            ::cynic::selection_set::field_alias(
+                "eyeColors",
+                alias,
                 self.args,
                 ::cynic::selection_set::option(::cynic::selection_set::vec(
                     ::cynic::selection_set::option(inner),
@@ -4677,6 +6439,21 @@ pub mod species {
                 )),
             )
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<Vec<Option<T>>>, super::Species>
+        {
+            ::cynic::selection_set::field_alias(
+                "hairColors",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(::cynic::selection_set::vec(
+                    ::cynic::selection_set::option(inner),
+                )),
+            )
+        }
     }
     pub struct SkinColorsSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -4692,6 +6469,21 @@ pub mod species {
         {
             ::cynic::selection_set::field(
                 "skinColors",
+                self.args,
+                ::cynic::selection_set::option(::cynic::selection_set::vec(
+                    ::cynic::selection_set::option(inner),
+                )),
+            )
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<Vec<Option<T>>>, super::Species>
+        {
+            ::cynic::selection_set::field_alias(
+                "skinColors",
+                alias,
                 self.args,
                 ::cynic::selection_set::option(::cynic::selection_set::vec(
                     ::cynic::selection_set::option(inner),
@@ -4716,6 +6508,18 @@ pub mod species {
                 ::cynic::selection_set::option(inner),
             )
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Species> {
+            ::cynic::selection_set::field_alias(
+                "language",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(inner),
+            )
+        }
     }
     pub struct HomeworldSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -4730,6 +6534,18 @@ pub mod species {
         ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Species> {
             ::cynic::selection_set::field(
                 "homeworld",
+                self.args,
+                ::cynic::selection_set::option(fields),
+            )
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::Planet>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Species> {
+            ::cynic::selection_set::field_alias(
+                "homeworld",
+                alias,
                 self.args,
                 ::cynic::selection_set::option(fields),
             )
@@ -4802,6 +6618,18 @@ pub mod species {
                 ::cynic::selection_set::option(fields),
             )
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::SpeciesPeopleConnection>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Species> {
+            ::cynic::selection_set::field_alias(
+                "personConnection",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(fields),
+            )
+        }
     }
     pub struct FilmConnectionSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -4870,6 +6698,18 @@ pub mod species {
                 ::cynic::selection_set::option(fields),
             )
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::SpeciesFilmsConnection>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Species> {
+            ::cynic::selection_set::field_alias(
+                "filmConnection",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(fields),
+            )
+        }
     }
     pub struct CreatedSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -4884,6 +6724,18 @@ pub mod species {
         ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Species> {
             ::cynic::selection_set::field(
                 "created",
+                self.args,
+                ::cynic::selection_set::option(inner),
+            )
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Species> {
+            ::cynic::selection_set::field_alias(
+                "created",
+                alias,
                 self.args,
                 ::cynic::selection_set::option(inner),
             )
@@ -4906,6 +6758,18 @@ pub mod species {
                 ::cynic::selection_set::option(inner),
             )
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Species> {
+            ::cynic::selection_set::field_alias(
+                "edited",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(inner),
+            )
+        }
     }
     pub struct IdSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -4919,6 +6783,13 @@ pub mod species {
             inner: ::cynic::selection_set::SelectionSet<'a, T, ::cynic::Id>,
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::Species> {
             ::cynic::selection_set::field("id", self.args, inner)
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, ::cynic::Id>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::Species> {
+            ::cynic::selection_set::field_alias("id", alias, self.args, inner)
         }
     }
 }
@@ -4936,6 +6807,13 @@ pub mod species_connection {
             fields: ::cynic::selection_set::SelectionSet<'a, T, super::PageInfo>,
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::SpeciesConnection> {
             ::cynic::selection_set::field("pageInfo", self.args, fields)
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::PageInfo>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::SpeciesConnection> {
+            ::cynic::selection_set::field_alias("pageInfo", alias, self.args, fields)
         }
     }
     pub struct EdgesSelectionBuilder {
@@ -4961,6 +6839,24 @@ pub mod species_connection {
                 )),
             )
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::SpeciesEdge>,
+        ) -> ::cynic::selection_set::SelectionSet<
+            'a,
+            Option<Vec<Option<T>>>,
+            super::SpeciesConnection,
+        > {
+            ::cynic::selection_set::field_alias(
+                "edges",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(::cynic::selection_set::vec(
+                    ::cynic::selection_set::option(fields),
+                )),
+            )
+        }
     }
     pub struct TotalCountSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -4975,6 +6871,18 @@ pub mod species_connection {
         ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::SpeciesConnection> {
             ::cynic::selection_set::field(
                 "totalCount",
+                self.args,
+                ::cynic::selection_set::option(inner),
+            )
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, i32>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::SpeciesConnection> {
+            ::cynic::selection_set::field_alias(
+                "totalCount",
+                alias,
                 self.args,
                 ::cynic::selection_set::option(inner),
             )
@@ -5003,6 +6911,24 @@ pub mod species_connection {
                 )),
             )
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::Species>,
+        ) -> ::cynic::selection_set::SelectionSet<
+            'a,
+            Option<Vec<Option<T>>>,
+            super::SpeciesConnection,
+        > {
+            ::cynic::selection_set::field_alias(
+                "species",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(::cynic::selection_set::vec(
+                    ::cynic::selection_set::option(fields),
+                )),
+            )
+        }
     }
 }
 #[allow(dead_code)]
@@ -5020,6 +6946,18 @@ pub mod species_edge {
         ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::SpeciesEdge> {
             ::cynic::selection_set::field("node", self.args, ::cynic::selection_set::option(fields))
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::Species>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::SpeciesEdge> {
+            ::cynic::selection_set::field_alias(
+                "node",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(fields),
+            )
+        }
     }
     pub struct CursorSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -5033,6 +6971,13 @@ pub mod species_edge {
             inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::SpeciesEdge> {
             ::cynic::selection_set::field("cursor", self.args, inner)
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::SpeciesEdge> {
+            ::cynic::selection_set::field_alias("cursor", alias, self.args, inner)
         }
     }
 }
@@ -5050,6 +6995,13 @@ pub mod species_films_connection {
             fields: ::cynic::selection_set::SelectionSet<'a, T, super::PageInfo>,
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::SpeciesFilmsConnection> {
             ::cynic::selection_set::field("pageInfo", self.args, fields)
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::PageInfo>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::SpeciesFilmsConnection> {
+            ::cynic::selection_set::field_alias("pageInfo", alias, self.args, fields)
         }
     }
     pub struct EdgesSelectionBuilder {
@@ -5075,6 +7027,24 @@ pub mod species_films_connection {
                 )),
             )
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::SpeciesFilmsEdge>,
+        ) -> ::cynic::selection_set::SelectionSet<
+            'a,
+            Option<Vec<Option<T>>>,
+            super::SpeciesFilmsConnection,
+        > {
+            ::cynic::selection_set::field_alias(
+                "edges",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(::cynic::selection_set::vec(
+                    ::cynic::selection_set::option(fields),
+                )),
+            )
+        }
     }
     pub struct TotalCountSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -5090,6 +7060,19 @@ pub mod species_films_connection {
         {
             ::cynic::selection_set::field(
                 "totalCount",
+                self.args,
+                ::cynic::selection_set::option(inner),
+            )
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, i32>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::SpeciesFilmsConnection>
+        {
+            ::cynic::selection_set::field_alias(
+                "totalCount",
+                alias,
                 self.args,
                 ::cynic::selection_set::option(inner),
             )
@@ -5118,6 +7101,24 @@ pub mod species_films_connection {
                 )),
             )
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::Film>,
+        ) -> ::cynic::selection_set::SelectionSet<
+            'a,
+            Option<Vec<Option<T>>>,
+            super::SpeciesFilmsConnection,
+        > {
+            ::cynic::selection_set::field_alias(
+                "films",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(::cynic::selection_set::vec(
+                    ::cynic::selection_set::option(fields),
+                )),
+            )
+        }
     }
 }
 #[allow(dead_code)]
@@ -5135,6 +7136,18 @@ pub mod species_films_edge {
         ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::SpeciesFilmsEdge> {
             ::cynic::selection_set::field("node", self.args, ::cynic::selection_set::option(fields))
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::Film>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::SpeciesFilmsEdge> {
+            ::cynic::selection_set::field_alias(
+                "node",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(fields),
+            )
+        }
     }
     pub struct CursorSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -5148,6 +7161,13 @@ pub mod species_films_edge {
             inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::SpeciesFilmsEdge> {
             ::cynic::selection_set::field("cursor", self.args, inner)
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::SpeciesFilmsEdge> {
+            ::cynic::selection_set::field_alias("cursor", alias, self.args, inner)
         }
     }
 }
@@ -5165,6 +7185,13 @@ pub mod species_people_connection {
             fields: ::cynic::selection_set::SelectionSet<'a, T, super::PageInfo>,
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::SpeciesPeopleConnection> {
             ::cynic::selection_set::field("pageInfo", self.args, fields)
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::PageInfo>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::SpeciesPeopleConnection> {
+            ::cynic::selection_set::field_alias("pageInfo", alias, self.args, fields)
         }
     }
     pub struct EdgesSelectionBuilder {
@@ -5190,6 +7217,24 @@ pub mod species_people_connection {
                 )),
             )
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::SpeciesPeopleEdge>,
+        ) -> ::cynic::selection_set::SelectionSet<
+            'a,
+            Option<Vec<Option<T>>>,
+            super::SpeciesPeopleConnection,
+        > {
+            ::cynic::selection_set::field_alias(
+                "edges",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(::cynic::selection_set::vec(
+                    ::cynic::selection_set::option(fields),
+                )),
+            )
+        }
     }
     pub struct TotalCountSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -5205,6 +7250,19 @@ pub mod species_people_connection {
         {
             ::cynic::selection_set::field(
                 "totalCount",
+                self.args,
+                ::cynic::selection_set::option(inner),
+            )
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, i32>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::SpeciesPeopleConnection>
+        {
+            ::cynic::selection_set::field_alias(
+                "totalCount",
+                alias,
                 self.args,
                 ::cynic::selection_set::option(inner),
             )
@@ -5233,6 +7291,24 @@ pub mod species_people_connection {
                 )),
             )
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::Person>,
+        ) -> ::cynic::selection_set::SelectionSet<
+            'a,
+            Option<Vec<Option<T>>>,
+            super::SpeciesPeopleConnection,
+        > {
+            ::cynic::selection_set::field_alias(
+                "people",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(::cynic::selection_set::vec(
+                    ::cynic::selection_set::option(fields),
+                )),
+            )
+        }
     }
 }
 #[allow(dead_code)]
@@ -5250,6 +7326,18 @@ pub mod species_people_edge {
         ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::SpeciesPeopleEdge> {
             ::cynic::selection_set::field("node", self.args, ::cynic::selection_set::option(fields))
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::Person>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::SpeciesPeopleEdge> {
+            ::cynic::selection_set::field_alias(
+                "node",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(fields),
+            )
+        }
     }
     pub struct CursorSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -5263,6 +7351,13 @@ pub mod species_people_edge {
             inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::SpeciesPeopleEdge> {
             ::cynic::selection_set::field("cursor", self.args, inner)
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::SpeciesPeopleEdge> {
+            ::cynic::selection_set::field_alias("cursor", alias, self.args, inner)
         }
     }
 }
@@ -5281,6 +7376,18 @@ pub mod starship {
         ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Starship> {
             ::cynic::selection_set::field("name", self.args, ::cynic::selection_set::option(inner))
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Starship> {
+            ::cynic::selection_set::field_alias(
+                "name",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(inner),
+            )
+        }
     }
     pub struct ModelSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -5294,6 +7401,18 @@ pub mod starship {
             inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
         ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Starship> {
             ::cynic::selection_set::field("model", self.args, ::cynic::selection_set::option(inner))
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Starship> {
+            ::cynic::selection_set::field_alias(
+                "model",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(inner),
+            )
         }
     }
     pub struct StarshipClassSelectionBuilder {
@@ -5309,6 +7428,18 @@ pub mod starship {
         ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Starship> {
             ::cynic::selection_set::field(
                 "starshipClass",
+                self.args,
+                ::cynic::selection_set::option(inner),
+            )
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Starship> {
+            ::cynic::selection_set::field_alias(
+                "starshipClass",
+                alias,
                 self.args,
                 ::cynic::selection_set::option(inner),
             )
@@ -5334,6 +7465,21 @@ pub mod starship {
                 )),
             )
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<Vec<Option<T>>>, super::Starship>
+        {
+            ::cynic::selection_set::field_alias(
+                "manufacturers",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(::cynic::selection_set::vec(
+                    ::cynic::selection_set::option(inner),
+                )),
+            )
+        }
     }
     pub struct CostInCreditsSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -5348,6 +7494,18 @@ pub mod starship {
         ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Starship> {
             ::cynic::selection_set::field(
                 "costInCredits",
+                self.args,
+                ::cynic::selection_set::option(inner),
+            )
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, f64>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Starship> {
+            ::cynic::selection_set::field_alias(
+                "costInCredits",
+                alias,
                 self.args,
                 ::cynic::selection_set::option(inner),
             )
@@ -5370,6 +7528,18 @@ pub mod starship {
                 ::cynic::selection_set::option(inner),
             )
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, f64>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Starship> {
+            ::cynic::selection_set::field_alias(
+                "length",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(inner),
+            )
+        }
     }
     pub struct CrewSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -5383,6 +7553,18 @@ pub mod starship {
             inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
         ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Starship> {
             ::cynic::selection_set::field("crew", self.args, ::cynic::selection_set::option(inner))
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Starship> {
+            ::cynic::selection_set::field_alias(
+                "crew",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(inner),
+            )
         }
     }
     pub struct PassengersSelectionBuilder {
@@ -5398,6 +7580,18 @@ pub mod starship {
         ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Starship> {
             ::cynic::selection_set::field(
                 "passengers",
+                self.args,
+                ::cynic::selection_set::option(inner),
+            )
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Starship> {
+            ::cynic::selection_set::field_alias(
+                "passengers",
+                alias,
                 self.args,
                 ::cynic::selection_set::option(inner),
             )
@@ -5420,6 +7614,18 @@ pub mod starship {
                 ::cynic::selection_set::option(inner),
             )
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, i32>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Starship> {
+            ::cynic::selection_set::field_alias(
+                "maxAtmospheringSpeed",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(inner),
+            )
+        }
     }
     pub struct HyperdriveRatingSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -5438,6 +7644,18 @@ pub mod starship {
                 ::cynic::selection_set::option(inner),
             )
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, f64>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Starship> {
+            ::cynic::selection_set::field_alias(
+                "hyperdriveRating",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(inner),
+            )
+        }
     }
     pub struct MgltselectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -5451,6 +7669,18 @@ pub mod starship {
             inner: ::cynic::selection_set::SelectionSet<'a, T, i32>,
         ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Starship> {
             ::cynic::selection_set::field("MGLT", self.args, ::cynic::selection_set::option(inner))
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, i32>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Starship> {
+            ::cynic::selection_set::field_alias(
+                "MGLT",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(inner),
+            )
         }
     }
     pub struct CargoCapacitySelectionBuilder {
@@ -5470,6 +7700,18 @@ pub mod starship {
                 ::cynic::selection_set::option(inner),
             )
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, f64>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Starship> {
+            ::cynic::selection_set::field_alias(
+                "cargoCapacity",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(inner),
+            )
+        }
     }
     pub struct ConsumablesSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -5484,6 +7726,18 @@ pub mod starship {
         ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Starship> {
             ::cynic::selection_set::field(
                 "consumables",
+                self.args,
+                ::cynic::selection_set::option(inner),
+            )
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Starship> {
+            ::cynic::selection_set::field_alias(
+                "consumables",
+                alias,
                 self.args,
                 ::cynic::selection_set::option(inner),
             )
@@ -5556,6 +7810,18 @@ pub mod starship {
                 ::cynic::selection_set::option(fields),
             )
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::StarshipPilotsConnection>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Starship> {
+            ::cynic::selection_set::field_alias(
+                "pilotConnection",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(fields),
+            )
+        }
     }
     pub struct FilmConnectionSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -5624,6 +7890,18 @@ pub mod starship {
                 ::cynic::selection_set::option(fields),
             )
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::StarshipFilmsConnection>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Starship> {
+            ::cynic::selection_set::field_alias(
+                "filmConnection",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(fields),
+            )
+        }
     }
     pub struct CreatedSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -5638,6 +7916,18 @@ pub mod starship {
         ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Starship> {
             ::cynic::selection_set::field(
                 "created",
+                self.args,
+                ::cynic::selection_set::option(inner),
+            )
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Starship> {
+            ::cynic::selection_set::field_alias(
+                "created",
+                alias,
                 self.args,
                 ::cynic::selection_set::option(inner),
             )
@@ -5660,6 +7950,18 @@ pub mod starship {
                 ::cynic::selection_set::option(inner),
             )
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Starship> {
+            ::cynic::selection_set::field_alias(
+                "edited",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(inner),
+            )
+        }
     }
     pub struct IdSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -5673,6 +7975,13 @@ pub mod starship {
             inner: ::cynic::selection_set::SelectionSet<'a, T, ::cynic::Id>,
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::Starship> {
             ::cynic::selection_set::field("id", self.args, inner)
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, ::cynic::Id>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::Starship> {
+            ::cynic::selection_set::field_alias("id", alias, self.args, inner)
         }
     }
 }
@@ -5690,6 +7999,13 @@ pub mod starship_films_connection {
             fields: ::cynic::selection_set::SelectionSet<'a, T, super::PageInfo>,
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::StarshipFilmsConnection> {
             ::cynic::selection_set::field("pageInfo", self.args, fields)
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::PageInfo>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::StarshipFilmsConnection> {
+            ::cynic::selection_set::field_alias("pageInfo", alias, self.args, fields)
         }
     }
     pub struct EdgesSelectionBuilder {
@@ -5715,6 +8031,24 @@ pub mod starship_films_connection {
                 )),
             )
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::StarshipFilmsEdge>,
+        ) -> ::cynic::selection_set::SelectionSet<
+            'a,
+            Option<Vec<Option<T>>>,
+            super::StarshipFilmsConnection,
+        > {
+            ::cynic::selection_set::field_alias(
+                "edges",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(::cynic::selection_set::vec(
+                    ::cynic::selection_set::option(fields),
+                )),
+            )
+        }
     }
     pub struct TotalCountSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -5730,6 +8064,19 @@ pub mod starship_films_connection {
         {
             ::cynic::selection_set::field(
                 "totalCount",
+                self.args,
+                ::cynic::selection_set::option(inner),
+            )
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, i32>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::StarshipFilmsConnection>
+        {
+            ::cynic::selection_set::field_alias(
+                "totalCount",
+                alias,
                 self.args,
                 ::cynic::selection_set::option(inner),
             )
@@ -5758,6 +8105,24 @@ pub mod starship_films_connection {
                 )),
             )
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::Film>,
+        ) -> ::cynic::selection_set::SelectionSet<
+            'a,
+            Option<Vec<Option<T>>>,
+            super::StarshipFilmsConnection,
+        > {
+            ::cynic::selection_set::field_alias(
+                "films",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(::cynic::selection_set::vec(
+                    ::cynic::selection_set::option(fields),
+                )),
+            )
+        }
     }
 }
 #[allow(dead_code)]
@@ -5775,6 +8140,18 @@ pub mod starship_films_edge {
         ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::StarshipFilmsEdge> {
             ::cynic::selection_set::field("node", self.args, ::cynic::selection_set::option(fields))
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::Film>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::StarshipFilmsEdge> {
+            ::cynic::selection_set::field_alias(
+                "node",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(fields),
+            )
+        }
     }
     pub struct CursorSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -5788,6 +8165,13 @@ pub mod starship_films_edge {
             inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::StarshipFilmsEdge> {
             ::cynic::selection_set::field("cursor", self.args, inner)
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::StarshipFilmsEdge> {
+            ::cynic::selection_set::field_alias("cursor", alias, self.args, inner)
         }
     }
 }
@@ -5805,6 +8189,13 @@ pub mod starship_pilots_connection {
             fields: ::cynic::selection_set::SelectionSet<'a, T, super::PageInfo>,
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::StarshipPilotsConnection> {
             ::cynic::selection_set::field("pageInfo", self.args, fields)
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::PageInfo>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::StarshipPilotsConnection> {
+            ::cynic::selection_set::field_alias("pageInfo", alias, self.args, fields)
         }
     }
     pub struct EdgesSelectionBuilder {
@@ -5830,6 +8221,24 @@ pub mod starship_pilots_connection {
                 )),
             )
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::StarshipPilotsEdge>,
+        ) -> ::cynic::selection_set::SelectionSet<
+            'a,
+            Option<Vec<Option<T>>>,
+            super::StarshipPilotsConnection,
+        > {
+            ::cynic::selection_set::field_alias(
+                "edges",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(::cynic::selection_set::vec(
+                    ::cynic::selection_set::option(fields),
+                )),
+            )
+        }
     }
     pub struct TotalCountSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -5845,6 +8254,19 @@ pub mod starship_pilots_connection {
         {
             ::cynic::selection_set::field(
                 "totalCount",
+                self.args,
+                ::cynic::selection_set::option(inner),
+            )
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, i32>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::StarshipPilotsConnection>
+        {
+            ::cynic::selection_set::field_alias(
+                "totalCount",
+                alias,
                 self.args,
                 ::cynic::selection_set::option(inner),
             )
@@ -5873,6 +8295,24 @@ pub mod starship_pilots_connection {
                 )),
             )
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::Person>,
+        ) -> ::cynic::selection_set::SelectionSet<
+            'a,
+            Option<Vec<Option<T>>>,
+            super::StarshipPilotsConnection,
+        > {
+            ::cynic::selection_set::field_alias(
+                "pilots",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(::cynic::selection_set::vec(
+                    ::cynic::selection_set::option(fields),
+                )),
+            )
+        }
     }
 }
 #[allow(dead_code)]
@@ -5891,6 +8331,19 @@ pub mod starship_pilots_edge {
         {
             ::cynic::selection_set::field("node", self.args, ::cynic::selection_set::option(fields))
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::Person>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::StarshipPilotsEdge>
+        {
+            ::cynic::selection_set::field_alias(
+                "node",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(fields),
+            )
+        }
     }
     pub struct CursorSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -5904,6 +8357,13 @@ pub mod starship_pilots_edge {
             inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::StarshipPilotsEdge> {
             ::cynic::selection_set::field("cursor", self.args, inner)
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::StarshipPilotsEdge> {
+            ::cynic::selection_set::field_alias("cursor", alias, self.args, inner)
         }
     }
 }
@@ -5921,6 +8381,13 @@ pub mod starships_connection {
             fields: ::cynic::selection_set::SelectionSet<'a, T, super::PageInfo>,
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::StarshipsConnection> {
             ::cynic::selection_set::field("pageInfo", self.args, fields)
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::PageInfo>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::StarshipsConnection> {
+            ::cynic::selection_set::field_alias("pageInfo", alias, self.args, fields)
         }
     }
     pub struct EdgesSelectionBuilder {
@@ -5946,6 +8413,24 @@ pub mod starships_connection {
                 )),
             )
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::StarshipsEdge>,
+        ) -> ::cynic::selection_set::SelectionSet<
+            'a,
+            Option<Vec<Option<T>>>,
+            super::StarshipsConnection,
+        > {
+            ::cynic::selection_set::field_alias(
+                "edges",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(::cynic::selection_set::vec(
+                    ::cynic::selection_set::option(fields),
+                )),
+            )
+        }
     }
     pub struct TotalCountSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -5961,6 +8446,19 @@ pub mod starships_connection {
         {
             ::cynic::selection_set::field(
                 "totalCount",
+                self.args,
+                ::cynic::selection_set::option(inner),
+            )
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, i32>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::StarshipsConnection>
+        {
+            ::cynic::selection_set::field_alias(
+                "totalCount",
+                alias,
                 self.args,
                 ::cynic::selection_set::option(inner),
             )
@@ -5989,6 +8487,24 @@ pub mod starships_connection {
                 )),
             )
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::Starship>,
+        ) -> ::cynic::selection_set::SelectionSet<
+            'a,
+            Option<Vec<Option<T>>>,
+            super::StarshipsConnection,
+        > {
+            ::cynic::selection_set::field_alias(
+                "starships",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(::cynic::selection_set::vec(
+                    ::cynic::selection_set::option(fields),
+                )),
+            )
+        }
     }
 }
 #[allow(dead_code)]
@@ -6006,6 +8522,18 @@ pub mod starships_edge {
         ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::StarshipsEdge> {
             ::cynic::selection_set::field("node", self.args, ::cynic::selection_set::option(fields))
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::Starship>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::StarshipsEdge> {
+            ::cynic::selection_set::field_alias(
+                "node",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(fields),
+            )
+        }
     }
     pub struct CursorSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -6019,6 +8547,13 @@ pub mod starships_edge {
             inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::StarshipsEdge> {
             ::cynic::selection_set::field("cursor", self.args, inner)
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::StarshipsEdge> {
+            ::cynic::selection_set::field_alias("cursor", alias, self.args, inner)
         }
     }
 }
@@ -6037,6 +8572,18 @@ pub mod vehicle {
         ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Vehicle> {
             ::cynic::selection_set::field("name", self.args, ::cynic::selection_set::option(inner))
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Vehicle> {
+            ::cynic::selection_set::field_alias(
+                "name",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(inner),
+            )
+        }
     }
     pub struct ModelSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -6050,6 +8597,18 @@ pub mod vehicle {
             inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
         ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Vehicle> {
             ::cynic::selection_set::field("model", self.args, ::cynic::selection_set::option(inner))
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Vehicle> {
+            ::cynic::selection_set::field_alias(
+                "model",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(inner),
+            )
         }
     }
     pub struct VehicleClassSelectionBuilder {
@@ -6065,6 +8624,18 @@ pub mod vehicle {
         ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Vehicle> {
             ::cynic::selection_set::field(
                 "vehicleClass",
+                self.args,
+                ::cynic::selection_set::option(inner),
+            )
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Vehicle> {
+            ::cynic::selection_set::field_alias(
+                "vehicleClass",
+                alias,
                 self.args,
                 ::cynic::selection_set::option(inner),
             )
@@ -6090,6 +8661,21 @@ pub mod vehicle {
                 )),
             )
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<Vec<Option<T>>>, super::Vehicle>
+        {
+            ::cynic::selection_set::field_alias(
+                "manufacturers",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(::cynic::selection_set::vec(
+                    ::cynic::selection_set::option(inner),
+                )),
+            )
+        }
     }
     pub struct CostInCreditsSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -6104,6 +8690,18 @@ pub mod vehicle {
         ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Vehicle> {
             ::cynic::selection_set::field(
                 "costInCredits",
+                self.args,
+                ::cynic::selection_set::option(inner),
+            )
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, f64>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Vehicle> {
+            ::cynic::selection_set::field_alias(
+                "costInCredits",
+                alias,
                 self.args,
                 ::cynic::selection_set::option(inner),
             )
@@ -6126,6 +8724,18 @@ pub mod vehicle {
                 ::cynic::selection_set::option(inner),
             )
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, f64>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Vehicle> {
+            ::cynic::selection_set::field_alias(
+                "length",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(inner),
+            )
+        }
     }
     pub struct CrewSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -6139,6 +8749,18 @@ pub mod vehicle {
             inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
         ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Vehicle> {
             ::cynic::selection_set::field("crew", self.args, ::cynic::selection_set::option(inner))
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Vehicle> {
+            ::cynic::selection_set::field_alias(
+                "crew",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(inner),
+            )
         }
     }
     pub struct PassengersSelectionBuilder {
@@ -6154,6 +8776,18 @@ pub mod vehicle {
         ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Vehicle> {
             ::cynic::selection_set::field(
                 "passengers",
+                self.args,
+                ::cynic::selection_set::option(inner),
+            )
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Vehicle> {
+            ::cynic::selection_set::field_alias(
+                "passengers",
+                alias,
                 self.args,
                 ::cynic::selection_set::option(inner),
             )
@@ -6176,6 +8810,18 @@ pub mod vehicle {
                 ::cynic::selection_set::option(inner),
             )
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, i32>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Vehicle> {
+            ::cynic::selection_set::field_alias(
+                "maxAtmospheringSpeed",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(inner),
+            )
+        }
     }
     pub struct CargoCapacitySelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -6194,6 +8840,18 @@ pub mod vehicle {
                 ::cynic::selection_set::option(inner),
             )
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, f64>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Vehicle> {
+            ::cynic::selection_set::field_alias(
+                "cargoCapacity",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(inner),
+            )
+        }
     }
     pub struct ConsumablesSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -6208,6 +8866,18 @@ pub mod vehicle {
         ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Vehicle> {
             ::cynic::selection_set::field(
                 "consumables",
+                self.args,
+                ::cynic::selection_set::option(inner),
+            )
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Vehicle> {
+            ::cynic::selection_set::field_alias(
+                "consumables",
+                alias,
                 self.args,
                 ::cynic::selection_set::option(inner),
             )
@@ -6280,6 +8950,18 @@ pub mod vehicle {
                 ::cynic::selection_set::option(fields),
             )
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::VehiclePilotsConnection>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Vehicle> {
+            ::cynic::selection_set::field_alias(
+                "pilotConnection",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(fields),
+            )
+        }
     }
     pub struct FilmConnectionSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -6348,6 +9030,18 @@ pub mod vehicle {
                 ::cynic::selection_set::option(fields),
             )
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::VehicleFilmsConnection>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Vehicle> {
+            ::cynic::selection_set::field_alias(
+                "filmConnection",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(fields),
+            )
+        }
     }
     pub struct CreatedSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -6362,6 +9056,18 @@ pub mod vehicle {
         ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Vehicle> {
             ::cynic::selection_set::field(
                 "created",
+                self.args,
+                ::cynic::selection_set::option(inner),
+            )
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Vehicle> {
+            ::cynic::selection_set::field_alias(
+                "created",
+                alias,
                 self.args,
                 ::cynic::selection_set::option(inner),
             )
@@ -6384,6 +9090,18 @@ pub mod vehicle {
                 ::cynic::selection_set::option(inner),
             )
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Vehicle> {
+            ::cynic::selection_set::field_alias(
+                "edited",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(inner),
+            )
+        }
     }
     pub struct IdSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -6397,6 +9115,13 @@ pub mod vehicle {
             inner: ::cynic::selection_set::SelectionSet<'a, T, ::cynic::Id>,
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::Vehicle> {
             ::cynic::selection_set::field("id", self.args, inner)
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, ::cynic::Id>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::Vehicle> {
+            ::cynic::selection_set::field_alias("id", alias, self.args, inner)
         }
     }
 }
@@ -6414,6 +9139,13 @@ pub mod vehicle_films_connection {
             fields: ::cynic::selection_set::SelectionSet<'a, T, super::PageInfo>,
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::VehicleFilmsConnection> {
             ::cynic::selection_set::field("pageInfo", self.args, fields)
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::PageInfo>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::VehicleFilmsConnection> {
+            ::cynic::selection_set::field_alias("pageInfo", alias, self.args, fields)
         }
     }
     pub struct EdgesSelectionBuilder {
@@ -6439,6 +9171,24 @@ pub mod vehicle_films_connection {
                 )),
             )
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::VehicleFilmsEdge>,
+        ) -> ::cynic::selection_set::SelectionSet<
+            'a,
+            Option<Vec<Option<T>>>,
+            super::VehicleFilmsConnection,
+        > {
+            ::cynic::selection_set::field_alias(
+                "edges",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(::cynic::selection_set::vec(
+                    ::cynic::selection_set::option(fields),
+                )),
+            )
+        }
     }
     pub struct TotalCountSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -6454,6 +9204,19 @@ pub mod vehicle_films_connection {
         {
             ::cynic::selection_set::field(
                 "totalCount",
+                self.args,
+                ::cynic::selection_set::option(inner),
+            )
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, i32>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::VehicleFilmsConnection>
+        {
+            ::cynic::selection_set::field_alias(
+                "totalCount",
+                alias,
                 self.args,
                 ::cynic::selection_set::option(inner),
             )
@@ -6482,6 +9245,24 @@ pub mod vehicle_films_connection {
                 )),
             )
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::Film>,
+        ) -> ::cynic::selection_set::SelectionSet<
+            'a,
+            Option<Vec<Option<T>>>,
+            super::VehicleFilmsConnection,
+        > {
+            ::cynic::selection_set::field_alias(
+                "films",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(::cynic::selection_set::vec(
+                    ::cynic::selection_set::option(fields),
+                )),
+            )
+        }
     }
 }
 #[allow(dead_code)]
@@ -6499,6 +9280,18 @@ pub mod vehicle_films_edge {
         ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::VehicleFilmsEdge> {
             ::cynic::selection_set::field("node", self.args, ::cynic::selection_set::option(fields))
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::Film>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::VehicleFilmsEdge> {
+            ::cynic::selection_set::field_alias(
+                "node",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(fields),
+            )
+        }
     }
     pub struct CursorSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -6512,6 +9305,13 @@ pub mod vehicle_films_edge {
             inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::VehicleFilmsEdge> {
             ::cynic::selection_set::field("cursor", self.args, inner)
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::VehicleFilmsEdge> {
+            ::cynic::selection_set::field_alias("cursor", alias, self.args, inner)
         }
     }
 }
@@ -6529,6 +9329,13 @@ pub mod vehicle_pilots_connection {
             fields: ::cynic::selection_set::SelectionSet<'a, T, super::PageInfo>,
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::VehiclePilotsConnection> {
             ::cynic::selection_set::field("pageInfo", self.args, fields)
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::PageInfo>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::VehiclePilotsConnection> {
+            ::cynic::selection_set::field_alias("pageInfo", alias, self.args, fields)
         }
     }
     pub struct EdgesSelectionBuilder {
@@ -6554,6 +9361,24 @@ pub mod vehicle_pilots_connection {
                 )),
             )
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::VehiclePilotsEdge>,
+        ) -> ::cynic::selection_set::SelectionSet<
+            'a,
+            Option<Vec<Option<T>>>,
+            super::VehiclePilotsConnection,
+        > {
+            ::cynic::selection_set::field_alias(
+                "edges",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(::cynic::selection_set::vec(
+                    ::cynic::selection_set::option(fields),
+                )),
+            )
+        }
     }
     pub struct TotalCountSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -6569,6 +9394,19 @@ pub mod vehicle_pilots_connection {
         {
             ::cynic::selection_set::field(
                 "totalCount",
+                self.args,
+                ::cynic::selection_set::option(inner),
+            )
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, i32>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::VehiclePilotsConnection>
+        {
+            ::cynic::selection_set::field_alias(
+                "totalCount",
+                alias,
                 self.args,
                 ::cynic::selection_set::option(inner),
             )
@@ -6597,6 +9435,24 @@ pub mod vehicle_pilots_connection {
                 )),
             )
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::Person>,
+        ) -> ::cynic::selection_set::SelectionSet<
+            'a,
+            Option<Vec<Option<T>>>,
+            super::VehiclePilotsConnection,
+        > {
+            ::cynic::selection_set::field_alias(
+                "pilots",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(::cynic::selection_set::vec(
+                    ::cynic::selection_set::option(fields),
+                )),
+            )
+        }
     }
 }
 #[allow(dead_code)]
@@ -6614,6 +9470,18 @@ pub mod vehicle_pilots_edge {
         ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::VehiclePilotsEdge> {
             ::cynic::selection_set::field("node", self.args, ::cynic::selection_set::option(fields))
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::Person>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::VehiclePilotsEdge> {
+            ::cynic::selection_set::field_alias(
+                "node",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(fields),
+            )
+        }
     }
     pub struct CursorSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -6627,6 +9495,13 @@ pub mod vehicle_pilots_edge {
             inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::VehiclePilotsEdge> {
             ::cynic::selection_set::field("cursor", self.args, inner)
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::VehiclePilotsEdge> {
+            ::cynic::selection_set::field_alias("cursor", alias, self.args, inner)
         }
     }
 }
@@ -6644,6 +9519,13 @@ pub mod vehicles_connection {
             fields: ::cynic::selection_set::SelectionSet<'a, T, super::PageInfo>,
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::VehiclesConnection> {
             ::cynic::selection_set::field("pageInfo", self.args, fields)
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::PageInfo>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::VehiclesConnection> {
+            ::cynic::selection_set::field_alias("pageInfo", alias, self.args, fields)
         }
     }
     pub struct EdgesSelectionBuilder {
@@ -6669,6 +9551,24 @@ pub mod vehicles_connection {
                 )),
             )
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::VehiclesEdge>,
+        ) -> ::cynic::selection_set::SelectionSet<
+            'a,
+            Option<Vec<Option<T>>>,
+            super::VehiclesConnection,
+        > {
+            ::cynic::selection_set::field_alias(
+                "edges",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(::cynic::selection_set::vec(
+                    ::cynic::selection_set::option(fields),
+                )),
+            )
+        }
     }
     pub struct TotalCountSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -6684,6 +9584,19 @@ pub mod vehicles_connection {
         {
             ::cynic::selection_set::field(
                 "totalCount",
+                self.args,
+                ::cynic::selection_set::option(inner),
+            )
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, i32>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::VehiclesConnection>
+        {
+            ::cynic::selection_set::field_alias(
+                "totalCount",
+                alias,
                 self.args,
                 ::cynic::selection_set::option(inner),
             )
@@ -6712,6 +9625,24 @@ pub mod vehicles_connection {
                 )),
             )
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::Vehicle>,
+        ) -> ::cynic::selection_set::SelectionSet<
+            'a,
+            Option<Vec<Option<T>>>,
+            super::VehiclesConnection,
+        > {
+            ::cynic::selection_set::field_alias(
+                "vehicles",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(::cynic::selection_set::vec(
+                    ::cynic::selection_set::option(fields),
+                )),
+            )
+        }
     }
 }
 #[allow(dead_code)]
@@ -6729,6 +9660,18 @@ pub mod vehicles_edge {
         ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::VehiclesEdge> {
             ::cynic::selection_set::field("node", self.args, ::cynic::selection_set::option(fields))
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            fields: ::cynic::selection_set::SelectionSet<'a, T, super::Vehicle>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::VehiclesEdge> {
+            ::cynic::selection_set::field_alias(
+                "node",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(fields),
+            )
+        }
     }
     pub struct CursorSelectionBuilder {
         args: Vec<::cynic::Argument>,
@@ -6742,6 +9685,13 @@ pub mod vehicles_edge {
             inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
         ) -> ::cynic::selection_set::SelectionSet<'a, T, super::VehiclesEdge> {
             ::cynic::selection_set::field("cursor", self.args, inner)
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, String>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, T, super::VehiclesEdge> {
+            ::cynic::selection_set::field_alias("cursor", alias, self.args, inner)
         }
     }
 }

--- a/cynic-codegen/tests/snapshots/use_schema__schema_file_4.snap
+++ b/cynic-codegen/tests/snapshots/use_schema__schema_file_4.snap
@@ -26,6 +26,18 @@ pub mod foo {
         ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Foo> {
             ::cynic::selection_set::field("_", self.args, ::cynic::selection_set::option(inner))
         }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, bool>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Foo> {
+            ::cynic::selection_set::field_alias(
+                "_",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(inner),
+            )
+        }
     }
 }
 

--- a/cynic-querygen/src/output/query_fragment.rs
+++ b/cynic-querygen/src/output/query_fragment.rs
@@ -45,6 +45,7 @@ impl std::fmt::Display for QueryFragment<'_, '_> {
 #[derive(Debug, PartialEq)]
 pub struct OutputField<'query, 'schema> {
     pub name: &'schema str,
+    pub rename: Option<&'schema str>,
     pub field_type: RustOutputFieldType,
 
     pub arguments: Vec<FieldArgument<'query, 'schema>>,
@@ -69,6 +70,10 @@ impl std::fmt::Display for OutputField<'_, '_> {
                 .join(", ");
 
             writeln!(f, "#[arguments({})]", arguments_string)?;
+        }
+
+        if let Some(rename) = self.rename {
+            writeln!(f, "#[cynic(rename = \"{}\")]", rename)?;
         }
 
         writeln!(

--- a/cynic-querygen/src/query_parsing/mod.rs
+++ b/cynic-querygen/src/query_parsing/mod.rs
@@ -85,7 +85,8 @@ fn make_query_fragment<'text>(
                     };
 
                     OutputField {
-                        name: schema_field.name,
+                        name: field.alias.unwrap_or(schema_field.name),
+                        rename: field.alias.map(|_| schema_field.name),
                         field_type: RustOutputFieldType::from_schema_type(
                             &schema_field.value_type,
                             inner_type_name,

--- a/cynic-querygen/tests/queries/starwars/aliases.graphql
+++ b/cynic-querygen/tests/queries/starwars/aliases.graphql
@@ -1,0 +1,8 @@
+query {
+  a_new_hope: film(id: "ZmlsbXM6MQ==") {
+    title
+  }
+  empire_strikes_back: film(id: "ZmlsbXM6Mg==") {
+    title
+  }
+}

--- a/cynic-querygen/tests/snapshots/starwars_tests__aliases.snap
+++ b/cynic-querygen/tests/snapshots/starwars_tests__aliases.snap
@@ -1,0 +1,35 @@
+---
+source: cynic-querygen/tests/starwars-tests.rs
+expression: "document_to_fragment_structs(query, schema,\n                             &QueryGenOptions::default()).expect(\"QueryGen Failed\")"
+
+---
+#[cynic::schema_for_derives(
+    file = r#"schema.graphql"#,
+    module = "schema",
+)]
+mod queries {
+    use super::schema;
+
+    #[derive(cynic::QueryFragment, Debug)]
+    #[cynic(graphql_type = "Root")]
+    pub struct UnnamedQuery {
+        #[arguments(id = cynic::Id::new("ZmlsbXM6MQ=="))]
+        #[cynic(rename = "film")]
+        pub a_new_hope: Option<Film>,
+        #[arguments(id = cynic::Id::new("ZmlsbXM6Mg=="))]
+        #[cynic(rename = "film")]
+        pub empire_strikes_back: Option<Film>,
+    }
+
+    #[derive(cynic::QueryFragment, Debug)]
+    pub struct Film {
+        pub title: Option<String>,
+    }
+
+}
+
+mod schema {
+    cynic::use_schema!(r#"schema.graphql"#);
+}
+
+

--- a/cynic-querygen/tests/starwars-tests.rs
+++ b/cynic-querygen/tests/starwars-tests.rs
@@ -24,3 +24,4 @@ test_query_file!(test_nested_arguments, "nested-arguments.graphql");
 test_query_file!(bare_selection_sets, "bare-selection-set.graphql");
 test_query_file!(multiple_queries, "multiple-queries.graphql");
 test_query_file!(fragment_spreads, "fragment-spreads.graphql");
+test_query_file!(aliases, "aliases.graphql");

--- a/cynic/Cargo.toml
+++ b/cynic/Cargo.toml
@@ -40,7 +40,7 @@ reqwest = { version = "0.11", optional = true, features = ["json"] }
 [dev-dependencies]
 maplit = "1.0.2"
 assert_matches = "1.4"
-insta = "1.5"
+insta = "1.7"
 
 [package.metadata.docs.rs]
 features = ["all"]

--- a/cynic/tests/aliases.rs
+++ b/cynic/tests/aliases.rs
@@ -1,0 +1,131 @@
+use cynic::QueryBuilder;
+use serde_json::json;
+
+#[derive(cynic::QueryFragment, Debug, PartialEq)]
+#[cynic(
+    schema_path = "../schemas/starwars.schema.graphql",
+    graphql_type = "Root"
+)]
+struct FilmQueryWithExplicitAlias {
+    #[arguments(id = cynic::Id::new("ZmlsbXM6MQ=="))]
+    #[cynic(rename = "film", alias)]
+    a_new_hope: Option<Film>,
+
+    #[arguments(id = cynic::Id::new("ZmlsbXM6Mg=="))]
+    #[cynic(rename = "film", alias)]
+    empire_strikes_back: Option<Film>,
+}
+
+#[derive(cynic::QueryFragment, Debug, PartialEq)]
+#[cynic(
+    schema_path = "../schemas/starwars.schema.graphql",
+    query_module = "schema"
+)]
+struct Film {
+    title: Option<String>,
+}
+
+mod schema {
+    cynic::use_schema!("../schemas/starwars.schema.graphql");
+}
+
+#[test]
+fn test_explicit_alias_query_output() {
+    let operation = FilmQueryWithExplicitAlias::build(());
+
+    insta::assert_display_snapshot!(operation.query, @r###"
+    query Query($_0: ID, $_1: ID) {
+      a_new_hope:   film(id: $_0) {
+        title
+      }
+      empire_strikes_back:   film(id: $_1) {
+        title
+      }
+    }
+    "###);
+}
+
+#[test]
+fn test_explicit_alias_decoding() {
+    let operation = FilmQueryWithExplicitAlias::build(());
+
+    assert_eq!(
+        operation
+            .decode_response(cynic::GraphQlResponse {
+                errors: None,
+                data: Some(json!({
+                    "a_new_hope": {"title": "A New Hope"},
+                    "empire_strikes_back": {"title": "The Empire Strikes Back"}
+                }))
+            })
+            .unwrap()
+            .data
+            .unwrap(),
+        FilmQueryWithExplicitAlias {
+            a_new_hope: Some(Film {
+                title: Some("A New Hope".into()),
+            }),
+            empire_strikes_back: Some(Film {
+                title: Some("The Empire Strikes Back".into())
+            })
+        }
+    );
+}
+
+#[derive(cynic::QueryFragment, Debug, PartialEq)]
+#[cynic(
+    schema_path = "../schemas/starwars.schema.graphql",
+    graphql_type = "Root"
+)]
+struct FilmQueryWithImplicitAlias {
+    #[arguments(id = cynic::Id::new("ZmlsbXM6MQ=="))]
+    #[cynic(rename = "film")]
+    a_new_hope: Option<Film>,
+
+    #[arguments(id = cynic::Id::new("ZmlsbXM6Mg=="))]
+    #[cynic(rename = "film")]
+    empire_strikes_back: Option<Film>,
+}
+
+#[test]
+fn test_implicit_alias_query_output() {
+    let operation = FilmQueryWithImplicitAlias::build(());
+
+    insta::assert_display_snapshot!(operation.query, @r###"
+    query Query($_0: ID, $_1: ID) {
+      film(id: $_0) {
+        title
+      }
+      empire_strikes_back:   film(id: $_1) {
+        title
+      }
+    }
+    "###);
+}
+
+#[test]
+fn test_implicit_alias_decoding() {
+    let operation = FilmQueryWithImplicitAlias::build(());
+
+    assert_eq!(
+        operation
+            .decode_response(cynic::GraphQlResponse {
+                errors: None,
+                data: Some(json!({
+                    "film": {"title": "A New Hope"},
+                    "empire_strikes_back": {"title": "The Empire Strikes Back"}
+                }))
+            })
+            .unwrap()
+            .data
+            .unwrap(),
+        FilmQueryWithImplicitAlias {
+            a_new_hope: Some(Film {
+                title: Some("A New Hope".into()),
+            }),
+            empire_strikes_back: Some(Film {
+                title: Some("The Empire Strikes Back".into())
+            })
+        }
+    );
+}

--- a/tests/ui-tests/tests/cases/rename-failures.rs
+++ b/tests/ui-tests/tests/cases/rename-failures.rs
@@ -10,3 +10,10 @@ struct Film {
     #[cynic(rename = "episode")]
     episode_id: Option<i32>,
 }
+
+#[derive(cynic::QueryFragment, Debug)]
+#[cynic(schema_path = "../../../schemas/starwars.schema.graphql")]
+struct AliasWithoutRename {
+    #[cynic(alias)]
+    episode_id: Option<i32>,
+}

--- a/tests/ui-tests/tests/cases/rename-failures.stderr
+++ b/tests/ui-tests/tests/cases/rename-failures.stderr
@@ -3,3 +3,9 @@ error: Field episode does not exist on the GraphQL type Film. Did you mean creat
    |
 10 |     #[cynic(rename = "episode")]
    |             ^^^^^^
+
+error: You can only alias a renamed field.  Try removing `alias` or adding a rename
+  --> $DIR/rename-failures.rs:17:13
+   |
+17 |     #[cynic(alias)]
+   |             ^^^^^


### PR DESCRIPTION
#### Why are we making this change?

PR #253 added support for a rename attribute on individual fields of a
QueryFragment.  This opened up the possibility of selecting the same GraphQL
field multiple times in a query.

GraphQL supports doing this in queries via field aliases.  But cynic doesn't
quite understand how to do this yet - it'll just output an invalid GraphQL
query that attempts to select the same field twice.

#### What effects does this change have?

This updates the rename functionality on `QueryFragment` to be smarter when a
field ends up being selected twice via renames.  It'll automatically detect
this and request an `alias` which will result in a valid query being output.
You can also add the `alias` attribute onto any field with a `rename` to
explicitly request this.

The generator will also now do the right thing when faced with a query that
contains field aliases.

Part of #155 