### PR TITLE
[Merged by Bors] - Add a github schema crate, stop feature flagging the github example

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,57 +15,50 @@ env:
 
 jobs:
   build-rust:
-
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-    - uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: stable
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
 
-    - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v1
 
-    - name: Check formatting
-      uses: actions-rs/cargo@v1
-      with:
-        command: fmt
-        args: -- --check
+      - name: Check formatting
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check
 
-    - name: Build cynic
-      uses: actions-rs/cargo@v1
-      with:
-        command: build
+      - name: Build cynic
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --workspace
 
-    - name: Build tests
-      uses: actions-rs/cargo@v1
-      with:
-        command: test
-        args: --no-run --all-features
+      - name: Build tests
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --workspace --no-run --all-features
 
-    - name: Run tests
-      uses: actions-rs/cargo@v1
-      with:
-        command: test
-        args: --all-features
+      - name: Run tests
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --workspace --all-features
 
-    - name: Build example tests
-      uses: actions-rs/cargo@v1
-      with:
-        command: test
-        args: --no-run --examples
+      - name: Build example tests
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --workspace --no-run --examples
 
-    - name: Run example tests
-      uses: actions-rs/cargo@v1
-      with:
-        command: test
-        args: --examples
-
-    - name: Build GitHub example
-      uses: actions-rs/cargo@v1
-      with:
-        command: check
-        args: --example github --all-features
-
+      - name: Run example tests
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --workspace --examples

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -652,9 +652,9 @@ dependencies = [
  "chrono",
  "cynic",
  "cynic-codegen",
+ "github-schema",
  "insta",
  "reqwest",
- "serde_json",
  "surf",
  "tokio",
 ]
@@ -1042,6 +1042,14 @@ checksum = "97304e4cd182c3846f7575ced3890c53012ce534ad9114046b0a9e00bb30a375"
 dependencies = [
  "opaque-debug",
  "polyval",
+]
+
+[[package]]
+name = "github-schema"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "cynic",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,12 @@ members = [
     "cynic-querygen",
     "cynic-querygen-web",
     "tests/querygen-compile-run",
-    "tests/ui-tests"
+    "tests/ui-tests",
+    "schemas/github"
+]
+
+default-members = [
+    "cynic", "cynic-codegen", "cynic-proc-macros"
 ]
 
 [profile.dev]

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -6,13 +6,9 @@ edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
-[features]
-github = ["serde_json"]
-
 [dependencies]
 cynic = { path = "../cynic", features = ["surf", "reqwest-blocking"] }
 cynic-codegen = { path = "../cynic-codegen" }
-serde_json = { version = "1.0", optional = true }
 
 # Reqwest example requirements
 reqwest = { version = "0.11", features = ["json", "blocking"] }
@@ -22,7 +18,11 @@ tokio = { version = "1.15", features = ["macros"] }
 surf = "2.3"
 async-std = "1.10"
 
-chrono = { version = "0.4", features = ["serde"]}
+chrono = { version = "0.4", features = ["serde"] }
+
+# We pull the github schema from a separate crate so we don't
+# have to recompile it as often.
+github-schema = { path = "../schemas/github" }
 
 [dev-dependencies]
 insta = "1.9"

--- a/examples/examples/github-mutation.rs
+++ b/examples/examples/github-mutation.rs
@@ -1,23 +1,21 @@
 //! A mutation example using the GitHub API
 //!
-//! Note that a lot of this example is feature flagged: this is because rust-analyzer
-//! wants to build it as part of the cynic package when I'm working on cynic.  It
-//! builds quite slow because of the size of the GitHub API (the schema output is
-//! around 100k lines of rust), and it's too much for normal development.
+//! Note that this example pulls a schema from the `github_schema` crate.
+//! This is because the github schema is massive and compiling the output
+//! of `use_schema` is quite slow.  Moving this into a separate crate
+//! means we won't have to recompile it every time this file changes
+//! and we'll only need to do so once per full build of cynic.
 //!
-//! If you want to use this example be sure to remove all the feature flagging.
+//! You may want to do similar if you're also working with cynic & the
+//! github API.
 //!
-//! This example also requires the `reqwest-blocking` feature to be active.
+//! This example requires the `reqwest-blocking` feature to be active.
 
 fn main() {
-    #[cfg(feature = "github")]
-    {
-        let result = run_query();
-        println!("{:?}", result);
-    }
+    let result = run_query();
+    println!("{:?}", result);
 }
 
-#[cfg(feature = "github")]
 fn run_query() -> cynic::GraphQlResponse<queries::CommentOnMutationSupportIssue> {
     use cynic::http::ReqwestBlockingExt;
 
@@ -33,7 +31,6 @@ fn run_query() -> cynic::GraphQlResponse<queries::CommentOnMutationSupportIssue>
         .unwrap()
 }
 
-#[cfg(feature = "github")]
 fn build_query() -> cynic::Operation<
     queries::CommentOnMutationSupportIssue,
     queries::CommentOnMutationSupportIssueArguments,
@@ -46,12 +43,11 @@ fn build_query() -> cynic::Operation<
     })
 }
 
-#[cfg(feature = "github")]
 #[cynic::schema_for_derives(file = "../schemas/github.graphql", module = "schema")]
 mod queries {
-    use super::schema;
+    use github_schema as schema;
 
-    #[derive(cynic::FragmentArguments, Debug)]
+    #[derive(cynic::QueryVariables, Debug)]
     pub struct CommentOnMutationSupportIssueArguments {
         pub comment_body: String,
     }
@@ -94,12 +90,7 @@ mod queries {
     }
 }
 
-#[cfg(feature = "github")]
-mod schema {
-    cynic::use_schema!("../schemas/github.graphql");
-}
-
-#[cfg(all(test, feature = "github"))]
+#[cfg(test)]
 mod test {
     use super::*;
 
@@ -115,6 +106,7 @@ mod test {
     }
 
     #[test]
+    #[ignore]
     fn test_running_query() {
         let result = run_query();
         if result.errors.is_some() {

--- a/examples/examples/snapshots/github__test__snapshot_test_query.snap
+++ b/examples/examples/snapshots/github__test__snapshot_test_query.snap
@@ -1,10 +1,12 @@
 ---
 source: examples/examples/github.rs
+assertion_line: 121
 expression: query.query
+
 ---
-query Query($_0: String!, $_1: String!, $_2: Int, $_3: IssueOrder) {
-  repository(name: $_0, owner: $_1) {
-    pullRequests(first: $_2, orderBy: $_3) {
+query($prOrder: IssueOrder!) {
+  repository(name: "cynic", owner: "obmarg") {
+    pullRequests(orderBy: $prOrder, first: 10) {
       nodes {
         title
         createdAt
@@ -12,4 +14,5 @@ query Query($_0: String!, $_1: String!, $_2: Int, $_3: IssueOrder) {
     }
   }
 }
+
 

--- a/examples/examples/snapshots/github_mutation__test__snapshot_test_query.snap
+++ b/examples/examples/snapshots/github_mutation__test__snapshot_test_query.snap
@@ -1,9 +1,11 @@
 ---
 source: examples/examples/github-mutation.rs
+assertion_line: 105
 expression: query.query
+
 ---
-mutation Mutation($_0: AddCommentInput!) {
-  addComment(input: $_0) {
+mutation($commentBody: String!) {
+  addComment(input: {body: $commentBody, subjectId: "MDU6SXNzdWU2ODU4NzUxMzQ=", clientMutationId: null, }) {
     commentEdge {
       node {
         id
@@ -11,4 +13,5 @@ mutation Mutation($_0: AddCommentInput!) {
     }
   }
 }
+
 

--- a/schemas/github/Cargo.toml
+++ b/schemas/github/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "github-schema"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+chrono = { version = "0.4", features = ["serde"] }
+cynic = { path = "../../cynic", version = "2.0.0-dev" }

--- a/schemas/github/README.md
+++ b/schemas/github/README.md
@@ -1,0 +1,9 @@
+### GitHub Schema
+
+This crate contains type definitions for using cynic with the GitHub schema.
+
+It's in a separate crate because the GitHub schema is quite large and defining
+it in it's own crate means we don't have to recompile it as often.  
+
+It also acts as a nice test of whether we can define schemas in separate crates
+from queries.

--- a/schemas/github/src/lib.rs
+++ b/schemas/github/src/lib.rs
@@ -1,0 +1,3 @@
+cynic::use_schema!("../github.graphql");
+
+cynic::impl_scalar!(chrono::DateTime<chrono::Utc>, DateTime);


### PR DESCRIPTION
#### Why are we making this change?

The GitHub example is currently feature flagged as working on cynic used to be
unbearable when it wasn't, as it output so much code and RA struggled to work
with it.  Things have moved on a bit now: cynic is generating less code, and
perhaps RA has also improved.

#### What effects does this change have?

Gets rid of the feature flag in the github examples, and creates a new github
schema crate so we can share a bit of code between the two examples.  I think
this might also be a good idea generally for consumers that want to work with
the GitHub API (although I'm not 100% certain).

This also acts as a good test for #373 (which seems to have been fixed by #391) 
and will ensure we don't regress it in the future.