### PR TITLE
Make InputObject serialzation order stable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ all APIs might be changed.
 
 ## Unreleased - xxxx-xx-xx
 
+### Bug Fixes
+
+- `InputObject` now serializes fields in a stable order.
+
 ## v0.14.0 - 2021-06-06
 
 ### New Features

--- a/cynic-codegen/src/ident.rs
+++ b/cynic-codegen/src/ident.rs
@@ -117,6 +117,20 @@ impl std::hash::Hash for Ident {
     }
 }
 
+impl std::cmp::PartialOrd for Ident {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        // We only care about the GraphQL ident for ordering purposes.
+        self.graphql.partial_cmp(&other.graphql)
+    }
+}
+
+impl std::cmp::Ord for Ident {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        // We only care about the GraphQL ident for ordering purposes.
+        self.graphql.cmp(&other.graphql)
+    }
+}
+
 impl From<proc_macro2::Ident> for Ident {
     fn from(ident: proc_macro2::Ident) -> Ident {
         Ident::from_proc_macro2(&ident, None)

--- a/cynic-codegen/src/input_object_derive/mod.rs
+++ b/cynic-codegen/src/input_object_derive/mod.rs
@@ -1,5 +1,5 @@
 use proc_macro2::{Span, TokenStream};
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use syn::spanned::Spanned;
 
 use crate::{
@@ -181,7 +181,7 @@ fn join_fields<'a>(
 ) -> Result<Vec<(&'a InputObjectDeriveField, &'a InputValue)>, TokenStream> {
     use crate::schema::TypeExt;
 
-    let mut map = HashMap::new();
+    let mut map = BTreeMap::new();
     for field in fields {
         let transformed_ident = Ident::from_proc_macro2(
             field

--- a/cynic/tests/input-object-tests.rs
+++ b/cynic/tests/input-object-tests.rs
@@ -60,3 +60,31 @@ fn test_input_object_skip_serializing() {
 
     assert_eq!(with_author, json!({ "content": "hi", "author": "Me" }));
 }
+
+#[test]
+fn test_input_object_stable_order() {
+    #[derive(cynic::InputObject)]
+    #[cynic(
+        graphql_type = "BlogPostInput",
+        schema_path = "tests/test-schema.graphql",
+        query_module = "schema"
+    )]
+    struct BlogPost {
+        content: String,
+        #[cynic(skip_serializing_if = "Option::is_none")]
+        author: Option<String>,
+    }
+
+    // Using a snapshot to ensure we have a stable order
+    insta::assert_yaml_snapshot!(
+        BlogPost {
+            content: "hi".into(),
+            author: Some("me".into()),
+        },
+        @r###"
+    ---
+    author: me
+    content: hi
+    "###
+    );
+}


### PR DESCRIPTION
#### Why are we making this change?

Some users might want to use a `cynic::InputObject` in a snapshot test.  These
tests can fail if the serialized output of an `InputObject` changes.  The
`InputObject` derive contained a `HashMap` that caused the order of
serialzation to differ for each compile.

#### What effects does this change have?

Uses a `BTreeMap` for pairing up fields in `cynic::InputObject` instead, which
should avoid this issue.