### PR TITLE
Fix `InputObject` generation for arguments on leaf types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@ all APIs might be changed.
   field twice.
 - The generator also now supports field aliases.
 
+### Bug Fixes
+
+- Fixed a case where the generator would not generate `InputObjects` that it
+  should have been generating, if those `InputObjects` were arguments to a leaf
+  field.
+
 ## v0.14.1 - 2021-07-29
 
 ### Bug Fixes

--- a/cynic-querygen/src/query_parsing/inputs.rs
+++ b/cynic-querygen/src/query_parsing/inputs.rs
@@ -74,13 +74,9 @@ fn extract_objects_from_selection_set<'query, 'schema>(
     for selection in &selection_set.selections {
         match selection {
             Selection::Field(field) => {
-                let selection_set = if let Field::Composite(ss) = &field.field {
-                    ss
-                } else {
-                    continue;
-                };
-
-                extract_objects_from_selection_set(selection_set, input_objects)?;
+                if let Field::Composite(selection_set) = &field.field {
+                    extract_objects_from_selection_set(selection_set, input_objects)?;
+                }
 
                 for (_, arg_value) in &field.arguments {
                     let arg_type = arg_value.value_type().inner_ref().lookup()?;

--- a/cynic-querygen/tests/misc-tests.rs
+++ b/cynic-querygen/tests/misc-tests.rs
@@ -1,0 +1,14 @@
+use insta::assert_snapshot;
+
+use cynic_querygen::{document_to_fragment_structs, QueryGenOptions};
+
+#[test]
+fn mutation_with_scalar_result_and_input() {
+    let schema = include_str!("../../schemas/raindancer.graphql");
+    let query = include_str!("queries/misc/mutation_with_scalar_result_and_input.graphql");
+
+    assert_snapshot!(
+        document_to_fragment_structs(query, schema, &QueryGenOptions::default())
+            .expect("QueryGen Failed")
+    )
+}

--- a/cynic-querygen/tests/queries/misc/mutation_with_scalar_result_and_input.graphql
+++ b/cynic-querygen/tests/queries/misc/mutation_with_scalar_result_and_input.graphql
@@ -1,0 +1,3 @@
+mutation SignIn($username: String!, $password: String!) {
+  signIn(input: { username: $username, password: $password })
+}

--- a/cynic-querygen/tests/snapshots/misc_tests__mutation_with_scalar_result_and_input.snap
+++ b/cynic-querygen/tests/snapshots/misc_tests__mutation_with_scalar_result_and_input.snap
@@ -1,0 +1,38 @@
+---
+source: cynic-querygen/tests/misc-tests.rs
+expression: "document_to_fragment_structs(query, schema,\n                             &QueryGenOptions::default()).expect(\"QueryGen Failed\")"
+
+---
+#[cynic::schema_for_derives(
+    file = r#"schema.graphql"#,
+    module = "schema",
+)]
+mod queries {
+    use super::schema;
+
+    #[derive(cynic::FragmentArguments, Debug)]
+    pub struct SignInArguments {
+        pub password: String,
+        pub username: String,
+    }
+
+    #[derive(cynic::QueryFragment, Debug)]
+    #[cynic(graphql_type = "MutationRoot", argument_struct = "SignInArguments")]
+    pub struct SignIn {
+        #[arguments(input = SignInInput { password: args.password.clone(), username: args.username.clone() })]
+        pub sign_in: String,
+    }
+
+    #[derive(cynic::InputObject, Debug)]
+    pub struct SignInInput {
+        pub password: String,
+        pub username: String,
+    }
+
+}
+
+mod schema {
+    cynic::use_schema!(r#"schema.graphql"#);
+}
+
+

--- a/schemas/raindancer.graphql
+++ b/schemas/raindancer.graphql
@@ -1,0 +1,35 @@
+type Device {
+  id: Int!
+  name: String!
+}
+type MutationRoot {
+  """
+  Returns a device with a certain `id`.
+  """
+  createDevice(name: String!): Int
+  signIn(input: SignInInput!): String!
+  refresh(token: String!): String!
+  create(input: UserData!): ID
+}
+type QueryRoot {
+  """
+  Returns a device with a certain `id`.
+  """
+  user(id: Int!): Device
+}
+input SignInInput {
+  username: String!
+  password: String!
+}
+type SubscriptionRoot {
+  interval(n: Int! = 1): Int!
+}
+input UserData {
+  username: String!
+  password: String!
+}
+schema {
+  query: QueryRoot
+  mutation: MutationRoot
+  subscription: SubscriptionRoot
+}

--- a/tests/querygen-compile-run/build.rs
+++ b/tests/querygen-compile-run/build.rs
@@ -16,6 +16,9 @@ fn main() {
     let github_schema =
         Schema::from_repo_schemas("https://api.github.com/graphql", "github.graphql");
 
+    let raindancer_schema =
+        Schema::from_repo_schemas("https://api.github.com/graphql", "raindancer.graphql");
+
     let cases = &[
         TestCase::query(
             &starwars_schema,
@@ -130,6 +133,16 @@ fn main() {
             r#"queries::PullRequestTitles::build(
                 queries::PullRequestTitlesArguments {
                     pr_order: None
+                },
+            )"#,
+        ),
+        TestCase::mutation(
+            &raindancer_schema,
+            "tests/queries/misc/mutation_with_scalar_result_and_input.graphql",
+            r#"queries::SignIn::build(
+                queries::SignInArguments {
+                    username: "hello".into(),
+                    password: "hello".into()
                 },
             )"#,
         ),

--- a/tests/querygen-compile-run/tests/queries/misc/mutation_with_scalar_result_and_input.graphql
+++ b/tests/querygen-compile-run/tests/queries/misc/mutation_with_scalar_result_and_input.graphql
@@ -1,0 +1,3 @@
+mutation SignIn($username: String!, $password: String!) {
+  signIn(input: { username: $username, password: $password })
+}

--- a/tests/ui-tests/tests/cases/inline-fragment-exhaustiveness.stderr
+++ b/tests/ui-tests/tests/cases/inline-fragment-exhaustiveness.stderr
@@ -10,4 +10,4 @@ error: This InlineFragment is missing a variant for Nested.  Either provide a va
 7 | #[derive(cynic::InlineFragments)]
   |          ^^^^^^^^^^^^^^^^^^^^^^
   |
-  = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+  = note: this error originates in the derive macro `cynic::InlineFragments` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
#### Why are we making this change?

It was reported on discord that certain queries don't get the correct
`InputObject`s generated.  This turned out to be because we were only scanning
the arguments of composite types for InputObjects.

#### What effects does this change have?

Fixes this code to consider the arguments regardless of whether the field is a
composite or leaf.