### PR TITLE
[Merged by Bors] - Deprecate argument_struct attribute in favour of variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 ### Deprecations
 
 - The `FragmentArguments` trait & derive has been renamed to `QueryVariables`
+- The `argument_struct` attribute for `QueryFragment` and `InlineFragments` has
+  been deprecated in favour of `variables`
 
 ### Bug Fixes
 

--- a/cynic-book/src/derives/query-arguments.md
+++ b/cynic-book/src/derives/query-arguments.md
@@ -1,11 +1,11 @@
 # Query Arguments
 
 A hierarchy of QueryFragments can take a struct of arguments. This struct must
-implement `FragmentArguments` which can be derived:
+implement `QueryVariables` which can be derived:
 
 ```rust
-#[derive(cynic::FragmentArguments)]
-struct FilmArguments {
+#[derive(cynic::QueryVariables)]
+struct FilmVariables {
     id: Option<cynic::Id>,
 }
 ```
@@ -14,11 +14,11 @@ This derive can be used on any struct containing any fields - the fields do not
 need to be specifically related to GraphQL or used in a query, though if you
 don't use them at all you should get dead code warnings from Rust.
 
-### Using FragmentArguments
+### Using QueryVariables
 
 To use any fields of this struct as an argument to a QueryFragment, the struct
-must provide an `argument_struct` parameter that points to the `FilmArguments`
-struct. This allows arguments to be passed in using the `arguments`
+must provide a `variables` parameter that points to the `FilmArguments`
+struct. This allows variables to be passed in using the `arguments`
 attribute on the fields where you wish to pass them.
 
 ```rust
@@ -26,22 +26,22 @@ attribute on the fields where you wish to pass them.
 #[cynic(
     schema_path = "examples/starwars.schema.graphql",
     graphql_type = "Root",
-    argument_struct = "FilmArguments"
+    variables = "FilmVariables"
 )]
 struct FilmQuery {
-    #[arguments(id = &args.id)]
+    #[arguments(id: $id)]
     film: Option<Film>,
 }
 ```
 
-This example uses our `FilmArguments` at the root of the query to specify which
+This example uses our `FilmVariables` at the root of the query to specify which
 film we want to fetch.
 
-It's also possible to pass arguments down to lower levels of the query using
+It's also possible to pass variables down to lower levels of the query using
 the same technique. Though it's worth noting that all the QueryFragments from
 the Root to the point that requires arguments must define the same
-`argument_struct` in their cynic attribute. If no nested QueryFragments
-require any arguments then it's OK to omit `argument_struct`.
+`variables` in their cynic attribute. If no nested QueryFragments
+require any variables then it's OK to omit `variables`.
 
 ### InputType
 

--- a/cynic-codegen/src/fragment_derive/arguments/mod.rs
+++ b/cynic-codegen/src/fragment_derive/arguments/mod.rs
@@ -15,10 +15,10 @@ pub fn process_arguments<'a>(
     literals: Vec<parsing::FieldArgument>,
     field: &crate::schema::types::Field<'a>,
     schema_module: syn::Path,
-    argument_struct: Option<&syn::Ident>,
+    variables: Option<&syn::Path>,
     span: Span,
 ) -> Result<Output<'a>, Errors> {
-    let analysed = analyse::analyse(literals, field, argument_struct, span)?;
+    let analysed = analyse::analyse(literals, field, variables, span)?;
 
     Ok(Output {
         analysed,

--- a/cynic-codegen/src/fragment_derive/arguments/output.rs
+++ b/cynic-codegen/src/fragment_derive/arguments/output.rs
@@ -107,10 +107,10 @@ impl ToTokens for ArgumentValueTokens<'_> {
             }),
             ArgumentValue::Variable(var) => {
                 let var_ident = &var.ident;
-                let argument_struct = &var.argument_struct;
+                let variables = &var.variable_struct;
 
                 tokens.append_all(quote! {
-                    .variable(<#argument_struct as ::cynic::QueryVariables>::Fields::#var_ident())
+                    .variable(<#variables as ::cynic::QueryVariables>::Fields::#var_ident())
                 });
             }
             ArgumentValue::Some(inner) => {

--- a/cynic-codegen/src/fragment_derive/arguments/snapshots/cynic_codegen__fragment_derive__arguments__tests__analyse_errors_without_argument_struct.snap
+++ b/cynic-codegen/src/fragment_derive/arguments/snapshots/cynic_codegen__fragment_derive__arguments__tests__analyse_errors_without_argument_struct.snap
@@ -1,6 +1,6 @@
 ---
 source: cynic-codegen/src/fragment_derive/arguments/tests.rs
-assertion_line: 54
+assertion_line: 52
 expression: "analyse(literals, field, None, Span::call_site()).map(|o| o.arguments)"
 
 ---
@@ -8,10 +8,10 @@ Err(
     Errors {
         errors: [
             Error(
-                "You've provided a variable here, but this QueryFragment does not have an argument_struct.  Please add an argument_struct attribute to the struct.",
+                "You've provided a variable here, but this QueryFragment does not take any variables.  Please add the variables attribute to the struct.",
             ),
             Error(
-                "You've provided a variable here, but this QueryFragment does not have an argument_struct.  Please add an argument_struct attribute to the struct.",
+                "You've provided a variable here, but this QueryFragment does not take any variables.  Please add the variables attribute to the struct.",
             ),
         ],
     },

--- a/cynic-codegen/src/fragment_derive/arguments/snapshots/cynic_codegen__fragment_derive__arguments__tests__case_07_variable_in_object.snap
+++ b/cynic-codegen/src/fragment_derive/arguments/snapshots/cynic_codegen__fragment_derive__arguments__tests__case_07_variable_in_object.snap
@@ -1,7 +1,7 @@
 ---
 source: cynic-codegen/src/fragment_derive/arguments/tests.rs
 assertion_line: 32
-expression: "analyse(literals, field, Some(&format_ident!(\"MyArguments\")),\n        Span::call_site()).map(|o| o.arguments)"
+expression: "analyse(literals, field, Some(&format_ident!(\"MyArguments\").into()),\n        Span::call_site()).map(|o| o.arguments)"
 
 ---
 Ok(
@@ -71,9 +71,17 @@ Ok(
                                             "BookState",
                                         ),
                                     ),
-                                    argument_struct: Ident(
-                                        MyArguments,
-                                    ),
+                                    variable_struct: Path {
+                                        leading_colon: None,
+                                        segments: [
+                                            PathSegment {
+                                                ident: Ident(
+                                                    MyArguments,
+                                                ),
+                                                arguments: None,
+                                            },
+                                        ],
+                                    },
                                 },
                             ),
                         },

--- a/cynic-codegen/src/fragment_derive/arguments/snapshots/cynic_codegen__fragment_derive__arguments__tests__case_08_top_level_variable.snap
+++ b/cynic-codegen/src/fragment_derive/arguments/snapshots/cynic_codegen__fragment_derive__arguments__tests__case_08_top_level_variable.snap
@@ -1,7 +1,7 @@
 ---
 source: cynic-codegen/src/fragment_derive/arguments/tests.rs
 assertion_line: 32
-expression: "analyse(literals, field, Some(&format_ident!(\"MyArguments\")),\n        Span::call_site()).map(|o| o.arguments)"
+expression: "analyse(literals, field, Some(&format_ident!(\"MyArguments\").into()),\n        Span::call_site()).map(|o| o.arguments)"
 
 ---
 Ok(
@@ -24,9 +24,17 @@ Ok(
                     value_type: NamedInputType(
                         "BookFilters",
                     ),
-                    argument_struct: Ident(
-                        MyArguments,
-                    ),
+                    variable_struct: Path {
+                        leading_colon: None,
+                        segments: [
+                            PathSegment {
+                                ident: Ident(
+                                    MyArguments,
+                                ),
+                                arguments: None,
+                            },
+                        ],
+                    },
                 },
             ),
         },

--- a/cynic-codegen/src/fragment_derive/arguments/snapshots/cynic_codegen__fragment_derive__arguments__tests__case_09_top_level_variable.snap
+++ b/cynic-codegen/src/fragment_derive/arguments/snapshots/cynic_codegen__fragment_derive__arguments__tests__case_09_top_level_variable.snap
@@ -1,7 +1,7 @@
 ---
 source: cynic-codegen/src/fragment_derive/arguments/tests.rs
 assertion_line: 32
-expression: "analyse(literals, field, Some(&format_ident!(\"MyArguments\")),\n        Span::call_site()).map(|o| o.arguments)"
+expression: "analyse(literals, field, Some(&format_ident!(\"MyArguments\").into()),\n        Span::call_site()).map(|o| o.arguments)"
 
 ---
 Ok(
@@ -24,9 +24,17 @@ Ok(
                     value_type: NamedInputType(
                         "BookFilters",
                     ),
-                    argument_struct: Ident(
-                        MyArguments,
-                    ),
+                    variable_struct: Path {
+                        leading_colon: None,
+                        segments: [
+                            PathSegment {
+                                ident: Ident(
+                                    MyArguments,
+                                ),
+                                arguments: None,
+                            },
+                        ],
+                    },
                 },
             ),
         },
@@ -52,9 +60,17 @@ Ok(
                             "BookFilters",
                         ),
                     ),
-                    argument_struct: Ident(
-                        MyArguments,
-                    ),
+                    variable_struct: Path {
+                        leading_colon: None,
+                        segments: [
+                            PathSegment {
+                                ident: Ident(
+                                    MyArguments,
+                                ),
+                                arguments: None,
+                            },
+                        ],
+                    },
                 },
             ),
         },

--- a/cynic-codegen/src/fragment_derive/arguments/tests.rs
+++ b/cynic-codegen/src/fragment_derive/arguments/tests.rs
@@ -32,7 +32,7 @@ fn test_analyse(#[case] field: &str, #[case] literals: CynicArguments) {
     insta::assert_debug_snapshot!(analyse(
         literals,
         field,
-        Some(&format_ident!("MyArguments")),
+        Some(&format_ident!("MyArguments").into()),
         Span::call_site()
     )
     .map(|o| o.arguments))

--- a/cynic-codegen/src/fragment_derive/mod.rs
+++ b/cynic-codegen/src/fragment_derive/mod.rs
@@ -57,6 +57,8 @@ pub fn fragment_derive_impl(
 
     let graphql_name = &(input.graphql_type_name());
     let schema_module = input.schema_module();
+    let variables = input.variables();
+    let deprecations = input.deprecations();
     let ident = input.ident;
     if let darling::ast::Data::Struct(fields) = input.data {
         let fields = pair_fields(fields.iter(), &schema_type)?;
@@ -67,7 +69,7 @@ pub fn fragment_derive_impl(
             &schema_type,
             &schema_module,
             graphql_name,
-            input.argument_struct.as_ref(),
+            variables.as_ref(),
         )?;
 
         let deserialize_impl = DeserializeImpl::new(&fields, &ident);
@@ -75,6 +77,7 @@ pub fn fragment_derive_impl(
         Ok(quote::quote! {
             #fragment_impl
             #deserialize_impl
+            #deprecations
         })
     } else {
         Err(syn::Error::new(

--- a/cynic-codegen/src/fragment_derive/tests.rs
+++ b/cynic-codegen/src/fragment_derive/tests.rs
@@ -47,7 +47,7 @@ use super::fragment_derive;
             schema_path = "../cynic/tests/test-schema.graphql",
             schema_module = "schema",
             graphql_type = "Query",
-            argument_struct = "AnArgumentStruct"
+            variables = "AnArgumentStruct"
         )]
         struct MyQuery {
             #[arguments(filters: $filters)]

--- a/cynic-querygen/src/lib.rs
+++ b/cynic-querygen/src/lib.rs
@@ -127,8 +127,8 @@ pub fn document_to_fragment_structs(
 
     writeln!(mod_output, "use super::{};\n", options.query_module).unwrap();
 
-    for argument_struct in parsed_output.argument_structs {
-        writeln!(mod_output, "{}", argument_struct).unwrap();
+    for variables in parsed_output.variables_structs {
+        writeln!(mod_output, "{}", variables).unwrap();
     }
 
     for fragment in parsed_output.query_fragments {

--- a/cynic-querygen/src/output/inline_fragments.rs
+++ b/cynic-querygen/src/output/inline_fragments.rs
@@ -7,7 +7,7 @@ pub struct InlineFragments {
     // TODO: Should this be a string?
     pub inner_type_names: Vec<String>,
     pub target_type: String,
-    pub argument_struct_name: Option<String>,
+    pub variable_struct_name: Option<String>,
 
     pub name: String,
 }
@@ -15,17 +15,17 @@ pub struct InlineFragments {
 impl std::fmt::Display for InlineFragments {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
         writeln!(f, "#[derive(cynic::InlineFragments, Debug)]")?;
-        if self.target_type != self.name || self.argument_struct_name.is_some() {
+        if self.target_type != self.name || self.variable_struct_name.is_some() {
             write!(f, "#[cynic(")?;
             if self.target_type != self.name {
                 write!(f, "graphql_type = \"{}\"", self.target_type)?;
             }
 
-            if let Some(name) = &self.argument_struct_name {
+            if let Some(name) = &self.variable_struct_name {
                 if self.target_type != self.name {
                     write!(f, ", ")?;
                 }
-                write!(f, "argument_struct = \"{}\"", name)?;
+                write!(f, "variables = \"{}\"", name)?;
             }
             writeln!(f, ")]",)?;
         }

--- a/cynic-querygen/src/output/mod.rs
+++ b/cynic-querygen/src/output/mod.rs
@@ -2,19 +2,19 @@ use crate::casings::CasingExt;
 
 use crate::schema::EnumDetails;
 
-mod argument_struct;
 mod enums;
 mod field;
 mod indent;
 mod inline_fragments;
 mod input_object;
 pub mod query_fragment;
+mod variables_struct;
 
-pub use argument_struct::{ArgumentStruct, ArgumentStructField};
 pub use indent::indented;
 pub use inline_fragments::InlineFragments;
 pub use input_object::InputObject;
 pub use query_fragment::QueryFragment;
+pub use variables_struct::{VariablesStruct, VariablesStructField};
 
 use field::Field;
 
@@ -24,7 +24,7 @@ pub struct Output<'query, 'schema> {
     pub input_objects: Vec<InputObject<'schema>>,
     pub enums: Vec<EnumDetails<'schema>>,
     pub scalars: Vec<Scalar<'schema>>,
-    pub argument_structs: Vec<ArgumentStruct<'query, 'schema>>,
+    pub variables_structs: Vec<VariablesStruct<'query, 'schema>>,
 }
 
 pub struct Scalar<'schema>(pub &'schema str);

--- a/cynic-querygen/src/output/query_fragment.rs
+++ b/cynic-querygen/src/output/query_fragment.rs
@@ -9,7 +9,7 @@ use crate::{query_parsing::TypedValue, schema::OutputFieldType, Error};
 pub struct QueryFragment<'query, 'schema> {
     pub fields: Vec<OutputField<'query, 'schema>>,
     pub target_type: String,
-    pub argument_struct_name: Option<String>,
+    pub variable_struct_name: Option<String>,
 
     pub name: String,
 }
@@ -18,17 +18,17 @@ impl std::fmt::Display for QueryFragment<'_, '_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         writeln!(f, "#[derive(cynic::QueryFragment, Debug)]")?;
 
-        if self.target_type != self.name || self.argument_struct_name.is_some() {
+        if self.target_type != self.name || self.variable_struct_name.is_some() {
             write!(f, "#[cynic(")?;
             if self.target_type != self.name {
                 write!(f, "graphql_type = \"{}\"", self.target_type)?;
             }
 
-            if let Some(name) = &self.argument_struct_name {
+            if let Some(name) = &self.variable_struct_name {
                 if self.target_type != self.name {
                     write!(f, ", ")?;
                 }
-                write!(f, "argument_struct = \"{}\"", name)?;
+                write!(f, "variables = \"{}\"", name)?;
             }
             writeln!(f, ")]",)?;
         }

--- a/cynic-querygen/src/output/variables_struct.rs
+++ b/cynic-querygen/src/output/variables_struct.rs
@@ -3,40 +3,40 @@ use crate::casings::CasingExt;
 use crate::query_parsing::Variable;
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct ArgumentStruct<'query, 'schema> {
+pub struct VariablesStruct<'query, 'schema> {
     name: String,
-    fields: Vec<ArgumentStructField<'query, 'schema>>,
+    fields: Vec<VariablesStructField<'query, 'schema>>,
 }
 
-impl<'query, 'schema> ArgumentStruct<'query, 'schema> {
-    pub fn new(name: String, fields: Vec<ArgumentStructField<'query, 'schema>>) -> Self {
-        ArgumentStruct { name, fields }
+impl<'query, 'schema> VariablesStruct<'query, 'schema> {
+    pub fn new(name: String, fields: Vec<VariablesStructField<'query, 'schema>>) -> Self {
+        VariablesStruct { name, fields }
     }
 }
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub enum ArgumentStructField<'query, 'schema> {
+pub enum VariablesStructField<'query, 'schema> {
     Variable(Variable<'query, 'schema>),
     NestedStruct(String),
 }
 
-impl<'query, 'schema> ArgumentStructField<'query, 'schema> {
+impl<'query, 'schema> VariablesStructField<'query, 'schema> {
     fn name(&self) -> String {
         match self {
-            ArgumentStructField::Variable(var) => var.name.to_snake_case(),
-            ArgumentStructField::NestedStruct(type_name) => type_name.to_snake_case(),
+            VariablesStructField::Variable(var) => var.name.to_snake_case(),
+            VariablesStructField::NestedStruct(type_name) => type_name.to_snake_case(),
         }
     }
 
     fn type_spec(&self) -> String {
         match self {
-            ArgumentStructField::Variable(var) => var.value_type.type_spec().to_string(),
-            ArgumentStructField::NestedStruct(type_name) => type_name.clone(),
+            VariablesStructField::Variable(var) => var.value_type.type_spec().to_string(),
+            VariablesStructField::NestedStruct(type_name) => type_name.clone(),
         }
     }
 }
 
-impl std::fmt::Display for ArgumentStruct<'_, '_> {
+impl std::fmt::Display for VariablesStruct<'_, '_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         use super::indented;
         use std::fmt::Write;
@@ -51,7 +51,7 @@ impl std::fmt::Display for ArgumentStruct<'_, '_> {
     }
 }
 
-impl std::fmt::Display for ArgumentStructField<'_, '_> {
+impl std::fmt::Display for VariablesStructField<'_, '_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", super::Field::new(&self.name(), &self.type_spec()))
     }

--- a/cynic-querygen/tests/snapshots/github_tests__add_comment_mutation.snap
+++ b/cynic-querygen/tests/snapshots/github_tests__add_comment_mutation.snap
@@ -12,12 +12,12 @@ mod queries {
     use super::schema;
 
     #[derive(cynic::QueryVariables, Debug)]
-    pub struct CommentOnMutationSupportIssueArguments {
+    pub struct CommentOnMutationSupportIssueVariables {
         pub comment_body: String,
     }
 
     #[derive(cynic::QueryFragment, Debug)]
-    #[cynic(graphql_type = "Mutation", argument_struct = "CommentOnMutationSupportIssueArguments")]
+    #[cynic(graphql_type = "Mutation", variables = "CommentOnMutationSupportIssueVariables")]
     pub struct CommentOnMutationSupportIssue {
         #[arguments(input: { body: $comment_body, subjectId: "MDU6SXNzdWU2ODU4NzUxMzQ=" })]
         pub add_comment: Option<AddCommentPayload>,

--- a/cynic-querygen/tests/snapshots/github_tests__inline_fragment_with_arguments.snap
+++ b/cynic-querygen/tests/snapshots/github_tests__inline_fragment_with_arguments.snap
@@ -12,26 +12,26 @@ mod queries {
     use super::schema;
 
     #[derive(cynic::QueryVariables, Debug)]
-    pub struct IssueOrPRArguments {
+    pub struct IssueOrPRVariables {
         pub assignee_count: i32,
     }
 
     #[derive(cynic::QueryFragment, Debug)]
-    #[cynic(graphql_type = "Query", argument_struct = "IssueOrPRArguments")]
+    #[cynic(graphql_type = "Query", variables = "IssueOrPRVariables")]
     pub struct IssueOrPR {
         #[arguments(owner: "obmarg", name: "cynic")]
         pub repository: Option<Repository>,
     }
 
     #[derive(cynic::QueryFragment, Debug)]
-    #[cynic(argument_struct = "IssueOrPRArguments")]
+    #[cynic(variables = "IssueOrPRVariables")]
     pub struct Repository {
         #[arguments(number: 1)]
         pub issue_or_pull_request: Option<IssueOrPullRequest>,
     }
 
     #[derive(cynic::QueryFragment, Debug)]
-    #[cynic(argument_struct = "IssueOrPRArguments")]
+    #[cynic(variables = "IssueOrPRVariables")]
     pub struct PullRequest {
         pub id: cynic::Id,
         pub title: String,
@@ -40,7 +40,7 @@ mod queries {
     }
 
     #[derive(cynic::QueryFragment, Debug)]
-    #[cynic(argument_struct = "IssueOrPRArguments")]
+    #[cynic(variables = "IssueOrPRVariables")]
     pub struct Issue {
         pub id: cynic::Id,
         pub title: String,
@@ -54,7 +54,7 @@ mod queries {
     }
 
     #[derive(cynic::InlineFragments, Debug)]
-    #[cynic(argument_struct = "IssueOrPRArguments")]
+    #[cynic(variables = "IssueOrPRVariables")]
     pub enum IssueOrPullRequest {
         Issue(Issue),
         PullRequest(PullRequest),

--- a/cynic-querygen/tests/snapshots/github_tests__input_object_arguments.snap
+++ b/cynic-querygen/tests/snapshots/github_tests__input_object_arguments.snap
@@ -12,19 +12,19 @@ mod queries {
     use super::schema;
 
     #[derive(cynic::QueryVariables, Debug)]
-    pub struct PullRequestTitlesArguments {
+    pub struct PullRequestTitlesVariables {
         pub pr_order: IssueOrder,
     }
 
     #[derive(cynic::QueryFragment, Debug)]
-    #[cynic(graphql_type = "Query", argument_struct = "PullRequestTitlesArguments")]
+    #[cynic(graphql_type = "Query", variables = "PullRequestTitlesVariables")]
     pub struct PullRequestTitles {
         #[arguments(name: "cynic", owner: "obmarg")]
         pub repository: Option<Repository>,
     }
 
     #[derive(cynic::QueryFragment, Debug)]
-    #[cynic(argument_struct = "PullRequestTitlesArguments")]
+    #[cynic(variables = "PullRequestTitlesVariables")]
     pub struct Repository {
         #[arguments(orderBy: $pr_order)]
         pub pull_requests: PullRequestConnection,

--- a/cynic-querygen/tests/snapshots/misc_tests__mutation_with_scalar_result_and_input.snap
+++ b/cynic-querygen/tests/snapshots/misc_tests__mutation_with_scalar_result_and_input.snap
@@ -12,13 +12,13 @@ mod queries {
     use super::schema;
 
     #[derive(cynic::QueryVariables, Debug)]
-    pub struct SignInArguments {
+    pub struct SignInVariables {
         pub password: String,
         pub username: String,
     }
 
     #[derive(cynic::QueryFragment, Debug)]
-    #[cynic(graphql_type = "MutationRoot", argument_struct = "SignInArguments")]
+    #[cynic(graphql_type = "MutationRoot", variables = "SignInVariables")]
     pub struct SignIn {
         #[arguments(input: { password: $password, username: $username })]
         pub sign_in: String,

--- a/cynic-querygen/tests/snapshots/misc_tests__scalar_casing.snap
+++ b/cynic-querygen/tests/snapshots/misc_tests__scalar_casing.snap
@@ -12,12 +12,12 @@ mod queries {
     use super::schema;
 
     #[derive(cynic::QueryVariables, Debug)]
-    pub struct MyQueryArguments {
+    pub struct MyQueryVariables {
         pub id: Uuid,
     }
 
     #[derive(cynic::QueryFragment, Debug)]
-    #[cynic(graphql_type = "Foo", argument_struct = "MyQueryArguments")]
+    #[cynic(graphql_type = "Foo", variables = "MyQueryVariables")]
     pub struct MyQuery {
         #[arguments(id: $id)]
         pub bar: Option<Bar>,

--- a/cynic-querygen/tests/snapshots/starwars_tests__multiple_queries.snap
+++ b/cynic-querygen/tests/snapshots/starwars_tests__multiple_queries.snap
@@ -12,12 +12,12 @@ mod queries {
     use super::schema;
 
     #[derive(cynic::QueryVariables, Debug)]
-    pub struct SingleFilmArguments {
+    pub struct SingleFilmVariables {
         pub id: cynic::Id,
     }
 
     #[derive(cynic::QueryFragment, Debug)]
-    #[cynic(graphql_type = "Root", argument_struct = "SingleFilmArguments")]
+    #[cynic(graphql_type = "Root", variables = "SingleFilmVariables")]
     pub struct SingleFilm {
         #[arguments(id: $id)]
         pub film: Option<Film>,

--- a/cynic-querygen/tests/snapshots/starwars_tests__nested_arguments.snap
+++ b/cynic-querygen/tests/snapshots/starwars_tests__nested_arguments.snap
@@ -12,21 +12,21 @@ mod queries {
     use super::schema;
 
     #[derive(cynic::QueryVariables, Debug)]
-    pub struct NestedArgsQueryArguments {
+    pub struct NestedArgsQueryVariables {
         pub film_id: cynic::Id,
         pub planet_cursor: Option<String>,
         pub resident_connection: Option<String>,
     }
 
     #[derive(cynic::QueryFragment, Debug)]
-    #[cynic(graphql_type = "Root", argument_struct = "NestedArgsQueryArguments")]
+    #[cynic(graphql_type = "Root", variables = "NestedArgsQueryVariables")]
     pub struct NestedArgsQuery {
         #[arguments(id: $film_id)]
         pub film: Option<Film>,
     }
 
     #[derive(cynic::QueryFragment, Debug)]
-    #[cynic(argument_struct = "NestedArgsQueryArguments")]
+    #[cynic(variables = "NestedArgsQueryVariables")]
     pub struct Film {
         pub title: Option<String>,
         pub director: Option<String>,
@@ -35,13 +35,13 @@ mod queries {
     }
 
     #[derive(cynic::QueryFragment, Debug)]
-    #[cynic(argument_struct = "NestedArgsQueryArguments")]
+    #[cynic(variables = "NestedArgsQueryVariables")]
     pub struct FilmPlanetsConnection {
         pub planets: Option<Vec<Option<Planet>>>,
     }
 
     #[derive(cynic::QueryFragment, Debug)]
-    #[cynic(argument_struct = "NestedArgsQueryArguments")]
+    #[cynic(variables = "NestedArgsQueryVariables")]
     pub struct Planet {
         #[arguments(after: $resident_connection)]
         pub resident_connection: Option<PlanetResidentsConnection>,

--- a/cynic-querygen/tests/snapshots/starwars_tests__sanity_test_starwars_query.snap
+++ b/cynic-querygen/tests/snapshots/starwars_tests__sanity_test_starwars_query.snap
@@ -12,12 +12,12 @@ mod queries {
     use super::schema;
 
     #[derive(cynic::QueryVariables, Debug)]
-    pub struct SanityCheckQueryArguments {
+    pub struct SanityCheckQueryVariables {
         pub film_id: Option<cynic::Id>,
     }
 
     #[derive(cynic::QueryFragment, Debug)]
-    #[cynic(graphql_type = "Root", argument_struct = "SanityCheckQueryArguments")]
+    #[cynic(graphql_type = "Root", variables = "SanityCheckQueryVariables")]
     pub struct SanityCheckQuery {
         #[arguments(id: $film_id)]
         pub film: Option<Film>,

--- a/cynic/src/bin/simple.rs
+++ b/cynic/src/bin/simple.rs
@@ -14,7 +14,7 @@ mod schema {
 struct TestArgs {}
 
 #[derive(cynic::QueryFragment)]
-#[cynic(schema_path = "src/bin/simple.graphql", argument_struct = "TestArgs")]
+#[cynic(schema_path = "src/bin/simple.graphql", variables = "TestArgs")]
 struct TestStruct {
     #[arguments(x = Some(1), y = "1")]
     pub field_one: String,

--- a/cynic/src/bin/simple_v2.rs
+++ b/cynic/src/bin/simple_v2.rs
@@ -17,7 +17,7 @@ mod queries {
     pub struct TestArgs {}
 
     #[derive(cynic::QueryFragment)]
-    #[cynic(argument_struct = "TestArgs")]
+    #[cynic(variables = "TestArgs")]
     pub struct TestStruct {
         #[arguments(x = 1, y = "1")]
         pub field_one: String,

--- a/cynic/src/lib.rs
+++ b/cynic/src/lib.rs
@@ -129,9 +129,9 @@
 //! #[cynic(
 //!     schema_path = "../schemas/starwars.schema.graphql",
 //!     graphql_type = "Root",
-//!     // By adding the `argument_struct` parameter to our `QueryFragment` we've made a variable
+//!     // By adding the `variables` parameter to our `QueryFragment` we've made a variable
 //!     // named `args` avaiable for use in the `arguments` attribute.
-//!     argument_struct = "FilmArguments"
+//!     variables = "FilmArguments"
 //! )]
 //! struct FilmDirectorQueryWithArgs {
 //!     // Here we use `args`, which we've declared above to be an instance of `FilmArguments`

--- a/cynic/tests/simple_schema_tests.rs
+++ b/cynic/tests/simple_schema_tests.rs
@@ -8,7 +8,7 @@ struct TestArgs {
 }
 
 #[derive(cynic::QueryFragment, PartialEq, Debug)]
-#[cynic(schema_path = "src/bin/simple.graphql", argument_struct = "TestArgs")]
+#[cynic(schema_path = "src/bin/simple.graphql", variables = "TestArgs")]
 struct TestStruct {
     #[arguments(x: $an_int, y = Some("1".to_string()))]
     field_one: String,
@@ -28,7 +28,7 @@ struct Nested {
 #[cynic(
     schema_path = "src/bin/simple.graphql",
     graphql_type = "Query",
-    argument_struct = "TestArgs"
+    variables = "TestArgs"
 )]
 struct TestQuery {
     test_struct: Option<TestStruct>,

--- a/examples/examples/github-mutation.rs
+++ b/examples/examples/github-mutation.rs
@@ -55,7 +55,7 @@ mod queries {
     #[derive(cynic::QueryFragment, Debug)]
     #[cynic(
         graphql_type = "Mutation",
-        argument_struct = "CommentOnMutationSupportIssueArguments"
+        variables = "CommentOnMutationSupportIssueArguments"
     )]
     pub struct CommentOnMutationSupportIssue {
         #[arguments(input: {

--- a/examples/examples/github.rs
+++ b/examples/examples/github.rs
@@ -80,14 +80,14 @@ mod queries {
     }
 
     #[derive(cynic::QueryFragment, Debug)]
-    #[cynic(graphql_type = "Query", argument_struct = "PullRequestTitlesArguments")]
+    #[cynic(graphql_type = "Query", variables = "PullRequestTitlesArguments")]
     pub struct PullRequestTitles {
         #[arguments(name = "cynic".to_string(), owner = "obmarg".to_string())]
         pub repository: Option<Repository>,
     }
 
     #[derive(cynic::QueryFragment, Debug)]
-    #[cynic(argument_struct = "PullRequestTitlesArguments")]
+    #[cynic(variables = "PullRequestTitlesArguments")]
     pub struct Repository {
         #[arguments(orderBy: $pr_order, first: 10)]
         pub pull_requests: PullRequestConnection,

--- a/examples/examples/manual-reqwest.rs
+++ b/examples/examples/manual-reqwest.rs
@@ -24,7 +24,7 @@ struct FilmArguments {
 #[cynic(
     schema_path = "../schemas/starwars.schema.graphql",
     graphql_type = "Root",
-    argument_struct = "FilmArguments"
+    variables = "FilmArguments"
 )]
 struct FilmDirectorQuery {
     #[arguments(id: $id)]

--- a/examples/examples/querying-interfaces.rs
+++ b/examples/examples/querying-interfaces.rs
@@ -53,7 +53,7 @@ struct Arguments {
 #[cynic(
     schema_path = "../schemas/starwars.schema.graphql",
     graphql_type = "Root",
-    argument_struct = "Arguments"
+    variables = "Arguments"
 )]
 struct Query {
     #[arguments(id: $id)]

--- a/examples/examples/reqwest-async.rs
+++ b/examples/examples/reqwest-async.rs
@@ -26,7 +26,7 @@ struct FilmArguments {
 #[cynic(
     schema_path = "../schemas/starwars.schema.graphql",
     graphql_type = "Root",
-    argument_struct = "FilmArguments"
+    variables = "FilmArguments"
 )]
 struct FilmDirectorQuery {
     #[arguments(id: $id)]

--- a/examples/examples/spread.rs
+++ b/examples/examples/spread.rs
@@ -34,7 +34,7 @@ struct FilmArguments {
 #[cynic(
     schema_path = "../schemas/starwars.schema.graphql",
     graphql_type = "Root",
-    argument_struct = "FilmArguments"
+    variables = "FilmArguments"
 )]
 struct FilmDirectorQuery {
     #[arguments(id: $id)]

--- a/examples/examples/starwars.rs
+++ b/examples/examples/starwars.rs
@@ -23,7 +23,7 @@ struct FilmArguments {
 #[cynic(
     schema_path = "../schemas/starwars.schema.graphql",
     graphql_type = "Root",
-    argument_struct = "FilmArguments"
+    variables = "FilmArguments"
 )]
 struct FilmDirectorQuery {
     #[arguments(id: $id)]

--- a/examples/examples/surf-client.rs
+++ b/examples/examples/surf-client.rs
@@ -26,7 +26,7 @@ struct FilmArguments {
 #[cynic(
     schema_path = "../schemas/starwars.schema.graphql",
     graphql_type = "Root",
-    argument_struct = "FilmArguments"
+    variables = "FilmArguments"
 )]
 struct FilmDirectorQuery {
     #[arguments(id: $id)]

--- a/tests/compile-benchmarks/github-query/src/lib.rs
+++ b/tests/compile-benchmarks/github-query/src/lib.rs
@@ -54,14 +54,14 @@ mod pr_query {
     /// }
     /// ```
     #[derive(cynic::QueryFragment, Debug)]
-    #[cynic(graphql_type = "Query", argument_struct = "PRsArguments")]
+    #[cynic(graphql_type = "Query", variables = "PRsArguments")]
     pub struct PRs {
         #[arguments(name: $repo_name, owner: $repo_owner)]
         pub repository: Option<Repository>,
     }
 
     #[derive(cynic::QueryFragment, Debug)]
-    #[cynic(graphql_type = "Repository", argument_struct = "PRsArguments")]
+    #[cynic(graphql_type = "Repository", variables = "PRsArguments")]
     pub struct Repository {
         #[arguments(first: $page_size, states = Some(vec![PullRequestState::Merged]), after: $pr_cursor)]
         pub pull_requests: PullRequestConnection,
@@ -223,17 +223,14 @@ mod team_query {
     }
 
     #[derive(cynic::QueryFragment, Debug)]
-    #[cynic(graphql_type = "Query", argument_struct = "TeamMembersArguments")]
+    #[cynic(graphql_type = "Query", variables = "TeamMembersArguments")]
     pub struct TeamMembers {
         #[arguments(login: $org)]
         pub organization: Option<Organization>,
     }
 
     #[derive(cynic::QueryFragment, Debug)]
-    #[cynic(
-        graphql_type = "Organization",
-        argument_struct = "TeamMembersArguments"
-    )]
+    #[cynic(graphql_type = "Organization", variables = "TeamMembersArguments")]
     pub struct Organization {
         #[arguments(slug: $team)]
         pub team: Option<Team>,

--- a/tests/querygen-compile-run/build.rs
+++ b/tests/querygen-compile-run/build.rs
@@ -26,7 +26,7 @@ fn main() {
             &starwars_schema,
             "../../cynic-querygen/tests/queries/starwars/sanity.graphql",
             r#"queries::SanityCheckQuery::build(
-                queries::SanityCheckQueryArguments {
+                queries::SanityCheckQueryVariables {
                     film_id: Some("ZmlsbXM6MQ==".into())
                 }
             )"#,
@@ -35,7 +35,7 @@ fn main() {
             &starwars_schema,
             "../../cynic-querygen/tests/queries/starwars/nested-arguments.graphql",
             r#"queries::NestedArgsQuery::build(
-                queries::NestedArgsQueryArguments {
+                queries::NestedArgsQueryVariables {
                     film_id: "ZmlsbXM6MQ==".into(),
                     planet_cursor: None,
                     resident_connection: None
@@ -66,7 +66,7 @@ fn main() {
             &jobs_schema,
             "tests/queries/graphql.jobs/jobs.graphql",
             r#"queries::Jobs::build(
-                queries::JobsArguments {
+                queries::JobsVariables {
                     input: queries::LocationInput {
                         slug: "london".into()
                     }
@@ -77,7 +77,7 @@ fn main() {
             &github_schema,
             "../../cynic-querygen/tests/queries/github/add-comment-mutation.graphql",
             r#"queries::CommentOnMutationSupportIssue::build(
-                queries::CommentOnMutationSupportIssueArguments {
+                queries::CommentOnMutationSupportIssueVariables {
                     comment_body: "This is a test comment, posted by the new cynic mutation support"
                         .into(),
                 },
@@ -87,7 +87,7 @@ fn main() {
             &github_schema,
             "../../cynic-querygen/tests/queries/github/input-object-arguments.graphql",
             r#"queries::PullRequestTitles::build(
-                queries::PullRequestTitlesArguments {
+                queries::PullRequestTitlesVariables {
                     pr_order: queries::IssueOrder {
                         direction: queries::OrderDirection::Asc,
                         field: queries::IssueOrderField::CreatedAt,
@@ -99,7 +99,7 @@ fn main() {
             &github_schema,
             "tests/queries/github/nested-arguments.graphql",
             r#"queries::PullRequestTitles::build(
-                queries::PullRequestTitlesArguments {
+                queries::PullRequestTitlesVariables {
                     owner: "obmarg".into(),
                     repo: "cynic".into(),
                     pr_order: queries::IssueOrder {
@@ -118,7 +118,7 @@ fn main() {
             &test_schema,
             "../../cynic-querygen/tests/queries/misc/scalar-casing.graphql",
             r#"queries::MyQuery::build(
-                queries::MyQueryArguments {
+                queries::MyQueryVariables {
                     id: queries::Uuid("not-really-a-uuid-but-whatever".into())
                 }
             )"#,
@@ -127,7 +127,7 @@ fn main() {
             &github_schema,
             "tests/queries/github/scalar-inside-input-object.graphql",
             r#"queries::AddPRComment::build(
-                queries::AddPRCommentArguments{
+                queries::AddPRCommentVariables {
                     body: "hello!".into(),
                     commit: queries::GitObjectID("abcd".into())
                 }
@@ -142,7 +142,7 @@ fn main() {
             &github_schema,
             "tests/queries/github/optional-input-object-argument.graphql",
             r#"queries::PullRequestTitles::build(
-                queries::PullRequestTitlesArguments {
+                queries::PullRequestTitlesVariables {
                     pr_order: None
                 },
             )"#,
@@ -151,7 +151,7 @@ fn main() {
             &raindancer_schema,
             "tests/queries/misc/mutation_with_scalar_result_and_input.graphql",
             r#"queries::SignIn::build(
-                queries::SignInArguments {
+                queries::SignInVariables {
                     username: "hello".into(),
                     password: "hello".into()
                 },
@@ -166,7 +166,7 @@ fn main() {
             &github_schema,
             "tests/queries/github/inline-fragment-with-arguments.graphql",
             r#"queries::IssueOrPR::build(
-                queries::IssueOrPRArguments {
+                queries::IssueOrPRVariables {
                     assignee_count: 10
                 }
             )"#,

--- a/tests/ui-tests/tests/cases/argument-missing-fields.rs
+++ b/tests/ui-tests/tests/cases/argument-missing-fields.rs
@@ -7,7 +7,7 @@ mod queries {
     use super::schema;
 
     #[derive(cynic::QueryFragment, Debug)]
-    #[cynic(argument_struct = "PullRequestTitlesArguments")]
+    #[cynic(variables = "PullRequestTitlesArguments")]
     pub struct Repository {
         #[arguments(order_by: "COMMENTS", first: 10)]
         pub pull_requests: PullRequestConnection,

--- a/tests/ui-tests/tests/cases/missing-variable.rs
+++ b/tests/ui-tests/tests/cases/missing-variable.rs
@@ -15,7 +15,7 @@ mod queries {
     }
 
     #[derive(cynic::QueryFragment, Debug)]
-    #[cynic(graphql_type = "Root", argument_struct = "Variables")]
+    #[cynic(graphql_type = "Root", variables = "Variables")]
     pub struct AllFilms {
         #[arguments(id: $missing_var)]
         pub film: Option<Film>,

--- a/tests/ui-tests/tests/cases/wrong-variable-type.rs
+++ b/tests/ui-tests/tests/cases/wrong-variable-type.rs
@@ -13,7 +13,7 @@ mod queries {
     }
 
     #[derive(cynic::QueryFragment, Debug)]
-    #[cynic(graphql_type = "Root", argument_struct = "Variables")]
+    #[cynic(graphql_type = "Root", variables = "Variables")]
     pub struct AllFilms {
         #[arguments(id: $id)]
         pub film: Option<Film>,


### PR DESCRIPTION
Decided that the term `variables` was more in line with graphql
terminology than `arguments` ever was, so have renamed the
`argument_struct` attribute to `variables`.  The old attr will still
work but will emit a deprecation warning.