### PR TITLE
[Merged by Bors] - Add a loading spinner to the generator

### DIFF
--- a/cynic-querygen-web/index.html
+++ b/cynic-querygen-web/index.html
@@ -41,9 +41,6 @@
         <div class="loader" />
       </div>
     </section>
-      <div id="loaderContainer">
-        <div class="loader" />
-      </div>
     <script type="module">
         import init from '/pkg/package.js';
         init('/pkg/package_bg.wasm');


### PR DESCRIPTION
The generator has quite a large wasm payload so there's often a visible delay
before its first render.  Currently this is just a blank white page, so it kind
of looks broken.  This PR adds a simple spinner to the initial HTML so it's
obvious that it is still loading.

Fixes #238 