### PR TITLE
[Merged by Bors] - Allow types with generic parameters as QueryFragment fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ all APIs might be changed.
 
 - The `InlineFragments` derive now supports a rename attribute on variants
 
+### Changes
+
+- The `QueryFragment` derive now supports fields with types that take generic
+  parameters directly, e.g. `DateTime<Utc>` from chrono.  Previously this would
+  have required a type alias to hide the generic parameters from cynic.
+
 ### Bug Fixes
 
 - The various HTTP client integrations will now return HTTP error details and


### PR DESCRIPTION
#### Why are we making this change?

Cynic does some parsing of the types of fields in structs it is deriving for.
It does this to provide better error messages for cases where a field was
optional in GraphQL but is not in the provided struct.  However, it wasn't very
thorough parsing code - if it encounters a generic it doesn't know about it
would throw an error saying "don't do that".  Which was a bit rubbish.

#### What effects does this change have?

This removes the limitation above - we still parse types, but we just ignore
"Unknown" types unless we're specifically expecting an `Option` or a `Vec`.

Fixes #223 