### PR TITLE
[Merged by Bors] - Fix to_pascal_case by removing inflector.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 - Fixed a case where the generator would output the incorrect casing for some
   occurrences of a custom scalar in the output (#346)
 
+### Changes
+
+- `cynic` no longer uses `inflector` to re-case things.  Hopefully this won't cause
+  any regressions, but if it does please raise an issue.
+
 ## v1.0.0 - 2021-12-09
 
 ### Breaking Changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -597,7 +597,6 @@ dependencies = [
 name = "cynic-codegen"
 version = "1.0.0"
 dependencies = [
- "Inflector",
  "assert_matches",
  "darling",
  "graphql-parser",

--- a/cynic-codegen/Cargo.toml
+++ b/cynic-codegen/Cargo.toml
@@ -20,7 +20,6 @@ graphql-parser = "0.3.0"
 proc-macro2 = "1.0"
 syn = "1.0"
 quote = "1.0"
-Inflector = { version = "0.11.4", default-features = false }
 darling = "0.13"
 lazy_static = "1.4.0"
 strsim = "0.10.0"

--- a/cynic-codegen/src/scalar_derive/mod.rs
+++ b/cynic-codegen/src/scalar_derive/mod.rs
@@ -35,7 +35,7 @@ pub fn scalar_derive_impl(input: ScalarDeriveInput) -> Result<TokenStream, syn::
     let type_lock_ident = if let Some(graphql_type) = input.graphql_type {
         Ident::new_spanned((*graphql_type).clone(), graphql_type.span())
     } else {
-        ident.clone().into()
+        Ident::for_type(ident.to_string()).with_span(ident.span())
     };
 
     Ok(quote! {

--- a/cynic-codegen/src/use_schema/selection_builder.rs
+++ b/cynic-codegen/src/use_schema/selection_builder.rs
@@ -26,7 +26,10 @@ impl FieldSelectionBuilder {
         type_index: &TypeIndex,
     ) -> FieldSelectionBuilder {
         FieldSelectionBuilder {
-            name: Ident::for_type(format!("{}SelectionBuilder", field_name)),
+            name: Ident::new(format!(
+                "{}SelectionBuilder",
+                Ident::for_type(field_name).rust_name()
+            )),
             field_type,
             type_lock,
             optional_args: optional_args

--- a/cynic-codegen/tests/snapshots/use_schema__schema_file_3.snap
+++ b/cynic-codegen/tests/snapshots/use_schema__schema_file_3.snap
@@ -18,8 +18,8 @@ impl Film {
     pub fn title() -> film::TitleSelectionBuilder {
         film::TitleSelectionBuilder::new(vec![])
     }
-    pub fn episode_id() -> film::EpisodeIDSelectionBuilder {
-        film::EpisodeIDSelectionBuilder::new(vec![])
+    pub fn episode_id() -> film::EpisodeIdSelectionBuilder {
+        film::EpisodeIdSelectionBuilder::new(vec![])
     }
     pub fn opening_crawl() -> film::OpeningCrawlSelectionBuilder {
         film::OpeningCrawlSelectionBuilder::new(vec![])
@@ -757,8 +757,8 @@ impl Starship {
     pub fn hyperdrive_rating() -> starship::HyperdriveRatingSelectionBuilder {
         starship::HyperdriveRatingSelectionBuilder::new(vec![])
     }
-    pub fn mglt() -> starship::MgltselectionBuilder {
-        starship::MgltselectionBuilder::new(vec![])
+    pub fn mglt() -> starship::MgltSelectionBuilder {
+        starship::MgltSelectionBuilder::new(vec![])
     }
     pub fn cargo_capacity() -> starship::CargoCapacitySelectionBuilder {
         starship::CargoCapacitySelectionBuilder::new(vec![])
@@ -1031,12 +1031,12 @@ pub mod film {
             )
         }
     }
-    pub struct EpisodeIDSelectionBuilder {
+    pub struct EpisodeIdSelectionBuilder {
         args: Vec<::cynic::Argument>,
     }
-    impl EpisodeIDSelectionBuilder {
+    impl EpisodeIdSelectionBuilder {
         pub(super) fn new(args: Vec<::cynic::Argument>) -> Self {
-            EpisodeIDSelectionBuilder { args }
+            EpisodeIdSelectionBuilder { args }
         }
         pub fn select<'a, T: 'a + Send + Sync>(
             self,
@@ -7657,12 +7657,12 @@ pub mod starship {
             )
         }
     }
-    pub struct MgltselectionBuilder {
+    pub struct MgltSelectionBuilder {
         args: Vec<::cynic::Argument>,
     }
-    impl MgltselectionBuilder {
+    impl MgltSelectionBuilder {
         pub(super) fn new(args: Vec<::cynic::Argument>) -> Self {
-            MgltselectionBuilder { args }
+            MgltSelectionBuilder { args }
         }
         pub fn select<'a, T: 'a + Send + Sync>(
             self,

--- a/cynic-codegen/tests/snapshots/use_schema__schema_file_4.snap
+++ b/cynic-codegen/tests/snapshots/use_schema__schema_file_4.snap
@@ -7,11 +7,11 @@ expression: "format_code(format!(\"{}\", tokens))"
 pub struct Foo;
 #[allow(dead_code)]
 impl Foo {
-    pub fn __underscore() -> foo::SelectionBuilder {
-        foo::SelectionBuilder::new(vec![])
+    pub fn __underscore() -> foo::__underscoreSelectionBuilder {
+        foo::__underscoreSelectionBuilder::new(vec![])
     }
-    pub fn self_() -> foo::SelfSelectionBuilder {
-        foo::SelfSelectionBuilder::new(vec![])
+    pub fn self_() -> foo::Self_SelectionBuilder {
+        foo::Self_SelectionBuilder::new(vec![])
     }
     pub fn super_() -> foo::SuperSelectionBuilder {
         foo::SuperSelectionBuilder::new(vec![])
@@ -45,12 +45,12 @@ impl Bar {
 }
 #[allow(dead_code)]
 pub mod foo {
-    pub struct SelectionBuilder {
+    pub struct __underscoreSelectionBuilder {
         args: Vec<::cynic::Argument>,
     }
-    impl SelectionBuilder {
+    impl __underscoreSelectionBuilder {
         pub(super) fn new(args: Vec<::cynic::Argument>) -> Self {
-            SelectionBuilder { args }
+            __underscoreSelectionBuilder { args }
         }
         pub fn select<'a, T: 'a + Send + Sync>(
             self,
@@ -71,12 +71,12 @@ pub mod foo {
             )
         }
     }
-    pub struct SelfSelectionBuilder {
+    pub struct Self_SelectionBuilder {
         args: Vec<::cynic::Argument>,
     }
-    impl SelfSelectionBuilder {
+    impl Self_SelectionBuilder {
         pub(super) fn new(args: Vec<::cynic::Argument>) -> Self {
-            SelfSelectionBuilder { args }
+            Self_SelectionBuilder { args }
         }
         pub fn select<'a, T: 'a + Send + Sync>(
             self,


### PR DESCRIPTION
#### Why are we making this change?

I discovered another issue with inflector, where the to_pascal_case
transform converted `aString` to `Astring`.  This isn't right.

#### What effects does this change have?

It strips out inflector from cynic (not yet cynic-querygen) in favor of
implementing the tranform directly in cynic.  Hopefully this hasn't
broken other things, although it's surprisingly hard to get this right
so who knows.