### PR TITLE
[Merged by Bors] - Cynic book: manual-http-request - Fix typo in code example

### DIFF
--- a/cynic-book/src/manual-http-requests.md
+++ b/cynic-book/src/manual-http-requests.md
@@ -27,7 +27,7 @@ let response = reqwest::blocking::Client::new()
     .send()
     .unwrap();
 
-let all_films_result = query.decode_response(response.json().unwrap()).unwrap();
+let all_films_result = operation.decode_response(response.json().unwrap()).unwrap();
 ```
 
 Now you can do whatever you want with the result.


### PR DESCRIPTION
#### What effects does this change have?

The call to `decode_response` was using wrong variable name.