### PR TITLE
[Merged by Bors] - Handle non-2XX errors in http extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,21 @@ all APIs might be changed.
 
 ## Unreleased - xxxx-xx-xx
 
+### Breaking Changes
+
+- The `CynicReqwestError` enum (behind the `reqwest` & `reqwest-blocking`
+  feature flags) has a new variant to handle non 2XX responses from servers.
+
 ### New Features
 
 - The `InlineFragments` derive now supports a rename attribute on variants
+
+### Bug Fixes
+
+- The various HTTP client integrations will now return HTTP error details and
+  the full body on non 2XX responses that don't contain a valid GraphQL
+  response.  Previously they would have tried to decode the response as GraphQL
+  and returned the error from that operation.
 
 ## v0.15.1 - xxxx-xx-xx
 


### PR DESCRIPTION
#### Why are we making this change?

[The GraphQL over HTTP spec](https://github.com/graphql/graphql-over-http/blob/master/spec/GraphQLOverHTTP.md)
says that clients should not assume a response is well formed GraphQL when a
server responds with a non-2XX error code.  Cynic was not doing this - instead
it always attempted to decode and returned the JSON decoding error on a
failure.

#### What effects does this change have?

Updates the HTTP extension code to always check the status code before trying
to decode - and return the HTTP error if the body is not a well formed response
and the HTTP code is not 2XX

Fixes #178 