### PR TITLE
[Merged by Bors] - Add argument support to `InlineFragment`s in generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ all APIs might be changed.
 
 - Querygen now supports inline fragments on union types & interfaces.
 
+### Bug Fixes
+
+- Querygen no longer duplicates variable names in generated `ArgumentStruct`s
+  when an argument is used twice in a query.
+
 ## v0.15.0 - 2021-09-23
 
 ### Breaking Changes

--- a/cynic-querygen/src/query_parsing/arguments.rs
+++ b/cynic-querygen/src/query_parsing/arguments.rs
@@ -1,7 +1,7 @@
 //! Generation of argument structs
 use std::{
     cell::RefCell,
-    collections::{HashMap, HashSet},
+    collections::{BTreeMap, BTreeSet, HashMap, HashSet},
     rc::Rc,
 };
 
@@ -86,7 +86,9 @@ impl<'query, 'schema> SelectionArguments<'query, 'schema> {
             .iter()
             .flat_map(|field| match field {
                 SelectionArgument::VariableArgument(var) => {
-                    vec![ArgumentStructField::Variable(var.clone())]
+                    let mut rv = BTreeSet::new();
+                    rv.insert(ArgumentStructField::Variable(var.clone()));
+                    rv
                 }
                 SelectionArgument::NestedArguments(nested) => {
                     let nested_struct = nested.as_argument_struct(parent_map, output_mapping);
@@ -99,7 +101,9 @@ impl<'query, 'schema> SelectionArguments<'query, 'schema> {
 
                         Rc::try_unwrap(nested_struct).unwrap().fields
                     } else {
-                        vec![ArgumentStructField::NestedStruct(nested_struct)]
+                        let mut rv = BTreeSet::new();
+                        rv.insert(ArgumentStructField::NestedStruct(nested_struct));
+                        rv
                     }
                 }
             })
@@ -138,7 +142,7 @@ impl<'query, 'schema> SelectionArguments<'query, 'schema> {
 struct ArgumentStruct<'query, 'schema> {
     id: Uuid,
     target_type_name: String,
-    fields: Vec<ArgumentStructField<'query, 'schema>>,
+    fields: BTreeSet<ArgumentStructField<'query, 'schema>>,
 }
 
 impl<'query, 'schema> crate::naming::Nameable for Rc<ArgumentStruct<'query, 'schema>> {

--- a/cynic-querygen/src/query_parsing/mod.rs
+++ b/cynic-querygen/src/query_parsing/mod.rs
@@ -125,7 +125,7 @@ fn make_query_fragment<'text>(
 fn make_inline_fragments<'text>(
     inline_fragments: Rc<normalisation::InlineFragments<'text, 'text>>,
     namers: &mut Namers<'text>,
-    _argument_struct_details: &ArgumentStructDetails<'text, 'text>,
+    argument_struct_details: &ArgumentStructDetails<'text, 'text>,
 ) -> crate::output::InlineFragments {
     crate::output::InlineFragments {
         inner_type_names: inline_fragments
@@ -134,8 +134,16 @@ fn make_inline_fragments<'text>(
             .map(|s| namers.selection_sets.name_subject(s))
             .collect(),
         target_type: inline_fragments.abstract_type.name().to_string(),
-        // TODO: Deal with argument structs
-        argument_struct_name: None,
+        // Note: we just look for the first selection set with an argument struct.
+        // Think it might be possible that there are two different argument structs within
+        // and this will fall over in that case.  But it should be good enough for a first
+        // pass
+        argument_struct_name: inline_fragments
+            .inner_selections
+            .iter()
+            .map(|selection| argument_struct_details.argument_name_for_selection(selection))
+            .flatten()
+            .next(),
         name: namers.inline_fragments.name_subject(&inline_fragments),
     }
 }

--- a/cynic-querygen/tests/github-tests.rs
+++ b/cynic-querygen/tests/github-tests.rs
@@ -24,3 +24,7 @@ test_query!(input_object_literals, "input-object-literals.graphql");
 test_query!(input_object_arguments, "input-object-arguments.graphql");
 test_query!(add_comment_mutation, "add-comment-mutation.graphql");
 test_query!(inline_fragment_on_union, "inline-fragment-on-union.graphql");
+test_query!(
+    inline_fragment_with_arguments,
+    "inline-fragment-with-arguments.graphql"
+);

--- a/cynic-querygen/tests/queries/github/inline-fragment-with-arguments.graphql
+++ b/cynic-querygen/tests/queries/github/inline-fragment-with-arguments.graphql
@@ -1,0 +1,20 @@
+query IssueOrPR($assigneeCount: Int!) {
+  repository(owner: "obmarg", name: "cynic") {
+    issueOrPullRequest(number: 1) {
+      ... on Issue {
+        id
+        title
+        assignees(first: $assigneeCount) {
+          totalCount
+        }
+      }
+      ... on PullRequest {
+        id
+        title
+        assignees(first: $assigneeCount) {
+          totalCount
+        }
+      }
+    }
+  }
+}

--- a/cynic-querygen/tests/snapshots/github_tests__inline_fragment_with_arguments.snap
+++ b/cynic-querygen/tests/snapshots/github_tests__inline_fragment_with_arguments.snap
@@ -1,0 +1,68 @@
+---
+source: cynic-querygen/tests/github-tests.rs
+expression: "document_to_fragment_structs(query, schema,\n                             &QueryGenOptions::default()).expect(\"QueryGen Failed\")"
+
+---
+#[cynic::schema_for_derives(
+    file = r#"schema.graphql"#,
+    module = "schema",
+)]
+mod queries {
+    use super::schema;
+
+    #[derive(cynic::FragmentArguments, Debug)]
+    pub struct IssueOrPRArguments {
+        pub assignee_count: i32,
+    }
+
+    #[derive(cynic::QueryFragment, Debug)]
+    #[cynic(graphql_type = "Query", argument_struct = "IssueOrPRArguments")]
+    pub struct IssueOrPR {
+        #[arguments(owner = "obmarg", name = "cynic")]
+        pub repository: Option<Repository>,
+    }
+
+    #[derive(cynic::QueryFragment, Debug)]
+    #[cynic(argument_struct = "IssueOrPRArguments")]
+    pub struct Repository {
+        #[arguments(number = 1)]
+        pub issue_or_pull_request: Option<IssueOrPullRequest>,
+    }
+
+    #[derive(cynic::QueryFragment, Debug)]
+    #[cynic(argument_struct = "IssueOrPRArguments")]
+    pub struct PullRequest {
+        pub id: cynic::Id,
+        pub title: String,
+        #[arguments(first = args.assignee_count)]
+        pub assignees: UserConnection,
+    }
+
+    #[derive(cynic::QueryFragment, Debug)]
+    #[cynic(argument_struct = "IssueOrPRArguments")]
+    pub struct Issue {
+        pub id: cynic::Id,
+        pub title: String,
+        #[arguments(first = args.assignee_count)]
+        pub assignees: UserConnection,
+    }
+
+    #[derive(cynic::QueryFragment, Debug)]
+    pub struct UserConnection {
+        pub total_count: i32,
+    }
+
+    #[derive(cynic::InlineFragments, Debug)]
+    #[cynic(argument_struct = "IssueOrPRArguments")]
+    pub enum IssueOrPullRequest {
+        Issue(Issue),
+        PullRequest(PullRequest),
+    }
+
+}
+
+mod schema {
+    cynic::use_schema!(r#"schema.graphql"#);
+}
+
+

--- a/tests/querygen-compile-run/build.rs
+++ b/tests/querygen-compile-run/build.rs
@@ -151,6 +151,15 @@ fn main() {
             "tests/queries/github/inline-fragment-on-union.graphql",
             r#"queries::IssueOrPR::build(())"#,
         ),
+        TestCase::query_norun(
+            &github_schema,
+            "tests/queries/github/inline-fragment-with-arguments.graphql",
+            r#"queries::IssueOrPR::build(
+                queries::IssueOrPRArguments {
+                    assignee_count: 10
+                }
+            )"#,
+        ),
     ];
 
     for case in cases {

--- a/tests/querygen-compile-run/tests/queries/github/inline-fragment-with-arguments.graphql
+++ b/tests/querygen-compile-run/tests/queries/github/inline-fragment-with-arguments.graphql
@@ -1,0 +1,20 @@
+query IssueOrPR($assigneeCount: Int!) {
+  repository(owner: "obmarg", name: "cynic") {
+    issueOrPullRequest(number: 1) {
+      ... on Issue {
+        id
+        title
+        assignees(first: $assigneeCount) {
+          totalCount
+        }
+      }
+      ... on PullRequest {
+        id
+        title
+        assignees(first: $assigneeCount) {
+          totalCount
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
#### Why are we making this change?

PR #293 added support for generating `InlineFragment`s to the generator, but
without working support for using arguments inside the `InlineFragment`s.

#### What effects does this change have?

Adds support for arguments inside `InlineFragment`s, and fixes an issue with                                                                             argument struct generation when the same argument is used more than once in a
query.

Fixes #104 