### PR TITLE
[Merged by Bors] - Add rename attribute to `InlineFragments` variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ all APIs might be changed.
 
 - Querygen now supports inline fragments on union types & interfaces.
 - Querygen now supports subscriptions
+- The `InlineFragments` derive now supports a rename attribute on variants
 
 ### Bug Fixes
 

--- a/cynic-book/src/derives/inline-fragments.md
+++ b/cynic-book/src/derives/inline-fragments.md
@@ -99,3 +99,5 @@ Each variant can also have it's own attributes:
   match one of the other variants. For interfaces this can contain a
   `QueryFragment` type. For union types it must be applied on a unit
   variant.
+- `rename = "SomeOtherName"` can be used to specify the name of the GraphQL
+  type when it doesn't exactly match the name of the variant.

--- a/cynic-codegen/src/inline_fragments_derive/input.rs
+++ b/cynic-codegen/src/inline_fragments_derive/input.rs
@@ -51,8 +51,11 @@ impl InlineFragmentsDeriveInput {
 #[derive(darling::FromVariant)]
 #[darling(attributes(cynic))]
 pub(super) struct InlineFragmentsDeriveVariant {
-    pub ident: proc_macro2::Ident,
+    pub(super) ident: proc_macro2::Ident,
     pub fields: darling::ast::Fields<InlineFragmentsDeriveField>,
+
+    #[darling(default)]
+    rename: Option<SpannedValue<String>>,
 
     #[darling(default)]
     pub(super) fallback: SpannedValue<bool>,
@@ -62,4 +65,14 @@ pub(super) struct InlineFragmentsDeriveVariant {
 #[darling(attributes(cynic))]
 pub(super) struct InlineFragmentsDeriveField {
     pub ty: syn::Type,
+}
+
+impl InlineFragmentsDeriveVariant {
+    pub(super) fn graphql_ident(&self) -> crate::Ident {
+        if let Some(rename) = &self.rename {
+            return crate::Ident::for_type(&**rename).with_span(rename.span());
+        }
+
+        crate::Ident::from_proc_macro2(&self.ident, None)
+    }
 }

--- a/cynic/tests/snapshots/renames__all_posts_query_output.snap
+++ b/cynic/tests/snapshots/renames__all_posts_query_output.snap
@@ -10,5 +10,17 @@ query Query {
       _
     }
   }
+  allData {
+    __typename
+    ... on BlogPost {
+      hasMetadata
+      metadata {
+        _
+      }
+    }
+    ... on Author {
+      name
+    }
+  }
 }
 

--- a/cynic/tests/snapshots/renames__decoding.snap
+++ b/cynic/tests/snapshots/renames__decoding.snap
@@ -7,4 +7,9 @@ all_posts:
   - metadata_present: true
     metadata:
       underscore: ~
+all_data:
+  - Post:
+      metadata_present: true
+      metadata:
+        underscore: ~
 

--- a/cynic/tests/test-schema.graphql
+++ b/cynic/tests/test-schema.graphql
@@ -33,7 +33,10 @@ type EmptyType {
 type Query {
   allPosts: [BlogPost!]!
   allAuthors: [Author!]!
+  allData: [PostOrAuthor!]!
 }
+
+union PostOrAuthor = BlogPost | Author
 
 schema {
   query: Query


### PR DESCRIPTION
#### Why are we making this change?

Sometimes users will want to name their `InlineFragments` variants something
other than the underlying graphql type name.  This has not been supported up
till now.

#### What effects does this change have?

Adds a `rename` variant attribute to the `InlineFragments` derive, which should
allow this case to be supported.

Fixes #155