### PR TITLE
[Merged by Bors] - Don't print query on mutations & subscriptions

### DIFF
--- a/cynic/src/operation.rs
+++ b/cynic/src/operation.rs
@@ -81,7 +81,7 @@ where
         let vars = VariableDefinitions::new::<Variables>();
 
         let mut query = String::new();
-        writeln!(&mut query, "query{vars}{selection_set}").expect("Couldn't stringify query");
+        writeln!(&mut query, "mutation{vars}{selection_set}").expect("Couldn't stringify query");
 
         Operation {
             query,
@@ -117,7 +117,8 @@ where
         let vars = VariableDefinitions::new::<Variables>();
 
         let mut query = String::new();
-        writeln!(&mut query, "query{vars}{selection_set}").expect("Couldn't stringify query");
+        writeln!(&mut query, "subscription{vars}{selection_set}")
+            .expect("Couldn't stringify query");
 
         StreamingOperation {
             inner: Operation {


### PR DESCRIPTION
#391 made a mistake and put `query` before subscription & mutation operations.

This fixes that.