### PR TITLE
[Merged by Bors] - Fix support for idents that can't be made into raw idents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ all APIs might be changed.
 - Querygen no longer duplicates variable names in generated `ArgumentStruct`s
   when an argument is used twice in a query.
 - Fixed support for `Float` scalars in the generator.
+- Fixed support for fields named `self`, `super` etc. which can't be made into
+  raw identifiers.
 
 ## v0.15.0 - 2021-09-23
 

--- a/cynic-codegen/src/ident.rs
+++ b/cynic-codegen/src/ident.rs
@@ -227,9 +227,9 @@ impl darling::FromMeta for RenameAll {
 }
 
 lazy_static! {
-    // A list of keywords in rust,
+    // A list of keywords in rust that can be converted to raw identifiers
     // Taken from https://doc.rust-lang.org/reference/keywords.html
-    static ref KEYWORDS: HashSet<&'static str> = {
+    static ref RAW_KEYWORDS: HashSet<&'static str> = {
         let mut set = HashSet::new();
 
         // Strict Keywords 2015
@@ -237,10 +237,8 @@ lazy_static! {
         set.insert("break");
         set.insert("const");
         set.insert("continue");
-        set.insert("crate");
         set.insert("else");
         set.insert("enum");
-        set.insert("extern");
         set.insert("false");
         set.insert("fn");
         set.insert("for");
@@ -256,11 +254,8 @@ lazy_static! {
         set.insert("pub");
         set.insert("ref");
         set.insert("return");
-        set.insert("self");
-        set.insert("Self");
         set.insert("static");
         set.insert("struct");
-        set.insert("super");
         set.insert("trait");
         set.insert("true");
         set.insert("type");
@@ -295,9 +290,27 @@ lazy_static! {
     };
 }
 
+lazy_static! {
+    // A list of keywords in rust that cannot be converted to raw identifiers
+    // Taken from https://github.com/rust-lang/rust/blob/1.31.1/src/libsyntax_pos/symbol.rs#L456-L460
+    static ref NON_RAW_KEYWORDS: HashSet<&'static str> = {
+        let mut set = HashSet::new();
+
+        set.insert("super");
+        set.insert("self");
+        set.insert("Self");
+        set.insert("extern");
+        set.insert("crate");
+
+        set
+    };
+}
+
 fn transform_keywords(s: &str) -> Cow<str> {
     let s_ref: &str = s;
-    if KEYWORDS.contains(s_ref) {
+    if NON_RAW_KEYWORDS.contains(s_ref) {
+        format!("{}_", s).into()
+    } else if RAW_KEYWORDS.contains(s_ref) {
         format!("r#{}", s).into()
     } else {
         s.into()

--- a/cynic-codegen/tests/snapshots/use_schema__schema_file_4.snap
+++ b/cynic-codegen/tests/snapshots/use_schema__schema_file_4.snap
@@ -10,6 +10,18 @@ impl Foo {
     pub fn __underscore() -> foo::SelectionBuilder {
         foo::SelectionBuilder::new(vec![])
     }
+    pub fn self_() -> foo::SelfSelectionBuilder {
+        foo::SelfSelectionBuilder::new(vec![])
+    }
+    pub fn super_() -> foo::SuperSelectionBuilder {
+        foo::SuperSelectionBuilder::new(vec![])
+    }
+    pub fn crate_() -> foo::CrateSelectionBuilder {
+        foo::CrateSelectionBuilder::new(vec![])
+    }
+    pub fn r#async() -> foo::AsyncSelectionBuilder {
+        foo::AsyncSelectionBuilder::new(vec![])
+    }
 }
 #[allow(dead_code)]
 pub mod foo {
@@ -39,5 +51,110 @@ pub mod foo {
             )
         }
     }
+    pub struct SelfSelectionBuilder {
+        args: Vec<::cynic::Argument>,
+    }
+    impl SelfSelectionBuilder {
+        pub(super) fn new(args: Vec<::cynic::Argument>) -> Self {
+            SelfSelectionBuilder { args }
+        }
+        pub fn select<'a, T: 'a + Send + Sync>(
+            self,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, bool>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Foo> {
+            ::cynic::selection_set::field("self", self.args, ::cynic::selection_set::option(inner))
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, bool>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Foo> {
+            ::cynic::selection_set::field_alias(
+                "self",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(inner),
+            )
+        }
+    }
+    pub struct SuperSelectionBuilder {
+        args: Vec<::cynic::Argument>,
+    }
+    impl SuperSelectionBuilder {
+        pub(super) fn new(args: Vec<::cynic::Argument>) -> Self {
+            SuperSelectionBuilder { args }
+        }
+        pub fn select<'a, T: 'a + Send + Sync>(
+            self,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, bool>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Foo> {
+            ::cynic::selection_set::field("super", self.args, ::cynic::selection_set::option(inner))
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, bool>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Foo> {
+            ::cynic::selection_set::field_alias(
+                "super",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(inner),
+            )
+        }
+    }
+    pub struct CrateSelectionBuilder {
+        args: Vec<::cynic::Argument>,
+    }
+    impl CrateSelectionBuilder {
+        pub(super) fn new(args: Vec<::cynic::Argument>) -> Self {
+            CrateSelectionBuilder { args }
+        }
+        pub fn select<'a, T: 'a + Send + Sync>(
+            self,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, bool>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Foo> {
+            ::cynic::selection_set::field("crate", self.args, ::cynic::selection_set::option(inner))
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, bool>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Foo> {
+            ::cynic::selection_set::field_alias(
+                "crate",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(inner),
+            )
+        }
+    }
+    pub struct AsyncSelectionBuilder {
+        args: Vec<::cynic::Argument>,
+    }
+    impl AsyncSelectionBuilder {
+        pub(super) fn new(args: Vec<::cynic::Argument>) -> Self {
+            AsyncSelectionBuilder { args }
+        }
+        pub fn select<'a, T: 'a + Send + Sync>(
+            self,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, bool>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Foo> {
+            ::cynic::selection_set::field("async", self.args, ::cynic::selection_set::option(inner))
+        }
+        pub fn select_aliased<'a, T: 'a + Send + Sync>(
+            self,
+            alias: &str,
+            inner: ::cynic::selection_set::SelectionSet<'a, T, bool>,
+        ) -> ::cynic::selection_set::SelectionSet<'a, Option<T>, super::Foo> {
+            ::cynic::selection_set::field_alias(
+                "async",
+                alias,
+                self.args,
+                ::cynic::selection_set::option(inner),
+            )
+        }
+    }
 }
+impl ::cynic::QueryRoot for Foo {}
 

--- a/cynic-codegen/tests/use-schema.rs
+++ b/cynic-codegen/tests/use-schema.rs
@@ -11,7 +11,7 @@ use cynic_codegen::use_schema::{use_schema, QueryDslParams};
     "graphql.jobs.graphql",
     "books.graphql",
     "starwars.schema.graphql",
-    "test_cases.graphql"
+    "test_cases.graphql",
 ])]
 fn snapshot_use_schema(schema_file: &str) {
     let schema_path = PathBuf::from("../schemas/").join(schema_file);

--- a/cynic/tests/keyword-queries.rs
+++ b/cynic/tests/keyword-queries.rs
@@ -1,0 +1,54 @@
+//! Testing the derives with some keyword fields
+
+use serde_json::json;
+
+#[test]
+fn test_query_output() {
+    use cynic::QueryBuilder;
+
+    let query = queries::KeywordQuery::build(());
+
+    insta::assert_display_snapshot!(query.query);
+}
+
+#[test]
+fn test_query_decoding() {
+    use cynic::{GraphQlResponse, QueryBuilder};
+
+    let query = queries::KeywordQuery::build(());
+
+    let result = query
+        .decode_response(GraphQlResponse {
+            data: Some(
+                json!({"_": false, "async": false, "crate": false, "self": false, "super": false}),
+            ),
+            errors: None,
+        })
+        .unwrap();
+
+    insta::assert_yaml_snapshot!(result.data);
+}
+
+#[cynic::schema_for_derives(file = r#"../schemas/test_cases.graphql"#, module = "schema")]
+mod queries {
+    use super::schema;
+
+    #[derive(cynic::QueryFragment, Debug, serde::Serialize)]
+    #[cynic(graphql_type = "Foo")]
+    pub struct KeywordQuery {
+        #[cynic(rename = "_")]
+        pub whatevs: Option<bool>,
+        #[cynic(rename = "async")]
+        pub whatevs2: Option<bool>,
+        #[cynic(rename = "crate")]
+        pub whatevs3: Option<bool>,
+        #[cynic(rename = "self")]
+        pub self_: Option<bool>,
+        #[cynic(rename = "super")]
+        pub super_: Option<bool>,
+    }
+}
+
+mod schema {
+    cynic::use_schema!(r#"../schemas/test_cases.graphql"#);
+}

--- a/cynic/tests/snapshots/keyword_queries__query_decoding.snap
+++ b/cynic/tests/snapshots/keyword_queries__query_decoding.snap
@@ -1,0 +1,11 @@
+---
+source: cynic/tests/keyword-queries.rs
+expression: result.data
+
+---
+whatevs: false
+whatevs2: false
+whatevs3: false
+self_: false
+super_: false
+

--- a/cynic/tests/snapshots/keyword_queries__query_output.snap
+++ b/cynic/tests/snapshots/keyword_queries__query_output.snap
@@ -1,0 +1,13 @@
+---
+source: cynic/tests/keyword-queries.rs
+expression: query.query
+
+---
+query Query {
+  _
+  async
+  crate
+  self
+  super
+}
+

--- a/schemas/test_cases.graphql
+++ b/schemas/test_cases.graphql
@@ -1,3 +1,11 @@
 type Foo {
   _: Boolean
+  self: Boolean
+  super: Boolean
+  crate: Boolean
+  async: Boolean
+}
+
+schema {
+  query: Foo
 }


### PR DESCRIPTION
#### Why are we making this change?

Turns out that raw identifiers don't cover all keywords in rust.  They're fine
for most of them, but for some you'll get the following error:

> error: `self` cannot be a raw identifier

Apparently this is because certain keywords [are used in path resolution](https://internals.rust-lang.org/t/raw-identifiers-dont-work-for-all-identifiers/9094/4)
so even if they were made into raw keywords, things with those names would not
be accessible.

This causes problems for cynic when a graphql schema has these keywords in it,
as it assumes everything is raw-able.

#### What effects does this change have?

Updates the keyword detection code to have two different ways of handling
keywords - those that can be raw will be made raw, those that can't will have
an underscore appended to their name.  This should be transparent to users -
they can name their fields whatever they want and provide a `rename = "self"` 
and it should just work.
