### PR TITLE
Make inflector lightweight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,11 @@ all APIs might be changed.
   should have been generating, if those `InputObjects` were arguments to a leaf
   field.
 
+### Changes
+
+- Disabled the heavyweight feature of inflector, which should make it (and
+  therefore cynic) a lighter dependency.
+
 ## v0.14.1 - 2021-07-29
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,10 +7,6 @@ name = "Inflector"
 version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
-dependencies = [
- "lazy_static",
- "regex",
-]
 
 [[package]]
 name = "aead"
@@ -64,15 +60,6 @@ checksum = "ea2e11f5e94c2f7d386164cc2aa1f97823fed6f259e486940a71c174dd01b0ce"
 dependencies = [
  "cipher",
  "opaque-debug",
-]
-
-[[package]]
-name = "aho-corasick"
-version = "0.7.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7404febffaa47dac81aa44dba71523c9d069b1bdc50a77db41195149e17f68e5"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -1989,23 +1976,6 @@ checksum = "94341e4e44e24f6b591b59e47a8a027df12e008d73fd5672dbea9cc22f4507d9"
 dependencies = [
  "bitflags",
 ]
-
-[[package]]
-name = "regex"
-version = "1.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "957056ecddbeba1b26965114e191d2e8589ce74db242b6ea25fc4062427a5c19"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-syntax"
-version = "0.6.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5f089152e60f62d28b835fbff2cd2e8dc0baf1ac13343bef92ab7eed84548"
 
 [[package]]
 name = "remove_dir_all"

--- a/cynic-codegen/Cargo.toml
+++ b/cynic-codegen/Cargo.toml
@@ -20,7 +20,7 @@ graphql-parser = "0.3.0"
 proc-macro2 = "1.0"
 syn = "1.0"
 quote = "1.0"
-Inflector = "0.11.4"
+Inflector = { version = "0.11.4", default-features = false }
 darling = "0.12"
 lazy_static = "1.4.0"
 strsim = "0.10.0"

--- a/cynic-querygen/Cargo.toml
+++ b/cynic-querygen/Cargo.toml
@@ -11,7 +11,7 @@ description = "QueryFragment generation for cynic, a GraphQL query builder & dat
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-Inflector = "0.11.4"
+Inflector = { version = "0.11.4", default-features = false }
 graphql-parser = "0.3"
 rust_decimal = "1.9"
 thiserror = "1.0.13"


### PR DESCRIPTION
#### Why are we making this change?

Cynic relies on `inflector`, which in turn pulls in `regex` and `lazy_static`.
`regex` in particular is quite a heavy dependency.  We don't need any of the
features that require these dependencies.

#### What effects does this change have?

Removes the `heavyweight` feature from `inflector`, which removes these deps
from the `cynic` tree.