### PR TITLE
[Merged by Bors] - Fix all the warnings in the examples

### DIFF
--- a/examples/examples/chrono-scalars.rs
+++ b/examples/examples/chrono-scalars.rs
@@ -28,7 +28,9 @@ struct JobsQuery {
 
 fn main() {
     let result = run_query();
-    println!("{:?}", result);
+    for job in result.data.unwrap().jobs {
+        println!("{}", job.created_at);
+    }
 }
 
 fn run_query() -> cynic::GraphQlResponse<JobsQuery> {

--- a/examples/examples/manual-reqwest.rs
+++ b/examples/examples/manual-reqwest.rs
@@ -15,7 +15,7 @@ struct Film {
     director: Option<String>,
 }
 
-#[derive(cynic::FragmentArguments)]
+#[derive(cynic::QueryVariables)]
 struct FilmArguments {
     id: Option<cynic::Id>,
 }
@@ -32,8 +32,14 @@ struct FilmDirectorQuery {
 }
 
 fn main() {
-    let result = run_query();
-    println!("{:?}", result);
+    match run_query().data {
+        Some(FilmDirectorQuery { film: Some(film) }) => {
+            println!("{:?} was directed by {:?}", film.title, film.director)
+        }
+        _ => {
+            println!("No film found");
+        }
+    }
 }
 
 fn run_query() -> cynic::GraphQlResponse<FilmDirectorQuery> {
@@ -44,8 +50,6 @@ fn run_query() -> cynic::GraphQlResponse<FilmDirectorQuery> {
         .json(&query)
         .send()
         .unwrap();
-
-    println!("{:?}", response);
 
     response.json().unwrap()
 }

--- a/examples/examples/querying-interfaces.rs
+++ b/examples/examples/querying-interfaces.rs
@@ -24,7 +24,6 @@ enum Node {
 )]
 struct Film {
     title: Option<String>,
-    director: Option<String>,
 }
 
 #[derive(cynic::QueryFragment, Debug)]
@@ -45,7 +44,7 @@ struct OtherNode {
     id: cynic::Id,
 }
 
-#[derive(cynic::FragmentArguments)]
+#[derive(cynic::QueryVariables)]
 struct Arguments {
     id: cynic::Id,
 }
@@ -56,17 +55,35 @@ struct Arguments {
     graphql_type = "Root",
     argument_struct = "Arguments"
 )]
-struct FilmDirectorQuery {
+struct Query {
     #[arguments(id: $id)]
     node: Option<Node>,
 }
 
 fn main() {
-    let result = run_query("ZmlsbXM6MQ==".into());
-    println!("{:?}", result);
+    match run_query("ZmlsbXM6MQ==".into()).data {
+        Some(Query {
+            node: Some(Node::Planet(planet)),
+        }) => {
+            println!("Found a planet: {:?}", planet.name);
+        }
+        Some(Query {
+            node: Some(Node::Film(film)),
+        }) => {
+            println!("Found a film: {:?}", film.title);
+        }
+        Some(Query {
+            node: Some(Node::Other(node)),
+        }) => {
+            println!("Found something else with the ID {:?}", node.id);
+        }
+        _ => {
+            println!("No node found");
+        }
+    }
 }
 
-fn run_query(id: cynic::Id) -> cynic::GraphQlResponse<FilmDirectorQuery> {
+fn run_query(id: cynic::Id) -> cynic::GraphQlResponse<Query> {
     use cynic::http::ReqwestBlockingExt;
 
     let query = build_query(id);
@@ -77,10 +94,10 @@ fn run_query(id: cynic::Id) -> cynic::GraphQlResponse<FilmDirectorQuery> {
         .unwrap()
 }
 
-fn build_query(id: cynic::Id) -> cynic::Operation<FilmDirectorQuery, Arguments> {
+fn build_query(id: cynic::Id) -> cynic::Operation<Query, Arguments> {
     use cynic::QueryBuilder;
 
-    FilmDirectorQuery::build(Arguments { id })
+    Query::build(Arguments { id })
 }
 
 #[cfg(test)]

--- a/examples/examples/reqwest-async.rs
+++ b/examples/examples/reqwest-async.rs
@@ -35,8 +35,14 @@ struct FilmDirectorQuery {
 
 #[tokio::main]
 async fn main() {
-    let result = run_query().await;
-    println!("{:?}", result);
+    match run_query().await.data {
+        Some(FilmDirectorQuery { film: Some(film) }) => {
+            println!("{:?} was directed by {:?}", film.title, film.director)
+        }
+        _ => {
+            println!("No film found");
+        }
+    }
 }
 
 async fn run_query() -> cynic::GraphQlResponse<FilmDirectorQuery> {

--- a/examples/examples/snapshots/querying_interfaces__test__running_query_with_film.snap
+++ b/examples/examples/snapshots/querying_interfaces__test__running_query_with_film.snap
@@ -1,17 +1,16 @@
 ---
 source: examples/examples/querying-interfaces.rs
+assertion_line: 124
 expression: result.data
+
 ---
 Some(
-    FilmDirectorQuery {
+    Query {
         node: Some(
             Film(
                 Film {
                     title: Some(
                         "A New Hope",
-                    ),
-                    director: Some(
-                        "George Lucas",
                     ),
                 },
             ),

--- a/examples/examples/snapshots/querying_interfaces__test__running_query_with_planet.snap
+++ b/examples/examples/snapshots/querying_interfaces__test__running_query_with_planet.snap
@@ -1,9 +1,11 @@
 ---
 source: examples/examples/querying-interfaces.rs
+assertion_line: 133
 expression: result.data
+
 ---
 Some(
-    FilmDirectorQuery {
+    Query {
         node: Some(
             Planet(
                 Planet {

--- a/examples/examples/snapshots/querying_interfaces__test__running_query_with_starship.snap
+++ b/examples/examples/snapshots/querying_interfaces__test__running_query_with_starship.snap
@@ -1,9 +1,11 @@
 ---
 source: examples/examples/querying-interfaces.rs
+assertion_line: 142
 expression: result.data
+
 ---
 Some(
-    FilmDirectorQuery {
+    Query {
         node: Some(
             Other(
                 OtherNode {

--- a/examples/examples/snapshots/querying_interfaces__test__snapshot_test_query.snap
+++ b/examples/examples/snapshots/querying_interfaces__test__snapshot_test_query.snap
@@ -1,6 +1,6 @@
 ---
 source: examples/examples/querying-interfaces.rs
-assertion_line: 98
+assertion_line: 115
 expression: query.query
 
 ---
@@ -9,7 +9,6 @@ query($id: ID!) {
     __typename
     ... on Film {
       title
-      director
     }
     ... on Planet {
       name

--- a/examples/examples/spread.rs
+++ b/examples/examples/spread.rs
@@ -42,8 +42,17 @@ struct FilmDirectorQuery {
 }
 
 fn main() {
-    let result = run_query();
-    println!("{:?}", result);
+    match run_query().data {
+        Some(FilmDirectorQuery { film: Some(film) }) => {
+            println!(
+                "{:?} was directed by {:?}",
+                film.details.title, film.details.director
+            )
+        }
+        _ => {
+            println!("No film found");
+        }
+    }
 }
 
 fn run_query() -> cynic::GraphQlResponse<FilmDirectorQuery> {

--- a/examples/examples/starwars.rs
+++ b/examples/examples/starwars.rs
@@ -14,7 +14,7 @@ struct Film {
     director: Option<String>,
 }
 
-#[derive(cynic::FragmentArguments)]
+#[derive(cynic::QueryVariables)]
 struct FilmArguments {
     id: Option<cynic::Id>,
 }
@@ -31,8 +31,14 @@ struct FilmDirectorQuery {
 }
 
 fn main() {
-    let result = run_query();
-    println!("{:?}", result);
+    match run_query().data {
+        Some(FilmDirectorQuery { film: Some(film) }) => {
+            println!("{:?} was directed by {:?}", film.title, film.director)
+        }
+        _ => {
+            println!("No film found");
+        }
+    }
 }
 
 fn run_query() -> cynic::GraphQlResponse<FilmDirectorQuery> {

--- a/examples/examples/surf-client.rs
+++ b/examples/examples/surf-client.rs
@@ -35,8 +35,14 @@ struct FilmDirectorQuery {
 
 fn main() {
     async_std::task::block_on(async {
-        let result = run_query().await;
-        println!("{:?}", result);
+        match run_query().await.data {
+            Some(FilmDirectorQuery { film: Some(film) }) => {
+                println!("{:?} was directed by {:?}", film.title, film.director)
+            }
+            _ => {
+                println!("No film found");
+            }
+        }
     })
 }
 


### PR DESCRIPTION
A lot of warnings appeared in the examples at some point.  Not sure what
changed, maybe a new version of rust? Either way, this commit fixes them all.

Fixes #399 