### PR TITLE
Remove `chrono` feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ all APIs might be changed.
 
 ## Unreleased - xxxx-xx-xx
 
+### Breaking Changes
+
+- Removed the no longer used `chrono` feature.  It didn't enable any code so
+  downstreams shouldn't really be broken by this (other than a possible
+  `Cargo.toml` tweak)
+
 ### New Features
 
 - Cynic now supports GraphQL field aliases.  These can be requested, but will

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -576,7 +576,6 @@ name = "cynic"
 version = "0.14.1"
 dependencies = [
  "assert_matches",
- "chrono",
  "cynic-proc-macros",
  "insta",
  "json-decode",

--- a/cynic/Cargo.toml
+++ b/cynic/Cargo.toml
@@ -24,7 +24,6 @@ surf-middleware-logger = ["surf/middleware-logger"]
 surf-encoding = ["surf/encoding"]
 
 [dependencies]
-chrono = { version = "0.4.11", optional = true }
 cynic-proc-macros = { path = "../cynic-proc-macros", version = "0.14.1" }
 json-decode = "0.6.0"
 serde = { version = "1.0.104", features = [ "derive" ] }


### PR DESCRIPTION
#### Why are we making this change?

We used to have a `chrono` feature.  We don't anymore, but the feature flag is still around.

#### What effects does this change have?

Removes the feature flag.