### PR TITLE
[Merged by Bors] - Use associated constants for GQL type/field names

### DIFF
--- a/cynic-codegen/src/use_schema/fields.rs
+++ b/cynic-codegen/src/use_schema/fields.rs
@@ -31,9 +31,7 @@ impl ToTokens for FieldOutput<'_> {
             impl ::cynic::schema::Field for #field_marker{
                 type Type = #field_type_marker;
 
-                fn name() -> &'static str {
-                    #field_name_literal
-                }
+                const NAME: &'static str = #field_name_literal;
             }
 
             impl ::cynic::schema::HasField<#field_marker> for super::#parent_marker {
@@ -75,9 +73,7 @@ impl ToTokens for ArgumentOutput<'_> {
             impl ::cynic::schema::HasArgument<#argument_ident> for super::#field_marker {
                 type ArgumentType = #schema_type;
 
-                fn name() -> &'static str {
-                    #name
-                }
+                const NAME: &'static str = #name;
             }
         })
     }

--- a/cynic-codegen/src/use_schema/input_object.rs
+++ b/cynic-codegen/src/use_schema/input_object.rs
@@ -60,9 +60,7 @@ impl ToTokens for FieldOutput<'_> {
             impl ::cynic::schema::Field for #field_marker{
                 type Type = #field_type_marker;
 
-                fn name() -> &'static str {
-                    #field_name_literal
-                }
+                const NAME: &'static str = #field_name_literal;
             }
 
             impl ::cynic::schema::HasInputField<#field_marker, #field_type_marker> for super::#object_marker {

--- a/cynic-codegen/src/use_schema/named_type.rs
+++ b/cynic-codegen/src/use_schema/named_type.rs
@@ -42,9 +42,7 @@ impl quote::ToTokens for NamedType<'_> {
 
         tokens.append_all(quote! {
             impl ::cynic::schema::NamedType for #target_struct {
-                fn name() -> &'static str {
-                    #graphql_name
-                }
+                const NAME: &'static str = #graphql_name;
             }
         });
     }

--- a/cynic-codegen/tests/snapshots/use_schema__schema_file_1.snap
+++ b/cynic-codegen/tests/snapshots/use_schema__schema_file_1.snap
@@ -11,9 +11,7 @@ pub mod city_fields {
     pub struct Id;
     impl ::cynic::schema::Field for Id {
         type Type = super::Id;
-        fn name() -> &'static str {
-            "id"
-        }
+        const NAME: &'static str = "id";
     }
     impl ::cynic::schema::HasField<Id> for super::City {
         type Type = super::Id;
@@ -21,9 +19,7 @@ pub mod city_fields {
     pub struct Name;
     impl ::cynic::schema::Field for Name {
         type Type = super::String;
-        fn name() -> &'static str {
-            "name"
-        }
+        const NAME: &'static str = "name";
     }
     impl ::cynic::schema::HasField<Name> for super::City {
         type Type = super::String;
@@ -31,9 +27,7 @@ pub mod city_fields {
     pub struct Slug;
     impl ::cynic::schema::Field for Slug {
         type Type = super::String;
-        fn name() -> &'static str {
-            "slug"
-        }
+        const NAME: &'static str = "slug";
     }
     impl ::cynic::schema::HasField<Slug> for super::City {
         type Type = super::String;
@@ -41,9 +35,7 @@ pub mod city_fields {
     pub struct Country;
     impl ::cynic::schema::Field for Country {
         type Type = super::Country;
-        fn name() -> &'static str {
-            "country"
-        }
+        const NAME: &'static str = "country";
     }
     impl ::cynic::schema::HasField<Country> for super::City {
         type Type = super::Country;
@@ -51,9 +43,7 @@ pub mod city_fields {
     pub struct Type;
     impl ::cynic::schema::Field for Type {
         type Type = super::String;
-        fn name() -> &'static str {
-            "type"
-        }
+        const NAME: &'static str = "type";
     }
     impl ::cynic::schema::HasField<Type> for super::City {
         type Type = super::String;
@@ -61,9 +51,7 @@ pub mod city_fields {
     pub struct Jobs;
     impl ::cynic::schema::Field for Jobs {
         type Type = Option<Vec<super::Job>>;
-        fn name() -> &'static str {
-            "jobs"
-        }
+        const NAME: &'static str = "jobs";
     }
     impl ::cynic::schema::HasField<Jobs> for super::City {
         type Type = Option<Vec<super::Job>>;
@@ -72,59 +60,43 @@ pub mod city_fields {
         pub struct Where;
         impl ::cynic::schema::HasArgument<Where> for super::Jobs {
             type ArgumentType = Option<super::super::JobWhereInput>;
-            fn name() -> &'static str {
-                "where"
-            }
+            const NAME: &'static str = "where";
         }
         pub struct OrderBy;
         impl ::cynic::schema::HasArgument<OrderBy> for super::Jobs {
             type ArgumentType = Option<super::super::JobOrderByInput>;
-            fn name() -> &'static str {
-                "orderBy"
-            }
+            const NAME: &'static str = "orderBy";
         }
         pub struct Skip;
         impl ::cynic::schema::HasArgument<Skip> for super::Jobs {
             type ArgumentType = Option<super::super::Int>;
-            fn name() -> &'static str {
-                "skip"
-            }
+            const NAME: &'static str = "skip";
         }
         pub struct After;
         impl ::cynic::schema::HasArgument<After> for super::Jobs {
             type ArgumentType = Option<super::super::String>;
-            fn name() -> &'static str {
-                "after"
-            }
+            const NAME: &'static str = "after";
         }
         pub struct Before;
         impl ::cynic::schema::HasArgument<Before> for super::Jobs {
             type ArgumentType = Option<super::super::String>;
-            fn name() -> &'static str {
-                "before"
-            }
+            const NAME: &'static str = "before";
         }
         pub struct First;
         impl ::cynic::schema::HasArgument<First> for super::Jobs {
             type ArgumentType = Option<super::super::Int>;
-            fn name() -> &'static str {
-                "first"
-            }
+            const NAME: &'static str = "first";
         }
         pub struct Last;
         impl ::cynic::schema::HasArgument<Last> for super::Jobs {
             type ArgumentType = Option<super::super::Int>;
-            fn name() -> &'static str {
-                "last"
-            }
+            const NAME: &'static str = "last";
         }
     }
     pub struct CreatedAt;
     impl ::cynic::schema::Field for CreatedAt {
         type Type = super::DateTime;
-        fn name() -> &'static str {
-            "createdAt"
-        }
+        const NAME: &'static str = "createdAt";
     }
     impl ::cynic::schema::HasField<CreatedAt> for super::City {
         type Type = super::DateTime;
@@ -132,9 +104,7 @@ pub mod city_fields {
     pub struct UpdatedAt;
     impl ::cynic::schema::Field for UpdatedAt {
         type Type = super::DateTime;
-        fn name() -> &'static str {
-            "updatedAt"
-        }
+        const NAME: &'static str = "updatedAt";
     }
     impl ::cynic::schema::HasField<UpdatedAt> for super::City {
         type Type = super::DateTime;
@@ -147,145 +117,109 @@ pub mod city_where_input_fields {
     pub struct Id;
     impl ::cynic::schema::Field for Id {
         type Type = Option<super::Id>;
-        fn name() -> &'static str {
-            "id"
-        }
+        const NAME: &'static str = "id";
     }
     impl ::cynic::schema::HasInputField<Id, Option<super::Id>> for super::CityWhereInput {}
     pub struct IdNot;
     impl ::cynic::schema::Field for IdNot {
         type Type = Option<super::Id>;
-        fn name() -> &'static str {
-            "id_not"
-        }
+        const NAME: &'static str = "id_not";
     }
     impl ::cynic::schema::HasInputField<IdNot, Option<super::Id>> for super::CityWhereInput {}
     pub struct IdIn;
     impl ::cynic::schema::Field for IdIn {
         type Type = Option<Vec<super::Id>>;
-        fn name() -> &'static str {
-            "id_in"
-        }
+        const NAME: &'static str = "id_in";
     }
     impl ::cynic::schema::HasInputField<IdIn, Option<Vec<super::Id>>> for super::CityWhereInput {}
     pub struct IdNotIn;
     impl ::cynic::schema::Field for IdNotIn {
         type Type = Option<Vec<super::Id>>;
-        fn name() -> &'static str {
-            "id_not_in"
-        }
+        const NAME: &'static str = "id_not_in";
     }
     impl ::cynic::schema::HasInputField<IdNotIn, Option<Vec<super::Id>>> for super::CityWhereInput {}
     pub struct IdLt;
     impl ::cynic::schema::Field for IdLt {
         type Type = Option<super::Id>;
-        fn name() -> &'static str {
-            "id_lt"
-        }
+        const NAME: &'static str = "id_lt";
     }
     impl ::cynic::schema::HasInputField<IdLt, Option<super::Id>> for super::CityWhereInput {}
     pub struct IdLte;
     impl ::cynic::schema::Field for IdLte {
         type Type = Option<super::Id>;
-        fn name() -> &'static str {
-            "id_lte"
-        }
+        const NAME: &'static str = "id_lte";
     }
     impl ::cynic::schema::HasInputField<IdLte, Option<super::Id>> for super::CityWhereInput {}
     pub struct IdGt;
     impl ::cynic::schema::Field for IdGt {
         type Type = Option<super::Id>;
-        fn name() -> &'static str {
-            "id_gt"
-        }
+        const NAME: &'static str = "id_gt";
     }
     impl ::cynic::schema::HasInputField<IdGt, Option<super::Id>> for super::CityWhereInput {}
     pub struct IdGte;
     impl ::cynic::schema::Field for IdGte {
         type Type = Option<super::Id>;
-        fn name() -> &'static str {
-            "id_gte"
-        }
+        const NAME: &'static str = "id_gte";
     }
     impl ::cynic::schema::HasInputField<IdGte, Option<super::Id>> for super::CityWhereInput {}
     pub struct IdContains;
     impl ::cynic::schema::Field for IdContains {
         type Type = Option<super::Id>;
-        fn name() -> &'static str {
-            "id_contains"
-        }
+        const NAME: &'static str = "id_contains";
     }
     impl ::cynic::schema::HasInputField<IdContains, Option<super::Id>> for super::CityWhereInput {}
     pub struct IdNotContains;
     impl ::cynic::schema::Field for IdNotContains {
         type Type = Option<super::Id>;
-        fn name() -> &'static str {
-            "id_not_contains"
-        }
+        const NAME: &'static str = "id_not_contains";
     }
     impl ::cynic::schema::HasInputField<IdNotContains, Option<super::Id>> for super::CityWhereInput {}
     pub struct IdStartsWith;
     impl ::cynic::schema::Field for IdStartsWith {
         type Type = Option<super::Id>;
-        fn name() -> &'static str {
-            "id_starts_with"
-        }
+        const NAME: &'static str = "id_starts_with";
     }
     impl ::cynic::schema::HasInputField<IdStartsWith, Option<super::Id>> for super::CityWhereInput {}
     pub struct IdNotStartsWith;
     impl ::cynic::schema::Field for IdNotStartsWith {
         type Type = Option<super::Id>;
-        fn name() -> &'static str {
-            "id_not_starts_with"
-        }
+        const NAME: &'static str = "id_not_starts_with";
     }
     impl ::cynic::schema::HasInputField<IdNotStartsWith, Option<super::Id>> for super::CityWhereInput {}
     pub struct IdEndsWith;
     impl ::cynic::schema::Field for IdEndsWith {
         type Type = Option<super::Id>;
-        fn name() -> &'static str {
-            "id_ends_with"
-        }
+        const NAME: &'static str = "id_ends_with";
     }
     impl ::cynic::schema::HasInputField<IdEndsWith, Option<super::Id>> for super::CityWhereInput {}
     pub struct IdNotEndsWith;
     impl ::cynic::schema::Field for IdNotEndsWith {
         type Type = Option<super::Id>;
-        fn name() -> &'static str {
-            "id_not_ends_with"
-        }
+        const NAME: &'static str = "id_not_ends_with";
     }
     impl ::cynic::schema::HasInputField<IdNotEndsWith, Option<super::Id>> for super::CityWhereInput {}
     pub struct Name;
     impl ::cynic::schema::Field for Name {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "name"
-        }
+        const NAME: &'static str = "name";
     }
     impl ::cynic::schema::HasInputField<Name, Option<super::String>> for super::CityWhereInput {}
     pub struct NameNot;
     impl ::cynic::schema::Field for NameNot {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "name_not"
-        }
+        const NAME: &'static str = "name_not";
     }
     impl ::cynic::schema::HasInputField<NameNot, Option<super::String>> for super::CityWhereInput {}
     pub struct NameIn;
     impl ::cynic::schema::Field for NameIn {
         type Type = Option<Vec<super::String>>;
-        fn name() -> &'static str {
-            "name_in"
-        }
+        const NAME: &'static str = "name_in";
     }
     impl ::cynic::schema::HasInputField<NameIn, Option<Vec<super::String>>> for super::CityWhereInput {}
     pub struct NameNotIn;
     impl ::cynic::schema::Field for NameNotIn {
         type Type = Option<Vec<super::String>>;
-        fn name() -> &'static str {
-            "name_not_in"
-        }
+        const NAME: &'static str = "name_not_in";
     }
     impl ::cynic::schema::HasInputField<NameNotIn, Option<Vec<super::String>>>
         for super::CityWhereInput
@@ -294,49 +228,37 @@ pub mod city_where_input_fields {
     pub struct NameLt;
     impl ::cynic::schema::Field for NameLt {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "name_lt"
-        }
+        const NAME: &'static str = "name_lt";
     }
     impl ::cynic::schema::HasInputField<NameLt, Option<super::String>> for super::CityWhereInput {}
     pub struct NameLte;
     impl ::cynic::schema::Field for NameLte {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "name_lte"
-        }
+        const NAME: &'static str = "name_lte";
     }
     impl ::cynic::schema::HasInputField<NameLte, Option<super::String>> for super::CityWhereInput {}
     pub struct NameGt;
     impl ::cynic::schema::Field for NameGt {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "name_gt"
-        }
+        const NAME: &'static str = "name_gt";
     }
     impl ::cynic::schema::HasInputField<NameGt, Option<super::String>> for super::CityWhereInput {}
     pub struct NameGte;
     impl ::cynic::schema::Field for NameGte {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "name_gte"
-        }
+        const NAME: &'static str = "name_gte";
     }
     impl ::cynic::schema::HasInputField<NameGte, Option<super::String>> for super::CityWhereInput {}
     pub struct NameContains;
     impl ::cynic::schema::Field for NameContains {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "name_contains"
-        }
+        const NAME: &'static str = "name_contains";
     }
     impl ::cynic::schema::HasInputField<NameContains, Option<super::String>> for super::CityWhereInput {}
     pub struct NameNotContains;
     impl ::cynic::schema::Field for NameNotContains {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "name_not_contains"
-        }
+        const NAME: &'static str = "name_not_contains";
     }
     impl ::cynic::schema::HasInputField<NameNotContains, Option<super::String>>
         for super::CityWhereInput
@@ -345,9 +267,7 @@ pub mod city_where_input_fields {
     pub struct NameStartsWith;
     impl ::cynic::schema::Field for NameStartsWith {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "name_starts_with"
-        }
+        const NAME: &'static str = "name_starts_with";
     }
     impl ::cynic::schema::HasInputField<NameStartsWith, Option<super::String>>
         for super::CityWhereInput
@@ -356,9 +276,7 @@ pub mod city_where_input_fields {
     pub struct NameNotStartsWith;
     impl ::cynic::schema::Field for NameNotStartsWith {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "name_not_starts_with"
-        }
+        const NAME: &'static str = "name_not_starts_with";
     }
     impl ::cynic::schema::HasInputField<NameNotStartsWith, Option<super::String>>
         for super::CityWhereInput
@@ -367,17 +285,13 @@ pub mod city_where_input_fields {
     pub struct NameEndsWith;
     impl ::cynic::schema::Field for NameEndsWith {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "name_ends_with"
-        }
+        const NAME: &'static str = "name_ends_with";
     }
     impl ::cynic::schema::HasInputField<NameEndsWith, Option<super::String>> for super::CityWhereInput {}
     pub struct NameNotEndsWith;
     impl ::cynic::schema::Field for NameNotEndsWith {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "name_not_ends_with"
-        }
+        const NAME: &'static str = "name_not_ends_with";
     }
     impl ::cynic::schema::HasInputField<NameNotEndsWith, Option<super::String>>
         for super::CityWhereInput
@@ -386,33 +300,25 @@ pub mod city_where_input_fields {
     pub struct Slug;
     impl ::cynic::schema::Field for Slug {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "slug"
-        }
+        const NAME: &'static str = "slug";
     }
     impl ::cynic::schema::HasInputField<Slug, Option<super::String>> for super::CityWhereInput {}
     pub struct SlugNot;
     impl ::cynic::schema::Field for SlugNot {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "slug_not"
-        }
+        const NAME: &'static str = "slug_not";
     }
     impl ::cynic::schema::HasInputField<SlugNot, Option<super::String>> for super::CityWhereInput {}
     pub struct SlugIn;
     impl ::cynic::schema::Field for SlugIn {
         type Type = Option<Vec<super::String>>;
-        fn name() -> &'static str {
-            "slug_in"
-        }
+        const NAME: &'static str = "slug_in";
     }
     impl ::cynic::schema::HasInputField<SlugIn, Option<Vec<super::String>>> for super::CityWhereInput {}
     pub struct SlugNotIn;
     impl ::cynic::schema::Field for SlugNotIn {
         type Type = Option<Vec<super::String>>;
-        fn name() -> &'static str {
-            "slug_not_in"
-        }
+        const NAME: &'static str = "slug_not_in";
     }
     impl ::cynic::schema::HasInputField<SlugNotIn, Option<Vec<super::String>>>
         for super::CityWhereInput
@@ -421,49 +327,37 @@ pub mod city_where_input_fields {
     pub struct SlugLt;
     impl ::cynic::schema::Field for SlugLt {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "slug_lt"
-        }
+        const NAME: &'static str = "slug_lt";
     }
     impl ::cynic::schema::HasInputField<SlugLt, Option<super::String>> for super::CityWhereInput {}
     pub struct SlugLte;
     impl ::cynic::schema::Field for SlugLte {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "slug_lte"
-        }
+        const NAME: &'static str = "slug_lte";
     }
     impl ::cynic::schema::HasInputField<SlugLte, Option<super::String>> for super::CityWhereInput {}
     pub struct SlugGt;
     impl ::cynic::schema::Field for SlugGt {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "slug_gt"
-        }
+        const NAME: &'static str = "slug_gt";
     }
     impl ::cynic::schema::HasInputField<SlugGt, Option<super::String>> for super::CityWhereInput {}
     pub struct SlugGte;
     impl ::cynic::schema::Field for SlugGte {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "slug_gte"
-        }
+        const NAME: &'static str = "slug_gte";
     }
     impl ::cynic::schema::HasInputField<SlugGte, Option<super::String>> for super::CityWhereInput {}
     pub struct SlugContains;
     impl ::cynic::schema::Field for SlugContains {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "slug_contains"
-        }
+        const NAME: &'static str = "slug_contains";
     }
     impl ::cynic::schema::HasInputField<SlugContains, Option<super::String>> for super::CityWhereInput {}
     pub struct SlugNotContains;
     impl ::cynic::schema::Field for SlugNotContains {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "slug_not_contains"
-        }
+        const NAME: &'static str = "slug_not_contains";
     }
     impl ::cynic::schema::HasInputField<SlugNotContains, Option<super::String>>
         for super::CityWhereInput
@@ -472,9 +366,7 @@ pub mod city_where_input_fields {
     pub struct SlugStartsWith;
     impl ::cynic::schema::Field for SlugStartsWith {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "slug_starts_with"
-        }
+        const NAME: &'static str = "slug_starts_with";
     }
     impl ::cynic::schema::HasInputField<SlugStartsWith, Option<super::String>>
         for super::CityWhereInput
@@ -483,9 +375,7 @@ pub mod city_where_input_fields {
     pub struct SlugNotStartsWith;
     impl ::cynic::schema::Field for SlugNotStartsWith {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "slug_not_starts_with"
-        }
+        const NAME: &'static str = "slug_not_starts_with";
     }
     impl ::cynic::schema::HasInputField<SlugNotStartsWith, Option<super::String>>
         for super::CityWhereInput
@@ -494,17 +384,13 @@ pub mod city_where_input_fields {
     pub struct SlugEndsWith;
     impl ::cynic::schema::Field for SlugEndsWith {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "slug_ends_with"
-        }
+        const NAME: &'static str = "slug_ends_with";
     }
     impl ::cynic::schema::HasInputField<SlugEndsWith, Option<super::String>> for super::CityWhereInput {}
     pub struct SlugNotEndsWith;
     impl ::cynic::schema::Field for SlugNotEndsWith {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "slug_not_ends_with"
-        }
+        const NAME: &'static str = "slug_not_ends_with";
     }
     impl ::cynic::schema::HasInputField<SlugNotEndsWith, Option<super::String>>
         for super::CityWhereInput
@@ -513,9 +399,7 @@ pub mod city_where_input_fields {
     pub struct Country;
     impl ::cynic::schema::Field for Country {
         type Type = Option<super::CountryWhereInput>;
-        fn name() -> &'static str {
-            "country"
-        }
+        const NAME: &'static str = "country";
     }
     impl ::cynic::schema::HasInputField<Country, Option<super::CountryWhereInput>>
         for super::CityWhereInput
@@ -524,33 +408,25 @@ pub mod city_where_input_fields {
     pub struct Type;
     impl ::cynic::schema::Field for Type {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "type"
-        }
+        const NAME: &'static str = "type";
     }
     impl ::cynic::schema::HasInputField<Type, Option<super::String>> for super::CityWhereInput {}
     pub struct TypeNot;
     impl ::cynic::schema::Field for TypeNot {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "type_not"
-        }
+        const NAME: &'static str = "type_not";
     }
     impl ::cynic::schema::HasInputField<TypeNot, Option<super::String>> for super::CityWhereInput {}
     pub struct TypeIn;
     impl ::cynic::schema::Field for TypeIn {
         type Type = Option<Vec<super::String>>;
-        fn name() -> &'static str {
-            "type_in"
-        }
+        const NAME: &'static str = "type_in";
     }
     impl ::cynic::schema::HasInputField<TypeIn, Option<Vec<super::String>>> for super::CityWhereInput {}
     pub struct TypeNotIn;
     impl ::cynic::schema::Field for TypeNotIn {
         type Type = Option<Vec<super::String>>;
-        fn name() -> &'static str {
-            "type_not_in"
-        }
+        const NAME: &'static str = "type_not_in";
     }
     impl ::cynic::schema::HasInputField<TypeNotIn, Option<Vec<super::String>>>
         for super::CityWhereInput
@@ -559,49 +435,37 @@ pub mod city_where_input_fields {
     pub struct TypeLt;
     impl ::cynic::schema::Field for TypeLt {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "type_lt"
-        }
+        const NAME: &'static str = "type_lt";
     }
     impl ::cynic::schema::HasInputField<TypeLt, Option<super::String>> for super::CityWhereInput {}
     pub struct TypeLte;
     impl ::cynic::schema::Field for TypeLte {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "type_lte"
-        }
+        const NAME: &'static str = "type_lte";
     }
     impl ::cynic::schema::HasInputField<TypeLte, Option<super::String>> for super::CityWhereInput {}
     pub struct TypeGt;
     impl ::cynic::schema::Field for TypeGt {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "type_gt"
-        }
+        const NAME: &'static str = "type_gt";
     }
     impl ::cynic::schema::HasInputField<TypeGt, Option<super::String>> for super::CityWhereInput {}
     pub struct TypeGte;
     impl ::cynic::schema::Field for TypeGte {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "type_gte"
-        }
+        const NAME: &'static str = "type_gte";
     }
     impl ::cynic::schema::HasInputField<TypeGte, Option<super::String>> for super::CityWhereInput {}
     pub struct TypeContains;
     impl ::cynic::schema::Field for TypeContains {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "type_contains"
-        }
+        const NAME: &'static str = "type_contains";
     }
     impl ::cynic::schema::HasInputField<TypeContains, Option<super::String>> for super::CityWhereInput {}
     pub struct TypeNotContains;
     impl ::cynic::schema::Field for TypeNotContains {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "type_not_contains"
-        }
+        const NAME: &'static str = "type_not_contains";
     }
     impl ::cynic::schema::HasInputField<TypeNotContains, Option<super::String>>
         for super::CityWhereInput
@@ -610,9 +474,7 @@ pub mod city_where_input_fields {
     pub struct TypeStartsWith;
     impl ::cynic::schema::Field for TypeStartsWith {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "type_starts_with"
-        }
+        const NAME: &'static str = "type_starts_with";
     }
     impl ::cynic::schema::HasInputField<TypeStartsWith, Option<super::String>>
         for super::CityWhereInput
@@ -621,9 +483,7 @@ pub mod city_where_input_fields {
     pub struct TypeNotStartsWith;
     impl ::cynic::schema::Field for TypeNotStartsWith {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "type_not_starts_with"
-        }
+        const NAME: &'static str = "type_not_starts_with";
     }
     impl ::cynic::schema::HasInputField<TypeNotStartsWith, Option<super::String>>
         for super::CityWhereInput
@@ -632,17 +492,13 @@ pub mod city_where_input_fields {
     pub struct TypeEndsWith;
     impl ::cynic::schema::Field for TypeEndsWith {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "type_ends_with"
-        }
+        const NAME: &'static str = "type_ends_with";
     }
     impl ::cynic::schema::HasInputField<TypeEndsWith, Option<super::String>> for super::CityWhereInput {}
     pub struct TypeNotEndsWith;
     impl ::cynic::schema::Field for TypeNotEndsWith {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "type_not_ends_with"
-        }
+        const NAME: &'static str = "type_not_ends_with";
     }
     impl ::cynic::schema::HasInputField<TypeNotEndsWith, Option<super::String>>
         for super::CityWhereInput
@@ -651,9 +507,7 @@ pub mod city_where_input_fields {
     pub struct JobsEvery;
     impl ::cynic::schema::Field for JobsEvery {
         type Type = Option<super::JobWhereInput>;
-        fn name() -> &'static str {
-            "jobs_every"
-        }
+        const NAME: &'static str = "jobs_every";
     }
     impl ::cynic::schema::HasInputField<JobsEvery, Option<super::JobWhereInput>>
         for super::CityWhereInput
@@ -662,9 +516,7 @@ pub mod city_where_input_fields {
     pub struct JobsSome;
     impl ::cynic::schema::Field for JobsSome {
         type Type = Option<super::JobWhereInput>;
-        fn name() -> &'static str {
-            "jobs_some"
-        }
+        const NAME: &'static str = "jobs_some";
     }
     impl ::cynic::schema::HasInputField<JobsSome, Option<super::JobWhereInput>>
         for super::CityWhereInput
@@ -673,9 +525,7 @@ pub mod city_where_input_fields {
     pub struct JobsNone;
     impl ::cynic::schema::Field for JobsNone {
         type Type = Option<super::JobWhereInput>;
-        fn name() -> &'static str {
-            "jobs_none"
-        }
+        const NAME: &'static str = "jobs_none";
     }
     impl ::cynic::schema::HasInputField<JobsNone, Option<super::JobWhereInput>>
         for super::CityWhereInput
@@ -684,17 +534,13 @@ pub mod city_where_input_fields {
     pub struct CreatedAt;
     impl ::cynic::schema::Field for CreatedAt {
         type Type = Option<super::DateTime>;
-        fn name() -> &'static str {
-            "createdAt"
-        }
+        const NAME: &'static str = "createdAt";
     }
     impl ::cynic::schema::HasInputField<CreatedAt, Option<super::DateTime>> for super::CityWhereInput {}
     pub struct CreatedAtNot;
     impl ::cynic::schema::Field for CreatedAtNot {
         type Type = Option<super::DateTime>;
-        fn name() -> &'static str {
-            "createdAt_not"
-        }
+        const NAME: &'static str = "createdAt_not";
     }
     impl ::cynic::schema::HasInputField<CreatedAtNot, Option<super::DateTime>>
         for super::CityWhereInput
@@ -703,9 +549,7 @@ pub mod city_where_input_fields {
     pub struct CreatedAtIn;
     impl ::cynic::schema::Field for CreatedAtIn {
         type Type = Option<Vec<super::DateTime>>;
-        fn name() -> &'static str {
-            "createdAt_in"
-        }
+        const NAME: &'static str = "createdAt_in";
     }
     impl ::cynic::schema::HasInputField<CreatedAtIn, Option<Vec<super::DateTime>>>
         for super::CityWhereInput
@@ -714,9 +558,7 @@ pub mod city_where_input_fields {
     pub struct CreatedAtNotIn;
     impl ::cynic::schema::Field for CreatedAtNotIn {
         type Type = Option<Vec<super::DateTime>>;
-        fn name() -> &'static str {
-            "createdAt_not_in"
-        }
+        const NAME: &'static str = "createdAt_not_in";
     }
     impl ::cynic::schema::HasInputField<CreatedAtNotIn, Option<Vec<super::DateTime>>>
         for super::CityWhereInput
@@ -725,9 +567,7 @@ pub mod city_where_input_fields {
     pub struct CreatedAtLt;
     impl ::cynic::schema::Field for CreatedAtLt {
         type Type = Option<super::DateTime>;
-        fn name() -> &'static str {
-            "createdAt_lt"
-        }
+        const NAME: &'static str = "createdAt_lt";
     }
     impl ::cynic::schema::HasInputField<CreatedAtLt, Option<super::DateTime>>
         for super::CityWhereInput
@@ -736,9 +576,7 @@ pub mod city_where_input_fields {
     pub struct CreatedAtLte;
     impl ::cynic::schema::Field for CreatedAtLte {
         type Type = Option<super::DateTime>;
-        fn name() -> &'static str {
-            "createdAt_lte"
-        }
+        const NAME: &'static str = "createdAt_lte";
     }
     impl ::cynic::schema::HasInputField<CreatedAtLte, Option<super::DateTime>>
         for super::CityWhereInput
@@ -747,9 +585,7 @@ pub mod city_where_input_fields {
     pub struct CreatedAtGt;
     impl ::cynic::schema::Field for CreatedAtGt {
         type Type = Option<super::DateTime>;
-        fn name() -> &'static str {
-            "createdAt_gt"
-        }
+        const NAME: &'static str = "createdAt_gt";
     }
     impl ::cynic::schema::HasInputField<CreatedAtGt, Option<super::DateTime>>
         for super::CityWhereInput
@@ -758,9 +594,7 @@ pub mod city_where_input_fields {
     pub struct CreatedAtGte;
     impl ::cynic::schema::Field for CreatedAtGte {
         type Type = Option<super::DateTime>;
-        fn name() -> &'static str {
-            "createdAt_gte"
-        }
+        const NAME: &'static str = "createdAt_gte";
     }
     impl ::cynic::schema::HasInputField<CreatedAtGte, Option<super::DateTime>>
         for super::CityWhereInput
@@ -769,17 +603,13 @@ pub mod city_where_input_fields {
     pub struct UpdatedAt;
     impl ::cynic::schema::Field for UpdatedAt {
         type Type = Option<super::DateTime>;
-        fn name() -> &'static str {
-            "updatedAt"
-        }
+        const NAME: &'static str = "updatedAt";
     }
     impl ::cynic::schema::HasInputField<UpdatedAt, Option<super::DateTime>> for super::CityWhereInput {}
     pub struct UpdatedAtNot;
     impl ::cynic::schema::Field for UpdatedAtNot {
         type Type = Option<super::DateTime>;
-        fn name() -> &'static str {
-            "updatedAt_not"
-        }
+        const NAME: &'static str = "updatedAt_not";
     }
     impl ::cynic::schema::HasInputField<UpdatedAtNot, Option<super::DateTime>>
         for super::CityWhereInput
@@ -788,9 +618,7 @@ pub mod city_where_input_fields {
     pub struct UpdatedAtIn;
     impl ::cynic::schema::Field for UpdatedAtIn {
         type Type = Option<Vec<super::DateTime>>;
-        fn name() -> &'static str {
-            "updatedAt_in"
-        }
+        const NAME: &'static str = "updatedAt_in";
     }
     impl ::cynic::schema::HasInputField<UpdatedAtIn, Option<Vec<super::DateTime>>>
         for super::CityWhereInput
@@ -799,9 +627,7 @@ pub mod city_where_input_fields {
     pub struct UpdatedAtNotIn;
     impl ::cynic::schema::Field for UpdatedAtNotIn {
         type Type = Option<Vec<super::DateTime>>;
-        fn name() -> &'static str {
-            "updatedAt_not_in"
-        }
+        const NAME: &'static str = "updatedAt_not_in";
     }
     impl ::cynic::schema::HasInputField<UpdatedAtNotIn, Option<Vec<super::DateTime>>>
         for super::CityWhereInput
@@ -810,9 +636,7 @@ pub mod city_where_input_fields {
     pub struct UpdatedAtLt;
     impl ::cynic::schema::Field for UpdatedAtLt {
         type Type = Option<super::DateTime>;
-        fn name() -> &'static str {
-            "updatedAt_lt"
-        }
+        const NAME: &'static str = "updatedAt_lt";
     }
     impl ::cynic::schema::HasInputField<UpdatedAtLt, Option<super::DateTime>>
         for super::CityWhereInput
@@ -821,9 +645,7 @@ pub mod city_where_input_fields {
     pub struct UpdatedAtLte;
     impl ::cynic::schema::Field for UpdatedAtLte {
         type Type = Option<super::DateTime>;
-        fn name() -> &'static str {
-            "updatedAt_lte"
-        }
+        const NAME: &'static str = "updatedAt_lte";
     }
     impl ::cynic::schema::HasInputField<UpdatedAtLte, Option<super::DateTime>>
         for super::CityWhereInput
@@ -832,9 +654,7 @@ pub mod city_where_input_fields {
     pub struct UpdatedAtGt;
     impl ::cynic::schema::Field for UpdatedAtGt {
         type Type = Option<super::DateTime>;
-        fn name() -> &'static str {
-            "updatedAt_gt"
-        }
+        const NAME: &'static str = "updatedAt_gt";
     }
     impl ::cynic::schema::HasInputField<UpdatedAtGt, Option<super::DateTime>>
         for super::CityWhereInput
@@ -843,9 +663,7 @@ pub mod city_where_input_fields {
     pub struct UpdatedAtGte;
     impl ::cynic::schema::Field for UpdatedAtGte {
         type Type = Option<super::DateTime>;
-        fn name() -> &'static str {
-            "updatedAt_gte"
-        }
+        const NAME: &'static str = "updatedAt_gte";
     }
     impl ::cynic::schema::HasInputField<UpdatedAtGte, Option<super::DateTime>>
         for super::CityWhereInput
@@ -854,9 +672,7 @@ pub mod city_where_input_fields {
     pub struct And;
     impl ::cynic::schema::Field for And {
         type Type = Option<Vec<super::CityWhereInput>>;
-        fn name() -> &'static str {
-            "AND"
-        }
+        const NAME: &'static str = "AND";
     }
     impl ::cynic::schema::HasInputField<And, Option<Vec<super::CityWhereInput>>>
         for super::CityWhereInput
@@ -865,9 +681,7 @@ pub mod city_where_input_fields {
     pub struct Or;
     impl ::cynic::schema::Field for Or {
         type Type = Option<Vec<super::CityWhereInput>>;
-        fn name() -> &'static str {
-            "OR"
-        }
+        const NAME: &'static str = "OR";
     }
     impl ::cynic::schema::HasInputField<Or, Option<Vec<super::CityWhereInput>>>
         for super::CityWhereInput
@@ -876,9 +690,7 @@ pub mod city_where_input_fields {
     pub struct Not;
     impl ::cynic::schema::Field for Not {
         type Type = Option<Vec<super::CityWhereInput>>;
-        fn name() -> &'static str {
-            "NOT"
-        }
+        const NAME: &'static str = "NOT";
     }
     impl ::cynic::schema::HasInputField<Not, Option<Vec<super::CityWhereInput>>>
         for super::CityWhereInput
@@ -890,9 +702,7 @@ pub mod commitment_fields {
     pub struct Id;
     impl ::cynic::schema::Field for Id {
         type Type = super::Id;
-        fn name() -> &'static str {
-            "id"
-        }
+        const NAME: &'static str = "id";
     }
     impl ::cynic::schema::HasField<Id> for super::Commitment {
         type Type = super::Id;
@@ -900,9 +710,7 @@ pub mod commitment_fields {
     pub struct Title;
     impl ::cynic::schema::Field for Title {
         type Type = super::String;
-        fn name() -> &'static str {
-            "title"
-        }
+        const NAME: &'static str = "title";
     }
     impl ::cynic::schema::HasField<Title> for super::Commitment {
         type Type = super::String;
@@ -910,9 +718,7 @@ pub mod commitment_fields {
     pub struct Slug;
     impl ::cynic::schema::Field for Slug {
         type Type = super::String;
-        fn name() -> &'static str {
-            "slug"
-        }
+        const NAME: &'static str = "slug";
     }
     impl ::cynic::schema::HasField<Slug> for super::Commitment {
         type Type = super::String;
@@ -920,9 +726,7 @@ pub mod commitment_fields {
     pub struct Jobs;
     impl ::cynic::schema::Field for Jobs {
         type Type = Option<Vec<super::Job>>;
-        fn name() -> &'static str {
-            "jobs"
-        }
+        const NAME: &'static str = "jobs";
     }
     impl ::cynic::schema::HasField<Jobs> for super::Commitment {
         type Type = Option<Vec<super::Job>>;
@@ -931,59 +735,43 @@ pub mod commitment_fields {
         pub struct Where;
         impl ::cynic::schema::HasArgument<Where> for super::Jobs {
             type ArgumentType = Option<super::super::JobWhereInput>;
-            fn name() -> &'static str {
-                "where"
-            }
+            const NAME: &'static str = "where";
         }
         pub struct OrderBy;
         impl ::cynic::schema::HasArgument<OrderBy> for super::Jobs {
             type ArgumentType = Option<super::super::JobOrderByInput>;
-            fn name() -> &'static str {
-                "orderBy"
-            }
+            const NAME: &'static str = "orderBy";
         }
         pub struct Skip;
         impl ::cynic::schema::HasArgument<Skip> for super::Jobs {
             type ArgumentType = Option<super::super::Int>;
-            fn name() -> &'static str {
-                "skip"
-            }
+            const NAME: &'static str = "skip";
         }
         pub struct After;
         impl ::cynic::schema::HasArgument<After> for super::Jobs {
             type ArgumentType = Option<super::super::String>;
-            fn name() -> &'static str {
-                "after"
-            }
+            const NAME: &'static str = "after";
         }
         pub struct Before;
         impl ::cynic::schema::HasArgument<Before> for super::Jobs {
             type ArgumentType = Option<super::super::String>;
-            fn name() -> &'static str {
-                "before"
-            }
+            const NAME: &'static str = "before";
         }
         pub struct First;
         impl ::cynic::schema::HasArgument<First> for super::Jobs {
             type ArgumentType = Option<super::super::Int>;
-            fn name() -> &'static str {
-                "first"
-            }
+            const NAME: &'static str = "first";
         }
         pub struct Last;
         impl ::cynic::schema::HasArgument<Last> for super::Jobs {
             type ArgumentType = Option<super::super::Int>;
-            fn name() -> &'static str {
-                "last"
-            }
+            const NAME: &'static str = "last";
         }
     }
     pub struct CreatedAt;
     impl ::cynic::schema::Field for CreatedAt {
         type Type = super::DateTime;
-        fn name() -> &'static str {
-            "createdAt"
-        }
+        const NAME: &'static str = "createdAt";
     }
     impl ::cynic::schema::HasField<CreatedAt> for super::Commitment {
         type Type = super::DateTime;
@@ -991,9 +779,7 @@ pub mod commitment_fields {
     pub struct UpdatedAt;
     impl ::cynic::schema::Field for UpdatedAt {
         type Type = super::DateTime;
-        fn name() -> &'static str {
-            "updatedAt"
-        }
+        const NAME: &'static str = "updatedAt";
     }
     impl ::cynic::schema::HasField<UpdatedAt> for super::Commitment {
         type Type = super::DateTime;
@@ -1005,33 +791,25 @@ pub mod commitment_where_input_fields {
     pub struct Id;
     impl ::cynic::schema::Field for Id {
         type Type = Option<super::Id>;
-        fn name() -> &'static str {
-            "id"
-        }
+        const NAME: &'static str = "id";
     }
     impl ::cynic::schema::HasInputField<Id, Option<super::Id>> for super::CommitmentWhereInput {}
     pub struct IdNot;
     impl ::cynic::schema::Field for IdNot {
         type Type = Option<super::Id>;
-        fn name() -> &'static str {
-            "id_not"
-        }
+        const NAME: &'static str = "id_not";
     }
     impl ::cynic::schema::HasInputField<IdNot, Option<super::Id>> for super::CommitmentWhereInput {}
     pub struct IdIn;
     impl ::cynic::schema::Field for IdIn {
         type Type = Option<Vec<super::Id>>;
-        fn name() -> &'static str {
-            "id_in"
-        }
+        const NAME: &'static str = "id_in";
     }
     impl ::cynic::schema::HasInputField<IdIn, Option<Vec<super::Id>>> for super::CommitmentWhereInput {}
     pub struct IdNotIn;
     impl ::cynic::schema::Field for IdNotIn {
         type Type = Option<Vec<super::Id>>;
-        fn name() -> &'static str {
-            "id_not_in"
-        }
+        const NAME: &'static str = "id_not_in";
     }
     impl ::cynic::schema::HasInputField<IdNotIn, Option<Vec<super::Id>>>
         for super::CommitmentWhereInput
@@ -1040,49 +818,37 @@ pub mod commitment_where_input_fields {
     pub struct IdLt;
     impl ::cynic::schema::Field for IdLt {
         type Type = Option<super::Id>;
-        fn name() -> &'static str {
-            "id_lt"
-        }
+        const NAME: &'static str = "id_lt";
     }
     impl ::cynic::schema::HasInputField<IdLt, Option<super::Id>> for super::CommitmentWhereInput {}
     pub struct IdLte;
     impl ::cynic::schema::Field for IdLte {
         type Type = Option<super::Id>;
-        fn name() -> &'static str {
-            "id_lte"
-        }
+        const NAME: &'static str = "id_lte";
     }
     impl ::cynic::schema::HasInputField<IdLte, Option<super::Id>> for super::CommitmentWhereInput {}
     pub struct IdGt;
     impl ::cynic::schema::Field for IdGt {
         type Type = Option<super::Id>;
-        fn name() -> &'static str {
-            "id_gt"
-        }
+        const NAME: &'static str = "id_gt";
     }
     impl ::cynic::schema::HasInputField<IdGt, Option<super::Id>> for super::CommitmentWhereInput {}
     pub struct IdGte;
     impl ::cynic::schema::Field for IdGte {
         type Type = Option<super::Id>;
-        fn name() -> &'static str {
-            "id_gte"
-        }
+        const NAME: &'static str = "id_gte";
     }
     impl ::cynic::schema::HasInputField<IdGte, Option<super::Id>> for super::CommitmentWhereInput {}
     pub struct IdContains;
     impl ::cynic::schema::Field for IdContains {
         type Type = Option<super::Id>;
-        fn name() -> &'static str {
-            "id_contains"
-        }
+        const NAME: &'static str = "id_contains";
     }
     impl ::cynic::schema::HasInputField<IdContains, Option<super::Id>> for super::CommitmentWhereInput {}
     pub struct IdNotContains;
     impl ::cynic::schema::Field for IdNotContains {
         type Type = Option<super::Id>;
-        fn name() -> &'static str {
-            "id_not_contains"
-        }
+        const NAME: &'static str = "id_not_contains";
     }
     impl ::cynic::schema::HasInputField<IdNotContains, Option<super::Id>>
         for super::CommitmentWhereInput
@@ -1091,9 +857,7 @@ pub mod commitment_where_input_fields {
     pub struct IdStartsWith;
     impl ::cynic::schema::Field for IdStartsWith {
         type Type = Option<super::Id>;
-        fn name() -> &'static str {
-            "id_starts_with"
-        }
+        const NAME: &'static str = "id_starts_with";
     }
     impl ::cynic::schema::HasInputField<IdStartsWith, Option<super::Id>>
         for super::CommitmentWhereInput
@@ -1102,9 +866,7 @@ pub mod commitment_where_input_fields {
     pub struct IdNotStartsWith;
     impl ::cynic::schema::Field for IdNotStartsWith {
         type Type = Option<super::Id>;
-        fn name() -> &'static str {
-            "id_not_starts_with"
-        }
+        const NAME: &'static str = "id_not_starts_with";
     }
     impl ::cynic::schema::HasInputField<IdNotStartsWith, Option<super::Id>>
         for super::CommitmentWhereInput
@@ -1113,17 +875,13 @@ pub mod commitment_where_input_fields {
     pub struct IdEndsWith;
     impl ::cynic::schema::Field for IdEndsWith {
         type Type = Option<super::Id>;
-        fn name() -> &'static str {
-            "id_ends_with"
-        }
+        const NAME: &'static str = "id_ends_with";
     }
     impl ::cynic::schema::HasInputField<IdEndsWith, Option<super::Id>> for super::CommitmentWhereInput {}
     pub struct IdNotEndsWith;
     impl ::cynic::schema::Field for IdNotEndsWith {
         type Type = Option<super::Id>;
-        fn name() -> &'static str {
-            "id_not_ends_with"
-        }
+        const NAME: &'static str = "id_not_ends_with";
     }
     impl ::cynic::schema::HasInputField<IdNotEndsWith, Option<super::Id>>
         for super::CommitmentWhereInput
@@ -1132,17 +890,13 @@ pub mod commitment_where_input_fields {
     pub struct Title;
     impl ::cynic::schema::Field for Title {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "title"
-        }
+        const NAME: &'static str = "title";
     }
     impl ::cynic::schema::HasInputField<Title, Option<super::String>> for super::CommitmentWhereInput {}
     pub struct TitleNot;
     impl ::cynic::schema::Field for TitleNot {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "title_not"
-        }
+        const NAME: &'static str = "title_not";
     }
     impl ::cynic::schema::HasInputField<TitleNot, Option<super::String>>
         for super::CommitmentWhereInput
@@ -1151,9 +905,7 @@ pub mod commitment_where_input_fields {
     pub struct TitleIn;
     impl ::cynic::schema::Field for TitleIn {
         type Type = Option<Vec<super::String>>;
-        fn name() -> &'static str {
-            "title_in"
-        }
+        const NAME: &'static str = "title_in";
     }
     impl ::cynic::schema::HasInputField<TitleIn, Option<Vec<super::String>>>
         for super::CommitmentWhereInput
@@ -1162,9 +914,7 @@ pub mod commitment_where_input_fields {
     pub struct TitleNotIn;
     impl ::cynic::schema::Field for TitleNotIn {
         type Type = Option<Vec<super::String>>;
-        fn name() -> &'static str {
-            "title_not_in"
-        }
+        const NAME: &'static str = "title_not_in";
     }
     impl ::cynic::schema::HasInputField<TitleNotIn, Option<Vec<super::String>>>
         for super::CommitmentWhereInput
@@ -1173,9 +923,7 @@ pub mod commitment_where_input_fields {
     pub struct TitleLt;
     impl ::cynic::schema::Field for TitleLt {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "title_lt"
-        }
+        const NAME: &'static str = "title_lt";
     }
     impl ::cynic::schema::HasInputField<TitleLt, Option<super::String>>
         for super::CommitmentWhereInput
@@ -1184,9 +932,7 @@ pub mod commitment_where_input_fields {
     pub struct TitleLte;
     impl ::cynic::schema::Field for TitleLte {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "title_lte"
-        }
+        const NAME: &'static str = "title_lte";
     }
     impl ::cynic::schema::HasInputField<TitleLte, Option<super::String>>
         for super::CommitmentWhereInput
@@ -1195,9 +941,7 @@ pub mod commitment_where_input_fields {
     pub struct TitleGt;
     impl ::cynic::schema::Field for TitleGt {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "title_gt"
-        }
+        const NAME: &'static str = "title_gt";
     }
     impl ::cynic::schema::HasInputField<TitleGt, Option<super::String>>
         for super::CommitmentWhereInput
@@ -1206,9 +950,7 @@ pub mod commitment_where_input_fields {
     pub struct TitleGte;
     impl ::cynic::schema::Field for TitleGte {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "title_gte"
-        }
+        const NAME: &'static str = "title_gte";
     }
     impl ::cynic::schema::HasInputField<TitleGte, Option<super::String>>
         for super::CommitmentWhereInput
@@ -1217,9 +959,7 @@ pub mod commitment_where_input_fields {
     pub struct TitleContains;
     impl ::cynic::schema::Field for TitleContains {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "title_contains"
-        }
+        const NAME: &'static str = "title_contains";
     }
     impl ::cynic::schema::HasInputField<TitleContains, Option<super::String>>
         for super::CommitmentWhereInput
@@ -1228,9 +968,7 @@ pub mod commitment_where_input_fields {
     pub struct TitleNotContains;
     impl ::cynic::schema::Field for TitleNotContains {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "title_not_contains"
-        }
+        const NAME: &'static str = "title_not_contains";
     }
     impl ::cynic::schema::HasInputField<TitleNotContains, Option<super::String>>
         for super::CommitmentWhereInput
@@ -1239,9 +977,7 @@ pub mod commitment_where_input_fields {
     pub struct TitleStartsWith;
     impl ::cynic::schema::Field for TitleStartsWith {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "title_starts_with"
-        }
+        const NAME: &'static str = "title_starts_with";
     }
     impl ::cynic::schema::HasInputField<TitleStartsWith, Option<super::String>>
         for super::CommitmentWhereInput
@@ -1250,9 +986,7 @@ pub mod commitment_where_input_fields {
     pub struct TitleNotStartsWith;
     impl ::cynic::schema::Field for TitleNotStartsWith {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "title_not_starts_with"
-        }
+        const NAME: &'static str = "title_not_starts_with";
     }
     impl ::cynic::schema::HasInputField<TitleNotStartsWith, Option<super::String>>
         for super::CommitmentWhereInput
@@ -1261,9 +995,7 @@ pub mod commitment_where_input_fields {
     pub struct TitleEndsWith;
     impl ::cynic::schema::Field for TitleEndsWith {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "title_ends_with"
-        }
+        const NAME: &'static str = "title_ends_with";
     }
     impl ::cynic::schema::HasInputField<TitleEndsWith, Option<super::String>>
         for super::CommitmentWhereInput
@@ -1272,9 +1004,7 @@ pub mod commitment_where_input_fields {
     pub struct TitleNotEndsWith;
     impl ::cynic::schema::Field for TitleNotEndsWith {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "title_not_ends_with"
-        }
+        const NAME: &'static str = "title_not_ends_with";
     }
     impl ::cynic::schema::HasInputField<TitleNotEndsWith, Option<super::String>>
         for super::CommitmentWhereInput
@@ -1283,17 +1013,13 @@ pub mod commitment_where_input_fields {
     pub struct Slug;
     impl ::cynic::schema::Field for Slug {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "slug"
-        }
+        const NAME: &'static str = "slug";
     }
     impl ::cynic::schema::HasInputField<Slug, Option<super::String>> for super::CommitmentWhereInput {}
     pub struct SlugNot;
     impl ::cynic::schema::Field for SlugNot {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "slug_not"
-        }
+        const NAME: &'static str = "slug_not";
     }
     impl ::cynic::schema::HasInputField<SlugNot, Option<super::String>>
         for super::CommitmentWhereInput
@@ -1302,9 +1028,7 @@ pub mod commitment_where_input_fields {
     pub struct SlugIn;
     impl ::cynic::schema::Field for SlugIn {
         type Type = Option<Vec<super::String>>;
-        fn name() -> &'static str {
-            "slug_in"
-        }
+        const NAME: &'static str = "slug_in";
     }
     impl ::cynic::schema::HasInputField<SlugIn, Option<Vec<super::String>>>
         for super::CommitmentWhereInput
@@ -1313,9 +1037,7 @@ pub mod commitment_where_input_fields {
     pub struct SlugNotIn;
     impl ::cynic::schema::Field for SlugNotIn {
         type Type = Option<Vec<super::String>>;
-        fn name() -> &'static str {
-            "slug_not_in"
-        }
+        const NAME: &'static str = "slug_not_in";
     }
     impl ::cynic::schema::HasInputField<SlugNotIn, Option<Vec<super::String>>>
         for super::CommitmentWhereInput
@@ -1324,17 +1046,13 @@ pub mod commitment_where_input_fields {
     pub struct SlugLt;
     impl ::cynic::schema::Field for SlugLt {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "slug_lt"
-        }
+        const NAME: &'static str = "slug_lt";
     }
     impl ::cynic::schema::HasInputField<SlugLt, Option<super::String>> for super::CommitmentWhereInput {}
     pub struct SlugLte;
     impl ::cynic::schema::Field for SlugLte {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "slug_lte"
-        }
+        const NAME: &'static str = "slug_lte";
     }
     impl ::cynic::schema::HasInputField<SlugLte, Option<super::String>>
         for super::CommitmentWhereInput
@@ -1343,17 +1061,13 @@ pub mod commitment_where_input_fields {
     pub struct SlugGt;
     impl ::cynic::schema::Field for SlugGt {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "slug_gt"
-        }
+        const NAME: &'static str = "slug_gt";
     }
     impl ::cynic::schema::HasInputField<SlugGt, Option<super::String>> for super::CommitmentWhereInput {}
     pub struct SlugGte;
     impl ::cynic::schema::Field for SlugGte {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "slug_gte"
-        }
+        const NAME: &'static str = "slug_gte";
     }
     impl ::cynic::schema::HasInputField<SlugGte, Option<super::String>>
         for super::CommitmentWhereInput
@@ -1362,9 +1076,7 @@ pub mod commitment_where_input_fields {
     pub struct SlugContains;
     impl ::cynic::schema::Field for SlugContains {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "slug_contains"
-        }
+        const NAME: &'static str = "slug_contains";
     }
     impl ::cynic::schema::HasInputField<SlugContains, Option<super::String>>
         for super::CommitmentWhereInput
@@ -1373,9 +1085,7 @@ pub mod commitment_where_input_fields {
     pub struct SlugNotContains;
     impl ::cynic::schema::Field for SlugNotContains {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "slug_not_contains"
-        }
+        const NAME: &'static str = "slug_not_contains";
     }
     impl ::cynic::schema::HasInputField<SlugNotContains, Option<super::String>>
         for super::CommitmentWhereInput
@@ -1384,9 +1094,7 @@ pub mod commitment_where_input_fields {
     pub struct SlugStartsWith;
     impl ::cynic::schema::Field for SlugStartsWith {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "slug_starts_with"
-        }
+        const NAME: &'static str = "slug_starts_with";
     }
     impl ::cynic::schema::HasInputField<SlugStartsWith, Option<super::String>>
         for super::CommitmentWhereInput
@@ -1395,9 +1103,7 @@ pub mod commitment_where_input_fields {
     pub struct SlugNotStartsWith;
     impl ::cynic::schema::Field for SlugNotStartsWith {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "slug_not_starts_with"
-        }
+        const NAME: &'static str = "slug_not_starts_with";
     }
     impl ::cynic::schema::HasInputField<SlugNotStartsWith, Option<super::String>>
         for super::CommitmentWhereInput
@@ -1406,9 +1112,7 @@ pub mod commitment_where_input_fields {
     pub struct SlugEndsWith;
     impl ::cynic::schema::Field for SlugEndsWith {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "slug_ends_with"
-        }
+        const NAME: &'static str = "slug_ends_with";
     }
     impl ::cynic::schema::HasInputField<SlugEndsWith, Option<super::String>>
         for super::CommitmentWhereInput
@@ -1417,9 +1121,7 @@ pub mod commitment_where_input_fields {
     pub struct SlugNotEndsWith;
     impl ::cynic::schema::Field for SlugNotEndsWith {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "slug_not_ends_with"
-        }
+        const NAME: &'static str = "slug_not_ends_with";
     }
     impl ::cynic::schema::HasInputField<SlugNotEndsWith, Option<super::String>>
         for super::CommitmentWhereInput
@@ -1428,9 +1130,7 @@ pub mod commitment_where_input_fields {
     pub struct JobsEvery;
     impl ::cynic::schema::Field for JobsEvery {
         type Type = Option<super::JobWhereInput>;
-        fn name() -> &'static str {
-            "jobs_every"
-        }
+        const NAME: &'static str = "jobs_every";
     }
     impl ::cynic::schema::HasInputField<JobsEvery, Option<super::JobWhereInput>>
         for super::CommitmentWhereInput
@@ -1439,9 +1139,7 @@ pub mod commitment_where_input_fields {
     pub struct JobsSome;
     impl ::cynic::schema::Field for JobsSome {
         type Type = Option<super::JobWhereInput>;
-        fn name() -> &'static str {
-            "jobs_some"
-        }
+        const NAME: &'static str = "jobs_some";
     }
     impl ::cynic::schema::HasInputField<JobsSome, Option<super::JobWhereInput>>
         for super::CommitmentWhereInput
@@ -1450,9 +1148,7 @@ pub mod commitment_where_input_fields {
     pub struct JobsNone;
     impl ::cynic::schema::Field for JobsNone {
         type Type = Option<super::JobWhereInput>;
-        fn name() -> &'static str {
-            "jobs_none"
-        }
+        const NAME: &'static str = "jobs_none";
     }
     impl ::cynic::schema::HasInputField<JobsNone, Option<super::JobWhereInput>>
         for super::CommitmentWhereInput
@@ -1461,9 +1157,7 @@ pub mod commitment_where_input_fields {
     pub struct CreatedAt;
     impl ::cynic::schema::Field for CreatedAt {
         type Type = Option<super::DateTime>;
-        fn name() -> &'static str {
-            "createdAt"
-        }
+        const NAME: &'static str = "createdAt";
     }
     impl ::cynic::schema::HasInputField<CreatedAt, Option<super::DateTime>>
         for super::CommitmentWhereInput
@@ -1472,9 +1166,7 @@ pub mod commitment_where_input_fields {
     pub struct CreatedAtNot;
     impl ::cynic::schema::Field for CreatedAtNot {
         type Type = Option<super::DateTime>;
-        fn name() -> &'static str {
-            "createdAt_not"
-        }
+        const NAME: &'static str = "createdAt_not";
     }
     impl ::cynic::schema::HasInputField<CreatedAtNot, Option<super::DateTime>>
         for super::CommitmentWhereInput
@@ -1483,9 +1175,7 @@ pub mod commitment_where_input_fields {
     pub struct CreatedAtIn;
     impl ::cynic::schema::Field for CreatedAtIn {
         type Type = Option<Vec<super::DateTime>>;
-        fn name() -> &'static str {
-            "createdAt_in"
-        }
+        const NAME: &'static str = "createdAt_in";
     }
     impl ::cynic::schema::HasInputField<CreatedAtIn, Option<Vec<super::DateTime>>>
         for super::CommitmentWhereInput
@@ -1494,9 +1184,7 @@ pub mod commitment_where_input_fields {
     pub struct CreatedAtNotIn;
     impl ::cynic::schema::Field for CreatedAtNotIn {
         type Type = Option<Vec<super::DateTime>>;
-        fn name() -> &'static str {
-            "createdAt_not_in"
-        }
+        const NAME: &'static str = "createdAt_not_in";
     }
     impl ::cynic::schema::HasInputField<CreatedAtNotIn, Option<Vec<super::DateTime>>>
         for super::CommitmentWhereInput
@@ -1505,9 +1193,7 @@ pub mod commitment_where_input_fields {
     pub struct CreatedAtLt;
     impl ::cynic::schema::Field for CreatedAtLt {
         type Type = Option<super::DateTime>;
-        fn name() -> &'static str {
-            "createdAt_lt"
-        }
+        const NAME: &'static str = "createdAt_lt";
     }
     impl ::cynic::schema::HasInputField<CreatedAtLt, Option<super::DateTime>>
         for super::CommitmentWhereInput
@@ -1516,9 +1202,7 @@ pub mod commitment_where_input_fields {
     pub struct CreatedAtLte;
     impl ::cynic::schema::Field for CreatedAtLte {
         type Type = Option<super::DateTime>;
-        fn name() -> &'static str {
-            "createdAt_lte"
-        }
+        const NAME: &'static str = "createdAt_lte";
     }
     impl ::cynic::schema::HasInputField<CreatedAtLte, Option<super::DateTime>>
         for super::CommitmentWhereInput
@@ -1527,9 +1211,7 @@ pub mod commitment_where_input_fields {
     pub struct CreatedAtGt;
     impl ::cynic::schema::Field for CreatedAtGt {
         type Type = Option<super::DateTime>;
-        fn name() -> &'static str {
-            "createdAt_gt"
-        }
+        const NAME: &'static str = "createdAt_gt";
     }
     impl ::cynic::schema::HasInputField<CreatedAtGt, Option<super::DateTime>>
         for super::CommitmentWhereInput
@@ -1538,9 +1220,7 @@ pub mod commitment_where_input_fields {
     pub struct CreatedAtGte;
     impl ::cynic::schema::Field for CreatedAtGte {
         type Type = Option<super::DateTime>;
-        fn name() -> &'static str {
-            "createdAt_gte"
-        }
+        const NAME: &'static str = "createdAt_gte";
     }
     impl ::cynic::schema::HasInputField<CreatedAtGte, Option<super::DateTime>>
         for super::CommitmentWhereInput
@@ -1549,9 +1229,7 @@ pub mod commitment_where_input_fields {
     pub struct UpdatedAt;
     impl ::cynic::schema::Field for UpdatedAt {
         type Type = Option<super::DateTime>;
-        fn name() -> &'static str {
-            "updatedAt"
-        }
+        const NAME: &'static str = "updatedAt";
     }
     impl ::cynic::schema::HasInputField<UpdatedAt, Option<super::DateTime>>
         for super::CommitmentWhereInput
@@ -1560,9 +1238,7 @@ pub mod commitment_where_input_fields {
     pub struct UpdatedAtNot;
     impl ::cynic::schema::Field for UpdatedAtNot {
         type Type = Option<super::DateTime>;
-        fn name() -> &'static str {
-            "updatedAt_not"
-        }
+        const NAME: &'static str = "updatedAt_not";
     }
     impl ::cynic::schema::HasInputField<UpdatedAtNot, Option<super::DateTime>>
         for super::CommitmentWhereInput
@@ -1571,9 +1247,7 @@ pub mod commitment_where_input_fields {
     pub struct UpdatedAtIn;
     impl ::cynic::schema::Field for UpdatedAtIn {
         type Type = Option<Vec<super::DateTime>>;
-        fn name() -> &'static str {
-            "updatedAt_in"
-        }
+        const NAME: &'static str = "updatedAt_in";
     }
     impl ::cynic::schema::HasInputField<UpdatedAtIn, Option<Vec<super::DateTime>>>
         for super::CommitmentWhereInput
@@ -1582,9 +1256,7 @@ pub mod commitment_where_input_fields {
     pub struct UpdatedAtNotIn;
     impl ::cynic::schema::Field for UpdatedAtNotIn {
         type Type = Option<Vec<super::DateTime>>;
-        fn name() -> &'static str {
-            "updatedAt_not_in"
-        }
+        const NAME: &'static str = "updatedAt_not_in";
     }
     impl ::cynic::schema::HasInputField<UpdatedAtNotIn, Option<Vec<super::DateTime>>>
         for super::CommitmentWhereInput
@@ -1593,9 +1265,7 @@ pub mod commitment_where_input_fields {
     pub struct UpdatedAtLt;
     impl ::cynic::schema::Field for UpdatedAtLt {
         type Type = Option<super::DateTime>;
-        fn name() -> &'static str {
-            "updatedAt_lt"
-        }
+        const NAME: &'static str = "updatedAt_lt";
     }
     impl ::cynic::schema::HasInputField<UpdatedAtLt, Option<super::DateTime>>
         for super::CommitmentWhereInput
@@ -1604,9 +1274,7 @@ pub mod commitment_where_input_fields {
     pub struct UpdatedAtLte;
     impl ::cynic::schema::Field for UpdatedAtLte {
         type Type = Option<super::DateTime>;
-        fn name() -> &'static str {
-            "updatedAt_lte"
-        }
+        const NAME: &'static str = "updatedAt_lte";
     }
     impl ::cynic::schema::HasInputField<UpdatedAtLte, Option<super::DateTime>>
         for super::CommitmentWhereInput
@@ -1615,9 +1283,7 @@ pub mod commitment_where_input_fields {
     pub struct UpdatedAtGt;
     impl ::cynic::schema::Field for UpdatedAtGt {
         type Type = Option<super::DateTime>;
-        fn name() -> &'static str {
-            "updatedAt_gt"
-        }
+        const NAME: &'static str = "updatedAt_gt";
     }
     impl ::cynic::schema::HasInputField<UpdatedAtGt, Option<super::DateTime>>
         for super::CommitmentWhereInput
@@ -1626,9 +1292,7 @@ pub mod commitment_where_input_fields {
     pub struct UpdatedAtGte;
     impl ::cynic::schema::Field for UpdatedAtGte {
         type Type = Option<super::DateTime>;
-        fn name() -> &'static str {
-            "updatedAt_gte"
-        }
+        const NAME: &'static str = "updatedAt_gte";
     }
     impl ::cynic::schema::HasInputField<UpdatedAtGte, Option<super::DateTime>>
         for super::CommitmentWhereInput
@@ -1637,9 +1301,7 @@ pub mod commitment_where_input_fields {
     pub struct And;
     impl ::cynic::schema::Field for And {
         type Type = Option<Vec<super::CommitmentWhereInput>>;
-        fn name() -> &'static str {
-            "AND"
-        }
+        const NAME: &'static str = "AND";
     }
     impl ::cynic::schema::HasInputField<And, Option<Vec<super::CommitmentWhereInput>>>
         for super::CommitmentWhereInput
@@ -1648,9 +1310,7 @@ pub mod commitment_where_input_fields {
     pub struct Or;
     impl ::cynic::schema::Field for Or {
         type Type = Option<Vec<super::CommitmentWhereInput>>;
-        fn name() -> &'static str {
-            "OR"
-        }
+        const NAME: &'static str = "OR";
     }
     impl ::cynic::schema::HasInputField<Or, Option<Vec<super::CommitmentWhereInput>>>
         for super::CommitmentWhereInput
@@ -1659,9 +1319,7 @@ pub mod commitment_where_input_fields {
     pub struct Not;
     impl ::cynic::schema::Field for Not {
         type Type = Option<Vec<super::CommitmentWhereInput>>;
-        fn name() -> &'static str {
-            "NOT"
-        }
+        const NAME: &'static str = "NOT";
     }
     impl ::cynic::schema::HasInputField<Not, Option<Vec<super::CommitmentWhereInput>>>
         for super::CommitmentWhereInput
@@ -1673,9 +1331,7 @@ pub mod company_fields {
     pub struct Id;
     impl ::cynic::schema::Field for Id {
         type Type = super::Id;
-        fn name() -> &'static str {
-            "id"
-        }
+        const NAME: &'static str = "id";
     }
     impl ::cynic::schema::HasField<Id> for super::Company {
         type Type = super::Id;
@@ -1683,9 +1339,7 @@ pub mod company_fields {
     pub struct Name;
     impl ::cynic::schema::Field for Name {
         type Type = super::String;
-        fn name() -> &'static str {
-            "name"
-        }
+        const NAME: &'static str = "name";
     }
     impl ::cynic::schema::HasField<Name> for super::Company {
         type Type = super::String;
@@ -1693,9 +1347,7 @@ pub mod company_fields {
     pub struct Slug;
     impl ::cynic::schema::Field for Slug {
         type Type = super::String;
-        fn name() -> &'static str {
-            "slug"
-        }
+        const NAME: &'static str = "slug";
     }
     impl ::cynic::schema::HasField<Slug> for super::Company {
         type Type = super::String;
@@ -1703,9 +1355,7 @@ pub mod company_fields {
     pub struct WebsiteUrl;
     impl ::cynic::schema::Field for WebsiteUrl {
         type Type = super::String;
-        fn name() -> &'static str {
-            "websiteUrl"
-        }
+        const NAME: &'static str = "websiteUrl";
     }
     impl ::cynic::schema::HasField<WebsiteUrl> for super::Company {
         type Type = super::String;
@@ -1713,9 +1363,7 @@ pub mod company_fields {
     pub struct LogoUrl;
     impl ::cynic::schema::Field for LogoUrl {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "logoUrl"
-        }
+        const NAME: &'static str = "logoUrl";
     }
     impl ::cynic::schema::HasField<LogoUrl> for super::Company {
         type Type = Option<super::String>;
@@ -1723,9 +1371,7 @@ pub mod company_fields {
     pub struct Jobs;
     impl ::cynic::schema::Field for Jobs {
         type Type = Option<Vec<super::Job>>;
-        fn name() -> &'static str {
-            "jobs"
-        }
+        const NAME: &'static str = "jobs";
     }
     impl ::cynic::schema::HasField<Jobs> for super::Company {
         type Type = Option<Vec<super::Job>>;
@@ -1734,59 +1380,43 @@ pub mod company_fields {
         pub struct Where;
         impl ::cynic::schema::HasArgument<Where> for super::Jobs {
             type ArgumentType = Option<super::super::JobWhereInput>;
-            fn name() -> &'static str {
-                "where"
-            }
+            const NAME: &'static str = "where";
         }
         pub struct OrderBy;
         impl ::cynic::schema::HasArgument<OrderBy> for super::Jobs {
             type ArgumentType = Option<super::super::JobOrderByInput>;
-            fn name() -> &'static str {
-                "orderBy"
-            }
+            const NAME: &'static str = "orderBy";
         }
         pub struct Skip;
         impl ::cynic::schema::HasArgument<Skip> for super::Jobs {
             type ArgumentType = Option<super::super::Int>;
-            fn name() -> &'static str {
-                "skip"
-            }
+            const NAME: &'static str = "skip";
         }
         pub struct After;
         impl ::cynic::schema::HasArgument<After> for super::Jobs {
             type ArgumentType = Option<super::super::String>;
-            fn name() -> &'static str {
-                "after"
-            }
+            const NAME: &'static str = "after";
         }
         pub struct Before;
         impl ::cynic::schema::HasArgument<Before> for super::Jobs {
             type ArgumentType = Option<super::super::String>;
-            fn name() -> &'static str {
-                "before"
-            }
+            const NAME: &'static str = "before";
         }
         pub struct First;
         impl ::cynic::schema::HasArgument<First> for super::Jobs {
             type ArgumentType = Option<super::super::Int>;
-            fn name() -> &'static str {
-                "first"
-            }
+            const NAME: &'static str = "first";
         }
         pub struct Last;
         impl ::cynic::schema::HasArgument<Last> for super::Jobs {
             type ArgumentType = Option<super::super::Int>;
-            fn name() -> &'static str {
-                "last"
-            }
+            const NAME: &'static str = "last";
         }
     }
     pub struct Twitter;
     impl ::cynic::schema::Field for Twitter {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "twitter"
-        }
+        const NAME: &'static str = "twitter";
     }
     impl ::cynic::schema::HasField<Twitter> for super::Company {
         type Type = Option<super::String>;
@@ -1794,9 +1424,7 @@ pub mod company_fields {
     pub struct Emailed;
     impl ::cynic::schema::Field for Emailed {
         type Type = Option<super::Boolean>;
-        fn name() -> &'static str {
-            "emailed"
-        }
+        const NAME: &'static str = "emailed";
     }
     impl ::cynic::schema::HasField<Emailed> for super::Company {
         type Type = Option<super::Boolean>;
@@ -1804,9 +1432,7 @@ pub mod company_fields {
     pub struct CreatedAt;
     impl ::cynic::schema::Field for CreatedAt {
         type Type = super::DateTime;
-        fn name() -> &'static str {
-            "createdAt"
-        }
+        const NAME: &'static str = "createdAt";
     }
     impl ::cynic::schema::HasField<CreatedAt> for super::Company {
         type Type = super::DateTime;
@@ -1814,9 +1440,7 @@ pub mod company_fields {
     pub struct UpdatedAt;
     impl ::cynic::schema::Field for UpdatedAt {
         type Type = super::DateTime;
-        fn name() -> &'static str {
-            "updatedAt"
-        }
+        const NAME: &'static str = "updatedAt";
     }
     impl ::cynic::schema::HasField<UpdatedAt> for super::Company {
         type Type = super::DateTime;
@@ -1828,97 +1452,73 @@ pub mod company_where_input_fields {
     pub struct Id;
     impl ::cynic::schema::Field for Id {
         type Type = Option<super::Id>;
-        fn name() -> &'static str {
-            "id"
-        }
+        const NAME: &'static str = "id";
     }
     impl ::cynic::schema::HasInputField<Id, Option<super::Id>> for super::CompanyWhereInput {}
     pub struct IdNot;
     impl ::cynic::schema::Field for IdNot {
         type Type = Option<super::Id>;
-        fn name() -> &'static str {
-            "id_not"
-        }
+        const NAME: &'static str = "id_not";
     }
     impl ::cynic::schema::HasInputField<IdNot, Option<super::Id>> for super::CompanyWhereInput {}
     pub struct IdIn;
     impl ::cynic::schema::Field for IdIn {
         type Type = Option<Vec<super::Id>>;
-        fn name() -> &'static str {
-            "id_in"
-        }
+        const NAME: &'static str = "id_in";
     }
     impl ::cynic::schema::HasInputField<IdIn, Option<Vec<super::Id>>> for super::CompanyWhereInput {}
     pub struct IdNotIn;
     impl ::cynic::schema::Field for IdNotIn {
         type Type = Option<Vec<super::Id>>;
-        fn name() -> &'static str {
-            "id_not_in"
-        }
+        const NAME: &'static str = "id_not_in";
     }
     impl ::cynic::schema::HasInputField<IdNotIn, Option<Vec<super::Id>>> for super::CompanyWhereInput {}
     pub struct IdLt;
     impl ::cynic::schema::Field for IdLt {
         type Type = Option<super::Id>;
-        fn name() -> &'static str {
-            "id_lt"
-        }
+        const NAME: &'static str = "id_lt";
     }
     impl ::cynic::schema::HasInputField<IdLt, Option<super::Id>> for super::CompanyWhereInput {}
     pub struct IdLte;
     impl ::cynic::schema::Field for IdLte {
         type Type = Option<super::Id>;
-        fn name() -> &'static str {
-            "id_lte"
-        }
+        const NAME: &'static str = "id_lte";
     }
     impl ::cynic::schema::HasInputField<IdLte, Option<super::Id>> for super::CompanyWhereInput {}
     pub struct IdGt;
     impl ::cynic::schema::Field for IdGt {
         type Type = Option<super::Id>;
-        fn name() -> &'static str {
-            "id_gt"
-        }
+        const NAME: &'static str = "id_gt";
     }
     impl ::cynic::schema::HasInputField<IdGt, Option<super::Id>> for super::CompanyWhereInput {}
     pub struct IdGte;
     impl ::cynic::schema::Field for IdGte {
         type Type = Option<super::Id>;
-        fn name() -> &'static str {
-            "id_gte"
-        }
+        const NAME: &'static str = "id_gte";
     }
     impl ::cynic::schema::HasInputField<IdGte, Option<super::Id>> for super::CompanyWhereInput {}
     pub struct IdContains;
     impl ::cynic::schema::Field for IdContains {
         type Type = Option<super::Id>;
-        fn name() -> &'static str {
-            "id_contains"
-        }
+        const NAME: &'static str = "id_contains";
     }
     impl ::cynic::schema::HasInputField<IdContains, Option<super::Id>> for super::CompanyWhereInput {}
     pub struct IdNotContains;
     impl ::cynic::schema::Field for IdNotContains {
         type Type = Option<super::Id>;
-        fn name() -> &'static str {
-            "id_not_contains"
-        }
+        const NAME: &'static str = "id_not_contains";
     }
     impl ::cynic::schema::HasInputField<IdNotContains, Option<super::Id>> for super::CompanyWhereInput {}
     pub struct IdStartsWith;
     impl ::cynic::schema::Field for IdStartsWith {
         type Type = Option<super::Id>;
-        fn name() -> &'static str {
-            "id_starts_with"
-        }
+        const NAME: &'static str = "id_starts_with";
     }
     impl ::cynic::schema::HasInputField<IdStartsWith, Option<super::Id>> for super::CompanyWhereInput {}
     pub struct IdNotStartsWith;
     impl ::cynic::schema::Field for IdNotStartsWith {
         type Type = Option<super::Id>;
-        fn name() -> &'static str {
-            "id_not_starts_with"
-        }
+        const NAME: &'static str = "id_not_starts_with";
     }
     impl ::cynic::schema::HasInputField<IdNotStartsWith, Option<super::Id>>
         for super::CompanyWhereInput
@@ -1927,41 +1527,31 @@ pub mod company_where_input_fields {
     pub struct IdEndsWith;
     impl ::cynic::schema::Field for IdEndsWith {
         type Type = Option<super::Id>;
-        fn name() -> &'static str {
-            "id_ends_with"
-        }
+        const NAME: &'static str = "id_ends_with";
     }
     impl ::cynic::schema::HasInputField<IdEndsWith, Option<super::Id>> for super::CompanyWhereInput {}
     pub struct IdNotEndsWith;
     impl ::cynic::schema::Field for IdNotEndsWith {
         type Type = Option<super::Id>;
-        fn name() -> &'static str {
-            "id_not_ends_with"
-        }
+        const NAME: &'static str = "id_not_ends_with";
     }
     impl ::cynic::schema::HasInputField<IdNotEndsWith, Option<super::Id>> for super::CompanyWhereInput {}
     pub struct Name;
     impl ::cynic::schema::Field for Name {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "name"
-        }
+        const NAME: &'static str = "name";
     }
     impl ::cynic::schema::HasInputField<Name, Option<super::String>> for super::CompanyWhereInput {}
     pub struct NameNot;
     impl ::cynic::schema::Field for NameNot {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "name_not"
-        }
+        const NAME: &'static str = "name_not";
     }
     impl ::cynic::schema::HasInputField<NameNot, Option<super::String>> for super::CompanyWhereInput {}
     pub struct NameIn;
     impl ::cynic::schema::Field for NameIn {
         type Type = Option<Vec<super::String>>;
-        fn name() -> &'static str {
-            "name_in"
-        }
+        const NAME: &'static str = "name_in";
     }
     impl ::cynic::schema::HasInputField<NameIn, Option<Vec<super::String>>>
         for super::CompanyWhereInput
@@ -1970,9 +1560,7 @@ pub mod company_where_input_fields {
     pub struct NameNotIn;
     impl ::cynic::schema::Field for NameNotIn {
         type Type = Option<Vec<super::String>>;
-        fn name() -> &'static str {
-            "name_not_in"
-        }
+        const NAME: &'static str = "name_not_in";
     }
     impl ::cynic::schema::HasInputField<NameNotIn, Option<Vec<super::String>>>
         for super::CompanyWhereInput
@@ -1981,41 +1569,31 @@ pub mod company_where_input_fields {
     pub struct NameLt;
     impl ::cynic::schema::Field for NameLt {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "name_lt"
-        }
+        const NAME: &'static str = "name_lt";
     }
     impl ::cynic::schema::HasInputField<NameLt, Option<super::String>> for super::CompanyWhereInput {}
     pub struct NameLte;
     impl ::cynic::schema::Field for NameLte {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "name_lte"
-        }
+        const NAME: &'static str = "name_lte";
     }
     impl ::cynic::schema::HasInputField<NameLte, Option<super::String>> for super::CompanyWhereInput {}
     pub struct NameGt;
     impl ::cynic::schema::Field for NameGt {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "name_gt"
-        }
+        const NAME: &'static str = "name_gt";
     }
     impl ::cynic::schema::HasInputField<NameGt, Option<super::String>> for super::CompanyWhereInput {}
     pub struct NameGte;
     impl ::cynic::schema::Field for NameGte {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "name_gte"
-        }
+        const NAME: &'static str = "name_gte";
     }
     impl ::cynic::schema::HasInputField<NameGte, Option<super::String>> for super::CompanyWhereInput {}
     pub struct NameContains;
     impl ::cynic::schema::Field for NameContains {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "name_contains"
-        }
+        const NAME: &'static str = "name_contains";
     }
     impl ::cynic::schema::HasInputField<NameContains, Option<super::String>>
         for super::CompanyWhereInput
@@ -2024,9 +1602,7 @@ pub mod company_where_input_fields {
     pub struct NameNotContains;
     impl ::cynic::schema::Field for NameNotContains {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "name_not_contains"
-        }
+        const NAME: &'static str = "name_not_contains";
     }
     impl ::cynic::schema::HasInputField<NameNotContains, Option<super::String>>
         for super::CompanyWhereInput
@@ -2035,9 +1611,7 @@ pub mod company_where_input_fields {
     pub struct NameStartsWith;
     impl ::cynic::schema::Field for NameStartsWith {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "name_starts_with"
-        }
+        const NAME: &'static str = "name_starts_with";
     }
     impl ::cynic::schema::HasInputField<NameStartsWith, Option<super::String>>
         for super::CompanyWhereInput
@@ -2046,9 +1620,7 @@ pub mod company_where_input_fields {
     pub struct NameNotStartsWith;
     impl ::cynic::schema::Field for NameNotStartsWith {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "name_not_starts_with"
-        }
+        const NAME: &'static str = "name_not_starts_with";
     }
     impl ::cynic::schema::HasInputField<NameNotStartsWith, Option<super::String>>
         for super::CompanyWhereInput
@@ -2057,9 +1629,7 @@ pub mod company_where_input_fields {
     pub struct NameEndsWith;
     impl ::cynic::schema::Field for NameEndsWith {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "name_ends_with"
-        }
+        const NAME: &'static str = "name_ends_with";
     }
     impl ::cynic::schema::HasInputField<NameEndsWith, Option<super::String>>
         for super::CompanyWhereInput
@@ -2068,9 +1638,7 @@ pub mod company_where_input_fields {
     pub struct NameNotEndsWith;
     impl ::cynic::schema::Field for NameNotEndsWith {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "name_not_ends_with"
-        }
+        const NAME: &'static str = "name_not_ends_with";
     }
     impl ::cynic::schema::HasInputField<NameNotEndsWith, Option<super::String>>
         for super::CompanyWhereInput
@@ -2079,25 +1647,19 @@ pub mod company_where_input_fields {
     pub struct Slug;
     impl ::cynic::schema::Field for Slug {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "slug"
-        }
+        const NAME: &'static str = "slug";
     }
     impl ::cynic::schema::HasInputField<Slug, Option<super::String>> for super::CompanyWhereInput {}
     pub struct SlugNot;
     impl ::cynic::schema::Field for SlugNot {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "slug_not"
-        }
+        const NAME: &'static str = "slug_not";
     }
     impl ::cynic::schema::HasInputField<SlugNot, Option<super::String>> for super::CompanyWhereInput {}
     pub struct SlugIn;
     impl ::cynic::schema::Field for SlugIn {
         type Type = Option<Vec<super::String>>;
-        fn name() -> &'static str {
-            "slug_in"
-        }
+        const NAME: &'static str = "slug_in";
     }
     impl ::cynic::schema::HasInputField<SlugIn, Option<Vec<super::String>>>
         for super::CompanyWhereInput
@@ -2106,9 +1668,7 @@ pub mod company_where_input_fields {
     pub struct SlugNotIn;
     impl ::cynic::schema::Field for SlugNotIn {
         type Type = Option<Vec<super::String>>;
-        fn name() -> &'static str {
-            "slug_not_in"
-        }
+        const NAME: &'static str = "slug_not_in";
     }
     impl ::cynic::schema::HasInputField<SlugNotIn, Option<Vec<super::String>>>
         for super::CompanyWhereInput
@@ -2117,41 +1677,31 @@ pub mod company_where_input_fields {
     pub struct SlugLt;
     impl ::cynic::schema::Field for SlugLt {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "slug_lt"
-        }
+        const NAME: &'static str = "slug_lt";
     }
     impl ::cynic::schema::HasInputField<SlugLt, Option<super::String>> for super::CompanyWhereInput {}
     pub struct SlugLte;
     impl ::cynic::schema::Field for SlugLte {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "slug_lte"
-        }
+        const NAME: &'static str = "slug_lte";
     }
     impl ::cynic::schema::HasInputField<SlugLte, Option<super::String>> for super::CompanyWhereInput {}
     pub struct SlugGt;
     impl ::cynic::schema::Field for SlugGt {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "slug_gt"
-        }
+        const NAME: &'static str = "slug_gt";
     }
     impl ::cynic::schema::HasInputField<SlugGt, Option<super::String>> for super::CompanyWhereInput {}
     pub struct SlugGte;
     impl ::cynic::schema::Field for SlugGte {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "slug_gte"
-        }
+        const NAME: &'static str = "slug_gte";
     }
     impl ::cynic::schema::HasInputField<SlugGte, Option<super::String>> for super::CompanyWhereInput {}
     pub struct SlugContains;
     impl ::cynic::schema::Field for SlugContains {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "slug_contains"
-        }
+        const NAME: &'static str = "slug_contains";
     }
     impl ::cynic::schema::HasInputField<SlugContains, Option<super::String>>
         for super::CompanyWhereInput
@@ -2160,9 +1710,7 @@ pub mod company_where_input_fields {
     pub struct SlugNotContains;
     impl ::cynic::schema::Field for SlugNotContains {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "slug_not_contains"
-        }
+        const NAME: &'static str = "slug_not_contains";
     }
     impl ::cynic::schema::HasInputField<SlugNotContains, Option<super::String>>
         for super::CompanyWhereInput
@@ -2171,9 +1719,7 @@ pub mod company_where_input_fields {
     pub struct SlugStartsWith;
     impl ::cynic::schema::Field for SlugStartsWith {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "slug_starts_with"
-        }
+        const NAME: &'static str = "slug_starts_with";
     }
     impl ::cynic::schema::HasInputField<SlugStartsWith, Option<super::String>>
         for super::CompanyWhereInput
@@ -2182,9 +1728,7 @@ pub mod company_where_input_fields {
     pub struct SlugNotStartsWith;
     impl ::cynic::schema::Field for SlugNotStartsWith {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "slug_not_starts_with"
-        }
+        const NAME: &'static str = "slug_not_starts_with";
     }
     impl ::cynic::schema::HasInputField<SlugNotStartsWith, Option<super::String>>
         for super::CompanyWhereInput
@@ -2193,9 +1737,7 @@ pub mod company_where_input_fields {
     pub struct SlugEndsWith;
     impl ::cynic::schema::Field for SlugEndsWith {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "slug_ends_with"
-        }
+        const NAME: &'static str = "slug_ends_with";
     }
     impl ::cynic::schema::HasInputField<SlugEndsWith, Option<super::String>>
         for super::CompanyWhereInput
@@ -2204,9 +1746,7 @@ pub mod company_where_input_fields {
     pub struct SlugNotEndsWith;
     impl ::cynic::schema::Field for SlugNotEndsWith {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "slug_not_ends_with"
-        }
+        const NAME: &'static str = "slug_not_ends_with";
     }
     impl ::cynic::schema::HasInputField<SlugNotEndsWith, Option<super::String>>
         for super::CompanyWhereInput
@@ -2215,9 +1755,7 @@ pub mod company_where_input_fields {
     pub struct WebsiteUrl;
     impl ::cynic::schema::Field for WebsiteUrl {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "websiteUrl"
-        }
+        const NAME: &'static str = "websiteUrl";
     }
     impl ::cynic::schema::HasInputField<WebsiteUrl, Option<super::String>>
         for super::CompanyWhereInput
@@ -2226,9 +1764,7 @@ pub mod company_where_input_fields {
     pub struct WebsiteUrlNot;
     impl ::cynic::schema::Field for WebsiteUrlNot {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "websiteUrl_not"
-        }
+        const NAME: &'static str = "websiteUrl_not";
     }
     impl ::cynic::schema::HasInputField<WebsiteUrlNot, Option<super::String>>
         for super::CompanyWhereInput
@@ -2237,9 +1773,7 @@ pub mod company_where_input_fields {
     pub struct WebsiteUrlIn;
     impl ::cynic::schema::Field for WebsiteUrlIn {
         type Type = Option<Vec<super::String>>;
-        fn name() -> &'static str {
-            "websiteUrl_in"
-        }
+        const NAME: &'static str = "websiteUrl_in";
     }
     impl ::cynic::schema::HasInputField<WebsiteUrlIn, Option<Vec<super::String>>>
         for super::CompanyWhereInput
@@ -2248,9 +1782,7 @@ pub mod company_where_input_fields {
     pub struct WebsiteUrlNotIn;
     impl ::cynic::schema::Field for WebsiteUrlNotIn {
         type Type = Option<Vec<super::String>>;
-        fn name() -> &'static str {
-            "websiteUrl_not_in"
-        }
+        const NAME: &'static str = "websiteUrl_not_in";
     }
     impl ::cynic::schema::HasInputField<WebsiteUrlNotIn, Option<Vec<super::String>>>
         for super::CompanyWhereInput
@@ -2259,9 +1791,7 @@ pub mod company_where_input_fields {
     pub struct WebsiteUrlLt;
     impl ::cynic::schema::Field for WebsiteUrlLt {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "websiteUrl_lt"
-        }
+        const NAME: &'static str = "websiteUrl_lt";
     }
     impl ::cynic::schema::HasInputField<WebsiteUrlLt, Option<super::String>>
         for super::CompanyWhereInput
@@ -2270,9 +1800,7 @@ pub mod company_where_input_fields {
     pub struct WebsiteUrlLte;
     impl ::cynic::schema::Field for WebsiteUrlLte {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "websiteUrl_lte"
-        }
+        const NAME: &'static str = "websiteUrl_lte";
     }
     impl ::cynic::schema::HasInputField<WebsiteUrlLte, Option<super::String>>
         for super::CompanyWhereInput
@@ -2281,9 +1809,7 @@ pub mod company_where_input_fields {
     pub struct WebsiteUrlGt;
     impl ::cynic::schema::Field for WebsiteUrlGt {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "websiteUrl_gt"
-        }
+        const NAME: &'static str = "websiteUrl_gt";
     }
     impl ::cynic::schema::HasInputField<WebsiteUrlGt, Option<super::String>>
         for super::CompanyWhereInput
@@ -2292,9 +1818,7 @@ pub mod company_where_input_fields {
     pub struct WebsiteUrlGte;
     impl ::cynic::schema::Field for WebsiteUrlGte {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "websiteUrl_gte"
-        }
+        const NAME: &'static str = "websiteUrl_gte";
     }
     impl ::cynic::schema::HasInputField<WebsiteUrlGte, Option<super::String>>
         for super::CompanyWhereInput
@@ -2303,9 +1827,7 @@ pub mod company_where_input_fields {
     pub struct WebsiteUrlContains;
     impl ::cynic::schema::Field for WebsiteUrlContains {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "websiteUrl_contains"
-        }
+        const NAME: &'static str = "websiteUrl_contains";
     }
     impl ::cynic::schema::HasInputField<WebsiteUrlContains, Option<super::String>>
         for super::CompanyWhereInput
@@ -2314,9 +1836,7 @@ pub mod company_where_input_fields {
     pub struct WebsiteUrlNotContains;
     impl ::cynic::schema::Field for WebsiteUrlNotContains {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "websiteUrl_not_contains"
-        }
+        const NAME: &'static str = "websiteUrl_not_contains";
     }
     impl ::cynic::schema::HasInputField<WebsiteUrlNotContains, Option<super::String>>
         for super::CompanyWhereInput
@@ -2325,9 +1845,7 @@ pub mod company_where_input_fields {
     pub struct WebsiteUrlStartsWith;
     impl ::cynic::schema::Field for WebsiteUrlStartsWith {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "websiteUrl_starts_with"
-        }
+        const NAME: &'static str = "websiteUrl_starts_with";
     }
     impl ::cynic::schema::HasInputField<WebsiteUrlStartsWith, Option<super::String>>
         for super::CompanyWhereInput
@@ -2336,9 +1854,7 @@ pub mod company_where_input_fields {
     pub struct WebsiteUrlNotStartsWith;
     impl ::cynic::schema::Field for WebsiteUrlNotStartsWith {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "websiteUrl_not_starts_with"
-        }
+        const NAME: &'static str = "websiteUrl_not_starts_with";
     }
     impl ::cynic::schema::HasInputField<WebsiteUrlNotStartsWith, Option<super::String>>
         for super::CompanyWhereInput
@@ -2347,9 +1863,7 @@ pub mod company_where_input_fields {
     pub struct WebsiteUrlEndsWith;
     impl ::cynic::schema::Field for WebsiteUrlEndsWith {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "websiteUrl_ends_with"
-        }
+        const NAME: &'static str = "websiteUrl_ends_with";
     }
     impl ::cynic::schema::HasInputField<WebsiteUrlEndsWith, Option<super::String>>
         for super::CompanyWhereInput
@@ -2358,9 +1872,7 @@ pub mod company_where_input_fields {
     pub struct WebsiteUrlNotEndsWith;
     impl ::cynic::schema::Field for WebsiteUrlNotEndsWith {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "websiteUrl_not_ends_with"
-        }
+        const NAME: &'static str = "websiteUrl_not_ends_with";
     }
     impl ::cynic::schema::HasInputField<WebsiteUrlNotEndsWith, Option<super::String>>
         for super::CompanyWhereInput
@@ -2369,17 +1881,13 @@ pub mod company_where_input_fields {
     pub struct LogoUrl;
     impl ::cynic::schema::Field for LogoUrl {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "logoUrl"
-        }
+        const NAME: &'static str = "logoUrl";
     }
     impl ::cynic::schema::HasInputField<LogoUrl, Option<super::String>> for super::CompanyWhereInput {}
     pub struct LogoUrlNot;
     impl ::cynic::schema::Field for LogoUrlNot {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "logoUrl_not"
-        }
+        const NAME: &'static str = "logoUrl_not";
     }
     impl ::cynic::schema::HasInputField<LogoUrlNot, Option<super::String>>
         for super::CompanyWhereInput
@@ -2388,9 +1896,7 @@ pub mod company_where_input_fields {
     pub struct LogoUrlIn;
     impl ::cynic::schema::Field for LogoUrlIn {
         type Type = Option<Vec<super::String>>;
-        fn name() -> &'static str {
-            "logoUrl_in"
-        }
+        const NAME: &'static str = "logoUrl_in";
     }
     impl ::cynic::schema::HasInputField<LogoUrlIn, Option<Vec<super::String>>>
         for super::CompanyWhereInput
@@ -2399,9 +1905,7 @@ pub mod company_where_input_fields {
     pub struct LogoUrlNotIn;
     impl ::cynic::schema::Field for LogoUrlNotIn {
         type Type = Option<Vec<super::String>>;
-        fn name() -> &'static str {
-            "logoUrl_not_in"
-        }
+        const NAME: &'static str = "logoUrl_not_in";
     }
     impl ::cynic::schema::HasInputField<LogoUrlNotIn, Option<Vec<super::String>>>
         for super::CompanyWhereInput
@@ -2410,17 +1914,13 @@ pub mod company_where_input_fields {
     pub struct LogoUrlLt;
     impl ::cynic::schema::Field for LogoUrlLt {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "logoUrl_lt"
-        }
+        const NAME: &'static str = "logoUrl_lt";
     }
     impl ::cynic::schema::HasInputField<LogoUrlLt, Option<super::String>> for super::CompanyWhereInput {}
     pub struct LogoUrlLte;
     impl ::cynic::schema::Field for LogoUrlLte {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "logoUrl_lte"
-        }
+        const NAME: &'static str = "logoUrl_lte";
     }
     impl ::cynic::schema::HasInputField<LogoUrlLte, Option<super::String>>
         for super::CompanyWhereInput
@@ -2429,17 +1929,13 @@ pub mod company_where_input_fields {
     pub struct LogoUrlGt;
     impl ::cynic::schema::Field for LogoUrlGt {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "logoUrl_gt"
-        }
+        const NAME: &'static str = "logoUrl_gt";
     }
     impl ::cynic::schema::HasInputField<LogoUrlGt, Option<super::String>> for super::CompanyWhereInput {}
     pub struct LogoUrlGte;
     impl ::cynic::schema::Field for LogoUrlGte {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "logoUrl_gte"
-        }
+        const NAME: &'static str = "logoUrl_gte";
     }
     impl ::cynic::schema::HasInputField<LogoUrlGte, Option<super::String>>
         for super::CompanyWhereInput
@@ -2448,9 +1944,7 @@ pub mod company_where_input_fields {
     pub struct LogoUrlContains;
     impl ::cynic::schema::Field for LogoUrlContains {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "logoUrl_contains"
-        }
+        const NAME: &'static str = "logoUrl_contains";
     }
     impl ::cynic::schema::HasInputField<LogoUrlContains, Option<super::String>>
         for super::CompanyWhereInput
@@ -2459,9 +1953,7 @@ pub mod company_where_input_fields {
     pub struct LogoUrlNotContains;
     impl ::cynic::schema::Field for LogoUrlNotContains {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "logoUrl_not_contains"
-        }
+        const NAME: &'static str = "logoUrl_not_contains";
     }
     impl ::cynic::schema::HasInputField<LogoUrlNotContains, Option<super::String>>
         for super::CompanyWhereInput
@@ -2470,9 +1962,7 @@ pub mod company_where_input_fields {
     pub struct LogoUrlStartsWith;
     impl ::cynic::schema::Field for LogoUrlStartsWith {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "logoUrl_starts_with"
-        }
+        const NAME: &'static str = "logoUrl_starts_with";
     }
     impl ::cynic::schema::HasInputField<LogoUrlStartsWith, Option<super::String>>
         for super::CompanyWhereInput
@@ -2481,9 +1971,7 @@ pub mod company_where_input_fields {
     pub struct LogoUrlNotStartsWith;
     impl ::cynic::schema::Field for LogoUrlNotStartsWith {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "logoUrl_not_starts_with"
-        }
+        const NAME: &'static str = "logoUrl_not_starts_with";
     }
     impl ::cynic::schema::HasInputField<LogoUrlNotStartsWith, Option<super::String>>
         for super::CompanyWhereInput
@@ -2492,9 +1980,7 @@ pub mod company_where_input_fields {
     pub struct LogoUrlEndsWith;
     impl ::cynic::schema::Field for LogoUrlEndsWith {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "logoUrl_ends_with"
-        }
+        const NAME: &'static str = "logoUrl_ends_with";
     }
     impl ::cynic::schema::HasInputField<LogoUrlEndsWith, Option<super::String>>
         for super::CompanyWhereInput
@@ -2503,9 +1989,7 @@ pub mod company_where_input_fields {
     pub struct LogoUrlNotEndsWith;
     impl ::cynic::schema::Field for LogoUrlNotEndsWith {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "logoUrl_not_ends_with"
-        }
+        const NAME: &'static str = "logoUrl_not_ends_with";
     }
     impl ::cynic::schema::HasInputField<LogoUrlNotEndsWith, Option<super::String>>
         for super::CompanyWhereInput
@@ -2514,9 +1998,7 @@ pub mod company_where_input_fields {
     pub struct JobsEvery;
     impl ::cynic::schema::Field for JobsEvery {
         type Type = Option<super::JobWhereInput>;
-        fn name() -> &'static str {
-            "jobs_every"
-        }
+        const NAME: &'static str = "jobs_every";
     }
     impl ::cynic::schema::HasInputField<JobsEvery, Option<super::JobWhereInput>>
         for super::CompanyWhereInput
@@ -2525,9 +2007,7 @@ pub mod company_where_input_fields {
     pub struct JobsSome;
     impl ::cynic::schema::Field for JobsSome {
         type Type = Option<super::JobWhereInput>;
-        fn name() -> &'static str {
-            "jobs_some"
-        }
+        const NAME: &'static str = "jobs_some";
     }
     impl ::cynic::schema::HasInputField<JobsSome, Option<super::JobWhereInput>>
         for super::CompanyWhereInput
@@ -2536,9 +2016,7 @@ pub mod company_where_input_fields {
     pub struct JobsNone;
     impl ::cynic::schema::Field for JobsNone {
         type Type = Option<super::JobWhereInput>;
-        fn name() -> &'static str {
-            "jobs_none"
-        }
+        const NAME: &'static str = "jobs_none";
     }
     impl ::cynic::schema::HasInputField<JobsNone, Option<super::JobWhereInput>>
         for super::CompanyWhereInput
@@ -2547,17 +2025,13 @@ pub mod company_where_input_fields {
     pub struct Twitter;
     impl ::cynic::schema::Field for Twitter {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "twitter"
-        }
+        const NAME: &'static str = "twitter";
     }
     impl ::cynic::schema::HasInputField<Twitter, Option<super::String>> for super::CompanyWhereInput {}
     pub struct TwitterNot;
     impl ::cynic::schema::Field for TwitterNot {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "twitter_not"
-        }
+        const NAME: &'static str = "twitter_not";
     }
     impl ::cynic::schema::HasInputField<TwitterNot, Option<super::String>>
         for super::CompanyWhereInput
@@ -2566,9 +2040,7 @@ pub mod company_where_input_fields {
     pub struct TwitterIn;
     impl ::cynic::schema::Field for TwitterIn {
         type Type = Option<Vec<super::String>>;
-        fn name() -> &'static str {
-            "twitter_in"
-        }
+        const NAME: &'static str = "twitter_in";
     }
     impl ::cynic::schema::HasInputField<TwitterIn, Option<Vec<super::String>>>
         for super::CompanyWhereInput
@@ -2577,9 +2049,7 @@ pub mod company_where_input_fields {
     pub struct TwitterNotIn;
     impl ::cynic::schema::Field for TwitterNotIn {
         type Type = Option<Vec<super::String>>;
-        fn name() -> &'static str {
-            "twitter_not_in"
-        }
+        const NAME: &'static str = "twitter_not_in";
     }
     impl ::cynic::schema::HasInputField<TwitterNotIn, Option<Vec<super::String>>>
         for super::CompanyWhereInput
@@ -2588,17 +2058,13 @@ pub mod company_where_input_fields {
     pub struct TwitterLt;
     impl ::cynic::schema::Field for TwitterLt {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "twitter_lt"
-        }
+        const NAME: &'static str = "twitter_lt";
     }
     impl ::cynic::schema::HasInputField<TwitterLt, Option<super::String>> for super::CompanyWhereInput {}
     pub struct TwitterLte;
     impl ::cynic::schema::Field for TwitterLte {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "twitter_lte"
-        }
+        const NAME: &'static str = "twitter_lte";
     }
     impl ::cynic::schema::HasInputField<TwitterLte, Option<super::String>>
         for super::CompanyWhereInput
@@ -2607,17 +2073,13 @@ pub mod company_where_input_fields {
     pub struct TwitterGt;
     impl ::cynic::schema::Field for TwitterGt {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "twitter_gt"
-        }
+        const NAME: &'static str = "twitter_gt";
     }
     impl ::cynic::schema::HasInputField<TwitterGt, Option<super::String>> for super::CompanyWhereInput {}
     pub struct TwitterGte;
     impl ::cynic::schema::Field for TwitterGte {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "twitter_gte"
-        }
+        const NAME: &'static str = "twitter_gte";
     }
     impl ::cynic::schema::HasInputField<TwitterGte, Option<super::String>>
         for super::CompanyWhereInput
@@ -2626,9 +2088,7 @@ pub mod company_where_input_fields {
     pub struct TwitterContains;
     impl ::cynic::schema::Field for TwitterContains {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "twitter_contains"
-        }
+        const NAME: &'static str = "twitter_contains";
     }
     impl ::cynic::schema::HasInputField<TwitterContains, Option<super::String>>
         for super::CompanyWhereInput
@@ -2637,9 +2097,7 @@ pub mod company_where_input_fields {
     pub struct TwitterNotContains;
     impl ::cynic::schema::Field for TwitterNotContains {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "twitter_not_contains"
-        }
+        const NAME: &'static str = "twitter_not_contains";
     }
     impl ::cynic::schema::HasInputField<TwitterNotContains, Option<super::String>>
         for super::CompanyWhereInput
@@ -2648,9 +2106,7 @@ pub mod company_where_input_fields {
     pub struct TwitterStartsWith;
     impl ::cynic::schema::Field for TwitterStartsWith {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "twitter_starts_with"
-        }
+        const NAME: &'static str = "twitter_starts_with";
     }
     impl ::cynic::schema::HasInputField<TwitterStartsWith, Option<super::String>>
         for super::CompanyWhereInput
@@ -2659,9 +2115,7 @@ pub mod company_where_input_fields {
     pub struct TwitterNotStartsWith;
     impl ::cynic::schema::Field for TwitterNotStartsWith {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "twitter_not_starts_with"
-        }
+        const NAME: &'static str = "twitter_not_starts_with";
     }
     impl ::cynic::schema::HasInputField<TwitterNotStartsWith, Option<super::String>>
         for super::CompanyWhereInput
@@ -2670,9 +2124,7 @@ pub mod company_where_input_fields {
     pub struct TwitterEndsWith;
     impl ::cynic::schema::Field for TwitterEndsWith {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "twitter_ends_with"
-        }
+        const NAME: &'static str = "twitter_ends_with";
     }
     impl ::cynic::schema::HasInputField<TwitterEndsWith, Option<super::String>>
         for super::CompanyWhereInput
@@ -2681,9 +2133,7 @@ pub mod company_where_input_fields {
     pub struct TwitterNotEndsWith;
     impl ::cynic::schema::Field for TwitterNotEndsWith {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "twitter_not_ends_with"
-        }
+        const NAME: &'static str = "twitter_not_ends_with";
     }
     impl ::cynic::schema::HasInputField<TwitterNotEndsWith, Option<super::String>>
         for super::CompanyWhereInput
@@ -2692,17 +2142,13 @@ pub mod company_where_input_fields {
     pub struct Emailed;
     impl ::cynic::schema::Field for Emailed {
         type Type = Option<super::Boolean>;
-        fn name() -> &'static str {
-            "emailed"
-        }
+        const NAME: &'static str = "emailed";
     }
     impl ::cynic::schema::HasInputField<Emailed, Option<super::Boolean>> for super::CompanyWhereInput {}
     pub struct EmailedNot;
     impl ::cynic::schema::Field for EmailedNot {
         type Type = Option<super::Boolean>;
-        fn name() -> &'static str {
-            "emailed_not"
-        }
+        const NAME: &'static str = "emailed_not";
     }
     impl ::cynic::schema::HasInputField<EmailedNot, Option<super::Boolean>>
         for super::CompanyWhereInput
@@ -2711,9 +2157,7 @@ pub mod company_where_input_fields {
     pub struct CreatedAt;
     impl ::cynic::schema::Field for CreatedAt {
         type Type = Option<super::DateTime>;
-        fn name() -> &'static str {
-            "createdAt"
-        }
+        const NAME: &'static str = "createdAt";
     }
     impl ::cynic::schema::HasInputField<CreatedAt, Option<super::DateTime>>
         for super::CompanyWhereInput
@@ -2722,9 +2166,7 @@ pub mod company_where_input_fields {
     pub struct CreatedAtNot;
     impl ::cynic::schema::Field for CreatedAtNot {
         type Type = Option<super::DateTime>;
-        fn name() -> &'static str {
-            "createdAt_not"
-        }
+        const NAME: &'static str = "createdAt_not";
     }
     impl ::cynic::schema::HasInputField<CreatedAtNot, Option<super::DateTime>>
         for super::CompanyWhereInput
@@ -2733,9 +2175,7 @@ pub mod company_where_input_fields {
     pub struct CreatedAtIn;
     impl ::cynic::schema::Field for CreatedAtIn {
         type Type = Option<Vec<super::DateTime>>;
-        fn name() -> &'static str {
-            "createdAt_in"
-        }
+        const NAME: &'static str = "createdAt_in";
     }
     impl ::cynic::schema::HasInputField<CreatedAtIn, Option<Vec<super::DateTime>>>
         for super::CompanyWhereInput
@@ -2744,9 +2184,7 @@ pub mod company_where_input_fields {
     pub struct CreatedAtNotIn;
     impl ::cynic::schema::Field for CreatedAtNotIn {
         type Type = Option<Vec<super::DateTime>>;
-        fn name() -> &'static str {
-            "createdAt_not_in"
-        }
+        const NAME: &'static str = "createdAt_not_in";
     }
     impl ::cynic::schema::HasInputField<CreatedAtNotIn, Option<Vec<super::DateTime>>>
         for super::CompanyWhereInput
@@ -2755,9 +2193,7 @@ pub mod company_where_input_fields {
     pub struct CreatedAtLt;
     impl ::cynic::schema::Field for CreatedAtLt {
         type Type = Option<super::DateTime>;
-        fn name() -> &'static str {
-            "createdAt_lt"
-        }
+        const NAME: &'static str = "createdAt_lt";
     }
     impl ::cynic::schema::HasInputField<CreatedAtLt, Option<super::DateTime>>
         for super::CompanyWhereInput
@@ -2766,9 +2202,7 @@ pub mod company_where_input_fields {
     pub struct CreatedAtLte;
     impl ::cynic::schema::Field for CreatedAtLte {
         type Type = Option<super::DateTime>;
-        fn name() -> &'static str {
-            "createdAt_lte"
-        }
+        const NAME: &'static str = "createdAt_lte";
     }
     impl ::cynic::schema::HasInputField<CreatedAtLte, Option<super::DateTime>>
         for super::CompanyWhereInput
@@ -2777,9 +2211,7 @@ pub mod company_where_input_fields {
     pub struct CreatedAtGt;
     impl ::cynic::schema::Field for CreatedAtGt {
         type Type = Option<super::DateTime>;
-        fn name() -> &'static str {
-            "createdAt_gt"
-        }
+        const NAME: &'static str = "createdAt_gt";
     }
     impl ::cynic::schema::HasInputField<CreatedAtGt, Option<super::DateTime>>
         for super::CompanyWhereInput
@@ -2788,9 +2220,7 @@ pub mod company_where_input_fields {
     pub struct CreatedAtGte;
     impl ::cynic::schema::Field for CreatedAtGte {
         type Type = Option<super::DateTime>;
-        fn name() -> &'static str {
-            "createdAt_gte"
-        }
+        const NAME: &'static str = "createdAt_gte";
     }
     impl ::cynic::schema::HasInputField<CreatedAtGte, Option<super::DateTime>>
         for super::CompanyWhereInput
@@ -2799,9 +2229,7 @@ pub mod company_where_input_fields {
     pub struct UpdatedAt;
     impl ::cynic::schema::Field for UpdatedAt {
         type Type = Option<super::DateTime>;
-        fn name() -> &'static str {
-            "updatedAt"
-        }
+        const NAME: &'static str = "updatedAt";
     }
     impl ::cynic::schema::HasInputField<UpdatedAt, Option<super::DateTime>>
         for super::CompanyWhereInput
@@ -2810,9 +2238,7 @@ pub mod company_where_input_fields {
     pub struct UpdatedAtNot;
     impl ::cynic::schema::Field for UpdatedAtNot {
         type Type = Option<super::DateTime>;
-        fn name() -> &'static str {
-            "updatedAt_not"
-        }
+        const NAME: &'static str = "updatedAt_not";
     }
     impl ::cynic::schema::HasInputField<UpdatedAtNot, Option<super::DateTime>>
         for super::CompanyWhereInput
@@ -2821,9 +2247,7 @@ pub mod company_where_input_fields {
     pub struct UpdatedAtIn;
     impl ::cynic::schema::Field for UpdatedAtIn {
         type Type = Option<Vec<super::DateTime>>;
-        fn name() -> &'static str {
-            "updatedAt_in"
-        }
+        const NAME: &'static str = "updatedAt_in";
     }
     impl ::cynic::schema::HasInputField<UpdatedAtIn, Option<Vec<super::DateTime>>>
         for super::CompanyWhereInput
@@ -2832,9 +2256,7 @@ pub mod company_where_input_fields {
     pub struct UpdatedAtNotIn;
     impl ::cynic::schema::Field for UpdatedAtNotIn {
         type Type = Option<Vec<super::DateTime>>;
-        fn name() -> &'static str {
-            "updatedAt_not_in"
-        }
+        const NAME: &'static str = "updatedAt_not_in";
     }
     impl ::cynic::schema::HasInputField<UpdatedAtNotIn, Option<Vec<super::DateTime>>>
         for super::CompanyWhereInput
@@ -2843,9 +2265,7 @@ pub mod company_where_input_fields {
     pub struct UpdatedAtLt;
     impl ::cynic::schema::Field for UpdatedAtLt {
         type Type = Option<super::DateTime>;
-        fn name() -> &'static str {
-            "updatedAt_lt"
-        }
+        const NAME: &'static str = "updatedAt_lt";
     }
     impl ::cynic::schema::HasInputField<UpdatedAtLt, Option<super::DateTime>>
         for super::CompanyWhereInput
@@ -2854,9 +2274,7 @@ pub mod company_where_input_fields {
     pub struct UpdatedAtLte;
     impl ::cynic::schema::Field for UpdatedAtLte {
         type Type = Option<super::DateTime>;
-        fn name() -> &'static str {
-            "updatedAt_lte"
-        }
+        const NAME: &'static str = "updatedAt_lte";
     }
     impl ::cynic::schema::HasInputField<UpdatedAtLte, Option<super::DateTime>>
         for super::CompanyWhereInput
@@ -2865,9 +2283,7 @@ pub mod company_where_input_fields {
     pub struct UpdatedAtGt;
     impl ::cynic::schema::Field for UpdatedAtGt {
         type Type = Option<super::DateTime>;
-        fn name() -> &'static str {
-            "updatedAt_gt"
-        }
+        const NAME: &'static str = "updatedAt_gt";
     }
     impl ::cynic::schema::HasInputField<UpdatedAtGt, Option<super::DateTime>>
         for super::CompanyWhereInput
@@ -2876,9 +2292,7 @@ pub mod company_where_input_fields {
     pub struct UpdatedAtGte;
     impl ::cynic::schema::Field for UpdatedAtGte {
         type Type = Option<super::DateTime>;
-        fn name() -> &'static str {
-            "updatedAt_gte"
-        }
+        const NAME: &'static str = "updatedAt_gte";
     }
     impl ::cynic::schema::HasInputField<UpdatedAtGte, Option<super::DateTime>>
         for super::CompanyWhereInput
@@ -2887,9 +2301,7 @@ pub mod company_where_input_fields {
     pub struct And;
     impl ::cynic::schema::Field for And {
         type Type = Option<Vec<super::CompanyWhereInput>>;
-        fn name() -> &'static str {
-            "AND"
-        }
+        const NAME: &'static str = "AND";
     }
     impl ::cynic::schema::HasInputField<And, Option<Vec<super::CompanyWhereInput>>>
         for super::CompanyWhereInput
@@ -2898,9 +2310,7 @@ pub mod company_where_input_fields {
     pub struct Or;
     impl ::cynic::schema::Field for Or {
         type Type = Option<Vec<super::CompanyWhereInput>>;
-        fn name() -> &'static str {
-            "OR"
-        }
+        const NAME: &'static str = "OR";
     }
     impl ::cynic::schema::HasInputField<Or, Option<Vec<super::CompanyWhereInput>>>
         for super::CompanyWhereInput
@@ -2909,9 +2319,7 @@ pub mod company_where_input_fields {
     pub struct Not;
     impl ::cynic::schema::Field for Not {
         type Type = Option<Vec<super::CompanyWhereInput>>;
-        fn name() -> &'static str {
-            "NOT"
-        }
+        const NAME: &'static str = "NOT";
     }
     impl ::cynic::schema::HasInputField<Not, Option<Vec<super::CompanyWhereInput>>>
         for super::CompanyWhereInput
@@ -2923,9 +2331,7 @@ pub mod country_fields {
     pub struct Id;
     impl ::cynic::schema::Field for Id {
         type Type = super::Id;
-        fn name() -> &'static str {
-            "id"
-        }
+        const NAME: &'static str = "id";
     }
     impl ::cynic::schema::HasField<Id> for super::Country {
         type Type = super::Id;
@@ -2933,9 +2339,7 @@ pub mod country_fields {
     pub struct Name;
     impl ::cynic::schema::Field for Name {
         type Type = super::String;
-        fn name() -> &'static str {
-            "name"
-        }
+        const NAME: &'static str = "name";
     }
     impl ::cynic::schema::HasField<Name> for super::Country {
         type Type = super::String;
@@ -2943,9 +2347,7 @@ pub mod country_fields {
     pub struct Slug;
     impl ::cynic::schema::Field for Slug {
         type Type = super::String;
-        fn name() -> &'static str {
-            "slug"
-        }
+        const NAME: &'static str = "slug";
     }
     impl ::cynic::schema::HasField<Slug> for super::Country {
         type Type = super::String;
@@ -2953,9 +2355,7 @@ pub mod country_fields {
     pub struct Type;
     impl ::cynic::schema::Field for Type {
         type Type = super::String;
-        fn name() -> &'static str {
-            "type"
-        }
+        const NAME: &'static str = "type";
     }
     impl ::cynic::schema::HasField<Type> for super::Country {
         type Type = super::String;
@@ -2963,9 +2363,7 @@ pub mod country_fields {
     pub struct IsoCode;
     impl ::cynic::schema::Field for IsoCode {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "isoCode"
-        }
+        const NAME: &'static str = "isoCode";
     }
     impl ::cynic::schema::HasField<IsoCode> for super::Country {
         type Type = Option<super::String>;
@@ -2973,9 +2371,7 @@ pub mod country_fields {
     pub struct Cities;
     impl ::cynic::schema::Field for Cities {
         type Type = Option<Vec<super::City>>;
-        fn name() -> &'static str {
-            "cities"
-        }
+        const NAME: &'static str = "cities";
     }
     impl ::cynic::schema::HasField<Cities> for super::Country {
         type Type = Option<Vec<super::City>>;
@@ -2984,59 +2380,43 @@ pub mod country_fields {
         pub struct Where;
         impl ::cynic::schema::HasArgument<Where> for super::Cities {
             type ArgumentType = Option<super::super::CityWhereInput>;
-            fn name() -> &'static str {
-                "where"
-            }
+            const NAME: &'static str = "where";
         }
         pub struct OrderBy;
         impl ::cynic::schema::HasArgument<OrderBy> for super::Cities {
             type ArgumentType = Option<super::super::CityOrderByInput>;
-            fn name() -> &'static str {
-                "orderBy"
-            }
+            const NAME: &'static str = "orderBy";
         }
         pub struct Skip;
         impl ::cynic::schema::HasArgument<Skip> for super::Cities {
             type ArgumentType = Option<super::super::Int>;
-            fn name() -> &'static str {
-                "skip"
-            }
+            const NAME: &'static str = "skip";
         }
         pub struct After;
         impl ::cynic::schema::HasArgument<After> for super::Cities {
             type ArgumentType = Option<super::super::String>;
-            fn name() -> &'static str {
-                "after"
-            }
+            const NAME: &'static str = "after";
         }
         pub struct Before;
         impl ::cynic::schema::HasArgument<Before> for super::Cities {
             type ArgumentType = Option<super::super::String>;
-            fn name() -> &'static str {
-                "before"
-            }
+            const NAME: &'static str = "before";
         }
         pub struct First;
         impl ::cynic::schema::HasArgument<First> for super::Cities {
             type ArgumentType = Option<super::super::Int>;
-            fn name() -> &'static str {
-                "first"
-            }
+            const NAME: &'static str = "first";
         }
         pub struct Last;
         impl ::cynic::schema::HasArgument<Last> for super::Cities {
             type ArgumentType = Option<super::super::Int>;
-            fn name() -> &'static str {
-                "last"
-            }
+            const NAME: &'static str = "last";
         }
     }
     pub struct Jobs;
     impl ::cynic::schema::Field for Jobs {
         type Type = Option<Vec<super::Job>>;
-        fn name() -> &'static str {
-            "jobs"
-        }
+        const NAME: &'static str = "jobs";
     }
     impl ::cynic::schema::HasField<Jobs> for super::Country {
         type Type = Option<Vec<super::Job>>;
@@ -3045,59 +2425,43 @@ pub mod country_fields {
         pub struct Where;
         impl ::cynic::schema::HasArgument<Where> for super::Jobs {
             type ArgumentType = Option<super::super::JobWhereInput>;
-            fn name() -> &'static str {
-                "where"
-            }
+            const NAME: &'static str = "where";
         }
         pub struct OrderBy;
         impl ::cynic::schema::HasArgument<OrderBy> for super::Jobs {
             type ArgumentType = Option<super::super::JobOrderByInput>;
-            fn name() -> &'static str {
-                "orderBy"
-            }
+            const NAME: &'static str = "orderBy";
         }
         pub struct Skip;
         impl ::cynic::schema::HasArgument<Skip> for super::Jobs {
             type ArgumentType = Option<super::super::Int>;
-            fn name() -> &'static str {
-                "skip"
-            }
+            const NAME: &'static str = "skip";
         }
         pub struct After;
         impl ::cynic::schema::HasArgument<After> for super::Jobs {
             type ArgumentType = Option<super::super::String>;
-            fn name() -> &'static str {
-                "after"
-            }
+            const NAME: &'static str = "after";
         }
         pub struct Before;
         impl ::cynic::schema::HasArgument<Before> for super::Jobs {
             type ArgumentType = Option<super::super::String>;
-            fn name() -> &'static str {
-                "before"
-            }
+            const NAME: &'static str = "before";
         }
         pub struct First;
         impl ::cynic::schema::HasArgument<First> for super::Jobs {
             type ArgumentType = Option<super::super::Int>;
-            fn name() -> &'static str {
-                "first"
-            }
+            const NAME: &'static str = "first";
         }
         pub struct Last;
         impl ::cynic::schema::HasArgument<Last> for super::Jobs {
             type ArgumentType = Option<super::super::Int>;
-            fn name() -> &'static str {
-                "last"
-            }
+            const NAME: &'static str = "last";
         }
     }
     pub struct CreatedAt;
     impl ::cynic::schema::Field for CreatedAt {
         type Type = super::DateTime;
-        fn name() -> &'static str {
-            "createdAt"
-        }
+        const NAME: &'static str = "createdAt";
     }
     impl ::cynic::schema::HasField<CreatedAt> for super::Country {
         type Type = super::DateTime;
@@ -3105,9 +2469,7 @@ pub mod country_fields {
     pub struct UpdatedAt;
     impl ::cynic::schema::Field for UpdatedAt {
         type Type = super::DateTime;
-        fn name() -> &'static str {
-            "updatedAt"
-        }
+        const NAME: &'static str = "updatedAt";
     }
     impl ::cynic::schema::HasField<UpdatedAt> for super::Country {
         type Type = super::DateTime;
@@ -3120,97 +2482,73 @@ pub mod country_where_input_fields {
     pub struct Id;
     impl ::cynic::schema::Field for Id {
         type Type = Option<super::Id>;
-        fn name() -> &'static str {
-            "id"
-        }
+        const NAME: &'static str = "id";
     }
     impl ::cynic::schema::HasInputField<Id, Option<super::Id>> for super::CountryWhereInput {}
     pub struct IdNot;
     impl ::cynic::schema::Field for IdNot {
         type Type = Option<super::Id>;
-        fn name() -> &'static str {
-            "id_not"
-        }
+        const NAME: &'static str = "id_not";
     }
     impl ::cynic::schema::HasInputField<IdNot, Option<super::Id>> for super::CountryWhereInput {}
     pub struct IdIn;
     impl ::cynic::schema::Field for IdIn {
         type Type = Option<Vec<super::Id>>;
-        fn name() -> &'static str {
-            "id_in"
-        }
+        const NAME: &'static str = "id_in";
     }
     impl ::cynic::schema::HasInputField<IdIn, Option<Vec<super::Id>>> for super::CountryWhereInput {}
     pub struct IdNotIn;
     impl ::cynic::schema::Field for IdNotIn {
         type Type = Option<Vec<super::Id>>;
-        fn name() -> &'static str {
-            "id_not_in"
-        }
+        const NAME: &'static str = "id_not_in";
     }
     impl ::cynic::schema::HasInputField<IdNotIn, Option<Vec<super::Id>>> for super::CountryWhereInput {}
     pub struct IdLt;
     impl ::cynic::schema::Field for IdLt {
         type Type = Option<super::Id>;
-        fn name() -> &'static str {
-            "id_lt"
-        }
+        const NAME: &'static str = "id_lt";
     }
     impl ::cynic::schema::HasInputField<IdLt, Option<super::Id>> for super::CountryWhereInput {}
     pub struct IdLte;
     impl ::cynic::schema::Field for IdLte {
         type Type = Option<super::Id>;
-        fn name() -> &'static str {
-            "id_lte"
-        }
+        const NAME: &'static str = "id_lte";
     }
     impl ::cynic::schema::HasInputField<IdLte, Option<super::Id>> for super::CountryWhereInput {}
     pub struct IdGt;
     impl ::cynic::schema::Field for IdGt {
         type Type = Option<super::Id>;
-        fn name() -> &'static str {
-            "id_gt"
-        }
+        const NAME: &'static str = "id_gt";
     }
     impl ::cynic::schema::HasInputField<IdGt, Option<super::Id>> for super::CountryWhereInput {}
     pub struct IdGte;
     impl ::cynic::schema::Field for IdGte {
         type Type = Option<super::Id>;
-        fn name() -> &'static str {
-            "id_gte"
-        }
+        const NAME: &'static str = "id_gte";
     }
     impl ::cynic::schema::HasInputField<IdGte, Option<super::Id>> for super::CountryWhereInput {}
     pub struct IdContains;
     impl ::cynic::schema::Field for IdContains {
         type Type = Option<super::Id>;
-        fn name() -> &'static str {
-            "id_contains"
-        }
+        const NAME: &'static str = "id_contains";
     }
     impl ::cynic::schema::HasInputField<IdContains, Option<super::Id>> for super::CountryWhereInput {}
     pub struct IdNotContains;
     impl ::cynic::schema::Field for IdNotContains {
         type Type = Option<super::Id>;
-        fn name() -> &'static str {
-            "id_not_contains"
-        }
+        const NAME: &'static str = "id_not_contains";
     }
     impl ::cynic::schema::HasInputField<IdNotContains, Option<super::Id>> for super::CountryWhereInput {}
     pub struct IdStartsWith;
     impl ::cynic::schema::Field for IdStartsWith {
         type Type = Option<super::Id>;
-        fn name() -> &'static str {
-            "id_starts_with"
-        }
+        const NAME: &'static str = "id_starts_with";
     }
     impl ::cynic::schema::HasInputField<IdStartsWith, Option<super::Id>> for super::CountryWhereInput {}
     pub struct IdNotStartsWith;
     impl ::cynic::schema::Field for IdNotStartsWith {
         type Type = Option<super::Id>;
-        fn name() -> &'static str {
-            "id_not_starts_with"
-        }
+        const NAME: &'static str = "id_not_starts_with";
     }
     impl ::cynic::schema::HasInputField<IdNotStartsWith, Option<super::Id>>
         for super::CountryWhereInput
@@ -3219,41 +2557,31 @@ pub mod country_where_input_fields {
     pub struct IdEndsWith;
     impl ::cynic::schema::Field for IdEndsWith {
         type Type = Option<super::Id>;
-        fn name() -> &'static str {
-            "id_ends_with"
-        }
+        const NAME: &'static str = "id_ends_with";
     }
     impl ::cynic::schema::HasInputField<IdEndsWith, Option<super::Id>> for super::CountryWhereInput {}
     pub struct IdNotEndsWith;
     impl ::cynic::schema::Field for IdNotEndsWith {
         type Type = Option<super::Id>;
-        fn name() -> &'static str {
-            "id_not_ends_with"
-        }
+        const NAME: &'static str = "id_not_ends_with";
     }
     impl ::cynic::schema::HasInputField<IdNotEndsWith, Option<super::Id>> for super::CountryWhereInput {}
     pub struct Name;
     impl ::cynic::schema::Field for Name {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "name"
-        }
+        const NAME: &'static str = "name";
     }
     impl ::cynic::schema::HasInputField<Name, Option<super::String>> for super::CountryWhereInput {}
     pub struct NameNot;
     impl ::cynic::schema::Field for NameNot {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "name_not"
-        }
+        const NAME: &'static str = "name_not";
     }
     impl ::cynic::schema::HasInputField<NameNot, Option<super::String>> for super::CountryWhereInput {}
     pub struct NameIn;
     impl ::cynic::schema::Field for NameIn {
         type Type = Option<Vec<super::String>>;
-        fn name() -> &'static str {
-            "name_in"
-        }
+        const NAME: &'static str = "name_in";
     }
     impl ::cynic::schema::HasInputField<NameIn, Option<Vec<super::String>>>
         for super::CountryWhereInput
@@ -3262,9 +2590,7 @@ pub mod country_where_input_fields {
     pub struct NameNotIn;
     impl ::cynic::schema::Field for NameNotIn {
         type Type = Option<Vec<super::String>>;
-        fn name() -> &'static str {
-            "name_not_in"
-        }
+        const NAME: &'static str = "name_not_in";
     }
     impl ::cynic::schema::HasInputField<NameNotIn, Option<Vec<super::String>>>
         for super::CountryWhereInput
@@ -3273,41 +2599,31 @@ pub mod country_where_input_fields {
     pub struct NameLt;
     impl ::cynic::schema::Field for NameLt {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "name_lt"
-        }
+        const NAME: &'static str = "name_lt";
     }
     impl ::cynic::schema::HasInputField<NameLt, Option<super::String>> for super::CountryWhereInput {}
     pub struct NameLte;
     impl ::cynic::schema::Field for NameLte {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "name_lte"
-        }
+        const NAME: &'static str = "name_lte";
     }
     impl ::cynic::schema::HasInputField<NameLte, Option<super::String>> for super::CountryWhereInput {}
     pub struct NameGt;
     impl ::cynic::schema::Field for NameGt {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "name_gt"
-        }
+        const NAME: &'static str = "name_gt";
     }
     impl ::cynic::schema::HasInputField<NameGt, Option<super::String>> for super::CountryWhereInput {}
     pub struct NameGte;
     impl ::cynic::schema::Field for NameGte {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "name_gte"
-        }
+        const NAME: &'static str = "name_gte";
     }
     impl ::cynic::schema::HasInputField<NameGte, Option<super::String>> for super::CountryWhereInput {}
     pub struct NameContains;
     impl ::cynic::schema::Field for NameContains {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "name_contains"
-        }
+        const NAME: &'static str = "name_contains";
     }
     impl ::cynic::schema::HasInputField<NameContains, Option<super::String>>
         for super::CountryWhereInput
@@ -3316,9 +2632,7 @@ pub mod country_where_input_fields {
     pub struct NameNotContains;
     impl ::cynic::schema::Field for NameNotContains {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "name_not_contains"
-        }
+        const NAME: &'static str = "name_not_contains";
     }
     impl ::cynic::schema::HasInputField<NameNotContains, Option<super::String>>
         for super::CountryWhereInput
@@ -3327,9 +2641,7 @@ pub mod country_where_input_fields {
     pub struct NameStartsWith;
     impl ::cynic::schema::Field for NameStartsWith {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "name_starts_with"
-        }
+        const NAME: &'static str = "name_starts_with";
     }
     impl ::cynic::schema::HasInputField<NameStartsWith, Option<super::String>>
         for super::CountryWhereInput
@@ -3338,9 +2650,7 @@ pub mod country_where_input_fields {
     pub struct NameNotStartsWith;
     impl ::cynic::schema::Field for NameNotStartsWith {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "name_not_starts_with"
-        }
+        const NAME: &'static str = "name_not_starts_with";
     }
     impl ::cynic::schema::HasInputField<NameNotStartsWith, Option<super::String>>
         for super::CountryWhereInput
@@ -3349,9 +2659,7 @@ pub mod country_where_input_fields {
     pub struct NameEndsWith;
     impl ::cynic::schema::Field for NameEndsWith {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "name_ends_with"
-        }
+        const NAME: &'static str = "name_ends_with";
     }
     impl ::cynic::schema::HasInputField<NameEndsWith, Option<super::String>>
         for super::CountryWhereInput
@@ -3360,9 +2668,7 @@ pub mod country_where_input_fields {
     pub struct NameNotEndsWith;
     impl ::cynic::schema::Field for NameNotEndsWith {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "name_not_ends_with"
-        }
+        const NAME: &'static str = "name_not_ends_with";
     }
     impl ::cynic::schema::HasInputField<NameNotEndsWith, Option<super::String>>
         for super::CountryWhereInput
@@ -3371,25 +2677,19 @@ pub mod country_where_input_fields {
     pub struct Slug;
     impl ::cynic::schema::Field for Slug {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "slug"
-        }
+        const NAME: &'static str = "slug";
     }
     impl ::cynic::schema::HasInputField<Slug, Option<super::String>> for super::CountryWhereInput {}
     pub struct SlugNot;
     impl ::cynic::schema::Field for SlugNot {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "slug_not"
-        }
+        const NAME: &'static str = "slug_not";
     }
     impl ::cynic::schema::HasInputField<SlugNot, Option<super::String>> for super::CountryWhereInput {}
     pub struct SlugIn;
     impl ::cynic::schema::Field for SlugIn {
         type Type = Option<Vec<super::String>>;
-        fn name() -> &'static str {
-            "slug_in"
-        }
+        const NAME: &'static str = "slug_in";
     }
     impl ::cynic::schema::HasInputField<SlugIn, Option<Vec<super::String>>>
         for super::CountryWhereInput
@@ -3398,9 +2698,7 @@ pub mod country_where_input_fields {
     pub struct SlugNotIn;
     impl ::cynic::schema::Field for SlugNotIn {
         type Type = Option<Vec<super::String>>;
-        fn name() -> &'static str {
-            "slug_not_in"
-        }
+        const NAME: &'static str = "slug_not_in";
     }
     impl ::cynic::schema::HasInputField<SlugNotIn, Option<Vec<super::String>>>
         for super::CountryWhereInput
@@ -3409,41 +2707,31 @@ pub mod country_where_input_fields {
     pub struct SlugLt;
     impl ::cynic::schema::Field for SlugLt {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "slug_lt"
-        }
+        const NAME: &'static str = "slug_lt";
     }
     impl ::cynic::schema::HasInputField<SlugLt, Option<super::String>> for super::CountryWhereInput {}
     pub struct SlugLte;
     impl ::cynic::schema::Field for SlugLte {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "slug_lte"
-        }
+        const NAME: &'static str = "slug_lte";
     }
     impl ::cynic::schema::HasInputField<SlugLte, Option<super::String>> for super::CountryWhereInput {}
     pub struct SlugGt;
     impl ::cynic::schema::Field for SlugGt {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "slug_gt"
-        }
+        const NAME: &'static str = "slug_gt";
     }
     impl ::cynic::schema::HasInputField<SlugGt, Option<super::String>> for super::CountryWhereInput {}
     pub struct SlugGte;
     impl ::cynic::schema::Field for SlugGte {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "slug_gte"
-        }
+        const NAME: &'static str = "slug_gte";
     }
     impl ::cynic::schema::HasInputField<SlugGte, Option<super::String>> for super::CountryWhereInput {}
     pub struct SlugContains;
     impl ::cynic::schema::Field for SlugContains {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "slug_contains"
-        }
+        const NAME: &'static str = "slug_contains";
     }
     impl ::cynic::schema::HasInputField<SlugContains, Option<super::String>>
         for super::CountryWhereInput
@@ -3452,9 +2740,7 @@ pub mod country_where_input_fields {
     pub struct SlugNotContains;
     impl ::cynic::schema::Field for SlugNotContains {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "slug_not_contains"
-        }
+        const NAME: &'static str = "slug_not_contains";
     }
     impl ::cynic::schema::HasInputField<SlugNotContains, Option<super::String>>
         for super::CountryWhereInput
@@ -3463,9 +2749,7 @@ pub mod country_where_input_fields {
     pub struct SlugStartsWith;
     impl ::cynic::schema::Field for SlugStartsWith {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "slug_starts_with"
-        }
+        const NAME: &'static str = "slug_starts_with";
     }
     impl ::cynic::schema::HasInputField<SlugStartsWith, Option<super::String>>
         for super::CountryWhereInput
@@ -3474,9 +2758,7 @@ pub mod country_where_input_fields {
     pub struct SlugNotStartsWith;
     impl ::cynic::schema::Field for SlugNotStartsWith {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "slug_not_starts_with"
-        }
+        const NAME: &'static str = "slug_not_starts_with";
     }
     impl ::cynic::schema::HasInputField<SlugNotStartsWith, Option<super::String>>
         for super::CountryWhereInput
@@ -3485,9 +2767,7 @@ pub mod country_where_input_fields {
     pub struct SlugEndsWith;
     impl ::cynic::schema::Field for SlugEndsWith {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "slug_ends_with"
-        }
+        const NAME: &'static str = "slug_ends_with";
     }
     impl ::cynic::schema::HasInputField<SlugEndsWith, Option<super::String>>
         for super::CountryWhereInput
@@ -3496,9 +2776,7 @@ pub mod country_where_input_fields {
     pub struct SlugNotEndsWith;
     impl ::cynic::schema::Field for SlugNotEndsWith {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "slug_not_ends_with"
-        }
+        const NAME: &'static str = "slug_not_ends_with";
     }
     impl ::cynic::schema::HasInputField<SlugNotEndsWith, Option<super::String>>
         for super::CountryWhereInput
@@ -3507,25 +2785,19 @@ pub mod country_where_input_fields {
     pub struct Type;
     impl ::cynic::schema::Field for Type {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "type"
-        }
+        const NAME: &'static str = "type";
     }
     impl ::cynic::schema::HasInputField<Type, Option<super::String>> for super::CountryWhereInput {}
     pub struct TypeNot;
     impl ::cynic::schema::Field for TypeNot {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "type_not"
-        }
+        const NAME: &'static str = "type_not";
     }
     impl ::cynic::schema::HasInputField<TypeNot, Option<super::String>> for super::CountryWhereInput {}
     pub struct TypeIn;
     impl ::cynic::schema::Field for TypeIn {
         type Type = Option<Vec<super::String>>;
-        fn name() -> &'static str {
-            "type_in"
-        }
+        const NAME: &'static str = "type_in";
     }
     impl ::cynic::schema::HasInputField<TypeIn, Option<Vec<super::String>>>
         for super::CountryWhereInput
@@ -3534,9 +2806,7 @@ pub mod country_where_input_fields {
     pub struct TypeNotIn;
     impl ::cynic::schema::Field for TypeNotIn {
         type Type = Option<Vec<super::String>>;
-        fn name() -> &'static str {
-            "type_not_in"
-        }
+        const NAME: &'static str = "type_not_in";
     }
     impl ::cynic::schema::HasInputField<TypeNotIn, Option<Vec<super::String>>>
         for super::CountryWhereInput
@@ -3545,41 +2815,31 @@ pub mod country_where_input_fields {
     pub struct TypeLt;
     impl ::cynic::schema::Field for TypeLt {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "type_lt"
-        }
+        const NAME: &'static str = "type_lt";
     }
     impl ::cynic::schema::HasInputField<TypeLt, Option<super::String>> for super::CountryWhereInput {}
     pub struct TypeLte;
     impl ::cynic::schema::Field for TypeLte {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "type_lte"
-        }
+        const NAME: &'static str = "type_lte";
     }
     impl ::cynic::schema::HasInputField<TypeLte, Option<super::String>> for super::CountryWhereInput {}
     pub struct TypeGt;
     impl ::cynic::schema::Field for TypeGt {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "type_gt"
-        }
+        const NAME: &'static str = "type_gt";
     }
     impl ::cynic::schema::HasInputField<TypeGt, Option<super::String>> for super::CountryWhereInput {}
     pub struct TypeGte;
     impl ::cynic::schema::Field for TypeGte {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "type_gte"
-        }
+        const NAME: &'static str = "type_gte";
     }
     impl ::cynic::schema::HasInputField<TypeGte, Option<super::String>> for super::CountryWhereInput {}
     pub struct TypeContains;
     impl ::cynic::schema::Field for TypeContains {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "type_contains"
-        }
+        const NAME: &'static str = "type_contains";
     }
     impl ::cynic::schema::HasInputField<TypeContains, Option<super::String>>
         for super::CountryWhereInput
@@ -3588,9 +2848,7 @@ pub mod country_where_input_fields {
     pub struct TypeNotContains;
     impl ::cynic::schema::Field for TypeNotContains {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "type_not_contains"
-        }
+        const NAME: &'static str = "type_not_contains";
     }
     impl ::cynic::schema::HasInputField<TypeNotContains, Option<super::String>>
         for super::CountryWhereInput
@@ -3599,9 +2857,7 @@ pub mod country_where_input_fields {
     pub struct TypeStartsWith;
     impl ::cynic::schema::Field for TypeStartsWith {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "type_starts_with"
-        }
+        const NAME: &'static str = "type_starts_with";
     }
     impl ::cynic::schema::HasInputField<TypeStartsWith, Option<super::String>>
         for super::CountryWhereInput
@@ -3610,9 +2866,7 @@ pub mod country_where_input_fields {
     pub struct TypeNotStartsWith;
     impl ::cynic::schema::Field for TypeNotStartsWith {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "type_not_starts_with"
-        }
+        const NAME: &'static str = "type_not_starts_with";
     }
     impl ::cynic::schema::HasInputField<TypeNotStartsWith, Option<super::String>>
         for super::CountryWhereInput
@@ -3621,9 +2875,7 @@ pub mod country_where_input_fields {
     pub struct TypeEndsWith;
     impl ::cynic::schema::Field for TypeEndsWith {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "type_ends_with"
-        }
+        const NAME: &'static str = "type_ends_with";
     }
     impl ::cynic::schema::HasInputField<TypeEndsWith, Option<super::String>>
         for super::CountryWhereInput
@@ -3632,9 +2884,7 @@ pub mod country_where_input_fields {
     pub struct TypeNotEndsWith;
     impl ::cynic::schema::Field for TypeNotEndsWith {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "type_not_ends_with"
-        }
+        const NAME: &'static str = "type_not_ends_with";
     }
     impl ::cynic::schema::HasInputField<TypeNotEndsWith, Option<super::String>>
         for super::CountryWhereInput
@@ -3643,17 +2893,13 @@ pub mod country_where_input_fields {
     pub struct IsoCode;
     impl ::cynic::schema::Field for IsoCode {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "isoCode"
-        }
+        const NAME: &'static str = "isoCode";
     }
     impl ::cynic::schema::HasInputField<IsoCode, Option<super::String>> for super::CountryWhereInput {}
     pub struct IsoCodeNot;
     impl ::cynic::schema::Field for IsoCodeNot {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "isoCode_not"
-        }
+        const NAME: &'static str = "isoCode_not";
     }
     impl ::cynic::schema::HasInputField<IsoCodeNot, Option<super::String>>
         for super::CountryWhereInput
@@ -3662,9 +2908,7 @@ pub mod country_where_input_fields {
     pub struct IsoCodeIn;
     impl ::cynic::schema::Field for IsoCodeIn {
         type Type = Option<Vec<super::String>>;
-        fn name() -> &'static str {
-            "isoCode_in"
-        }
+        const NAME: &'static str = "isoCode_in";
     }
     impl ::cynic::schema::HasInputField<IsoCodeIn, Option<Vec<super::String>>>
         for super::CountryWhereInput
@@ -3673,9 +2917,7 @@ pub mod country_where_input_fields {
     pub struct IsoCodeNotIn;
     impl ::cynic::schema::Field for IsoCodeNotIn {
         type Type = Option<Vec<super::String>>;
-        fn name() -> &'static str {
-            "isoCode_not_in"
-        }
+        const NAME: &'static str = "isoCode_not_in";
     }
     impl ::cynic::schema::HasInputField<IsoCodeNotIn, Option<Vec<super::String>>>
         for super::CountryWhereInput
@@ -3684,17 +2926,13 @@ pub mod country_where_input_fields {
     pub struct IsoCodeLt;
     impl ::cynic::schema::Field for IsoCodeLt {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "isoCode_lt"
-        }
+        const NAME: &'static str = "isoCode_lt";
     }
     impl ::cynic::schema::HasInputField<IsoCodeLt, Option<super::String>> for super::CountryWhereInput {}
     pub struct IsoCodeLte;
     impl ::cynic::schema::Field for IsoCodeLte {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "isoCode_lte"
-        }
+        const NAME: &'static str = "isoCode_lte";
     }
     impl ::cynic::schema::HasInputField<IsoCodeLte, Option<super::String>>
         for super::CountryWhereInput
@@ -3703,17 +2941,13 @@ pub mod country_where_input_fields {
     pub struct IsoCodeGt;
     impl ::cynic::schema::Field for IsoCodeGt {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "isoCode_gt"
-        }
+        const NAME: &'static str = "isoCode_gt";
     }
     impl ::cynic::schema::HasInputField<IsoCodeGt, Option<super::String>> for super::CountryWhereInput {}
     pub struct IsoCodeGte;
     impl ::cynic::schema::Field for IsoCodeGte {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "isoCode_gte"
-        }
+        const NAME: &'static str = "isoCode_gte";
     }
     impl ::cynic::schema::HasInputField<IsoCodeGte, Option<super::String>>
         for super::CountryWhereInput
@@ -3722,9 +2956,7 @@ pub mod country_where_input_fields {
     pub struct IsoCodeContains;
     impl ::cynic::schema::Field for IsoCodeContains {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "isoCode_contains"
-        }
+        const NAME: &'static str = "isoCode_contains";
     }
     impl ::cynic::schema::HasInputField<IsoCodeContains, Option<super::String>>
         for super::CountryWhereInput
@@ -3733,9 +2965,7 @@ pub mod country_where_input_fields {
     pub struct IsoCodeNotContains;
     impl ::cynic::schema::Field for IsoCodeNotContains {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "isoCode_not_contains"
-        }
+        const NAME: &'static str = "isoCode_not_contains";
     }
     impl ::cynic::schema::HasInputField<IsoCodeNotContains, Option<super::String>>
         for super::CountryWhereInput
@@ -3744,9 +2974,7 @@ pub mod country_where_input_fields {
     pub struct IsoCodeStartsWith;
     impl ::cynic::schema::Field for IsoCodeStartsWith {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "isoCode_starts_with"
-        }
+        const NAME: &'static str = "isoCode_starts_with";
     }
     impl ::cynic::schema::HasInputField<IsoCodeStartsWith, Option<super::String>>
         for super::CountryWhereInput
@@ -3755,9 +2983,7 @@ pub mod country_where_input_fields {
     pub struct IsoCodeNotStartsWith;
     impl ::cynic::schema::Field for IsoCodeNotStartsWith {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "isoCode_not_starts_with"
-        }
+        const NAME: &'static str = "isoCode_not_starts_with";
     }
     impl ::cynic::schema::HasInputField<IsoCodeNotStartsWith, Option<super::String>>
         for super::CountryWhereInput
@@ -3766,9 +2992,7 @@ pub mod country_where_input_fields {
     pub struct IsoCodeEndsWith;
     impl ::cynic::schema::Field for IsoCodeEndsWith {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "isoCode_ends_with"
-        }
+        const NAME: &'static str = "isoCode_ends_with";
     }
     impl ::cynic::schema::HasInputField<IsoCodeEndsWith, Option<super::String>>
         for super::CountryWhereInput
@@ -3777,9 +3001,7 @@ pub mod country_where_input_fields {
     pub struct IsoCodeNotEndsWith;
     impl ::cynic::schema::Field for IsoCodeNotEndsWith {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "isoCode_not_ends_with"
-        }
+        const NAME: &'static str = "isoCode_not_ends_with";
     }
     impl ::cynic::schema::HasInputField<IsoCodeNotEndsWith, Option<super::String>>
         for super::CountryWhereInput
@@ -3788,9 +3010,7 @@ pub mod country_where_input_fields {
     pub struct CitiesEvery;
     impl ::cynic::schema::Field for CitiesEvery {
         type Type = Option<super::CityWhereInput>;
-        fn name() -> &'static str {
-            "cities_every"
-        }
+        const NAME: &'static str = "cities_every";
     }
     impl ::cynic::schema::HasInputField<CitiesEvery, Option<super::CityWhereInput>>
         for super::CountryWhereInput
@@ -3799,9 +3019,7 @@ pub mod country_where_input_fields {
     pub struct CitiesSome;
     impl ::cynic::schema::Field for CitiesSome {
         type Type = Option<super::CityWhereInput>;
-        fn name() -> &'static str {
-            "cities_some"
-        }
+        const NAME: &'static str = "cities_some";
     }
     impl ::cynic::schema::HasInputField<CitiesSome, Option<super::CityWhereInput>>
         for super::CountryWhereInput
@@ -3810,9 +3028,7 @@ pub mod country_where_input_fields {
     pub struct CitiesNone;
     impl ::cynic::schema::Field for CitiesNone {
         type Type = Option<super::CityWhereInput>;
-        fn name() -> &'static str {
-            "cities_none"
-        }
+        const NAME: &'static str = "cities_none";
     }
     impl ::cynic::schema::HasInputField<CitiesNone, Option<super::CityWhereInput>>
         for super::CountryWhereInput
@@ -3821,9 +3037,7 @@ pub mod country_where_input_fields {
     pub struct JobsEvery;
     impl ::cynic::schema::Field for JobsEvery {
         type Type = Option<super::JobWhereInput>;
-        fn name() -> &'static str {
-            "jobs_every"
-        }
+        const NAME: &'static str = "jobs_every";
     }
     impl ::cynic::schema::HasInputField<JobsEvery, Option<super::JobWhereInput>>
         for super::CountryWhereInput
@@ -3832,9 +3046,7 @@ pub mod country_where_input_fields {
     pub struct JobsSome;
     impl ::cynic::schema::Field for JobsSome {
         type Type = Option<super::JobWhereInput>;
-        fn name() -> &'static str {
-            "jobs_some"
-        }
+        const NAME: &'static str = "jobs_some";
     }
     impl ::cynic::schema::HasInputField<JobsSome, Option<super::JobWhereInput>>
         for super::CountryWhereInput
@@ -3843,9 +3055,7 @@ pub mod country_where_input_fields {
     pub struct JobsNone;
     impl ::cynic::schema::Field for JobsNone {
         type Type = Option<super::JobWhereInput>;
-        fn name() -> &'static str {
-            "jobs_none"
-        }
+        const NAME: &'static str = "jobs_none";
     }
     impl ::cynic::schema::HasInputField<JobsNone, Option<super::JobWhereInput>>
         for super::CountryWhereInput
@@ -3854,9 +3064,7 @@ pub mod country_where_input_fields {
     pub struct CreatedAt;
     impl ::cynic::schema::Field for CreatedAt {
         type Type = Option<super::DateTime>;
-        fn name() -> &'static str {
-            "createdAt"
-        }
+        const NAME: &'static str = "createdAt";
     }
     impl ::cynic::schema::HasInputField<CreatedAt, Option<super::DateTime>>
         for super::CountryWhereInput
@@ -3865,9 +3073,7 @@ pub mod country_where_input_fields {
     pub struct CreatedAtNot;
     impl ::cynic::schema::Field for CreatedAtNot {
         type Type = Option<super::DateTime>;
-        fn name() -> &'static str {
-            "createdAt_not"
-        }
+        const NAME: &'static str = "createdAt_not";
     }
     impl ::cynic::schema::HasInputField<CreatedAtNot, Option<super::DateTime>>
         for super::CountryWhereInput
@@ -3876,9 +3082,7 @@ pub mod country_where_input_fields {
     pub struct CreatedAtIn;
     impl ::cynic::schema::Field for CreatedAtIn {
         type Type = Option<Vec<super::DateTime>>;
-        fn name() -> &'static str {
-            "createdAt_in"
-        }
+        const NAME: &'static str = "createdAt_in";
     }
     impl ::cynic::schema::HasInputField<CreatedAtIn, Option<Vec<super::DateTime>>>
         for super::CountryWhereInput
@@ -3887,9 +3091,7 @@ pub mod country_where_input_fields {
     pub struct CreatedAtNotIn;
     impl ::cynic::schema::Field for CreatedAtNotIn {
         type Type = Option<Vec<super::DateTime>>;
-        fn name() -> &'static str {
-            "createdAt_not_in"
-        }
+        const NAME: &'static str = "createdAt_not_in";
     }
     impl ::cynic::schema::HasInputField<CreatedAtNotIn, Option<Vec<super::DateTime>>>
         for super::CountryWhereInput
@@ -3898,9 +3100,7 @@ pub mod country_where_input_fields {
     pub struct CreatedAtLt;
     impl ::cynic::schema::Field for CreatedAtLt {
         type Type = Option<super::DateTime>;
-        fn name() -> &'static str {
-            "createdAt_lt"
-        }
+        const NAME: &'static str = "createdAt_lt";
     }
     impl ::cynic::schema::HasInputField<CreatedAtLt, Option<super::DateTime>>
         for super::CountryWhereInput
@@ -3909,9 +3109,7 @@ pub mod country_where_input_fields {
     pub struct CreatedAtLte;
     impl ::cynic::schema::Field for CreatedAtLte {
         type Type = Option<super::DateTime>;
-        fn name() -> &'static str {
-            "createdAt_lte"
-        }
+        const NAME: &'static str = "createdAt_lte";
     }
     impl ::cynic::schema::HasInputField<CreatedAtLte, Option<super::DateTime>>
         for super::CountryWhereInput
@@ -3920,9 +3118,7 @@ pub mod country_where_input_fields {
     pub struct CreatedAtGt;
     impl ::cynic::schema::Field for CreatedAtGt {
         type Type = Option<super::DateTime>;
-        fn name() -> &'static str {
-            "createdAt_gt"
-        }
+        const NAME: &'static str = "createdAt_gt";
     }
     impl ::cynic::schema::HasInputField<CreatedAtGt, Option<super::DateTime>>
         for super::CountryWhereInput
@@ -3931,9 +3127,7 @@ pub mod country_where_input_fields {
     pub struct CreatedAtGte;
     impl ::cynic::schema::Field for CreatedAtGte {
         type Type = Option<super::DateTime>;
-        fn name() -> &'static str {
-            "createdAt_gte"
-        }
+        const NAME: &'static str = "createdAt_gte";
     }
     impl ::cynic::schema::HasInputField<CreatedAtGte, Option<super::DateTime>>
         for super::CountryWhereInput
@@ -3942,9 +3136,7 @@ pub mod country_where_input_fields {
     pub struct UpdatedAt;
     impl ::cynic::schema::Field for UpdatedAt {
         type Type = Option<super::DateTime>;
-        fn name() -> &'static str {
-            "updatedAt"
-        }
+        const NAME: &'static str = "updatedAt";
     }
     impl ::cynic::schema::HasInputField<UpdatedAt, Option<super::DateTime>>
         for super::CountryWhereInput
@@ -3953,9 +3145,7 @@ pub mod country_where_input_fields {
     pub struct UpdatedAtNot;
     impl ::cynic::schema::Field for UpdatedAtNot {
         type Type = Option<super::DateTime>;
-        fn name() -> &'static str {
-            "updatedAt_not"
-        }
+        const NAME: &'static str = "updatedAt_not";
     }
     impl ::cynic::schema::HasInputField<UpdatedAtNot, Option<super::DateTime>>
         for super::CountryWhereInput
@@ -3964,9 +3154,7 @@ pub mod country_where_input_fields {
     pub struct UpdatedAtIn;
     impl ::cynic::schema::Field for UpdatedAtIn {
         type Type = Option<Vec<super::DateTime>>;
-        fn name() -> &'static str {
-            "updatedAt_in"
-        }
+        const NAME: &'static str = "updatedAt_in";
     }
     impl ::cynic::schema::HasInputField<UpdatedAtIn, Option<Vec<super::DateTime>>>
         for super::CountryWhereInput
@@ -3975,9 +3163,7 @@ pub mod country_where_input_fields {
     pub struct UpdatedAtNotIn;
     impl ::cynic::schema::Field for UpdatedAtNotIn {
         type Type = Option<Vec<super::DateTime>>;
-        fn name() -> &'static str {
-            "updatedAt_not_in"
-        }
+        const NAME: &'static str = "updatedAt_not_in";
     }
     impl ::cynic::schema::HasInputField<UpdatedAtNotIn, Option<Vec<super::DateTime>>>
         for super::CountryWhereInput
@@ -3986,9 +3172,7 @@ pub mod country_where_input_fields {
     pub struct UpdatedAtLt;
     impl ::cynic::schema::Field for UpdatedAtLt {
         type Type = Option<super::DateTime>;
-        fn name() -> &'static str {
-            "updatedAt_lt"
-        }
+        const NAME: &'static str = "updatedAt_lt";
     }
     impl ::cynic::schema::HasInputField<UpdatedAtLt, Option<super::DateTime>>
         for super::CountryWhereInput
@@ -3997,9 +3181,7 @@ pub mod country_where_input_fields {
     pub struct UpdatedAtLte;
     impl ::cynic::schema::Field for UpdatedAtLte {
         type Type = Option<super::DateTime>;
-        fn name() -> &'static str {
-            "updatedAt_lte"
-        }
+        const NAME: &'static str = "updatedAt_lte";
     }
     impl ::cynic::schema::HasInputField<UpdatedAtLte, Option<super::DateTime>>
         for super::CountryWhereInput
@@ -4008,9 +3190,7 @@ pub mod country_where_input_fields {
     pub struct UpdatedAtGt;
     impl ::cynic::schema::Field for UpdatedAtGt {
         type Type = Option<super::DateTime>;
-        fn name() -> &'static str {
-            "updatedAt_gt"
-        }
+        const NAME: &'static str = "updatedAt_gt";
     }
     impl ::cynic::schema::HasInputField<UpdatedAtGt, Option<super::DateTime>>
         for super::CountryWhereInput
@@ -4019,9 +3199,7 @@ pub mod country_where_input_fields {
     pub struct UpdatedAtGte;
     impl ::cynic::schema::Field for UpdatedAtGte {
         type Type = Option<super::DateTime>;
-        fn name() -> &'static str {
-            "updatedAt_gte"
-        }
+        const NAME: &'static str = "updatedAt_gte";
     }
     impl ::cynic::schema::HasInputField<UpdatedAtGte, Option<super::DateTime>>
         for super::CountryWhereInput
@@ -4030,9 +3208,7 @@ pub mod country_where_input_fields {
     pub struct And;
     impl ::cynic::schema::Field for And {
         type Type = Option<Vec<super::CountryWhereInput>>;
-        fn name() -> &'static str {
-            "AND"
-        }
+        const NAME: &'static str = "AND";
     }
     impl ::cynic::schema::HasInputField<And, Option<Vec<super::CountryWhereInput>>>
         for super::CountryWhereInput
@@ -4041,9 +3217,7 @@ pub mod country_where_input_fields {
     pub struct Or;
     impl ::cynic::schema::Field for Or {
         type Type = Option<Vec<super::CountryWhereInput>>;
-        fn name() -> &'static str {
-            "OR"
-        }
+        const NAME: &'static str = "OR";
     }
     impl ::cynic::schema::HasInputField<Or, Option<Vec<super::CountryWhereInput>>>
         for super::CountryWhereInput
@@ -4052,9 +3226,7 @@ pub mod country_where_input_fields {
     pub struct Not;
     impl ::cynic::schema::Field for Not {
         type Type = Option<Vec<super::CountryWhereInput>>;
-        fn name() -> &'static str {
-            "NOT"
-        }
+        const NAME: &'static str = "NOT";
     }
     impl ::cynic::schema::HasInputField<Not, Option<Vec<super::CountryWhereInput>>>
         for super::CountryWhereInput
@@ -4067,9 +3239,7 @@ pub mod job_fields {
     pub struct Id;
     impl ::cynic::schema::Field for Id {
         type Type = super::Id;
-        fn name() -> &'static str {
-            "id"
-        }
+        const NAME: &'static str = "id";
     }
     impl ::cynic::schema::HasField<Id> for super::Job {
         type Type = super::Id;
@@ -4077,9 +3247,7 @@ pub mod job_fields {
     pub struct Title;
     impl ::cynic::schema::Field for Title {
         type Type = super::String;
-        fn name() -> &'static str {
-            "title"
-        }
+        const NAME: &'static str = "title";
     }
     impl ::cynic::schema::HasField<Title> for super::Job {
         type Type = super::String;
@@ -4087,9 +3255,7 @@ pub mod job_fields {
     pub struct Slug;
     impl ::cynic::schema::Field for Slug {
         type Type = super::String;
-        fn name() -> &'static str {
-            "slug"
-        }
+        const NAME: &'static str = "slug";
     }
     impl ::cynic::schema::HasField<Slug> for super::Job {
         type Type = super::String;
@@ -4097,9 +3263,7 @@ pub mod job_fields {
     pub struct Commitment;
     impl ::cynic::schema::Field for Commitment {
         type Type = super::Commitment;
-        fn name() -> &'static str {
-            "commitment"
-        }
+        const NAME: &'static str = "commitment";
     }
     impl ::cynic::schema::HasField<Commitment> for super::Job {
         type Type = super::Commitment;
@@ -4107,9 +3271,7 @@ pub mod job_fields {
     pub struct Cities;
     impl ::cynic::schema::Field for Cities {
         type Type = Option<Vec<super::City>>;
-        fn name() -> &'static str {
-            "cities"
-        }
+        const NAME: &'static str = "cities";
     }
     impl ::cynic::schema::HasField<Cities> for super::Job {
         type Type = Option<Vec<super::City>>;
@@ -4118,59 +3280,43 @@ pub mod job_fields {
         pub struct Where;
         impl ::cynic::schema::HasArgument<Where> for super::Cities {
             type ArgumentType = Option<super::super::CityWhereInput>;
-            fn name() -> &'static str {
-                "where"
-            }
+            const NAME: &'static str = "where";
         }
         pub struct OrderBy;
         impl ::cynic::schema::HasArgument<OrderBy> for super::Cities {
             type ArgumentType = Option<super::super::CityOrderByInput>;
-            fn name() -> &'static str {
-                "orderBy"
-            }
+            const NAME: &'static str = "orderBy";
         }
         pub struct Skip;
         impl ::cynic::schema::HasArgument<Skip> for super::Cities {
             type ArgumentType = Option<super::super::Int>;
-            fn name() -> &'static str {
-                "skip"
-            }
+            const NAME: &'static str = "skip";
         }
         pub struct After;
         impl ::cynic::schema::HasArgument<After> for super::Cities {
             type ArgumentType = Option<super::super::String>;
-            fn name() -> &'static str {
-                "after"
-            }
+            const NAME: &'static str = "after";
         }
         pub struct Before;
         impl ::cynic::schema::HasArgument<Before> for super::Cities {
             type ArgumentType = Option<super::super::String>;
-            fn name() -> &'static str {
-                "before"
-            }
+            const NAME: &'static str = "before";
         }
         pub struct First;
         impl ::cynic::schema::HasArgument<First> for super::Cities {
             type ArgumentType = Option<super::super::Int>;
-            fn name() -> &'static str {
-                "first"
-            }
+            const NAME: &'static str = "first";
         }
         pub struct Last;
         impl ::cynic::schema::HasArgument<Last> for super::Cities {
             type ArgumentType = Option<super::super::Int>;
-            fn name() -> &'static str {
-                "last"
-            }
+            const NAME: &'static str = "last";
         }
     }
     pub struct Countries;
     impl ::cynic::schema::Field for Countries {
         type Type = Option<Vec<super::Country>>;
-        fn name() -> &'static str {
-            "countries"
-        }
+        const NAME: &'static str = "countries";
     }
     impl ::cynic::schema::HasField<Countries> for super::Job {
         type Type = Option<Vec<super::Country>>;
@@ -4179,59 +3325,43 @@ pub mod job_fields {
         pub struct Where;
         impl ::cynic::schema::HasArgument<Where> for super::Countries {
             type ArgumentType = Option<super::super::CountryWhereInput>;
-            fn name() -> &'static str {
-                "where"
-            }
+            const NAME: &'static str = "where";
         }
         pub struct OrderBy;
         impl ::cynic::schema::HasArgument<OrderBy> for super::Countries {
             type ArgumentType = Option<super::super::CountryOrderByInput>;
-            fn name() -> &'static str {
-                "orderBy"
-            }
+            const NAME: &'static str = "orderBy";
         }
         pub struct Skip;
         impl ::cynic::schema::HasArgument<Skip> for super::Countries {
             type ArgumentType = Option<super::super::Int>;
-            fn name() -> &'static str {
-                "skip"
-            }
+            const NAME: &'static str = "skip";
         }
         pub struct After;
         impl ::cynic::schema::HasArgument<After> for super::Countries {
             type ArgumentType = Option<super::super::String>;
-            fn name() -> &'static str {
-                "after"
-            }
+            const NAME: &'static str = "after";
         }
         pub struct Before;
         impl ::cynic::schema::HasArgument<Before> for super::Countries {
             type ArgumentType = Option<super::super::String>;
-            fn name() -> &'static str {
-                "before"
-            }
+            const NAME: &'static str = "before";
         }
         pub struct First;
         impl ::cynic::schema::HasArgument<First> for super::Countries {
             type ArgumentType = Option<super::super::Int>;
-            fn name() -> &'static str {
-                "first"
-            }
+            const NAME: &'static str = "first";
         }
         pub struct Last;
         impl ::cynic::schema::HasArgument<Last> for super::Countries {
             type ArgumentType = Option<super::super::Int>;
-            fn name() -> &'static str {
-                "last"
-            }
+            const NAME: &'static str = "last";
         }
     }
     pub struct Remotes;
     impl ::cynic::schema::Field for Remotes {
         type Type = Option<Vec<super::Remote>>;
-        fn name() -> &'static str {
-            "remotes"
-        }
+        const NAME: &'static str = "remotes";
     }
     impl ::cynic::schema::HasField<Remotes> for super::Job {
         type Type = Option<Vec<super::Remote>>;
@@ -4240,59 +3370,43 @@ pub mod job_fields {
         pub struct Where;
         impl ::cynic::schema::HasArgument<Where> for super::Remotes {
             type ArgumentType = Option<super::super::RemoteWhereInput>;
-            fn name() -> &'static str {
-                "where"
-            }
+            const NAME: &'static str = "where";
         }
         pub struct OrderBy;
         impl ::cynic::schema::HasArgument<OrderBy> for super::Remotes {
             type ArgumentType = Option<super::super::RemoteOrderByInput>;
-            fn name() -> &'static str {
-                "orderBy"
-            }
+            const NAME: &'static str = "orderBy";
         }
         pub struct Skip;
         impl ::cynic::schema::HasArgument<Skip> for super::Remotes {
             type ArgumentType = Option<super::super::Int>;
-            fn name() -> &'static str {
-                "skip"
-            }
+            const NAME: &'static str = "skip";
         }
         pub struct After;
         impl ::cynic::schema::HasArgument<After> for super::Remotes {
             type ArgumentType = Option<super::super::String>;
-            fn name() -> &'static str {
-                "after"
-            }
+            const NAME: &'static str = "after";
         }
         pub struct Before;
         impl ::cynic::schema::HasArgument<Before> for super::Remotes {
             type ArgumentType = Option<super::super::String>;
-            fn name() -> &'static str {
-                "before"
-            }
+            const NAME: &'static str = "before";
         }
         pub struct First;
         impl ::cynic::schema::HasArgument<First> for super::Remotes {
             type ArgumentType = Option<super::super::Int>;
-            fn name() -> &'static str {
-                "first"
-            }
+            const NAME: &'static str = "first";
         }
         pub struct Last;
         impl ::cynic::schema::HasArgument<Last> for super::Remotes {
             type ArgumentType = Option<super::super::Int>;
-            fn name() -> &'static str {
-                "last"
-            }
+            const NAME: &'static str = "last";
         }
     }
     pub struct Description;
     impl ::cynic::schema::Field for Description {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "description"
-        }
+        const NAME: &'static str = "description";
     }
     impl ::cynic::schema::HasField<Description> for super::Job {
         type Type = Option<super::String>;
@@ -4300,9 +3414,7 @@ pub mod job_fields {
     pub struct ApplyUrl;
     impl ::cynic::schema::Field for ApplyUrl {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "applyUrl"
-        }
+        const NAME: &'static str = "applyUrl";
     }
     impl ::cynic::schema::HasField<ApplyUrl> for super::Job {
         type Type = Option<super::String>;
@@ -4310,9 +3422,7 @@ pub mod job_fields {
     pub struct Company;
     impl ::cynic::schema::Field for Company {
         type Type = Option<super::Company>;
-        fn name() -> &'static str {
-            "company"
-        }
+        const NAME: &'static str = "company";
     }
     impl ::cynic::schema::HasField<Company> for super::Job {
         type Type = Option<super::Company>;
@@ -4320,9 +3430,7 @@ pub mod job_fields {
     pub struct Tags;
     impl ::cynic::schema::Field for Tags {
         type Type = Option<Vec<super::Tag>>;
-        fn name() -> &'static str {
-            "tags"
-        }
+        const NAME: &'static str = "tags";
     }
     impl ::cynic::schema::HasField<Tags> for super::Job {
         type Type = Option<Vec<super::Tag>>;
@@ -4331,59 +3439,43 @@ pub mod job_fields {
         pub struct Where;
         impl ::cynic::schema::HasArgument<Where> for super::Tags {
             type ArgumentType = Option<super::super::TagWhereInput>;
-            fn name() -> &'static str {
-                "where"
-            }
+            const NAME: &'static str = "where";
         }
         pub struct OrderBy;
         impl ::cynic::schema::HasArgument<OrderBy> for super::Tags {
             type ArgumentType = Option<super::super::TagOrderByInput>;
-            fn name() -> &'static str {
-                "orderBy"
-            }
+            const NAME: &'static str = "orderBy";
         }
         pub struct Skip;
         impl ::cynic::schema::HasArgument<Skip> for super::Tags {
             type ArgumentType = Option<super::super::Int>;
-            fn name() -> &'static str {
-                "skip"
-            }
+            const NAME: &'static str = "skip";
         }
         pub struct After;
         impl ::cynic::schema::HasArgument<After> for super::Tags {
             type ArgumentType = Option<super::super::String>;
-            fn name() -> &'static str {
-                "after"
-            }
+            const NAME: &'static str = "after";
         }
         pub struct Before;
         impl ::cynic::schema::HasArgument<Before> for super::Tags {
             type ArgumentType = Option<super::super::String>;
-            fn name() -> &'static str {
-                "before"
-            }
+            const NAME: &'static str = "before";
         }
         pub struct First;
         impl ::cynic::schema::HasArgument<First> for super::Tags {
             type ArgumentType = Option<super::super::Int>;
-            fn name() -> &'static str {
-                "first"
-            }
+            const NAME: &'static str = "first";
         }
         pub struct Last;
         impl ::cynic::schema::HasArgument<Last> for super::Tags {
             type ArgumentType = Option<super::super::Int>;
-            fn name() -> &'static str {
-                "last"
-            }
+            const NAME: &'static str = "last";
         }
     }
     pub struct IsPublished;
     impl ::cynic::schema::Field for IsPublished {
         type Type = Option<super::Boolean>;
-        fn name() -> &'static str {
-            "isPublished"
-        }
+        const NAME: &'static str = "isPublished";
     }
     impl ::cynic::schema::HasField<IsPublished> for super::Job {
         type Type = Option<super::Boolean>;
@@ -4391,9 +3483,7 @@ pub mod job_fields {
     pub struct IsFeatured;
     impl ::cynic::schema::Field for IsFeatured {
         type Type = Option<super::Boolean>;
-        fn name() -> &'static str {
-            "isFeatured"
-        }
+        const NAME: &'static str = "isFeatured";
     }
     impl ::cynic::schema::HasField<IsFeatured> for super::Job {
         type Type = Option<super::Boolean>;
@@ -4401,9 +3491,7 @@ pub mod job_fields {
     pub struct LocationNames;
     impl ::cynic::schema::Field for LocationNames {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "locationNames"
-        }
+        const NAME: &'static str = "locationNames";
     }
     impl ::cynic::schema::HasField<LocationNames> for super::Job {
         type Type = Option<super::String>;
@@ -4411,9 +3499,7 @@ pub mod job_fields {
     pub struct UserEmail;
     impl ::cynic::schema::Field for UserEmail {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "userEmail"
-        }
+        const NAME: &'static str = "userEmail";
     }
     impl ::cynic::schema::HasField<UserEmail> for super::Job {
         type Type = Option<super::String>;
@@ -4421,9 +3507,7 @@ pub mod job_fields {
     pub struct PostedAt;
     impl ::cynic::schema::Field for PostedAt {
         type Type = super::DateTime;
-        fn name() -> &'static str {
-            "postedAt"
-        }
+        const NAME: &'static str = "postedAt";
     }
     impl ::cynic::schema::HasField<PostedAt> for super::Job {
         type Type = super::DateTime;
@@ -4431,9 +3515,7 @@ pub mod job_fields {
     pub struct CreatedAt;
     impl ::cynic::schema::Field for CreatedAt {
         type Type = super::DateTime;
-        fn name() -> &'static str {
-            "createdAt"
-        }
+        const NAME: &'static str = "createdAt";
     }
     impl ::cynic::schema::HasField<CreatedAt> for super::Job {
         type Type = super::DateTime;
@@ -4441,9 +3523,7 @@ pub mod job_fields {
     pub struct UpdatedAt;
     impl ::cynic::schema::Field for UpdatedAt {
         type Type = super::DateTime;
-        fn name() -> &'static str {
-            "updatedAt"
-        }
+        const NAME: &'static str = "updatedAt";
     }
     impl ::cynic::schema::HasField<UpdatedAt> for super::Job {
         type Type = super::DateTime;
@@ -4455,17 +3535,13 @@ pub mod job_input_fields {
     pub struct CompanySlug;
     impl ::cynic::schema::Field for CompanySlug {
         type Type = super::String;
-        fn name() -> &'static str {
-            "companySlug"
-        }
+        const NAME: &'static str = "companySlug";
     }
     impl ::cynic::schema::HasInputField<CompanySlug, super::String> for super::JobInput {}
     pub struct JobSlug;
     impl ::cynic::schema::Field for JobSlug {
         type Type = super::String;
-        fn name() -> &'static str {
-            "jobSlug"
-        }
+        const NAME: &'static str = "jobSlug";
     }
     impl ::cynic::schema::HasInputField<JobSlug, super::String> for super::JobInput {}
 }
@@ -4476,145 +3552,109 @@ pub mod job_where_input_fields {
     pub struct Id;
     impl ::cynic::schema::Field for Id {
         type Type = Option<super::Id>;
-        fn name() -> &'static str {
-            "id"
-        }
+        const NAME: &'static str = "id";
     }
     impl ::cynic::schema::HasInputField<Id, Option<super::Id>> for super::JobWhereInput {}
     pub struct IdNot;
     impl ::cynic::schema::Field for IdNot {
         type Type = Option<super::Id>;
-        fn name() -> &'static str {
-            "id_not"
-        }
+        const NAME: &'static str = "id_not";
     }
     impl ::cynic::schema::HasInputField<IdNot, Option<super::Id>> for super::JobWhereInput {}
     pub struct IdIn;
     impl ::cynic::schema::Field for IdIn {
         type Type = Option<Vec<super::Id>>;
-        fn name() -> &'static str {
-            "id_in"
-        }
+        const NAME: &'static str = "id_in";
     }
     impl ::cynic::schema::HasInputField<IdIn, Option<Vec<super::Id>>> for super::JobWhereInput {}
     pub struct IdNotIn;
     impl ::cynic::schema::Field for IdNotIn {
         type Type = Option<Vec<super::Id>>;
-        fn name() -> &'static str {
-            "id_not_in"
-        }
+        const NAME: &'static str = "id_not_in";
     }
     impl ::cynic::schema::HasInputField<IdNotIn, Option<Vec<super::Id>>> for super::JobWhereInput {}
     pub struct IdLt;
     impl ::cynic::schema::Field for IdLt {
         type Type = Option<super::Id>;
-        fn name() -> &'static str {
-            "id_lt"
-        }
+        const NAME: &'static str = "id_lt";
     }
     impl ::cynic::schema::HasInputField<IdLt, Option<super::Id>> for super::JobWhereInput {}
     pub struct IdLte;
     impl ::cynic::schema::Field for IdLte {
         type Type = Option<super::Id>;
-        fn name() -> &'static str {
-            "id_lte"
-        }
+        const NAME: &'static str = "id_lte";
     }
     impl ::cynic::schema::HasInputField<IdLte, Option<super::Id>> for super::JobWhereInput {}
     pub struct IdGt;
     impl ::cynic::schema::Field for IdGt {
         type Type = Option<super::Id>;
-        fn name() -> &'static str {
-            "id_gt"
-        }
+        const NAME: &'static str = "id_gt";
     }
     impl ::cynic::schema::HasInputField<IdGt, Option<super::Id>> for super::JobWhereInput {}
     pub struct IdGte;
     impl ::cynic::schema::Field for IdGte {
         type Type = Option<super::Id>;
-        fn name() -> &'static str {
-            "id_gte"
-        }
+        const NAME: &'static str = "id_gte";
     }
     impl ::cynic::schema::HasInputField<IdGte, Option<super::Id>> for super::JobWhereInput {}
     pub struct IdContains;
     impl ::cynic::schema::Field for IdContains {
         type Type = Option<super::Id>;
-        fn name() -> &'static str {
-            "id_contains"
-        }
+        const NAME: &'static str = "id_contains";
     }
     impl ::cynic::schema::HasInputField<IdContains, Option<super::Id>> for super::JobWhereInput {}
     pub struct IdNotContains;
     impl ::cynic::schema::Field for IdNotContains {
         type Type = Option<super::Id>;
-        fn name() -> &'static str {
-            "id_not_contains"
-        }
+        const NAME: &'static str = "id_not_contains";
     }
     impl ::cynic::schema::HasInputField<IdNotContains, Option<super::Id>> for super::JobWhereInput {}
     pub struct IdStartsWith;
     impl ::cynic::schema::Field for IdStartsWith {
         type Type = Option<super::Id>;
-        fn name() -> &'static str {
-            "id_starts_with"
-        }
+        const NAME: &'static str = "id_starts_with";
     }
     impl ::cynic::schema::HasInputField<IdStartsWith, Option<super::Id>> for super::JobWhereInput {}
     pub struct IdNotStartsWith;
     impl ::cynic::schema::Field for IdNotStartsWith {
         type Type = Option<super::Id>;
-        fn name() -> &'static str {
-            "id_not_starts_with"
-        }
+        const NAME: &'static str = "id_not_starts_with";
     }
     impl ::cynic::schema::HasInputField<IdNotStartsWith, Option<super::Id>> for super::JobWhereInput {}
     pub struct IdEndsWith;
     impl ::cynic::schema::Field for IdEndsWith {
         type Type = Option<super::Id>;
-        fn name() -> &'static str {
-            "id_ends_with"
-        }
+        const NAME: &'static str = "id_ends_with";
     }
     impl ::cynic::schema::HasInputField<IdEndsWith, Option<super::Id>> for super::JobWhereInput {}
     pub struct IdNotEndsWith;
     impl ::cynic::schema::Field for IdNotEndsWith {
         type Type = Option<super::Id>;
-        fn name() -> &'static str {
-            "id_not_ends_with"
-        }
+        const NAME: &'static str = "id_not_ends_with";
     }
     impl ::cynic::schema::HasInputField<IdNotEndsWith, Option<super::Id>> for super::JobWhereInput {}
     pub struct Title;
     impl ::cynic::schema::Field for Title {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "title"
-        }
+        const NAME: &'static str = "title";
     }
     impl ::cynic::schema::HasInputField<Title, Option<super::String>> for super::JobWhereInput {}
     pub struct TitleNot;
     impl ::cynic::schema::Field for TitleNot {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "title_not"
-        }
+        const NAME: &'static str = "title_not";
     }
     impl ::cynic::schema::HasInputField<TitleNot, Option<super::String>> for super::JobWhereInput {}
     pub struct TitleIn;
     impl ::cynic::schema::Field for TitleIn {
         type Type = Option<Vec<super::String>>;
-        fn name() -> &'static str {
-            "title_in"
-        }
+        const NAME: &'static str = "title_in";
     }
     impl ::cynic::schema::HasInputField<TitleIn, Option<Vec<super::String>>> for super::JobWhereInput {}
     pub struct TitleNotIn;
     impl ::cynic::schema::Field for TitleNotIn {
         type Type = Option<Vec<super::String>>;
-        fn name() -> &'static str {
-            "title_not_in"
-        }
+        const NAME: &'static str = "title_not_in";
     }
     impl ::cynic::schema::HasInputField<TitleNotIn, Option<Vec<super::String>>>
         for super::JobWhereInput
@@ -4623,49 +3663,37 @@ pub mod job_where_input_fields {
     pub struct TitleLt;
     impl ::cynic::schema::Field for TitleLt {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "title_lt"
-        }
+        const NAME: &'static str = "title_lt";
     }
     impl ::cynic::schema::HasInputField<TitleLt, Option<super::String>> for super::JobWhereInput {}
     pub struct TitleLte;
     impl ::cynic::schema::Field for TitleLte {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "title_lte"
-        }
+        const NAME: &'static str = "title_lte";
     }
     impl ::cynic::schema::HasInputField<TitleLte, Option<super::String>> for super::JobWhereInput {}
     pub struct TitleGt;
     impl ::cynic::schema::Field for TitleGt {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "title_gt"
-        }
+        const NAME: &'static str = "title_gt";
     }
     impl ::cynic::schema::HasInputField<TitleGt, Option<super::String>> for super::JobWhereInput {}
     pub struct TitleGte;
     impl ::cynic::schema::Field for TitleGte {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "title_gte"
-        }
+        const NAME: &'static str = "title_gte";
     }
     impl ::cynic::schema::HasInputField<TitleGte, Option<super::String>> for super::JobWhereInput {}
     pub struct TitleContains;
     impl ::cynic::schema::Field for TitleContains {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "title_contains"
-        }
+        const NAME: &'static str = "title_contains";
     }
     impl ::cynic::schema::HasInputField<TitleContains, Option<super::String>> for super::JobWhereInput {}
     pub struct TitleNotContains;
     impl ::cynic::schema::Field for TitleNotContains {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "title_not_contains"
-        }
+        const NAME: &'static str = "title_not_contains";
     }
     impl ::cynic::schema::HasInputField<TitleNotContains, Option<super::String>>
         for super::JobWhereInput
@@ -4674,9 +3702,7 @@ pub mod job_where_input_fields {
     pub struct TitleStartsWith;
     impl ::cynic::schema::Field for TitleStartsWith {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "title_starts_with"
-        }
+        const NAME: &'static str = "title_starts_with";
     }
     impl ::cynic::schema::HasInputField<TitleStartsWith, Option<super::String>>
         for super::JobWhereInput
@@ -4685,9 +3711,7 @@ pub mod job_where_input_fields {
     pub struct TitleNotStartsWith;
     impl ::cynic::schema::Field for TitleNotStartsWith {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "title_not_starts_with"
-        }
+        const NAME: &'static str = "title_not_starts_with";
     }
     impl ::cynic::schema::HasInputField<TitleNotStartsWith, Option<super::String>>
         for super::JobWhereInput
@@ -4696,17 +3720,13 @@ pub mod job_where_input_fields {
     pub struct TitleEndsWith;
     impl ::cynic::schema::Field for TitleEndsWith {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "title_ends_with"
-        }
+        const NAME: &'static str = "title_ends_with";
     }
     impl ::cynic::schema::HasInputField<TitleEndsWith, Option<super::String>> for super::JobWhereInput {}
     pub struct TitleNotEndsWith;
     impl ::cynic::schema::Field for TitleNotEndsWith {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "title_not_ends_with"
-        }
+        const NAME: &'static str = "title_not_ends_with";
     }
     impl ::cynic::schema::HasInputField<TitleNotEndsWith, Option<super::String>>
         for super::JobWhereInput
@@ -4715,33 +3735,25 @@ pub mod job_where_input_fields {
     pub struct Slug;
     impl ::cynic::schema::Field for Slug {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "slug"
-        }
+        const NAME: &'static str = "slug";
     }
     impl ::cynic::schema::HasInputField<Slug, Option<super::String>> for super::JobWhereInput {}
     pub struct SlugNot;
     impl ::cynic::schema::Field for SlugNot {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "slug_not"
-        }
+        const NAME: &'static str = "slug_not";
     }
     impl ::cynic::schema::HasInputField<SlugNot, Option<super::String>> for super::JobWhereInput {}
     pub struct SlugIn;
     impl ::cynic::schema::Field for SlugIn {
         type Type = Option<Vec<super::String>>;
-        fn name() -> &'static str {
-            "slug_in"
-        }
+        const NAME: &'static str = "slug_in";
     }
     impl ::cynic::schema::HasInputField<SlugIn, Option<Vec<super::String>>> for super::JobWhereInput {}
     pub struct SlugNotIn;
     impl ::cynic::schema::Field for SlugNotIn {
         type Type = Option<Vec<super::String>>;
-        fn name() -> &'static str {
-            "slug_not_in"
-        }
+        const NAME: &'static str = "slug_not_in";
     }
     impl ::cynic::schema::HasInputField<SlugNotIn, Option<Vec<super::String>>>
         for super::JobWhereInput
@@ -4750,49 +3762,37 @@ pub mod job_where_input_fields {
     pub struct SlugLt;
     impl ::cynic::schema::Field for SlugLt {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "slug_lt"
-        }
+        const NAME: &'static str = "slug_lt";
     }
     impl ::cynic::schema::HasInputField<SlugLt, Option<super::String>> for super::JobWhereInput {}
     pub struct SlugLte;
     impl ::cynic::schema::Field for SlugLte {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "slug_lte"
-        }
+        const NAME: &'static str = "slug_lte";
     }
     impl ::cynic::schema::HasInputField<SlugLte, Option<super::String>> for super::JobWhereInput {}
     pub struct SlugGt;
     impl ::cynic::schema::Field for SlugGt {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "slug_gt"
-        }
+        const NAME: &'static str = "slug_gt";
     }
     impl ::cynic::schema::HasInputField<SlugGt, Option<super::String>> for super::JobWhereInput {}
     pub struct SlugGte;
     impl ::cynic::schema::Field for SlugGte {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "slug_gte"
-        }
+        const NAME: &'static str = "slug_gte";
     }
     impl ::cynic::schema::HasInputField<SlugGte, Option<super::String>> for super::JobWhereInput {}
     pub struct SlugContains;
     impl ::cynic::schema::Field for SlugContains {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "slug_contains"
-        }
+        const NAME: &'static str = "slug_contains";
     }
     impl ::cynic::schema::HasInputField<SlugContains, Option<super::String>> for super::JobWhereInput {}
     pub struct SlugNotContains;
     impl ::cynic::schema::Field for SlugNotContains {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "slug_not_contains"
-        }
+        const NAME: &'static str = "slug_not_contains";
     }
     impl ::cynic::schema::HasInputField<SlugNotContains, Option<super::String>>
         for super::JobWhereInput
@@ -4801,9 +3801,7 @@ pub mod job_where_input_fields {
     pub struct SlugStartsWith;
     impl ::cynic::schema::Field for SlugStartsWith {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "slug_starts_with"
-        }
+        const NAME: &'static str = "slug_starts_with";
     }
     impl ::cynic::schema::HasInputField<SlugStartsWith, Option<super::String>>
         for super::JobWhereInput
@@ -4812,9 +3810,7 @@ pub mod job_where_input_fields {
     pub struct SlugNotStartsWith;
     impl ::cynic::schema::Field for SlugNotStartsWith {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "slug_not_starts_with"
-        }
+        const NAME: &'static str = "slug_not_starts_with";
     }
     impl ::cynic::schema::HasInputField<SlugNotStartsWith, Option<super::String>>
         for super::JobWhereInput
@@ -4823,17 +3819,13 @@ pub mod job_where_input_fields {
     pub struct SlugEndsWith;
     impl ::cynic::schema::Field for SlugEndsWith {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "slug_ends_with"
-        }
+        const NAME: &'static str = "slug_ends_with";
     }
     impl ::cynic::schema::HasInputField<SlugEndsWith, Option<super::String>> for super::JobWhereInput {}
     pub struct SlugNotEndsWith;
     impl ::cynic::schema::Field for SlugNotEndsWith {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "slug_not_ends_with"
-        }
+        const NAME: &'static str = "slug_not_ends_with";
     }
     impl ::cynic::schema::HasInputField<SlugNotEndsWith, Option<super::String>>
         for super::JobWhereInput
@@ -4842,9 +3834,7 @@ pub mod job_where_input_fields {
     pub struct Commitment;
     impl ::cynic::schema::Field for Commitment {
         type Type = Option<super::CommitmentWhereInput>;
-        fn name() -> &'static str {
-            "commitment"
-        }
+        const NAME: &'static str = "commitment";
     }
     impl ::cynic::schema::HasInputField<Commitment, Option<super::CommitmentWhereInput>>
         for super::JobWhereInput
@@ -4853,9 +3843,7 @@ pub mod job_where_input_fields {
     pub struct CitiesEvery;
     impl ::cynic::schema::Field for CitiesEvery {
         type Type = Option<super::CityWhereInput>;
-        fn name() -> &'static str {
-            "cities_every"
-        }
+        const NAME: &'static str = "cities_every";
     }
     impl ::cynic::schema::HasInputField<CitiesEvery, Option<super::CityWhereInput>>
         for super::JobWhereInput
@@ -4864,9 +3852,7 @@ pub mod job_where_input_fields {
     pub struct CitiesSome;
     impl ::cynic::schema::Field for CitiesSome {
         type Type = Option<super::CityWhereInput>;
-        fn name() -> &'static str {
-            "cities_some"
-        }
+        const NAME: &'static str = "cities_some";
     }
     impl ::cynic::schema::HasInputField<CitiesSome, Option<super::CityWhereInput>>
         for super::JobWhereInput
@@ -4875,9 +3861,7 @@ pub mod job_where_input_fields {
     pub struct CitiesNone;
     impl ::cynic::schema::Field for CitiesNone {
         type Type = Option<super::CityWhereInput>;
-        fn name() -> &'static str {
-            "cities_none"
-        }
+        const NAME: &'static str = "cities_none";
     }
     impl ::cynic::schema::HasInputField<CitiesNone, Option<super::CityWhereInput>>
         for super::JobWhereInput
@@ -4886,9 +3870,7 @@ pub mod job_where_input_fields {
     pub struct CountriesEvery;
     impl ::cynic::schema::Field for CountriesEvery {
         type Type = Option<super::CountryWhereInput>;
-        fn name() -> &'static str {
-            "countries_every"
-        }
+        const NAME: &'static str = "countries_every";
     }
     impl ::cynic::schema::HasInputField<CountriesEvery, Option<super::CountryWhereInput>>
         for super::JobWhereInput
@@ -4897,9 +3879,7 @@ pub mod job_where_input_fields {
     pub struct CountriesSome;
     impl ::cynic::schema::Field for CountriesSome {
         type Type = Option<super::CountryWhereInput>;
-        fn name() -> &'static str {
-            "countries_some"
-        }
+        const NAME: &'static str = "countries_some";
     }
     impl ::cynic::schema::HasInputField<CountriesSome, Option<super::CountryWhereInput>>
         for super::JobWhereInput
@@ -4908,9 +3888,7 @@ pub mod job_where_input_fields {
     pub struct CountriesNone;
     impl ::cynic::schema::Field for CountriesNone {
         type Type = Option<super::CountryWhereInput>;
-        fn name() -> &'static str {
-            "countries_none"
-        }
+        const NAME: &'static str = "countries_none";
     }
     impl ::cynic::schema::HasInputField<CountriesNone, Option<super::CountryWhereInput>>
         for super::JobWhereInput
@@ -4919,9 +3897,7 @@ pub mod job_where_input_fields {
     pub struct RemotesEvery;
     impl ::cynic::schema::Field for RemotesEvery {
         type Type = Option<super::RemoteWhereInput>;
-        fn name() -> &'static str {
-            "remotes_every"
-        }
+        const NAME: &'static str = "remotes_every";
     }
     impl ::cynic::schema::HasInputField<RemotesEvery, Option<super::RemoteWhereInput>>
         for super::JobWhereInput
@@ -4930,9 +3906,7 @@ pub mod job_where_input_fields {
     pub struct RemotesSome;
     impl ::cynic::schema::Field for RemotesSome {
         type Type = Option<super::RemoteWhereInput>;
-        fn name() -> &'static str {
-            "remotes_some"
-        }
+        const NAME: &'static str = "remotes_some";
     }
     impl ::cynic::schema::HasInputField<RemotesSome, Option<super::RemoteWhereInput>>
         for super::JobWhereInput
@@ -4941,9 +3915,7 @@ pub mod job_where_input_fields {
     pub struct RemotesNone;
     impl ::cynic::schema::Field for RemotesNone {
         type Type = Option<super::RemoteWhereInput>;
-        fn name() -> &'static str {
-            "remotes_none"
-        }
+        const NAME: &'static str = "remotes_none";
     }
     impl ::cynic::schema::HasInputField<RemotesNone, Option<super::RemoteWhereInput>>
         for super::JobWhereInput
@@ -4952,17 +3924,13 @@ pub mod job_where_input_fields {
     pub struct Description;
     impl ::cynic::schema::Field for Description {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "description"
-        }
+        const NAME: &'static str = "description";
     }
     impl ::cynic::schema::HasInputField<Description, Option<super::String>> for super::JobWhereInput {}
     pub struct DescriptionNot;
     impl ::cynic::schema::Field for DescriptionNot {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "description_not"
-        }
+        const NAME: &'static str = "description_not";
     }
     impl ::cynic::schema::HasInputField<DescriptionNot, Option<super::String>>
         for super::JobWhereInput
@@ -4971,9 +3939,7 @@ pub mod job_where_input_fields {
     pub struct DescriptionIn;
     impl ::cynic::schema::Field for DescriptionIn {
         type Type = Option<Vec<super::String>>;
-        fn name() -> &'static str {
-            "description_in"
-        }
+        const NAME: &'static str = "description_in";
     }
     impl ::cynic::schema::HasInputField<DescriptionIn, Option<Vec<super::String>>>
         for super::JobWhereInput
@@ -4982,9 +3948,7 @@ pub mod job_where_input_fields {
     pub struct DescriptionNotIn;
     impl ::cynic::schema::Field for DescriptionNotIn {
         type Type = Option<Vec<super::String>>;
-        fn name() -> &'static str {
-            "description_not_in"
-        }
+        const NAME: &'static str = "description_not_in";
     }
     impl ::cynic::schema::HasInputField<DescriptionNotIn, Option<Vec<super::String>>>
         for super::JobWhereInput
@@ -4993,17 +3957,13 @@ pub mod job_where_input_fields {
     pub struct DescriptionLt;
     impl ::cynic::schema::Field for DescriptionLt {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "description_lt"
-        }
+        const NAME: &'static str = "description_lt";
     }
     impl ::cynic::schema::HasInputField<DescriptionLt, Option<super::String>> for super::JobWhereInput {}
     pub struct DescriptionLte;
     impl ::cynic::schema::Field for DescriptionLte {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "description_lte"
-        }
+        const NAME: &'static str = "description_lte";
     }
     impl ::cynic::schema::HasInputField<DescriptionLte, Option<super::String>>
         for super::JobWhereInput
@@ -5012,17 +3972,13 @@ pub mod job_where_input_fields {
     pub struct DescriptionGt;
     impl ::cynic::schema::Field for DescriptionGt {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "description_gt"
-        }
+        const NAME: &'static str = "description_gt";
     }
     impl ::cynic::schema::HasInputField<DescriptionGt, Option<super::String>> for super::JobWhereInput {}
     pub struct DescriptionGte;
     impl ::cynic::schema::Field for DescriptionGte {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "description_gte"
-        }
+        const NAME: &'static str = "description_gte";
     }
     impl ::cynic::schema::HasInputField<DescriptionGte, Option<super::String>>
         for super::JobWhereInput
@@ -5031,9 +3987,7 @@ pub mod job_where_input_fields {
     pub struct DescriptionContains;
     impl ::cynic::schema::Field for DescriptionContains {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "description_contains"
-        }
+        const NAME: &'static str = "description_contains";
     }
     impl ::cynic::schema::HasInputField<DescriptionContains, Option<super::String>>
         for super::JobWhereInput
@@ -5042,9 +3996,7 @@ pub mod job_where_input_fields {
     pub struct DescriptionNotContains;
     impl ::cynic::schema::Field for DescriptionNotContains {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "description_not_contains"
-        }
+        const NAME: &'static str = "description_not_contains";
     }
     impl ::cynic::schema::HasInputField<DescriptionNotContains, Option<super::String>>
         for super::JobWhereInput
@@ -5053,9 +4005,7 @@ pub mod job_where_input_fields {
     pub struct DescriptionStartsWith;
     impl ::cynic::schema::Field for DescriptionStartsWith {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "description_starts_with"
-        }
+        const NAME: &'static str = "description_starts_with";
     }
     impl ::cynic::schema::HasInputField<DescriptionStartsWith, Option<super::String>>
         for super::JobWhereInput
@@ -5064,9 +4014,7 @@ pub mod job_where_input_fields {
     pub struct DescriptionNotStartsWith;
     impl ::cynic::schema::Field for DescriptionNotStartsWith {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "description_not_starts_with"
-        }
+        const NAME: &'static str = "description_not_starts_with";
     }
     impl ::cynic::schema::HasInputField<DescriptionNotStartsWith, Option<super::String>>
         for super::JobWhereInput
@@ -5075,9 +4023,7 @@ pub mod job_where_input_fields {
     pub struct DescriptionEndsWith;
     impl ::cynic::schema::Field for DescriptionEndsWith {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "description_ends_with"
-        }
+        const NAME: &'static str = "description_ends_with";
     }
     impl ::cynic::schema::HasInputField<DescriptionEndsWith, Option<super::String>>
         for super::JobWhereInput
@@ -5086,9 +4032,7 @@ pub mod job_where_input_fields {
     pub struct DescriptionNotEndsWith;
     impl ::cynic::schema::Field for DescriptionNotEndsWith {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "description_not_ends_with"
-        }
+        const NAME: &'static str = "description_not_ends_with";
     }
     impl ::cynic::schema::HasInputField<DescriptionNotEndsWith, Option<super::String>>
         for super::JobWhereInput
@@ -5097,25 +4041,19 @@ pub mod job_where_input_fields {
     pub struct ApplyUrl;
     impl ::cynic::schema::Field for ApplyUrl {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "applyUrl"
-        }
+        const NAME: &'static str = "applyUrl";
     }
     impl ::cynic::schema::HasInputField<ApplyUrl, Option<super::String>> for super::JobWhereInput {}
     pub struct ApplyUrlNot;
     impl ::cynic::schema::Field for ApplyUrlNot {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "applyUrl_not"
-        }
+        const NAME: &'static str = "applyUrl_not";
     }
     impl ::cynic::schema::HasInputField<ApplyUrlNot, Option<super::String>> for super::JobWhereInput {}
     pub struct ApplyUrlIn;
     impl ::cynic::schema::Field for ApplyUrlIn {
         type Type = Option<Vec<super::String>>;
-        fn name() -> &'static str {
-            "applyUrl_in"
-        }
+        const NAME: &'static str = "applyUrl_in";
     }
     impl ::cynic::schema::HasInputField<ApplyUrlIn, Option<Vec<super::String>>>
         for super::JobWhereInput
@@ -5124,9 +4062,7 @@ pub mod job_where_input_fields {
     pub struct ApplyUrlNotIn;
     impl ::cynic::schema::Field for ApplyUrlNotIn {
         type Type = Option<Vec<super::String>>;
-        fn name() -> &'static str {
-            "applyUrl_not_in"
-        }
+        const NAME: &'static str = "applyUrl_not_in";
     }
     impl ::cynic::schema::HasInputField<ApplyUrlNotIn, Option<Vec<super::String>>>
         for super::JobWhereInput
@@ -5135,41 +4071,31 @@ pub mod job_where_input_fields {
     pub struct ApplyUrlLt;
     impl ::cynic::schema::Field for ApplyUrlLt {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "applyUrl_lt"
-        }
+        const NAME: &'static str = "applyUrl_lt";
     }
     impl ::cynic::schema::HasInputField<ApplyUrlLt, Option<super::String>> for super::JobWhereInput {}
     pub struct ApplyUrlLte;
     impl ::cynic::schema::Field for ApplyUrlLte {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "applyUrl_lte"
-        }
+        const NAME: &'static str = "applyUrl_lte";
     }
     impl ::cynic::schema::HasInputField<ApplyUrlLte, Option<super::String>> for super::JobWhereInput {}
     pub struct ApplyUrlGt;
     impl ::cynic::schema::Field for ApplyUrlGt {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "applyUrl_gt"
-        }
+        const NAME: &'static str = "applyUrl_gt";
     }
     impl ::cynic::schema::HasInputField<ApplyUrlGt, Option<super::String>> for super::JobWhereInput {}
     pub struct ApplyUrlGte;
     impl ::cynic::schema::Field for ApplyUrlGte {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "applyUrl_gte"
-        }
+        const NAME: &'static str = "applyUrl_gte";
     }
     impl ::cynic::schema::HasInputField<ApplyUrlGte, Option<super::String>> for super::JobWhereInput {}
     pub struct ApplyUrlContains;
     impl ::cynic::schema::Field for ApplyUrlContains {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "applyUrl_contains"
-        }
+        const NAME: &'static str = "applyUrl_contains";
     }
     impl ::cynic::schema::HasInputField<ApplyUrlContains, Option<super::String>>
         for super::JobWhereInput
@@ -5178,9 +4104,7 @@ pub mod job_where_input_fields {
     pub struct ApplyUrlNotContains;
     impl ::cynic::schema::Field for ApplyUrlNotContains {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "applyUrl_not_contains"
-        }
+        const NAME: &'static str = "applyUrl_not_contains";
     }
     impl ::cynic::schema::HasInputField<ApplyUrlNotContains, Option<super::String>>
         for super::JobWhereInput
@@ -5189,9 +4113,7 @@ pub mod job_where_input_fields {
     pub struct ApplyUrlStartsWith;
     impl ::cynic::schema::Field for ApplyUrlStartsWith {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "applyUrl_starts_with"
-        }
+        const NAME: &'static str = "applyUrl_starts_with";
     }
     impl ::cynic::schema::HasInputField<ApplyUrlStartsWith, Option<super::String>>
         for super::JobWhereInput
@@ -5200,9 +4122,7 @@ pub mod job_where_input_fields {
     pub struct ApplyUrlNotStartsWith;
     impl ::cynic::schema::Field for ApplyUrlNotStartsWith {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "applyUrl_not_starts_with"
-        }
+        const NAME: &'static str = "applyUrl_not_starts_with";
     }
     impl ::cynic::schema::HasInputField<ApplyUrlNotStartsWith, Option<super::String>>
         for super::JobWhereInput
@@ -5211,9 +4131,7 @@ pub mod job_where_input_fields {
     pub struct ApplyUrlEndsWith;
     impl ::cynic::schema::Field for ApplyUrlEndsWith {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "applyUrl_ends_with"
-        }
+        const NAME: &'static str = "applyUrl_ends_with";
     }
     impl ::cynic::schema::HasInputField<ApplyUrlEndsWith, Option<super::String>>
         for super::JobWhereInput
@@ -5222,9 +4140,7 @@ pub mod job_where_input_fields {
     pub struct ApplyUrlNotEndsWith;
     impl ::cynic::schema::Field for ApplyUrlNotEndsWith {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "applyUrl_not_ends_with"
-        }
+        const NAME: &'static str = "applyUrl_not_ends_with";
     }
     impl ::cynic::schema::HasInputField<ApplyUrlNotEndsWith, Option<super::String>>
         for super::JobWhereInput
@@ -5233,9 +4149,7 @@ pub mod job_where_input_fields {
     pub struct Company;
     impl ::cynic::schema::Field for Company {
         type Type = Option<super::CompanyWhereInput>;
-        fn name() -> &'static str {
-            "company"
-        }
+        const NAME: &'static str = "company";
     }
     impl ::cynic::schema::HasInputField<Company, Option<super::CompanyWhereInput>>
         for super::JobWhereInput
@@ -5244,9 +4158,7 @@ pub mod job_where_input_fields {
     pub struct TagsEvery;
     impl ::cynic::schema::Field for TagsEvery {
         type Type = Option<super::TagWhereInput>;
-        fn name() -> &'static str {
-            "tags_every"
-        }
+        const NAME: &'static str = "tags_every";
     }
     impl ::cynic::schema::HasInputField<TagsEvery, Option<super::TagWhereInput>>
         for super::JobWhereInput
@@ -5255,9 +4167,7 @@ pub mod job_where_input_fields {
     pub struct TagsSome;
     impl ::cynic::schema::Field for TagsSome {
         type Type = Option<super::TagWhereInput>;
-        fn name() -> &'static str {
-            "tags_some"
-        }
+        const NAME: &'static str = "tags_some";
     }
     impl ::cynic::schema::HasInputField<TagsSome, Option<super::TagWhereInput>>
         for super::JobWhereInput
@@ -5266,9 +4176,7 @@ pub mod job_where_input_fields {
     pub struct TagsNone;
     impl ::cynic::schema::Field for TagsNone {
         type Type = Option<super::TagWhereInput>;
-        fn name() -> &'static str {
-            "tags_none"
-        }
+        const NAME: &'static str = "tags_none";
     }
     impl ::cynic::schema::HasInputField<TagsNone, Option<super::TagWhereInput>>
         for super::JobWhereInput
@@ -5277,17 +4185,13 @@ pub mod job_where_input_fields {
     pub struct IsPublished;
     impl ::cynic::schema::Field for IsPublished {
         type Type = Option<super::Boolean>;
-        fn name() -> &'static str {
-            "isPublished"
-        }
+        const NAME: &'static str = "isPublished";
     }
     impl ::cynic::schema::HasInputField<IsPublished, Option<super::Boolean>> for super::JobWhereInput {}
     pub struct IsPublishedNot;
     impl ::cynic::schema::Field for IsPublishedNot {
         type Type = Option<super::Boolean>;
-        fn name() -> &'static str {
-            "isPublished_not"
-        }
+        const NAME: &'static str = "isPublished_not";
     }
     impl ::cynic::schema::HasInputField<IsPublishedNot, Option<super::Boolean>>
         for super::JobWhereInput
@@ -5296,17 +4200,13 @@ pub mod job_where_input_fields {
     pub struct IsFeatured;
     impl ::cynic::schema::Field for IsFeatured {
         type Type = Option<super::Boolean>;
-        fn name() -> &'static str {
-            "isFeatured"
-        }
+        const NAME: &'static str = "isFeatured";
     }
     impl ::cynic::schema::HasInputField<IsFeatured, Option<super::Boolean>> for super::JobWhereInput {}
     pub struct IsFeaturedNot;
     impl ::cynic::schema::Field for IsFeaturedNot {
         type Type = Option<super::Boolean>;
-        fn name() -> &'static str {
-            "isFeatured_not"
-        }
+        const NAME: &'static str = "isFeatured_not";
     }
     impl ::cynic::schema::HasInputField<IsFeaturedNot, Option<super::Boolean>>
         for super::JobWhereInput
@@ -5315,17 +4215,13 @@ pub mod job_where_input_fields {
     pub struct LocationNames;
     impl ::cynic::schema::Field for LocationNames {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "locationNames"
-        }
+        const NAME: &'static str = "locationNames";
     }
     impl ::cynic::schema::HasInputField<LocationNames, Option<super::String>> for super::JobWhereInput {}
     pub struct LocationNamesNot;
     impl ::cynic::schema::Field for LocationNamesNot {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "locationNames_not"
-        }
+        const NAME: &'static str = "locationNames_not";
     }
     impl ::cynic::schema::HasInputField<LocationNamesNot, Option<super::String>>
         for super::JobWhereInput
@@ -5334,9 +4230,7 @@ pub mod job_where_input_fields {
     pub struct LocationNamesIn;
     impl ::cynic::schema::Field for LocationNamesIn {
         type Type = Option<Vec<super::String>>;
-        fn name() -> &'static str {
-            "locationNames_in"
-        }
+        const NAME: &'static str = "locationNames_in";
     }
     impl ::cynic::schema::HasInputField<LocationNamesIn, Option<Vec<super::String>>>
         for super::JobWhereInput
@@ -5345,9 +4239,7 @@ pub mod job_where_input_fields {
     pub struct LocationNamesNotIn;
     impl ::cynic::schema::Field for LocationNamesNotIn {
         type Type = Option<Vec<super::String>>;
-        fn name() -> &'static str {
-            "locationNames_not_in"
-        }
+        const NAME: &'static str = "locationNames_not_in";
     }
     impl ::cynic::schema::HasInputField<LocationNamesNotIn, Option<Vec<super::String>>>
         for super::JobWhereInput
@@ -5356,9 +4248,7 @@ pub mod job_where_input_fields {
     pub struct LocationNamesLt;
     impl ::cynic::schema::Field for LocationNamesLt {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "locationNames_lt"
-        }
+        const NAME: &'static str = "locationNames_lt";
     }
     impl ::cynic::schema::HasInputField<LocationNamesLt, Option<super::String>>
         for super::JobWhereInput
@@ -5367,9 +4257,7 @@ pub mod job_where_input_fields {
     pub struct LocationNamesLte;
     impl ::cynic::schema::Field for LocationNamesLte {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "locationNames_lte"
-        }
+        const NAME: &'static str = "locationNames_lte";
     }
     impl ::cynic::schema::HasInputField<LocationNamesLte, Option<super::String>>
         for super::JobWhereInput
@@ -5378,9 +4266,7 @@ pub mod job_where_input_fields {
     pub struct LocationNamesGt;
     impl ::cynic::schema::Field for LocationNamesGt {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "locationNames_gt"
-        }
+        const NAME: &'static str = "locationNames_gt";
     }
     impl ::cynic::schema::HasInputField<LocationNamesGt, Option<super::String>>
         for super::JobWhereInput
@@ -5389,9 +4275,7 @@ pub mod job_where_input_fields {
     pub struct LocationNamesGte;
     impl ::cynic::schema::Field for LocationNamesGte {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "locationNames_gte"
-        }
+        const NAME: &'static str = "locationNames_gte";
     }
     impl ::cynic::schema::HasInputField<LocationNamesGte, Option<super::String>>
         for super::JobWhereInput
@@ -5400,9 +4284,7 @@ pub mod job_where_input_fields {
     pub struct LocationNamesContains;
     impl ::cynic::schema::Field for LocationNamesContains {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "locationNames_contains"
-        }
+        const NAME: &'static str = "locationNames_contains";
     }
     impl ::cynic::schema::HasInputField<LocationNamesContains, Option<super::String>>
         for super::JobWhereInput
@@ -5411,9 +4293,7 @@ pub mod job_where_input_fields {
     pub struct LocationNamesNotContains;
     impl ::cynic::schema::Field for LocationNamesNotContains {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "locationNames_not_contains"
-        }
+        const NAME: &'static str = "locationNames_not_contains";
     }
     impl ::cynic::schema::HasInputField<LocationNamesNotContains, Option<super::String>>
         for super::JobWhereInput
@@ -5422,9 +4302,7 @@ pub mod job_where_input_fields {
     pub struct LocationNamesStartsWith;
     impl ::cynic::schema::Field for LocationNamesStartsWith {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "locationNames_starts_with"
-        }
+        const NAME: &'static str = "locationNames_starts_with";
     }
     impl ::cynic::schema::HasInputField<LocationNamesStartsWith, Option<super::String>>
         for super::JobWhereInput
@@ -5433,9 +4311,7 @@ pub mod job_where_input_fields {
     pub struct LocationNamesNotStartsWith;
     impl ::cynic::schema::Field for LocationNamesNotStartsWith {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "locationNames_not_starts_with"
-        }
+        const NAME: &'static str = "locationNames_not_starts_with";
     }
     impl ::cynic::schema::HasInputField<LocationNamesNotStartsWith, Option<super::String>>
         for super::JobWhereInput
@@ -5444,9 +4320,7 @@ pub mod job_where_input_fields {
     pub struct LocationNamesEndsWith;
     impl ::cynic::schema::Field for LocationNamesEndsWith {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "locationNames_ends_with"
-        }
+        const NAME: &'static str = "locationNames_ends_with";
     }
     impl ::cynic::schema::HasInputField<LocationNamesEndsWith, Option<super::String>>
         for super::JobWhereInput
@@ -5455,9 +4329,7 @@ pub mod job_where_input_fields {
     pub struct LocationNamesNotEndsWith;
     impl ::cynic::schema::Field for LocationNamesNotEndsWith {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "locationNames_not_ends_with"
-        }
+        const NAME: &'static str = "locationNames_not_ends_with";
     }
     impl ::cynic::schema::HasInputField<LocationNamesNotEndsWith, Option<super::String>>
         for super::JobWhereInput
@@ -5466,25 +4338,19 @@ pub mod job_where_input_fields {
     pub struct UserEmail;
     impl ::cynic::schema::Field for UserEmail {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "userEmail"
-        }
+        const NAME: &'static str = "userEmail";
     }
     impl ::cynic::schema::HasInputField<UserEmail, Option<super::String>> for super::JobWhereInput {}
     pub struct UserEmailNot;
     impl ::cynic::schema::Field for UserEmailNot {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "userEmail_not"
-        }
+        const NAME: &'static str = "userEmail_not";
     }
     impl ::cynic::schema::HasInputField<UserEmailNot, Option<super::String>> for super::JobWhereInput {}
     pub struct UserEmailIn;
     impl ::cynic::schema::Field for UserEmailIn {
         type Type = Option<Vec<super::String>>;
-        fn name() -> &'static str {
-            "userEmail_in"
-        }
+        const NAME: &'static str = "userEmail_in";
     }
     impl ::cynic::schema::HasInputField<UserEmailIn, Option<Vec<super::String>>>
         for super::JobWhereInput
@@ -5493,9 +4359,7 @@ pub mod job_where_input_fields {
     pub struct UserEmailNotIn;
     impl ::cynic::schema::Field for UserEmailNotIn {
         type Type = Option<Vec<super::String>>;
-        fn name() -> &'static str {
-            "userEmail_not_in"
-        }
+        const NAME: &'static str = "userEmail_not_in";
     }
     impl ::cynic::schema::HasInputField<UserEmailNotIn, Option<Vec<super::String>>>
         for super::JobWhereInput
@@ -5504,41 +4368,31 @@ pub mod job_where_input_fields {
     pub struct UserEmailLt;
     impl ::cynic::schema::Field for UserEmailLt {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "userEmail_lt"
-        }
+        const NAME: &'static str = "userEmail_lt";
     }
     impl ::cynic::schema::HasInputField<UserEmailLt, Option<super::String>> for super::JobWhereInput {}
     pub struct UserEmailLte;
     impl ::cynic::schema::Field for UserEmailLte {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "userEmail_lte"
-        }
+        const NAME: &'static str = "userEmail_lte";
     }
     impl ::cynic::schema::HasInputField<UserEmailLte, Option<super::String>> for super::JobWhereInput {}
     pub struct UserEmailGt;
     impl ::cynic::schema::Field for UserEmailGt {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "userEmail_gt"
-        }
+        const NAME: &'static str = "userEmail_gt";
     }
     impl ::cynic::schema::HasInputField<UserEmailGt, Option<super::String>> for super::JobWhereInput {}
     pub struct UserEmailGte;
     impl ::cynic::schema::Field for UserEmailGte {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "userEmail_gte"
-        }
+        const NAME: &'static str = "userEmail_gte";
     }
     impl ::cynic::schema::HasInputField<UserEmailGte, Option<super::String>> for super::JobWhereInput {}
     pub struct UserEmailContains;
     impl ::cynic::schema::Field for UserEmailContains {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "userEmail_contains"
-        }
+        const NAME: &'static str = "userEmail_contains";
     }
     impl ::cynic::schema::HasInputField<UserEmailContains, Option<super::String>>
         for super::JobWhereInput
@@ -5547,9 +4401,7 @@ pub mod job_where_input_fields {
     pub struct UserEmailNotContains;
     impl ::cynic::schema::Field for UserEmailNotContains {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "userEmail_not_contains"
-        }
+        const NAME: &'static str = "userEmail_not_contains";
     }
     impl ::cynic::schema::HasInputField<UserEmailNotContains, Option<super::String>>
         for super::JobWhereInput
@@ -5558,9 +4410,7 @@ pub mod job_where_input_fields {
     pub struct UserEmailStartsWith;
     impl ::cynic::schema::Field for UserEmailStartsWith {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "userEmail_starts_with"
-        }
+        const NAME: &'static str = "userEmail_starts_with";
     }
     impl ::cynic::schema::HasInputField<UserEmailStartsWith, Option<super::String>>
         for super::JobWhereInput
@@ -5569,9 +4419,7 @@ pub mod job_where_input_fields {
     pub struct UserEmailNotStartsWith;
     impl ::cynic::schema::Field for UserEmailNotStartsWith {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "userEmail_not_starts_with"
-        }
+        const NAME: &'static str = "userEmail_not_starts_with";
     }
     impl ::cynic::schema::HasInputField<UserEmailNotStartsWith, Option<super::String>>
         for super::JobWhereInput
@@ -5580,9 +4428,7 @@ pub mod job_where_input_fields {
     pub struct UserEmailEndsWith;
     impl ::cynic::schema::Field for UserEmailEndsWith {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "userEmail_ends_with"
-        }
+        const NAME: &'static str = "userEmail_ends_with";
     }
     impl ::cynic::schema::HasInputField<UserEmailEndsWith, Option<super::String>>
         for super::JobWhereInput
@@ -5591,9 +4437,7 @@ pub mod job_where_input_fields {
     pub struct UserEmailNotEndsWith;
     impl ::cynic::schema::Field for UserEmailNotEndsWith {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "userEmail_not_ends_with"
-        }
+        const NAME: &'static str = "userEmail_not_ends_with";
     }
     impl ::cynic::schema::HasInputField<UserEmailNotEndsWith, Option<super::String>>
         for super::JobWhereInput
@@ -5602,25 +4446,19 @@ pub mod job_where_input_fields {
     pub struct PostedAt;
     impl ::cynic::schema::Field for PostedAt {
         type Type = Option<super::DateTime>;
-        fn name() -> &'static str {
-            "postedAt"
-        }
+        const NAME: &'static str = "postedAt";
     }
     impl ::cynic::schema::HasInputField<PostedAt, Option<super::DateTime>> for super::JobWhereInput {}
     pub struct PostedAtNot;
     impl ::cynic::schema::Field for PostedAtNot {
         type Type = Option<super::DateTime>;
-        fn name() -> &'static str {
-            "postedAt_not"
-        }
+        const NAME: &'static str = "postedAt_not";
     }
     impl ::cynic::schema::HasInputField<PostedAtNot, Option<super::DateTime>> for super::JobWhereInput {}
     pub struct PostedAtIn;
     impl ::cynic::schema::Field for PostedAtIn {
         type Type = Option<Vec<super::DateTime>>;
-        fn name() -> &'static str {
-            "postedAt_in"
-        }
+        const NAME: &'static str = "postedAt_in";
     }
     impl ::cynic::schema::HasInputField<PostedAtIn, Option<Vec<super::DateTime>>>
         for super::JobWhereInput
@@ -5629,9 +4467,7 @@ pub mod job_where_input_fields {
     pub struct PostedAtNotIn;
     impl ::cynic::schema::Field for PostedAtNotIn {
         type Type = Option<Vec<super::DateTime>>;
-        fn name() -> &'static str {
-            "postedAt_not_in"
-        }
+        const NAME: &'static str = "postedAt_not_in";
     }
     impl ::cynic::schema::HasInputField<PostedAtNotIn, Option<Vec<super::DateTime>>>
         for super::JobWhereInput
@@ -5640,49 +4476,37 @@ pub mod job_where_input_fields {
     pub struct PostedAtLt;
     impl ::cynic::schema::Field for PostedAtLt {
         type Type = Option<super::DateTime>;
-        fn name() -> &'static str {
-            "postedAt_lt"
-        }
+        const NAME: &'static str = "postedAt_lt";
     }
     impl ::cynic::schema::HasInputField<PostedAtLt, Option<super::DateTime>> for super::JobWhereInput {}
     pub struct PostedAtLte;
     impl ::cynic::schema::Field for PostedAtLte {
         type Type = Option<super::DateTime>;
-        fn name() -> &'static str {
-            "postedAt_lte"
-        }
+        const NAME: &'static str = "postedAt_lte";
     }
     impl ::cynic::schema::HasInputField<PostedAtLte, Option<super::DateTime>> for super::JobWhereInput {}
     pub struct PostedAtGt;
     impl ::cynic::schema::Field for PostedAtGt {
         type Type = Option<super::DateTime>;
-        fn name() -> &'static str {
-            "postedAt_gt"
-        }
+        const NAME: &'static str = "postedAt_gt";
     }
     impl ::cynic::schema::HasInputField<PostedAtGt, Option<super::DateTime>> for super::JobWhereInput {}
     pub struct PostedAtGte;
     impl ::cynic::schema::Field for PostedAtGte {
         type Type = Option<super::DateTime>;
-        fn name() -> &'static str {
-            "postedAt_gte"
-        }
+        const NAME: &'static str = "postedAt_gte";
     }
     impl ::cynic::schema::HasInputField<PostedAtGte, Option<super::DateTime>> for super::JobWhereInput {}
     pub struct CreatedAt;
     impl ::cynic::schema::Field for CreatedAt {
         type Type = Option<super::DateTime>;
-        fn name() -> &'static str {
-            "createdAt"
-        }
+        const NAME: &'static str = "createdAt";
     }
     impl ::cynic::schema::HasInputField<CreatedAt, Option<super::DateTime>> for super::JobWhereInput {}
     pub struct CreatedAtNot;
     impl ::cynic::schema::Field for CreatedAtNot {
         type Type = Option<super::DateTime>;
-        fn name() -> &'static str {
-            "createdAt_not"
-        }
+        const NAME: &'static str = "createdAt_not";
     }
     impl ::cynic::schema::HasInputField<CreatedAtNot, Option<super::DateTime>>
         for super::JobWhereInput
@@ -5691,9 +4515,7 @@ pub mod job_where_input_fields {
     pub struct CreatedAtIn;
     impl ::cynic::schema::Field for CreatedAtIn {
         type Type = Option<Vec<super::DateTime>>;
-        fn name() -> &'static str {
-            "createdAt_in"
-        }
+        const NAME: &'static str = "createdAt_in";
     }
     impl ::cynic::schema::HasInputField<CreatedAtIn, Option<Vec<super::DateTime>>>
         for super::JobWhereInput
@@ -5702,9 +4524,7 @@ pub mod job_where_input_fields {
     pub struct CreatedAtNotIn;
     impl ::cynic::schema::Field for CreatedAtNotIn {
         type Type = Option<Vec<super::DateTime>>;
-        fn name() -> &'static str {
-            "createdAt_not_in"
-        }
+        const NAME: &'static str = "createdAt_not_in";
     }
     impl ::cynic::schema::HasInputField<CreatedAtNotIn, Option<Vec<super::DateTime>>>
         for super::JobWhereInput
@@ -5713,17 +4533,13 @@ pub mod job_where_input_fields {
     pub struct CreatedAtLt;
     impl ::cynic::schema::Field for CreatedAtLt {
         type Type = Option<super::DateTime>;
-        fn name() -> &'static str {
-            "createdAt_lt"
-        }
+        const NAME: &'static str = "createdAt_lt";
     }
     impl ::cynic::schema::HasInputField<CreatedAtLt, Option<super::DateTime>> for super::JobWhereInput {}
     pub struct CreatedAtLte;
     impl ::cynic::schema::Field for CreatedAtLte {
         type Type = Option<super::DateTime>;
-        fn name() -> &'static str {
-            "createdAt_lte"
-        }
+        const NAME: &'static str = "createdAt_lte";
     }
     impl ::cynic::schema::HasInputField<CreatedAtLte, Option<super::DateTime>>
         for super::JobWhereInput
@@ -5732,17 +4548,13 @@ pub mod job_where_input_fields {
     pub struct CreatedAtGt;
     impl ::cynic::schema::Field for CreatedAtGt {
         type Type = Option<super::DateTime>;
-        fn name() -> &'static str {
-            "createdAt_gt"
-        }
+        const NAME: &'static str = "createdAt_gt";
     }
     impl ::cynic::schema::HasInputField<CreatedAtGt, Option<super::DateTime>> for super::JobWhereInput {}
     pub struct CreatedAtGte;
     impl ::cynic::schema::Field for CreatedAtGte {
         type Type = Option<super::DateTime>;
-        fn name() -> &'static str {
-            "createdAt_gte"
-        }
+        const NAME: &'static str = "createdAt_gte";
     }
     impl ::cynic::schema::HasInputField<CreatedAtGte, Option<super::DateTime>>
         for super::JobWhereInput
@@ -5751,17 +4563,13 @@ pub mod job_where_input_fields {
     pub struct UpdatedAt;
     impl ::cynic::schema::Field for UpdatedAt {
         type Type = Option<super::DateTime>;
-        fn name() -> &'static str {
-            "updatedAt"
-        }
+        const NAME: &'static str = "updatedAt";
     }
     impl ::cynic::schema::HasInputField<UpdatedAt, Option<super::DateTime>> for super::JobWhereInput {}
     pub struct UpdatedAtNot;
     impl ::cynic::schema::Field for UpdatedAtNot {
         type Type = Option<super::DateTime>;
-        fn name() -> &'static str {
-            "updatedAt_not"
-        }
+        const NAME: &'static str = "updatedAt_not";
     }
     impl ::cynic::schema::HasInputField<UpdatedAtNot, Option<super::DateTime>>
         for super::JobWhereInput
@@ -5770,9 +4578,7 @@ pub mod job_where_input_fields {
     pub struct UpdatedAtIn;
     impl ::cynic::schema::Field for UpdatedAtIn {
         type Type = Option<Vec<super::DateTime>>;
-        fn name() -> &'static str {
-            "updatedAt_in"
-        }
+        const NAME: &'static str = "updatedAt_in";
     }
     impl ::cynic::schema::HasInputField<UpdatedAtIn, Option<Vec<super::DateTime>>>
         for super::JobWhereInput
@@ -5781,9 +4587,7 @@ pub mod job_where_input_fields {
     pub struct UpdatedAtNotIn;
     impl ::cynic::schema::Field for UpdatedAtNotIn {
         type Type = Option<Vec<super::DateTime>>;
-        fn name() -> &'static str {
-            "updatedAt_not_in"
-        }
+        const NAME: &'static str = "updatedAt_not_in";
     }
     impl ::cynic::schema::HasInputField<UpdatedAtNotIn, Option<Vec<super::DateTime>>>
         for super::JobWhereInput
@@ -5792,17 +4596,13 @@ pub mod job_where_input_fields {
     pub struct UpdatedAtLt;
     impl ::cynic::schema::Field for UpdatedAtLt {
         type Type = Option<super::DateTime>;
-        fn name() -> &'static str {
-            "updatedAt_lt"
-        }
+        const NAME: &'static str = "updatedAt_lt";
     }
     impl ::cynic::schema::HasInputField<UpdatedAtLt, Option<super::DateTime>> for super::JobWhereInput {}
     pub struct UpdatedAtLte;
     impl ::cynic::schema::Field for UpdatedAtLte {
         type Type = Option<super::DateTime>;
-        fn name() -> &'static str {
-            "updatedAt_lte"
-        }
+        const NAME: &'static str = "updatedAt_lte";
     }
     impl ::cynic::schema::HasInputField<UpdatedAtLte, Option<super::DateTime>>
         for super::JobWhereInput
@@ -5811,17 +4611,13 @@ pub mod job_where_input_fields {
     pub struct UpdatedAtGt;
     impl ::cynic::schema::Field for UpdatedAtGt {
         type Type = Option<super::DateTime>;
-        fn name() -> &'static str {
-            "updatedAt_gt"
-        }
+        const NAME: &'static str = "updatedAt_gt";
     }
     impl ::cynic::schema::HasInputField<UpdatedAtGt, Option<super::DateTime>> for super::JobWhereInput {}
     pub struct UpdatedAtGte;
     impl ::cynic::schema::Field for UpdatedAtGte {
         type Type = Option<super::DateTime>;
-        fn name() -> &'static str {
-            "updatedAt_gte"
-        }
+        const NAME: &'static str = "updatedAt_gte";
     }
     impl ::cynic::schema::HasInputField<UpdatedAtGte, Option<super::DateTime>>
         for super::JobWhereInput
@@ -5830,9 +4626,7 @@ pub mod job_where_input_fields {
     pub struct And;
     impl ::cynic::schema::Field for And {
         type Type = Option<Vec<super::JobWhereInput>>;
-        fn name() -> &'static str {
-            "AND"
-        }
+        const NAME: &'static str = "AND";
     }
     impl ::cynic::schema::HasInputField<And, Option<Vec<super::JobWhereInput>>>
         for super::JobWhereInput
@@ -5841,9 +4635,7 @@ pub mod job_where_input_fields {
     pub struct Or;
     impl ::cynic::schema::Field for Or {
         type Type = Option<Vec<super::JobWhereInput>>;
-        fn name() -> &'static str {
-            "OR"
-        }
+        const NAME: &'static str = "OR";
     }
     impl ::cynic::schema::HasInputField<Or, Option<Vec<super::JobWhereInput>>>
         for super::JobWhereInput
@@ -5852,9 +4644,7 @@ pub mod job_where_input_fields {
     pub struct Not;
     impl ::cynic::schema::Field for Not {
         type Type = Option<Vec<super::JobWhereInput>>;
-        fn name() -> &'static str {
-            "NOT"
-        }
+        const NAME: &'static str = "NOT";
     }
     impl ::cynic::schema::HasInputField<Not, Option<Vec<super::JobWhereInput>>>
         for super::JobWhereInput
@@ -5867,17 +4657,13 @@ pub mod jobs_input_fields {
     pub struct Type;
     impl ::cynic::schema::Field for Type {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "type"
-        }
+        const NAME: &'static str = "type";
     }
     impl ::cynic::schema::HasInputField<Type, Option<super::String>> for super::JobsInput {}
     pub struct Slug;
     impl ::cynic::schema::Field for Slug {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "slug"
-        }
+        const NAME: &'static str = "slug";
     }
     impl ::cynic::schema::HasInputField<Slug, Option<super::String>> for super::JobsInput {}
 }
@@ -5886,9 +4672,7 @@ pub mod location_fields {
     pub struct Id;
     impl ::cynic::schema::Field for Id {
         type Type = super::Id;
-        fn name() -> &'static str {
-            "id"
-        }
+        const NAME: &'static str = "id";
     }
     impl ::cynic::schema::HasField<Id> for super::Location {
         type Type = super::Id;
@@ -5896,9 +4680,7 @@ pub mod location_fields {
     pub struct Slug;
     impl ::cynic::schema::Field for Slug {
         type Type = super::String;
-        fn name() -> &'static str {
-            "slug"
-        }
+        const NAME: &'static str = "slug";
     }
     impl ::cynic::schema::HasField<Slug> for super::Location {
         type Type = super::String;
@@ -5906,9 +4688,7 @@ pub mod location_fields {
     pub struct Name;
     impl ::cynic::schema::Field for Name {
         type Type = super::String;
-        fn name() -> &'static str {
-            "name"
-        }
+        const NAME: &'static str = "name";
     }
     impl ::cynic::schema::HasField<Name> for super::Location {
         type Type = super::String;
@@ -5916,9 +4696,7 @@ pub mod location_fields {
     pub struct Type;
     impl ::cynic::schema::Field for Type {
         type Type = super::String;
-        fn name() -> &'static str {
-            "type"
-        }
+        const NAME: &'static str = "type";
     }
     impl ::cynic::schema::HasField<Type> for super::Location {
         type Type = super::String;
@@ -5930,9 +4708,7 @@ pub mod location_input_fields {
     pub struct Slug;
     impl ::cynic::schema::Field for Slug {
         type Type = super::String;
-        fn name() -> &'static str {
-            "slug"
-        }
+        const NAME: &'static str = "slug";
     }
     impl ::cynic::schema::HasInputField<Slug, super::String> for super::LocationInput {}
 }
@@ -5942,9 +4718,7 @@ pub mod locations_input_fields {
     pub struct Value;
     impl ::cynic::schema::Field for Value {
         type Type = super::String;
-        fn name() -> &'static str {
-            "value"
-        }
+        const NAME: &'static str = "value";
     }
     impl ::cynic::schema::HasInputField<Value, super::String> for super::LocationsInput {}
 }
@@ -5953,9 +4727,7 @@ pub mod mutation_fields {
     pub struct Subscribe;
     impl ::cynic::schema::Field for Subscribe {
         type Type = super::User;
-        fn name() -> &'static str {
-            "subscribe"
-        }
+        const NAME: &'static str = "subscribe";
     }
     impl ::cynic::schema::HasField<Subscribe> for super::Mutation {
         type Type = super::User;
@@ -5964,17 +4736,13 @@ pub mod mutation_fields {
         pub struct Input;
         impl ::cynic::schema::HasArgument<Input> for super::Subscribe {
             type ArgumentType = super::super::SubscribeInput;
-            fn name() -> &'static str {
-                "input"
-            }
+            const NAME: &'static str = "input";
         }
     }
     pub struct PostJob;
     impl ::cynic::schema::Field for PostJob {
         type Type = super::Job;
-        fn name() -> &'static str {
-            "postJob"
-        }
+        const NAME: &'static str = "postJob";
     }
     impl ::cynic::schema::HasField<PostJob> for super::Mutation {
         type Type = super::Job;
@@ -5983,17 +4751,13 @@ pub mod mutation_fields {
         pub struct Input;
         impl ::cynic::schema::HasArgument<Input> for super::PostJob {
             type ArgumentType = super::super::PostJobInput;
-            fn name() -> &'static str {
-                "input"
-            }
+            const NAME: &'static str = "input";
         }
     }
     pub struct UpdateJob;
     impl ::cynic::schema::Field for UpdateJob {
         type Type = super::Job;
-        fn name() -> &'static str {
-            "updateJob"
-        }
+        const NAME: &'static str = "updateJob";
     }
     impl ::cynic::schema::HasField<UpdateJob> for super::Mutation {
         type Type = super::Job;
@@ -6002,24 +4766,18 @@ pub mod mutation_fields {
         pub struct Input;
         impl ::cynic::schema::HasArgument<Input> for super::UpdateJob {
             type ArgumentType = super::super::UpdateJobInput;
-            fn name() -> &'static str {
-                "input"
-            }
+            const NAME: &'static str = "input";
         }
         pub struct AdminSecret;
         impl ::cynic::schema::HasArgument<AdminSecret> for super::UpdateJob {
             type ArgumentType = super::super::String;
-            fn name() -> &'static str {
-                "adminSecret"
-            }
+            const NAME: &'static str = "adminSecret";
         }
     }
     pub struct UpdateCompany;
     impl ::cynic::schema::Field for UpdateCompany {
         type Type = super::Company;
-        fn name() -> &'static str {
-            "updateCompany"
-        }
+        const NAME: &'static str = "updateCompany";
     }
     impl ::cynic::schema::HasField<UpdateCompany> for super::Mutation {
         type Type = super::Company;
@@ -6028,16 +4786,12 @@ pub mod mutation_fields {
         pub struct Input;
         impl ::cynic::schema::HasArgument<Input> for super::UpdateCompany {
             type ArgumentType = super::super::UpdateCompanyInput;
-            fn name() -> &'static str {
-                "input"
-            }
+            const NAME: &'static str = "input";
         }
         pub struct AdminSecret;
         impl ::cynic::schema::HasArgument<AdminSecret> for super::UpdateCompany {
             type ArgumentType = super::super::String;
-            fn name() -> &'static str {
-                "adminSecret"
-            }
+            const NAME: &'static str = "adminSecret";
         }
     }
 }
@@ -6047,57 +4801,43 @@ pub mod post_job_input_fields {
     pub struct Title;
     impl ::cynic::schema::Field for Title {
         type Type = super::String;
-        fn name() -> &'static str {
-            "title"
-        }
+        const NAME: &'static str = "title";
     }
     impl ::cynic::schema::HasInputField<Title, super::String> for super::PostJobInput {}
     pub struct CommitmentId;
     impl ::cynic::schema::Field for CommitmentId {
         type Type = super::Id;
-        fn name() -> &'static str {
-            "commitmentId"
-        }
+        const NAME: &'static str = "commitmentId";
     }
     impl ::cynic::schema::HasInputField<CommitmentId, super::Id> for super::PostJobInput {}
     pub struct CompanyName;
     impl ::cynic::schema::Field for CompanyName {
         type Type = super::String;
-        fn name() -> &'static str {
-            "companyName"
-        }
+        const NAME: &'static str = "companyName";
     }
     impl ::cynic::schema::HasInputField<CompanyName, super::String> for super::PostJobInput {}
     pub struct LocationNames;
     impl ::cynic::schema::Field for LocationNames {
         type Type = super::String;
-        fn name() -> &'static str {
-            "locationNames"
-        }
+        const NAME: &'static str = "locationNames";
     }
     impl ::cynic::schema::HasInputField<LocationNames, super::String> for super::PostJobInput {}
     pub struct UserEmail;
     impl ::cynic::schema::Field for UserEmail {
         type Type = super::String;
-        fn name() -> &'static str {
-            "userEmail"
-        }
+        const NAME: &'static str = "userEmail";
     }
     impl ::cynic::schema::HasInputField<UserEmail, super::String> for super::PostJobInput {}
     pub struct Description;
     impl ::cynic::schema::Field for Description {
         type Type = super::String;
-        fn name() -> &'static str {
-            "description"
-        }
+        const NAME: &'static str = "description";
     }
     impl ::cynic::schema::HasInputField<Description, super::String> for super::PostJobInput {}
     pub struct ApplyUrl;
     impl ::cynic::schema::Field for ApplyUrl {
         type Type = super::String;
-        fn name() -> &'static str {
-            "applyUrl"
-        }
+        const NAME: &'static str = "applyUrl";
     }
     impl ::cynic::schema::HasInputField<ApplyUrl, super::String> for super::PostJobInput {}
 }
@@ -6106,9 +4846,7 @@ pub mod query_fields {
     pub struct Jobs;
     impl ::cynic::schema::Field for Jobs {
         type Type = Vec<super::Job>;
-        fn name() -> &'static str {
-            "jobs"
-        }
+        const NAME: &'static str = "jobs";
     }
     impl ::cynic::schema::HasField<Jobs> for super::Query {
         type Type = Vec<super::Job>;
@@ -6117,17 +4855,13 @@ pub mod query_fields {
         pub struct Input;
         impl ::cynic::schema::HasArgument<Input> for super::Jobs {
             type ArgumentType = Option<super::super::JobsInput>;
-            fn name() -> &'static str {
-                "input"
-            }
+            const NAME: &'static str = "input";
         }
     }
     pub struct Job;
     impl ::cynic::schema::Field for Job {
         type Type = super::Job;
-        fn name() -> &'static str {
-            "job"
-        }
+        const NAME: &'static str = "job";
     }
     impl ::cynic::schema::HasField<Job> for super::Query {
         type Type = super::Job;
@@ -6136,17 +4870,13 @@ pub mod query_fields {
         pub struct Input;
         impl ::cynic::schema::HasArgument<Input> for super::Job {
             type ArgumentType = super::super::JobInput;
-            fn name() -> &'static str {
-                "input"
-            }
+            const NAME: &'static str = "input";
         }
     }
     pub struct Locations;
     impl ::cynic::schema::Field for Locations {
         type Type = Vec<super::Location>;
-        fn name() -> &'static str {
-            "locations"
-        }
+        const NAME: &'static str = "locations";
     }
     impl ::cynic::schema::HasField<Locations> for super::Query {
         type Type = Vec<super::Location>;
@@ -6155,17 +4885,13 @@ pub mod query_fields {
         pub struct Input;
         impl ::cynic::schema::HasArgument<Input> for super::Locations {
             type ArgumentType = super::super::LocationsInput;
-            fn name() -> &'static str {
-                "input"
-            }
+            const NAME: &'static str = "input";
         }
     }
     pub struct City;
     impl ::cynic::schema::Field for City {
         type Type = super::City;
-        fn name() -> &'static str {
-            "city"
-        }
+        const NAME: &'static str = "city";
     }
     impl ::cynic::schema::HasField<City> for super::Query {
         type Type = super::City;
@@ -6174,17 +4900,13 @@ pub mod query_fields {
         pub struct Input;
         impl ::cynic::schema::HasArgument<Input> for super::City {
             type ArgumentType = super::super::LocationInput;
-            fn name() -> &'static str {
-                "input"
-            }
+            const NAME: &'static str = "input";
         }
     }
     pub struct Country;
     impl ::cynic::schema::Field for Country {
         type Type = super::Country;
-        fn name() -> &'static str {
-            "country"
-        }
+        const NAME: &'static str = "country";
     }
     impl ::cynic::schema::HasField<Country> for super::Query {
         type Type = super::Country;
@@ -6193,17 +4915,13 @@ pub mod query_fields {
         pub struct Input;
         impl ::cynic::schema::HasArgument<Input> for super::Country {
             type ArgumentType = super::super::LocationInput;
-            fn name() -> &'static str {
-                "input"
-            }
+            const NAME: &'static str = "input";
         }
     }
     pub struct Remote;
     impl ::cynic::schema::Field for Remote {
         type Type = super::Remote;
-        fn name() -> &'static str {
-            "remote"
-        }
+        const NAME: &'static str = "remote";
     }
     impl ::cynic::schema::HasField<Remote> for super::Query {
         type Type = super::Remote;
@@ -6212,17 +4930,13 @@ pub mod query_fields {
         pub struct Input;
         impl ::cynic::schema::HasArgument<Input> for super::Remote {
             type ArgumentType = super::super::LocationInput;
-            fn name() -> &'static str {
-                "input"
-            }
+            const NAME: &'static str = "input";
         }
     }
     pub struct Commitments;
     impl ::cynic::schema::Field for Commitments {
         type Type = Vec<super::Commitment>;
-        fn name() -> &'static str {
-            "commitments"
-        }
+        const NAME: &'static str = "commitments";
     }
     impl ::cynic::schema::HasField<Commitments> for super::Query {
         type Type = Vec<super::Commitment>;
@@ -6230,9 +4944,7 @@ pub mod query_fields {
     pub struct Cities;
     impl ::cynic::schema::Field for Cities {
         type Type = Vec<super::City>;
-        fn name() -> &'static str {
-            "cities"
-        }
+        const NAME: &'static str = "cities";
     }
     impl ::cynic::schema::HasField<Cities> for super::Query {
         type Type = Vec<super::City>;
@@ -6240,9 +4952,7 @@ pub mod query_fields {
     pub struct Countries;
     impl ::cynic::schema::Field for Countries {
         type Type = Vec<super::Country>;
-        fn name() -> &'static str {
-            "countries"
-        }
+        const NAME: &'static str = "countries";
     }
     impl ::cynic::schema::HasField<Countries> for super::Query {
         type Type = Vec<super::Country>;
@@ -6250,9 +4960,7 @@ pub mod query_fields {
     pub struct Remotes;
     impl ::cynic::schema::Field for Remotes {
         type Type = Vec<super::Remote>;
-        fn name() -> &'static str {
-            "remotes"
-        }
+        const NAME: &'static str = "remotes";
     }
     impl ::cynic::schema::HasField<Remotes> for super::Query {
         type Type = Vec<super::Remote>;
@@ -6260,9 +4968,7 @@ pub mod query_fields {
     pub struct Companies;
     impl ::cynic::schema::Field for Companies {
         type Type = Vec<super::Company>;
-        fn name() -> &'static str {
-            "companies"
-        }
+        const NAME: &'static str = "companies";
     }
     impl ::cynic::schema::HasField<Companies> for super::Query {
         type Type = Vec<super::Company>;
@@ -6273,9 +4979,7 @@ pub mod remote_fields {
     pub struct Id;
     impl ::cynic::schema::Field for Id {
         type Type = super::Id;
-        fn name() -> &'static str {
-            "id"
-        }
+        const NAME: &'static str = "id";
     }
     impl ::cynic::schema::HasField<Id> for super::Remote {
         type Type = super::Id;
@@ -6283,9 +4987,7 @@ pub mod remote_fields {
     pub struct Name;
     impl ::cynic::schema::Field for Name {
         type Type = super::String;
-        fn name() -> &'static str {
-            "name"
-        }
+        const NAME: &'static str = "name";
     }
     impl ::cynic::schema::HasField<Name> for super::Remote {
         type Type = super::String;
@@ -6293,9 +4995,7 @@ pub mod remote_fields {
     pub struct Slug;
     impl ::cynic::schema::Field for Slug {
         type Type = super::String;
-        fn name() -> &'static str {
-            "slug"
-        }
+        const NAME: &'static str = "slug";
     }
     impl ::cynic::schema::HasField<Slug> for super::Remote {
         type Type = super::String;
@@ -6303,9 +5003,7 @@ pub mod remote_fields {
     pub struct Type;
     impl ::cynic::schema::Field for Type {
         type Type = super::String;
-        fn name() -> &'static str {
-            "type"
-        }
+        const NAME: &'static str = "type";
     }
     impl ::cynic::schema::HasField<Type> for super::Remote {
         type Type = super::String;
@@ -6313,9 +5011,7 @@ pub mod remote_fields {
     pub struct Jobs;
     impl ::cynic::schema::Field for Jobs {
         type Type = Option<Vec<super::Job>>;
-        fn name() -> &'static str {
-            "jobs"
-        }
+        const NAME: &'static str = "jobs";
     }
     impl ::cynic::schema::HasField<Jobs> for super::Remote {
         type Type = Option<Vec<super::Job>>;
@@ -6324,59 +5020,43 @@ pub mod remote_fields {
         pub struct Where;
         impl ::cynic::schema::HasArgument<Where> for super::Jobs {
             type ArgumentType = Option<super::super::JobWhereInput>;
-            fn name() -> &'static str {
-                "where"
-            }
+            const NAME: &'static str = "where";
         }
         pub struct OrderBy;
         impl ::cynic::schema::HasArgument<OrderBy> for super::Jobs {
             type ArgumentType = Option<super::super::JobOrderByInput>;
-            fn name() -> &'static str {
-                "orderBy"
-            }
+            const NAME: &'static str = "orderBy";
         }
         pub struct Skip;
         impl ::cynic::schema::HasArgument<Skip> for super::Jobs {
             type ArgumentType = Option<super::super::Int>;
-            fn name() -> &'static str {
-                "skip"
-            }
+            const NAME: &'static str = "skip";
         }
         pub struct After;
         impl ::cynic::schema::HasArgument<After> for super::Jobs {
             type ArgumentType = Option<super::super::String>;
-            fn name() -> &'static str {
-                "after"
-            }
+            const NAME: &'static str = "after";
         }
         pub struct Before;
         impl ::cynic::schema::HasArgument<Before> for super::Jobs {
             type ArgumentType = Option<super::super::String>;
-            fn name() -> &'static str {
-                "before"
-            }
+            const NAME: &'static str = "before";
         }
         pub struct First;
         impl ::cynic::schema::HasArgument<First> for super::Jobs {
             type ArgumentType = Option<super::super::Int>;
-            fn name() -> &'static str {
-                "first"
-            }
+            const NAME: &'static str = "first";
         }
         pub struct Last;
         impl ::cynic::schema::HasArgument<Last> for super::Jobs {
             type ArgumentType = Option<super::super::Int>;
-            fn name() -> &'static str {
-                "last"
-            }
+            const NAME: &'static str = "last";
         }
     }
     pub struct CreatedAt;
     impl ::cynic::schema::Field for CreatedAt {
         type Type = super::DateTime;
-        fn name() -> &'static str {
-            "createdAt"
-        }
+        const NAME: &'static str = "createdAt";
     }
     impl ::cynic::schema::HasField<CreatedAt> for super::Remote {
         type Type = super::DateTime;
@@ -6384,9 +5064,7 @@ pub mod remote_fields {
     pub struct UpdatedAt;
     impl ::cynic::schema::Field for UpdatedAt {
         type Type = super::DateTime;
-        fn name() -> &'static str {
-            "updatedAt"
-        }
+        const NAME: &'static str = "updatedAt";
     }
     impl ::cynic::schema::HasField<UpdatedAt> for super::Remote {
         type Type = super::DateTime;
@@ -6399,97 +5077,73 @@ pub mod remote_where_input_fields {
     pub struct Id;
     impl ::cynic::schema::Field for Id {
         type Type = Option<super::Id>;
-        fn name() -> &'static str {
-            "id"
-        }
+        const NAME: &'static str = "id";
     }
     impl ::cynic::schema::HasInputField<Id, Option<super::Id>> for super::RemoteWhereInput {}
     pub struct IdNot;
     impl ::cynic::schema::Field for IdNot {
         type Type = Option<super::Id>;
-        fn name() -> &'static str {
-            "id_not"
-        }
+        const NAME: &'static str = "id_not";
     }
     impl ::cynic::schema::HasInputField<IdNot, Option<super::Id>> for super::RemoteWhereInput {}
     pub struct IdIn;
     impl ::cynic::schema::Field for IdIn {
         type Type = Option<Vec<super::Id>>;
-        fn name() -> &'static str {
-            "id_in"
-        }
+        const NAME: &'static str = "id_in";
     }
     impl ::cynic::schema::HasInputField<IdIn, Option<Vec<super::Id>>> for super::RemoteWhereInput {}
     pub struct IdNotIn;
     impl ::cynic::schema::Field for IdNotIn {
         type Type = Option<Vec<super::Id>>;
-        fn name() -> &'static str {
-            "id_not_in"
-        }
+        const NAME: &'static str = "id_not_in";
     }
     impl ::cynic::schema::HasInputField<IdNotIn, Option<Vec<super::Id>>> for super::RemoteWhereInput {}
     pub struct IdLt;
     impl ::cynic::schema::Field for IdLt {
         type Type = Option<super::Id>;
-        fn name() -> &'static str {
-            "id_lt"
-        }
+        const NAME: &'static str = "id_lt";
     }
     impl ::cynic::schema::HasInputField<IdLt, Option<super::Id>> for super::RemoteWhereInput {}
     pub struct IdLte;
     impl ::cynic::schema::Field for IdLte {
         type Type = Option<super::Id>;
-        fn name() -> &'static str {
-            "id_lte"
-        }
+        const NAME: &'static str = "id_lte";
     }
     impl ::cynic::schema::HasInputField<IdLte, Option<super::Id>> for super::RemoteWhereInput {}
     pub struct IdGt;
     impl ::cynic::schema::Field for IdGt {
         type Type = Option<super::Id>;
-        fn name() -> &'static str {
-            "id_gt"
-        }
+        const NAME: &'static str = "id_gt";
     }
     impl ::cynic::schema::HasInputField<IdGt, Option<super::Id>> for super::RemoteWhereInput {}
     pub struct IdGte;
     impl ::cynic::schema::Field for IdGte {
         type Type = Option<super::Id>;
-        fn name() -> &'static str {
-            "id_gte"
-        }
+        const NAME: &'static str = "id_gte";
     }
     impl ::cynic::schema::HasInputField<IdGte, Option<super::Id>> for super::RemoteWhereInput {}
     pub struct IdContains;
     impl ::cynic::schema::Field for IdContains {
         type Type = Option<super::Id>;
-        fn name() -> &'static str {
-            "id_contains"
-        }
+        const NAME: &'static str = "id_contains";
     }
     impl ::cynic::schema::HasInputField<IdContains, Option<super::Id>> for super::RemoteWhereInput {}
     pub struct IdNotContains;
     impl ::cynic::schema::Field for IdNotContains {
         type Type = Option<super::Id>;
-        fn name() -> &'static str {
-            "id_not_contains"
-        }
+        const NAME: &'static str = "id_not_contains";
     }
     impl ::cynic::schema::HasInputField<IdNotContains, Option<super::Id>> for super::RemoteWhereInput {}
     pub struct IdStartsWith;
     impl ::cynic::schema::Field for IdStartsWith {
         type Type = Option<super::Id>;
-        fn name() -> &'static str {
-            "id_starts_with"
-        }
+        const NAME: &'static str = "id_starts_with";
     }
     impl ::cynic::schema::HasInputField<IdStartsWith, Option<super::Id>> for super::RemoteWhereInput {}
     pub struct IdNotStartsWith;
     impl ::cynic::schema::Field for IdNotStartsWith {
         type Type = Option<super::Id>;
-        fn name() -> &'static str {
-            "id_not_starts_with"
-        }
+        const NAME: &'static str = "id_not_starts_with";
     }
     impl ::cynic::schema::HasInputField<IdNotStartsWith, Option<super::Id>>
         for super::RemoteWhereInput
@@ -6498,41 +5152,31 @@ pub mod remote_where_input_fields {
     pub struct IdEndsWith;
     impl ::cynic::schema::Field for IdEndsWith {
         type Type = Option<super::Id>;
-        fn name() -> &'static str {
-            "id_ends_with"
-        }
+        const NAME: &'static str = "id_ends_with";
     }
     impl ::cynic::schema::HasInputField<IdEndsWith, Option<super::Id>> for super::RemoteWhereInput {}
     pub struct IdNotEndsWith;
     impl ::cynic::schema::Field for IdNotEndsWith {
         type Type = Option<super::Id>;
-        fn name() -> &'static str {
-            "id_not_ends_with"
-        }
+        const NAME: &'static str = "id_not_ends_with";
     }
     impl ::cynic::schema::HasInputField<IdNotEndsWith, Option<super::Id>> for super::RemoteWhereInput {}
     pub struct Name;
     impl ::cynic::schema::Field for Name {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "name"
-        }
+        const NAME: &'static str = "name";
     }
     impl ::cynic::schema::HasInputField<Name, Option<super::String>> for super::RemoteWhereInput {}
     pub struct NameNot;
     impl ::cynic::schema::Field for NameNot {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "name_not"
-        }
+        const NAME: &'static str = "name_not";
     }
     impl ::cynic::schema::HasInputField<NameNot, Option<super::String>> for super::RemoteWhereInput {}
     pub struct NameIn;
     impl ::cynic::schema::Field for NameIn {
         type Type = Option<Vec<super::String>>;
-        fn name() -> &'static str {
-            "name_in"
-        }
+        const NAME: &'static str = "name_in";
     }
     impl ::cynic::schema::HasInputField<NameIn, Option<Vec<super::String>>>
         for super::RemoteWhereInput
@@ -6541,9 +5185,7 @@ pub mod remote_where_input_fields {
     pub struct NameNotIn;
     impl ::cynic::schema::Field for NameNotIn {
         type Type = Option<Vec<super::String>>;
-        fn name() -> &'static str {
-            "name_not_in"
-        }
+        const NAME: &'static str = "name_not_in";
     }
     impl ::cynic::schema::HasInputField<NameNotIn, Option<Vec<super::String>>>
         for super::RemoteWhereInput
@@ -6552,41 +5194,31 @@ pub mod remote_where_input_fields {
     pub struct NameLt;
     impl ::cynic::schema::Field for NameLt {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "name_lt"
-        }
+        const NAME: &'static str = "name_lt";
     }
     impl ::cynic::schema::HasInputField<NameLt, Option<super::String>> for super::RemoteWhereInput {}
     pub struct NameLte;
     impl ::cynic::schema::Field for NameLte {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "name_lte"
-        }
+        const NAME: &'static str = "name_lte";
     }
     impl ::cynic::schema::HasInputField<NameLte, Option<super::String>> for super::RemoteWhereInput {}
     pub struct NameGt;
     impl ::cynic::schema::Field for NameGt {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "name_gt"
-        }
+        const NAME: &'static str = "name_gt";
     }
     impl ::cynic::schema::HasInputField<NameGt, Option<super::String>> for super::RemoteWhereInput {}
     pub struct NameGte;
     impl ::cynic::schema::Field for NameGte {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "name_gte"
-        }
+        const NAME: &'static str = "name_gte";
     }
     impl ::cynic::schema::HasInputField<NameGte, Option<super::String>> for super::RemoteWhereInput {}
     pub struct NameContains;
     impl ::cynic::schema::Field for NameContains {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "name_contains"
-        }
+        const NAME: &'static str = "name_contains";
     }
     impl ::cynic::schema::HasInputField<NameContains, Option<super::String>>
         for super::RemoteWhereInput
@@ -6595,9 +5227,7 @@ pub mod remote_where_input_fields {
     pub struct NameNotContains;
     impl ::cynic::schema::Field for NameNotContains {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "name_not_contains"
-        }
+        const NAME: &'static str = "name_not_contains";
     }
     impl ::cynic::schema::HasInputField<NameNotContains, Option<super::String>>
         for super::RemoteWhereInput
@@ -6606,9 +5236,7 @@ pub mod remote_where_input_fields {
     pub struct NameStartsWith;
     impl ::cynic::schema::Field for NameStartsWith {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "name_starts_with"
-        }
+        const NAME: &'static str = "name_starts_with";
     }
     impl ::cynic::schema::HasInputField<NameStartsWith, Option<super::String>>
         for super::RemoteWhereInput
@@ -6617,9 +5245,7 @@ pub mod remote_where_input_fields {
     pub struct NameNotStartsWith;
     impl ::cynic::schema::Field for NameNotStartsWith {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "name_not_starts_with"
-        }
+        const NAME: &'static str = "name_not_starts_with";
     }
     impl ::cynic::schema::HasInputField<NameNotStartsWith, Option<super::String>>
         for super::RemoteWhereInput
@@ -6628,9 +5254,7 @@ pub mod remote_where_input_fields {
     pub struct NameEndsWith;
     impl ::cynic::schema::Field for NameEndsWith {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "name_ends_with"
-        }
+        const NAME: &'static str = "name_ends_with";
     }
     impl ::cynic::schema::HasInputField<NameEndsWith, Option<super::String>>
         for super::RemoteWhereInput
@@ -6639,9 +5263,7 @@ pub mod remote_where_input_fields {
     pub struct NameNotEndsWith;
     impl ::cynic::schema::Field for NameNotEndsWith {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "name_not_ends_with"
-        }
+        const NAME: &'static str = "name_not_ends_with";
     }
     impl ::cynic::schema::HasInputField<NameNotEndsWith, Option<super::String>>
         for super::RemoteWhereInput
@@ -6650,25 +5272,19 @@ pub mod remote_where_input_fields {
     pub struct Slug;
     impl ::cynic::schema::Field for Slug {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "slug"
-        }
+        const NAME: &'static str = "slug";
     }
     impl ::cynic::schema::HasInputField<Slug, Option<super::String>> for super::RemoteWhereInput {}
     pub struct SlugNot;
     impl ::cynic::schema::Field for SlugNot {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "slug_not"
-        }
+        const NAME: &'static str = "slug_not";
     }
     impl ::cynic::schema::HasInputField<SlugNot, Option<super::String>> for super::RemoteWhereInput {}
     pub struct SlugIn;
     impl ::cynic::schema::Field for SlugIn {
         type Type = Option<Vec<super::String>>;
-        fn name() -> &'static str {
-            "slug_in"
-        }
+        const NAME: &'static str = "slug_in";
     }
     impl ::cynic::schema::HasInputField<SlugIn, Option<Vec<super::String>>>
         for super::RemoteWhereInput
@@ -6677,9 +5293,7 @@ pub mod remote_where_input_fields {
     pub struct SlugNotIn;
     impl ::cynic::schema::Field for SlugNotIn {
         type Type = Option<Vec<super::String>>;
-        fn name() -> &'static str {
-            "slug_not_in"
-        }
+        const NAME: &'static str = "slug_not_in";
     }
     impl ::cynic::schema::HasInputField<SlugNotIn, Option<Vec<super::String>>>
         for super::RemoteWhereInput
@@ -6688,41 +5302,31 @@ pub mod remote_where_input_fields {
     pub struct SlugLt;
     impl ::cynic::schema::Field for SlugLt {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "slug_lt"
-        }
+        const NAME: &'static str = "slug_lt";
     }
     impl ::cynic::schema::HasInputField<SlugLt, Option<super::String>> for super::RemoteWhereInput {}
     pub struct SlugLte;
     impl ::cynic::schema::Field for SlugLte {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "slug_lte"
-        }
+        const NAME: &'static str = "slug_lte";
     }
     impl ::cynic::schema::HasInputField<SlugLte, Option<super::String>> for super::RemoteWhereInput {}
     pub struct SlugGt;
     impl ::cynic::schema::Field for SlugGt {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "slug_gt"
-        }
+        const NAME: &'static str = "slug_gt";
     }
     impl ::cynic::schema::HasInputField<SlugGt, Option<super::String>> for super::RemoteWhereInput {}
     pub struct SlugGte;
     impl ::cynic::schema::Field for SlugGte {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "slug_gte"
-        }
+        const NAME: &'static str = "slug_gte";
     }
     impl ::cynic::schema::HasInputField<SlugGte, Option<super::String>> for super::RemoteWhereInput {}
     pub struct SlugContains;
     impl ::cynic::schema::Field for SlugContains {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "slug_contains"
-        }
+        const NAME: &'static str = "slug_contains";
     }
     impl ::cynic::schema::HasInputField<SlugContains, Option<super::String>>
         for super::RemoteWhereInput
@@ -6731,9 +5335,7 @@ pub mod remote_where_input_fields {
     pub struct SlugNotContains;
     impl ::cynic::schema::Field for SlugNotContains {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "slug_not_contains"
-        }
+        const NAME: &'static str = "slug_not_contains";
     }
     impl ::cynic::schema::HasInputField<SlugNotContains, Option<super::String>>
         for super::RemoteWhereInput
@@ -6742,9 +5344,7 @@ pub mod remote_where_input_fields {
     pub struct SlugStartsWith;
     impl ::cynic::schema::Field for SlugStartsWith {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "slug_starts_with"
-        }
+        const NAME: &'static str = "slug_starts_with";
     }
     impl ::cynic::schema::HasInputField<SlugStartsWith, Option<super::String>>
         for super::RemoteWhereInput
@@ -6753,9 +5353,7 @@ pub mod remote_where_input_fields {
     pub struct SlugNotStartsWith;
     impl ::cynic::schema::Field for SlugNotStartsWith {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "slug_not_starts_with"
-        }
+        const NAME: &'static str = "slug_not_starts_with";
     }
     impl ::cynic::schema::HasInputField<SlugNotStartsWith, Option<super::String>>
         for super::RemoteWhereInput
@@ -6764,9 +5362,7 @@ pub mod remote_where_input_fields {
     pub struct SlugEndsWith;
     impl ::cynic::schema::Field for SlugEndsWith {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "slug_ends_with"
-        }
+        const NAME: &'static str = "slug_ends_with";
     }
     impl ::cynic::schema::HasInputField<SlugEndsWith, Option<super::String>>
         for super::RemoteWhereInput
@@ -6775,9 +5371,7 @@ pub mod remote_where_input_fields {
     pub struct SlugNotEndsWith;
     impl ::cynic::schema::Field for SlugNotEndsWith {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "slug_not_ends_with"
-        }
+        const NAME: &'static str = "slug_not_ends_with";
     }
     impl ::cynic::schema::HasInputField<SlugNotEndsWith, Option<super::String>>
         for super::RemoteWhereInput
@@ -6786,25 +5380,19 @@ pub mod remote_where_input_fields {
     pub struct Type;
     impl ::cynic::schema::Field for Type {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "type"
-        }
+        const NAME: &'static str = "type";
     }
     impl ::cynic::schema::HasInputField<Type, Option<super::String>> for super::RemoteWhereInput {}
     pub struct TypeNot;
     impl ::cynic::schema::Field for TypeNot {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "type_not"
-        }
+        const NAME: &'static str = "type_not";
     }
     impl ::cynic::schema::HasInputField<TypeNot, Option<super::String>> for super::RemoteWhereInput {}
     pub struct TypeIn;
     impl ::cynic::schema::Field for TypeIn {
         type Type = Option<Vec<super::String>>;
-        fn name() -> &'static str {
-            "type_in"
-        }
+        const NAME: &'static str = "type_in";
     }
     impl ::cynic::schema::HasInputField<TypeIn, Option<Vec<super::String>>>
         for super::RemoteWhereInput
@@ -6813,9 +5401,7 @@ pub mod remote_where_input_fields {
     pub struct TypeNotIn;
     impl ::cynic::schema::Field for TypeNotIn {
         type Type = Option<Vec<super::String>>;
-        fn name() -> &'static str {
-            "type_not_in"
-        }
+        const NAME: &'static str = "type_not_in";
     }
     impl ::cynic::schema::HasInputField<TypeNotIn, Option<Vec<super::String>>>
         for super::RemoteWhereInput
@@ -6824,41 +5410,31 @@ pub mod remote_where_input_fields {
     pub struct TypeLt;
     impl ::cynic::schema::Field for TypeLt {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "type_lt"
-        }
+        const NAME: &'static str = "type_lt";
     }
     impl ::cynic::schema::HasInputField<TypeLt, Option<super::String>> for super::RemoteWhereInput {}
     pub struct TypeLte;
     impl ::cynic::schema::Field for TypeLte {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "type_lte"
-        }
+        const NAME: &'static str = "type_lte";
     }
     impl ::cynic::schema::HasInputField<TypeLte, Option<super::String>> for super::RemoteWhereInput {}
     pub struct TypeGt;
     impl ::cynic::schema::Field for TypeGt {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "type_gt"
-        }
+        const NAME: &'static str = "type_gt";
     }
     impl ::cynic::schema::HasInputField<TypeGt, Option<super::String>> for super::RemoteWhereInput {}
     pub struct TypeGte;
     impl ::cynic::schema::Field for TypeGte {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "type_gte"
-        }
+        const NAME: &'static str = "type_gte";
     }
     impl ::cynic::schema::HasInputField<TypeGte, Option<super::String>> for super::RemoteWhereInput {}
     pub struct TypeContains;
     impl ::cynic::schema::Field for TypeContains {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "type_contains"
-        }
+        const NAME: &'static str = "type_contains";
     }
     impl ::cynic::schema::HasInputField<TypeContains, Option<super::String>>
         for super::RemoteWhereInput
@@ -6867,9 +5443,7 @@ pub mod remote_where_input_fields {
     pub struct TypeNotContains;
     impl ::cynic::schema::Field for TypeNotContains {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "type_not_contains"
-        }
+        const NAME: &'static str = "type_not_contains";
     }
     impl ::cynic::schema::HasInputField<TypeNotContains, Option<super::String>>
         for super::RemoteWhereInput
@@ -6878,9 +5452,7 @@ pub mod remote_where_input_fields {
     pub struct TypeStartsWith;
     impl ::cynic::schema::Field for TypeStartsWith {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "type_starts_with"
-        }
+        const NAME: &'static str = "type_starts_with";
     }
     impl ::cynic::schema::HasInputField<TypeStartsWith, Option<super::String>>
         for super::RemoteWhereInput
@@ -6889,9 +5461,7 @@ pub mod remote_where_input_fields {
     pub struct TypeNotStartsWith;
     impl ::cynic::schema::Field for TypeNotStartsWith {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "type_not_starts_with"
-        }
+        const NAME: &'static str = "type_not_starts_with";
     }
     impl ::cynic::schema::HasInputField<TypeNotStartsWith, Option<super::String>>
         for super::RemoteWhereInput
@@ -6900,9 +5470,7 @@ pub mod remote_where_input_fields {
     pub struct TypeEndsWith;
     impl ::cynic::schema::Field for TypeEndsWith {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "type_ends_with"
-        }
+        const NAME: &'static str = "type_ends_with";
     }
     impl ::cynic::schema::HasInputField<TypeEndsWith, Option<super::String>>
         for super::RemoteWhereInput
@@ -6911,9 +5479,7 @@ pub mod remote_where_input_fields {
     pub struct TypeNotEndsWith;
     impl ::cynic::schema::Field for TypeNotEndsWith {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "type_not_ends_with"
-        }
+        const NAME: &'static str = "type_not_ends_with";
     }
     impl ::cynic::schema::HasInputField<TypeNotEndsWith, Option<super::String>>
         for super::RemoteWhereInput
@@ -6922,9 +5488,7 @@ pub mod remote_where_input_fields {
     pub struct JobsEvery;
     impl ::cynic::schema::Field for JobsEvery {
         type Type = Option<super::JobWhereInput>;
-        fn name() -> &'static str {
-            "jobs_every"
-        }
+        const NAME: &'static str = "jobs_every";
     }
     impl ::cynic::schema::HasInputField<JobsEvery, Option<super::JobWhereInput>>
         for super::RemoteWhereInput
@@ -6933,9 +5497,7 @@ pub mod remote_where_input_fields {
     pub struct JobsSome;
     impl ::cynic::schema::Field for JobsSome {
         type Type = Option<super::JobWhereInput>;
-        fn name() -> &'static str {
-            "jobs_some"
-        }
+        const NAME: &'static str = "jobs_some";
     }
     impl ::cynic::schema::HasInputField<JobsSome, Option<super::JobWhereInput>>
         for super::RemoteWhereInput
@@ -6944,9 +5506,7 @@ pub mod remote_where_input_fields {
     pub struct JobsNone;
     impl ::cynic::schema::Field for JobsNone {
         type Type = Option<super::JobWhereInput>;
-        fn name() -> &'static str {
-            "jobs_none"
-        }
+        const NAME: &'static str = "jobs_none";
     }
     impl ::cynic::schema::HasInputField<JobsNone, Option<super::JobWhereInput>>
         for super::RemoteWhereInput
@@ -6955,9 +5515,7 @@ pub mod remote_where_input_fields {
     pub struct CreatedAt;
     impl ::cynic::schema::Field for CreatedAt {
         type Type = Option<super::DateTime>;
-        fn name() -> &'static str {
-            "createdAt"
-        }
+        const NAME: &'static str = "createdAt";
     }
     impl ::cynic::schema::HasInputField<CreatedAt, Option<super::DateTime>>
         for super::RemoteWhereInput
@@ -6966,9 +5524,7 @@ pub mod remote_where_input_fields {
     pub struct CreatedAtNot;
     impl ::cynic::schema::Field for CreatedAtNot {
         type Type = Option<super::DateTime>;
-        fn name() -> &'static str {
-            "createdAt_not"
-        }
+        const NAME: &'static str = "createdAt_not";
     }
     impl ::cynic::schema::HasInputField<CreatedAtNot, Option<super::DateTime>>
         for super::RemoteWhereInput
@@ -6977,9 +5533,7 @@ pub mod remote_where_input_fields {
     pub struct CreatedAtIn;
     impl ::cynic::schema::Field for CreatedAtIn {
         type Type = Option<Vec<super::DateTime>>;
-        fn name() -> &'static str {
-            "createdAt_in"
-        }
+        const NAME: &'static str = "createdAt_in";
     }
     impl ::cynic::schema::HasInputField<CreatedAtIn, Option<Vec<super::DateTime>>>
         for super::RemoteWhereInput
@@ -6988,9 +5542,7 @@ pub mod remote_where_input_fields {
     pub struct CreatedAtNotIn;
     impl ::cynic::schema::Field for CreatedAtNotIn {
         type Type = Option<Vec<super::DateTime>>;
-        fn name() -> &'static str {
-            "createdAt_not_in"
-        }
+        const NAME: &'static str = "createdAt_not_in";
     }
     impl ::cynic::schema::HasInputField<CreatedAtNotIn, Option<Vec<super::DateTime>>>
         for super::RemoteWhereInput
@@ -6999,9 +5551,7 @@ pub mod remote_where_input_fields {
     pub struct CreatedAtLt;
     impl ::cynic::schema::Field for CreatedAtLt {
         type Type = Option<super::DateTime>;
-        fn name() -> &'static str {
-            "createdAt_lt"
-        }
+        const NAME: &'static str = "createdAt_lt";
     }
     impl ::cynic::schema::HasInputField<CreatedAtLt, Option<super::DateTime>>
         for super::RemoteWhereInput
@@ -7010,9 +5560,7 @@ pub mod remote_where_input_fields {
     pub struct CreatedAtLte;
     impl ::cynic::schema::Field for CreatedAtLte {
         type Type = Option<super::DateTime>;
-        fn name() -> &'static str {
-            "createdAt_lte"
-        }
+        const NAME: &'static str = "createdAt_lte";
     }
     impl ::cynic::schema::HasInputField<CreatedAtLte, Option<super::DateTime>>
         for super::RemoteWhereInput
@@ -7021,9 +5569,7 @@ pub mod remote_where_input_fields {
     pub struct CreatedAtGt;
     impl ::cynic::schema::Field for CreatedAtGt {
         type Type = Option<super::DateTime>;
-        fn name() -> &'static str {
-            "createdAt_gt"
-        }
+        const NAME: &'static str = "createdAt_gt";
     }
     impl ::cynic::schema::HasInputField<CreatedAtGt, Option<super::DateTime>>
         for super::RemoteWhereInput
@@ -7032,9 +5578,7 @@ pub mod remote_where_input_fields {
     pub struct CreatedAtGte;
     impl ::cynic::schema::Field for CreatedAtGte {
         type Type = Option<super::DateTime>;
-        fn name() -> &'static str {
-            "createdAt_gte"
-        }
+        const NAME: &'static str = "createdAt_gte";
     }
     impl ::cynic::schema::HasInputField<CreatedAtGte, Option<super::DateTime>>
         for super::RemoteWhereInput
@@ -7043,9 +5587,7 @@ pub mod remote_where_input_fields {
     pub struct UpdatedAt;
     impl ::cynic::schema::Field for UpdatedAt {
         type Type = Option<super::DateTime>;
-        fn name() -> &'static str {
-            "updatedAt"
-        }
+        const NAME: &'static str = "updatedAt";
     }
     impl ::cynic::schema::HasInputField<UpdatedAt, Option<super::DateTime>>
         for super::RemoteWhereInput
@@ -7054,9 +5596,7 @@ pub mod remote_where_input_fields {
     pub struct UpdatedAtNot;
     impl ::cynic::schema::Field for UpdatedAtNot {
         type Type = Option<super::DateTime>;
-        fn name() -> &'static str {
-            "updatedAt_not"
-        }
+        const NAME: &'static str = "updatedAt_not";
     }
     impl ::cynic::schema::HasInputField<UpdatedAtNot, Option<super::DateTime>>
         for super::RemoteWhereInput
@@ -7065,9 +5605,7 @@ pub mod remote_where_input_fields {
     pub struct UpdatedAtIn;
     impl ::cynic::schema::Field for UpdatedAtIn {
         type Type = Option<Vec<super::DateTime>>;
-        fn name() -> &'static str {
-            "updatedAt_in"
-        }
+        const NAME: &'static str = "updatedAt_in";
     }
     impl ::cynic::schema::HasInputField<UpdatedAtIn, Option<Vec<super::DateTime>>>
         for super::RemoteWhereInput
@@ -7076,9 +5614,7 @@ pub mod remote_where_input_fields {
     pub struct UpdatedAtNotIn;
     impl ::cynic::schema::Field for UpdatedAtNotIn {
         type Type = Option<Vec<super::DateTime>>;
-        fn name() -> &'static str {
-            "updatedAt_not_in"
-        }
+        const NAME: &'static str = "updatedAt_not_in";
     }
     impl ::cynic::schema::HasInputField<UpdatedAtNotIn, Option<Vec<super::DateTime>>>
         for super::RemoteWhereInput
@@ -7087,9 +5623,7 @@ pub mod remote_where_input_fields {
     pub struct UpdatedAtLt;
     impl ::cynic::schema::Field for UpdatedAtLt {
         type Type = Option<super::DateTime>;
-        fn name() -> &'static str {
-            "updatedAt_lt"
-        }
+        const NAME: &'static str = "updatedAt_lt";
     }
     impl ::cynic::schema::HasInputField<UpdatedAtLt, Option<super::DateTime>>
         for super::RemoteWhereInput
@@ -7098,9 +5632,7 @@ pub mod remote_where_input_fields {
     pub struct UpdatedAtLte;
     impl ::cynic::schema::Field for UpdatedAtLte {
         type Type = Option<super::DateTime>;
-        fn name() -> &'static str {
-            "updatedAt_lte"
-        }
+        const NAME: &'static str = "updatedAt_lte";
     }
     impl ::cynic::schema::HasInputField<UpdatedAtLte, Option<super::DateTime>>
         for super::RemoteWhereInput
@@ -7109,9 +5641,7 @@ pub mod remote_where_input_fields {
     pub struct UpdatedAtGt;
     impl ::cynic::schema::Field for UpdatedAtGt {
         type Type = Option<super::DateTime>;
-        fn name() -> &'static str {
-            "updatedAt_gt"
-        }
+        const NAME: &'static str = "updatedAt_gt";
     }
     impl ::cynic::schema::HasInputField<UpdatedAtGt, Option<super::DateTime>>
         for super::RemoteWhereInput
@@ -7120,9 +5650,7 @@ pub mod remote_where_input_fields {
     pub struct UpdatedAtGte;
     impl ::cynic::schema::Field for UpdatedAtGte {
         type Type = Option<super::DateTime>;
-        fn name() -> &'static str {
-            "updatedAt_gte"
-        }
+        const NAME: &'static str = "updatedAt_gte";
     }
     impl ::cynic::schema::HasInputField<UpdatedAtGte, Option<super::DateTime>>
         for super::RemoteWhereInput
@@ -7131,9 +5659,7 @@ pub mod remote_where_input_fields {
     pub struct And;
     impl ::cynic::schema::Field for And {
         type Type = Option<Vec<super::RemoteWhereInput>>;
-        fn name() -> &'static str {
-            "AND"
-        }
+        const NAME: &'static str = "AND";
     }
     impl ::cynic::schema::HasInputField<And, Option<Vec<super::RemoteWhereInput>>>
         for super::RemoteWhereInput
@@ -7142,9 +5668,7 @@ pub mod remote_where_input_fields {
     pub struct Or;
     impl ::cynic::schema::Field for Or {
         type Type = Option<Vec<super::RemoteWhereInput>>;
-        fn name() -> &'static str {
-            "OR"
-        }
+        const NAME: &'static str = "OR";
     }
     impl ::cynic::schema::HasInputField<Or, Option<Vec<super::RemoteWhereInput>>>
         for super::RemoteWhereInput
@@ -7153,9 +5677,7 @@ pub mod remote_where_input_fields {
     pub struct Not;
     impl ::cynic::schema::Field for Not {
         type Type = Option<Vec<super::RemoteWhereInput>>;
-        fn name() -> &'static str {
-            "NOT"
-        }
+        const NAME: &'static str = "NOT";
     }
     impl ::cynic::schema::HasInputField<Not, Option<Vec<super::RemoteWhereInput>>>
         for super::RemoteWhereInput
@@ -7168,17 +5690,13 @@ pub mod subscribe_input_fields {
     pub struct Name;
     impl ::cynic::schema::Field for Name {
         type Type = super::String;
-        fn name() -> &'static str {
-            "name"
-        }
+        const NAME: &'static str = "name";
     }
     impl ::cynic::schema::HasInputField<Name, super::String> for super::SubscribeInput {}
     pub struct Email;
     impl ::cynic::schema::Field for Email {
         type Type = super::String;
-        fn name() -> &'static str {
-            "email"
-        }
+        const NAME: &'static str = "email";
     }
     impl ::cynic::schema::HasInputField<Email, super::String> for super::SubscribeInput {}
 }
@@ -7187,9 +5705,7 @@ pub mod tag_fields {
     pub struct Id;
     impl ::cynic::schema::Field for Id {
         type Type = super::Id;
-        fn name() -> &'static str {
-            "id"
-        }
+        const NAME: &'static str = "id";
     }
     impl ::cynic::schema::HasField<Id> for super::Tag {
         type Type = super::Id;
@@ -7197,9 +5713,7 @@ pub mod tag_fields {
     pub struct Name;
     impl ::cynic::schema::Field for Name {
         type Type = super::String;
-        fn name() -> &'static str {
-            "name"
-        }
+        const NAME: &'static str = "name";
     }
     impl ::cynic::schema::HasField<Name> for super::Tag {
         type Type = super::String;
@@ -7207,9 +5721,7 @@ pub mod tag_fields {
     pub struct Slug;
     impl ::cynic::schema::Field for Slug {
         type Type = super::String;
-        fn name() -> &'static str {
-            "slug"
-        }
+        const NAME: &'static str = "slug";
     }
     impl ::cynic::schema::HasField<Slug> for super::Tag {
         type Type = super::String;
@@ -7217,9 +5729,7 @@ pub mod tag_fields {
     pub struct Jobs;
     impl ::cynic::schema::Field for Jobs {
         type Type = Option<Vec<super::Job>>;
-        fn name() -> &'static str {
-            "jobs"
-        }
+        const NAME: &'static str = "jobs";
     }
     impl ::cynic::schema::HasField<Jobs> for super::Tag {
         type Type = Option<Vec<super::Job>>;
@@ -7228,59 +5738,43 @@ pub mod tag_fields {
         pub struct Where;
         impl ::cynic::schema::HasArgument<Where> for super::Jobs {
             type ArgumentType = Option<super::super::JobWhereInput>;
-            fn name() -> &'static str {
-                "where"
-            }
+            const NAME: &'static str = "where";
         }
         pub struct OrderBy;
         impl ::cynic::schema::HasArgument<OrderBy> for super::Jobs {
             type ArgumentType = Option<super::super::JobOrderByInput>;
-            fn name() -> &'static str {
-                "orderBy"
-            }
+            const NAME: &'static str = "orderBy";
         }
         pub struct Skip;
         impl ::cynic::schema::HasArgument<Skip> for super::Jobs {
             type ArgumentType = Option<super::super::Int>;
-            fn name() -> &'static str {
-                "skip"
-            }
+            const NAME: &'static str = "skip";
         }
         pub struct After;
         impl ::cynic::schema::HasArgument<After> for super::Jobs {
             type ArgumentType = Option<super::super::String>;
-            fn name() -> &'static str {
-                "after"
-            }
+            const NAME: &'static str = "after";
         }
         pub struct Before;
         impl ::cynic::schema::HasArgument<Before> for super::Jobs {
             type ArgumentType = Option<super::super::String>;
-            fn name() -> &'static str {
-                "before"
-            }
+            const NAME: &'static str = "before";
         }
         pub struct First;
         impl ::cynic::schema::HasArgument<First> for super::Jobs {
             type ArgumentType = Option<super::super::Int>;
-            fn name() -> &'static str {
-                "first"
-            }
+            const NAME: &'static str = "first";
         }
         pub struct Last;
         impl ::cynic::schema::HasArgument<Last> for super::Jobs {
             type ArgumentType = Option<super::super::Int>;
-            fn name() -> &'static str {
-                "last"
-            }
+            const NAME: &'static str = "last";
         }
     }
     pub struct CreatedAt;
     impl ::cynic::schema::Field for CreatedAt {
         type Type = super::DateTime;
-        fn name() -> &'static str {
-            "createdAt"
-        }
+        const NAME: &'static str = "createdAt";
     }
     impl ::cynic::schema::HasField<CreatedAt> for super::Tag {
         type Type = super::DateTime;
@@ -7288,9 +5782,7 @@ pub mod tag_fields {
     pub struct UpdatedAt;
     impl ::cynic::schema::Field for UpdatedAt {
         type Type = super::DateTime;
-        fn name() -> &'static str {
-            "updatedAt"
-        }
+        const NAME: &'static str = "updatedAt";
     }
     impl ::cynic::schema::HasField<UpdatedAt> for super::Tag {
         type Type = super::DateTime;
@@ -7303,145 +5795,109 @@ pub mod tag_where_input_fields {
     pub struct Id;
     impl ::cynic::schema::Field for Id {
         type Type = Option<super::Id>;
-        fn name() -> &'static str {
-            "id"
-        }
+        const NAME: &'static str = "id";
     }
     impl ::cynic::schema::HasInputField<Id, Option<super::Id>> for super::TagWhereInput {}
     pub struct IdNot;
     impl ::cynic::schema::Field for IdNot {
         type Type = Option<super::Id>;
-        fn name() -> &'static str {
-            "id_not"
-        }
+        const NAME: &'static str = "id_not";
     }
     impl ::cynic::schema::HasInputField<IdNot, Option<super::Id>> for super::TagWhereInput {}
     pub struct IdIn;
     impl ::cynic::schema::Field for IdIn {
         type Type = Option<Vec<super::Id>>;
-        fn name() -> &'static str {
-            "id_in"
-        }
+        const NAME: &'static str = "id_in";
     }
     impl ::cynic::schema::HasInputField<IdIn, Option<Vec<super::Id>>> for super::TagWhereInput {}
     pub struct IdNotIn;
     impl ::cynic::schema::Field for IdNotIn {
         type Type = Option<Vec<super::Id>>;
-        fn name() -> &'static str {
-            "id_not_in"
-        }
+        const NAME: &'static str = "id_not_in";
     }
     impl ::cynic::schema::HasInputField<IdNotIn, Option<Vec<super::Id>>> for super::TagWhereInput {}
     pub struct IdLt;
     impl ::cynic::schema::Field for IdLt {
         type Type = Option<super::Id>;
-        fn name() -> &'static str {
-            "id_lt"
-        }
+        const NAME: &'static str = "id_lt";
     }
     impl ::cynic::schema::HasInputField<IdLt, Option<super::Id>> for super::TagWhereInput {}
     pub struct IdLte;
     impl ::cynic::schema::Field for IdLte {
         type Type = Option<super::Id>;
-        fn name() -> &'static str {
-            "id_lte"
-        }
+        const NAME: &'static str = "id_lte";
     }
     impl ::cynic::schema::HasInputField<IdLte, Option<super::Id>> for super::TagWhereInput {}
     pub struct IdGt;
     impl ::cynic::schema::Field for IdGt {
         type Type = Option<super::Id>;
-        fn name() -> &'static str {
-            "id_gt"
-        }
+        const NAME: &'static str = "id_gt";
     }
     impl ::cynic::schema::HasInputField<IdGt, Option<super::Id>> for super::TagWhereInput {}
     pub struct IdGte;
     impl ::cynic::schema::Field for IdGte {
         type Type = Option<super::Id>;
-        fn name() -> &'static str {
-            "id_gte"
-        }
+        const NAME: &'static str = "id_gte";
     }
     impl ::cynic::schema::HasInputField<IdGte, Option<super::Id>> for super::TagWhereInput {}
     pub struct IdContains;
     impl ::cynic::schema::Field for IdContains {
         type Type = Option<super::Id>;
-        fn name() -> &'static str {
-            "id_contains"
-        }
+        const NAME: &'static str = "id_contains";
     }
     impl ::cynic::schema::HasInputField<IdContains, Option<super::Id>> for super::TagWhereInput {}
     pub struct IdNotContains;
     impl ::cynic::schema::Field for IdNotContains {
         type Type = Option<super::Id>;
-        fn name() -> &'static str {
-            "id_not_contains"
-        }
+        const NAME: &'static str = "id_not_contains";
     }
     impl ::cynic::schema::HasInputField<IdNotContains, Option<super::Id>> for super::TagWhereInput {}
     pub struct IdStartsWith;
     impl ::cynic::schema::Field for IdStartsWith {
         type Type = Option<super::Id>;
-        fn name() -> &'static str {
-            "id_starts_with"
-        }
+        const NAME: &'static str = "id_starts_with";
     }
     impl ::cynic::schema::HasInputField<IdStartsWith, Option<super::Id>> for super::TagWhereInput {}
     pub struct IdNotStartsWith;
     impl ::cynic::schema::Field for IdNotStartsWith {
         type Type = Option<super::Id>;
-        fn name() -> &'static str {
-            "id_not_starts_with"
-        }
+        const NAME: &'static str = "id_not_starts_with";
     }
     impl ::cynic::schema::HasInputField<IdNotStartsWith, Option<super::Id>> for super::TagWhereInput {}
     pub struct IdEndsWith;
     impl ::cynic::schema::Field for IdEndsWith {
         type Type = Option<super::Id>;
-        fn name() -> &'static str {
-            "id_ends_with"
-        }
+        const NAME: &'static str = "id_ends_with";
     }
     impl ::cynic::schema::HasInputField<IdEndsWith, Option<super::Id>> for super::TagWhereInput {}
     pub struct IdNotEndsWith;
     impl ::cynic::schema::Field for IdNotEndsWith {
         type Type = Option<super::Id>;
-        fn name() -> &'static str {
-            "id_not_ends_with"
-        }
+        const NAME: &'static str = "id_not_ends_with";
     }
     impl ::cynic::schema::HasInputField<IdNotEndsWith, Option<super::Id>> for super::TagWhereInput {}
     pub struct Name;
     impl ::cynic::schema::Field for Name {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "name"
-        }
+        const NAME: &'static str = "name";
     }
     impl ::cynic::schema::HasInputField<Name, Option<super::String>> for super::TagWhereInput {}
     pub struct NameNot;
     impl ::cynic::schema::Field for NameNot {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "name_not"
-        }
+        const NAME: &'static str = "name_not";
     }
     impl ::cynic::schema::HasInputField<NameNot, Option<super::String>> for super::TagWhereInput {}
     pub struct NameIn;
     impl ::cynic::schema::Field for NameIn {
         type Type = Option<Vec<super::String>>;
-        fn name() -> &'static str {
-            "name_in"
-        }
+        const NAME: &'static str = "name_in";
     }
     impl ::cynic::schema::HasInputField<NameIn, Option<Vec<super::String>>> for super::TagWhereInput {}
     pub struct NameNotIn;
     impl ::cynic::schema::Field for NameNotIn {
         type Type = Option<Vec<super::String>>;
-        fn name() -> &'static str {
-            "name_not_in"
-        }
+        const NAME: &'static str = "name_not_in";
     }
     impl ::cynic::schema::HasInputField<NameNotIn, Option<Vec<super::String>>>
         for super::TagWhereInput
@@ -7450,49 +5906,37 @@ pub mod tag_where_input_fields {
     pub struct NameLt;
     impl ::cynic::schema::Field for NameLt {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "name_lt"
-        }
+        const NAME: &'static str = "name_lt";
     }
     impl ::cynic::schema::HasInputField<NameLt, Option<super::String>> for super::TagWhereInput {}
     pub struct NameLte;
     impl ::cynic::schema::Field for NameLte {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "name_lte"
-        }
+        const NAME: &'static str = "name_lte";
     }
     impl ::cynic::schema::HasInputField<NameLte, Option<super::String>> for super::TagWhereInput {}
     pub struct NameGt;
     impl ::cynic::schema::Field for NameGt {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "name_gt"
-        }
+        const NAME: &'static str = "name_gt";
     }
     impl ::cynic::schema::HasInputField<NameGt, Option<super::String>> for super::TagWhereInput {}
     pub struct NameGte;
     impl ::cynic::schema::Field for NameGte {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "name_gte"
-        }
+        const NAME: &'static str = "name_gte";
     }
     impl ::cynic::schema::HasInputField<NameGte, Option<super::String>> for super::TagWhereInput {}
     pub struct NameContains;
     impl ::cynic::schema::Field for NameContains {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "name_contains"
-        }
+        const NAME: &'static str = "name_contains";
     }
     impl ::cynic::schema::HasInputField<NameContains, Option<super::String>> for super::TagWhereInput {}
     pub struct NameNotContains;
     impl ::cynic::schema::Field for NameNotContains {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "name_not_contains"
-        }
+        const NAME: &'static str = "name_not_contains";
     }
     impl ::cynic::schema::HasInputField<NameNotContains, Option<super::String>>
         for super::TagWhereInput
@@ -7501,9 +5945,7 @@ pub mod tag_where_input_fields {
     pub struct NameStartsWith;
     impl ::cynic::schema::Field for NameStartsWith {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "name_starts_with"
-        }
+        const NAME: &'static str = "name_starts_with";
     }
     impl ::cynic::schema::HasInputField<NameStartsWith, Option<super::String>>
         for super::TagWhereInput
@@ -7512,9 +5954,7 @@ pub mod tag_where_input_fields {
     pub struct NameNotStartsWith;
     impl ::cynic::schema::Field for NameNotStartsWith {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "name_not_starts_with"
-        }
+        const NAME: &'static str = "name_not_starts_with";
     }
     impl ::cynic::schema::HasInputField<NameNotStartsWith, Option<super::String>>
         for super::TagWhereInput
@@ -7523,17 +5963,13 @@ pub mod tag_where_input_fields {
     pub struct NameEndsWith;
     impl ::cynic::schema::Field for NameEndsWith {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "name_ends_with"
-        }
+        const NAME: &'static str = "name_ends_with";
     }
     impl ::cynic::schema::HasInputField<NameEndsWith, Option<super::String>> for super::TagWhereInput {}
     pub struct NameNotEndsWith;
     impl ::cynic::schema::Field for NameNotEndsWith {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "name_not_ends_with"
-        }
+        const NAME: &'static str = "name_not_ends_with";
     }
     impl ::cynic::schema::HasInputField<NameNotEndsWith, Option<super::String>>
         for super::TagWhereInput
@@ -7542,33 +5978,25 @@ pub mod tag_where_input_fields {
     pub struct Slug;
     impl ::cynic::schema::Field for Slug {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "slug"
-        }
+        const NAME: &'static str = "slug";
     }
     impl ::cynic::schema::HasInputField<Slug, Option<super::String>> for super::TagWhereInput {}
     pub struct SlugNot;
     impl ::cynic::schema::Field for SlugNot {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "slug_not"
-        }
+        const NAME: &'static str = "slug_not";
     }
     impl ::cynic::schema::HasInputField<SlugNot, Option<super::String>> for super::TagWhereInput {}
     pub struct SlugIn;
     impl ::cynic::schema::Field for SlugIn {
         type Type = Option<Vec<super::String>>;
-        fn name() -> &'static str {
-            "slug_in"
-        }
+        const NAME: &'static str = "slug_in";
     }
     impl ::cynic::schema::HasInputField<SlugIn, Option<Vec<super::String>>> for super::TagWhereInput {}
     pub struct SlugNotIn;
     impl ::cynic::schema::Field for SlugNotIn {
         type Type = Option<Vec<super::String>>;
-        fn name() -> &'static str {
-            "slug_not_in"
-        }
+        const NAME: &'static str = "slug_not_in";
     }
     impl ::cynic::schema::HasInputField<SlugNotIn, Option<Vec<super::String>>>
         for super::TagWhereInput
@@ -7577,49 +6005,37 @@ pub mod tag_where_input_fields {
     pub struct SlugLt;
     impl ::cynic::schema::Field for SlugLt {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "slug_lt"
-        }
+        const NAME: &'static str = "slug_lt";
     }
     impl ::cynic::schema::HasInputField<SlugLt, Option<super::String>> for super::TagWhereInput {}
     pub struct SlugLte;
     impl ::cynic::schema::Field for SlugLte {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "slug_lte"
-        }
+        const NAME: &'static str = "slug_lte";
     }
     impl ::cynic::schema::HasInputField<SlugLte, Option<super::String>> for super::TagWhereInput {}
     pub struct SlugGt;
     impl ::cynic::schema::Field for SlugGt {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "slug_gt"
-        }
+        const NAME: &'static str = "slug_gt";
     }
     impl ::cynic::schema::HasInputField<SlugGt, Option<super::String>> for super::TagWhereInput {}
     pub struct SlugGte;
     impl ::cynic::schema::Field for SlugGte {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "slug_gte"
-        }
+        const NAME: &'static str = "slug_gte";
     }
     impl ::cynic::schema::HasInputField<SlugGte, Option<super::String>> for super::TagWhereInput {}
     pub struct SlugContains;
     impl ::cynic::schema::Field for SlugContains {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "slug_contains"
-        }
+        const NAME: &'static str = "slug_contains";
     }
     impl ::cynic::schema::HasInputField<SlugContains, Option<super::String>> for super::TagWhereInput {}
     pub struct SlugNotContains;
     impl ::cynic::schema::Field for SlugNotContains {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "slug_not_contains"
-        }
+        const NAME: &'static str = "slug_not_contains";
     }
     impl ::cynic::schema::HasInputField<SlugNotContains, Option<super::String>>
         for super::TagWhereInput
@@ -7628,9 +6044,7 @@ pub mod tag_where_input_fields {
     pub struct SlugStartsWith;
     impl ::cynic::schema::Field for SlugStartsWith {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "slug_starts_with"
-        }
+        const NAME: &'static str = "slug_starts_with";
     }
     impl ::cynic::schema::HasInputField<SlugStartsWith, Option<super::String>>
         for super::TagWhereInput
@@ -7639,9 +6053,7 @@ pub mod tag_where_input_fields {
     pub struct SlugNotStartsWith;
     impl ::cynic::schema::Field for SlugNotStartsWith {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "slug_not_starts_with"
-        }
+        const NAME: &'static str = "slug_not_starts_with";
     }
     impl ::cynic::schema::HasInputField<SlugNotStartsWith, Option<super::String>>
         for super::TagWhereInput
@@ -7650,17 +6062,13 @@ pub mod tag_where_input_fields {
     pub struct SlugEndsWith;
     impl ::cynic::schema::Field for SlugEndsWith {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "slug_ends_with"
-        }
+        const NAME: &'static str = "slug_ends_with";
     }
     impl ::cynic::schema::HasInputField<SlugEndsWith, Option<super::String>> for super::TagWhereInput {}
     pub struct SlugNotEndsWith;
     impl ::cynic::schema::Field for SlugNotEndsWith {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "slug_not_ends_with"
-        }
+        const NAME: &'static str = "slug_not_ends_with";
     }
     impl ::cynic::schema::HasInputField<SlugNotEndsWith, Option<super::String>>
         for super::TagWhereInput
@@ -7669,9 +6077,7 @@ pub mod tag_where_input_fields {
     pub struct JobsEvery;
     impl ::cynic::schema::Field for JobsEvery {
         type Type = Option<super::JobWhereInput>;
-        fn name() -> &'static str {
-            "jobs_every"
-        }
+        const NAME: &'static str = "jobs_every";
     }
     impl ::cynic::schema::HasInputField<JobsEvery, Option<super::JobWhereInput>>
         for super::TagWhereInput
@@ -7680,9 +6086,7 @@ pub mod tag_where_input_fields {
     pub struct JobsSome;
     impl ::cynic::schema::Field for JobsSome {
         type Type = Option<super::JobWhereInput>;
-        fn name() -> &'static str {
-            "jobs_some"
-        }
+        const NAME: &'static str = "jobs_some";
     }
     impl ::cynic::schema::HasInputField<JobsSome, Option<super::JobWhereInput>>
         for super::TagWhereInput
@@ -7691,9 +6095,7 @@ pub mod tag_where_input_fields {
     pub struct JobsNone;
     impl ::cynic::schema::Field for JobsNone {
         type Type = Option<super::JobWhereInput>;
-        fn name() -> &'static str {
-            "jobs_none"
-        }
+        const NAME: &'static str = "jobs_none";
     }
     impl ::cynic::schema::HasInputField<JobsNone, Option<super::JobWhereInput>>
         for super::TagWhereInput
@@ -7702,17 +6104,13 @@ pub mod tag_where_input_fields {
     pub struct CreatedAt;
     impl ::cynic::schema::Field for CreatedAt {
         type Type = Option<super::DateTime>;
-        fn name() -> &'static str {
-            "createdAt"
-        }
+        const NAME: &'static str = "createdAt";
     }
     impl ::cynic::schema::HasInputField<CreatedAt, Option<super::DateTime>> for super::TagWhereInput {}
     pub struct CreatedAtNot;
     impl ::cynic::schema::Field for CreatedAtNot {
         type Type = Option<super::DateTime>;
-        fn name() -> &'static str {
-            "createdAt_not"
-        }
+        const NAME: &'static str = "createdAt_not";
     }
     impl ::cynic::schema::HasInputField<CreatedAtNot, Option<super::DateTime>>
         for super::TagWhereInput
@@ -7721,9 +6119,7 @@ pub mod tag_where_input_fields {
     pub struct CreatedAtIn;
     impl ::cynic::schema::Field for CreatedAtIn {
         type Type = Option<Vec<super::DateTime>>;
-        fn name() -> &'static str {
-            "createdAt_in"
-        }
+        const NAME: &'static str = "createdAt_in";
     }
     impl ::cynic::schema::HasInputField<CreatedAtIn, Option<Vec<super::DateTime>>>
         for super::TagWhereInput
@@ -7732,9 +6128,7 @@ pub mod tag_where_input_fields {
     pub struct CreatedAtNotIn;
     impl ::cynic::schema::Field for CreatedAtNotIn {
         type Type = Option<Vec<super::DateTime>>;
-        fn name() -> &'static str {
-            "createdAt_not_in"
-        }
+        const NAME: &'static str = "createdAt_not_in";
     }
     impl ::cynic::schema::HasInputField<CreatedAtNotIn, Option<Vec<super::DateTime>>>
         for super::TagWhereInput
@@ -7743,17 +6137,13 @@ pub mod tag_where_input_fields {
     pub struct CreatedAtLt;
     impl ::cynic::schema::Field for CreatedAtLt {
         type Type = Option<super::DateTime>;
-        fn name() -> &'static str {
-            "createdAt_lt"
-        }
+        const NAME: &'static str = "createdAt_lt";
     }
     impl ::cynic::schema::HasInputField<CreatedAtLt, Option<super::DateTime>> for super::TagWhereInput {}
     pub struct CreatedAtLte;
     impl ::cynic::schema::Field for CreatedAtLte {
         type Type = Option<super::DateTime>;
-        fn name() -> &'static str {
-            "createdAt_lte"
-        }
+        const NAME: &'static str = "createdAt_lte";
     }
     impl ::cynic::schema::HasInputField<CreatedAtLte, Option<super::DateTime>>
         for super::TagWhereInput
@@ -7762,17 +6152,13 @@ pub mod tag_where_input_fields {
     pub struct CreatedAtGt;
     impl ::cynic::schema::Field for CreatedAtGt {
         type Type = Option<super::DateTime>;
-        fn name() -> &'static str {
-            "createdAt_gt"
-        }
+        const NAME: &'static str = "createdAt_gt";
     }
     impl ::cynic::schema::HasInputField<CreatedAtGt, Option<super::DateTime>> for super::TagWhereInput {}
     pub struct CreatedAtGte;
     impl ::cynic::schema::Field for CreatedAtGte {
         type Type = Option<super::DateTime>;
-        fn name() -> &'static str {
-            "createdAt_gte"
-        }
+        const NAME: &'static str = "createdAt_gte";
     }
     impl ::cynic::schema::HasInputField<CreatedAtGte, Option<super::DateTime>>
         for super::TagWhereInput
@@ -7781,17 +6167,13 @@ pub mod tag_where_input_fields {
     pub struct UpdatedAt;
     impl ::cynic::schema::Field for UpdatedAt {
         type Type = Option<super::DateTime>;
-        fn name() -> &'static str {
-            "updatedAt"
-        }
+        const NAME: &'static str = "updatedAt";
     }
     impl ::cynic::schema::HasInputField<UpdatedAt, Option<super::DateTime>> for super::TagWhereInput {}
     pub struct UpdatedAtNot;
     impl ::cynic::schema::Field for UpdatedAtNot {
         type Type = Option<super::DateTime>;
-        fn name() -> &'static str {
-            "updatedAt_not"
-        }
+        const NAME: &'static str = "updatedAt_not";
     }
     impl ::cynic::schema::HasInputField<UpdatedAtNot, Option<super::DateTime>>
         for super::TagWhereInput
@@ -7800,9 +6182,7 @@ pub mod tag_where_input_fields {
     pub struct UpdatedAtIn;
     impl ::cynic::schema::Field for UpdatedAtIn {
         type Type = Option<Vec<super::DateTime>>;
-        fn name() -> &'static str {
-            "updatedAt_in"
-        }
+        const NAME: &'static str = "updatedAt_in";
     }
     impl ::cynic::schema::HasInputField<UpdatedAtIn, Option<Vec<super::DateTime>>>
         for super::TagWhereInput
@@ -7811,9 +6191,7 @@ pub mod tag_where_input_fields {
     pub struct UpdatedAtNotIn;
     impl ::cynic::schema::Field for UpdatedAtNotIn {
         type Type = Option<Vec<super::DateTime>>;
-        fn name() -> &'static str {
-            "updatedAt_not_in"
-        }
+        const NAME: &'static str = "updatedAt_not_in";
     }
     impl ::cynic::schema::HasInputField<UpdatedAtNotIn, Option<Vec<super::DateTime>>>
         for super::TagWhereInput
@@ -7822,17 +6200,13 @@ pub mod tag_where_input_fields {
     pub struct UpdatedAtLt;
     impl ::cynic::schema::Field for UpdatedAtLt {
         type Type = Option<super::DateTime>;
-        fn name() -> &'static str {
-            "updatedAt_lt"
-        }
+        const NAME: &'static str = "updatedAt_lt";
     }
     impl ::cynic::schema::HasInputField<UpdatedAtLt, Option<super::DateTime>> for super::TagWhereInput {}
     pub struct UpdatedAtLte;
     impl ::cynic::schema::Field for UpdatedAtLte {
         type Type = Option<super::DateTime>;
-        fn name() -> &'static str {
-            "updatedAt_lte"
-        }
+        const NAME: &'static str = "updatedAt_lte";
     }
     impl ::cynic::schema::HasInputField<UpdatedAtLte, Option<super::DateTime>>
         for super::TagWhereInput
@@ -7841,17 +6215,13 @@ pub mod tag_where_input_fields {
     pub struct UpdatedAtGt;
     impl ::cynic::schema::Field for UpdatedAtGt {
         type Type = Option<super::DateTime>;
-        fn name() -> &'static str {
-            "updatedAt_gt"
-        }
+        const NAME: &'static str = "updatedAt_gt";
     }
     impl ::cynic::schema::HasInputField<UpdatedAtGt, Option<super::DateTime>> for super::TagWhereInput {}
     pub struct UpdatedAtGte;
     impl ::cynic::schema::Field for UpdatedAtGte {
         type Type = Option<super::DateTime>;
-        fn name() -> &'static str {
-            "updatedAt_gte"
-        }
+        const NAME: &'static str = "updatedAt_gte";
     }
     impl ::cynic::schema::HasInputField<UpdatedAtGte, Option<super::DateTime>>
         for super::TagWhereInput
@@ -7860,9 +6230,7 @@ pub mod tag_where_input_fields {
     pub struct And;
     impl ::cynic::schema::Field for And {
         type Type = Option<Vec<super::TagWhereInput>>;
-        fn name() -> &'static str {
-            "AND"
-        }
+        const NAME: &'static str = "AND";
     }
     impl ::cynic::schema::HasInputField<And, Option<Vec<super::TagWhereInput>>>
         for super::TagWhereInput
@@ -7871,9 +6239,7 @@ pub mod tag_where_input_fields {
     pub struct Or;
     impl ::cynic::schema::Field for Or {
         type Type = Option<Vec<super::TagWhereInput>>;
-        fn name() -> &'static str {
-            "OR"
-        }
+        const NAME: &'static str = "OR";
     }
     impl ::cynic::schema::HasInputField<Or, Option<Vec<super::TagWhereInput>>>
         for super::TagWhereInput
@@ -7882,9 +6248,7 @@ pub mod tag_where_input_fields {
     pub struct Not;
     impl ::cynic::schema::Field for Not {
         type Type = Option<Vec<super::TagWhereInput>>;
-        fn name() -> &'static str {
-            "NOT"
-        }
+        const NAME: &'static str = "NOT";
     }
     impl ::cynic::schema::HasInputField<Not, Option<Vec<super::TagWhereInput>>>
         for super::TagWhereInput
@@ -7897,17 +6261,13 @@ pub mod update_company_input_fields {
     pub struct Id;
     impl ::cynic::schema::Field for Id {
         type Type = super::Id;
-        fn name() -> &'static str {
-            "id"
-        }
+        const NAME: &'static str = "id";
     }
     impl ::cynic::schema::HasInputField<Id, super::Id> for super::UpdateCompanyInput {}
     pub struct LogoUrl;
     impl ::cynic::schema::Field for LogoUrl {
         type Type = super::String;
-        fn name() -> &'static str {
-            "logoUrl"
-        }
+        const NAME: &'static str = "logoUrl";
     }
     impl ::cynic::schema::HasInputField<LogoUrl, super::String> for super::UpdateCompanyInput {}
 }
@@ -7917,17 +6277,13 @@ pub mod update_job_input_fields {
     pub struct Id;
     impl ::cynic::schema::Field for Id {
         type Type = super::Id;
-        fn name() -> &'static str {
-            "id"
-        }
+        const NAME: &'static str = "id";
     }
     impl ::cynic::schema::HasInputField<Id, super::Id> for super::UpdateJobInput {}
     pub struct Description;
     impl ::cynic::schema::Field for Description {
         type Type = super::String;
-        fn name() -> &'static str {
-            "description"
-        }
+        const NAME: &'static str = "description";
     }
     impl ::cynic::schema::HasInputField<Description, super::String> for super::UpdateJobInput {}
 }
@@ -7936,9 +6292,7 @@ pub mod user_fields {
     pub struct Id;
     impl ::cynic::schema::Field for Id {
         type Type = super::Id;
-        fn name() -> &'static str {
-            "id"
-        }
+        const NAME: &'static str = "id";
     }
     impl ::cynic::schema::HasField<Id> for super::User {
         type Type = super::Id;
@@ -7946,9 +6300,7 @@ pub mod user_fields {
     pub struct Name;
     impl ::cynic::schema::Field for Name {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "name"
-        }
+        const NAME: &'static str = "name";
     }
     impl ::cynic::schema::HasField<Name> for super::User {
         type Type = Option<super::String>;
@@ -7956,9 +6308,7 @@ pub mod user_fields {
     pub struct Email;
     impl ::cynic::schema::Field for Email {
         type Type = super::String;
-        fn name() -> &'static str {
-            "email"
-        }
+        const NAME: &'static str = "email";
     }
     impl ::cynic::schema::HasField<Email> for super::User {
         type Type = super::String;
@@ -7966,9 +6316,7 @@ pub mod user_fields {
     pub struct Subscribe;
     impl ::cynic::schema::Field for Subscribe {
         type Type = super::Boolean;
-        fn name() -> &'static str {
-            "subscribe"
-        }
+        const NAME: &'static str = "subscribe";
     }
     impl ::cynic::schema::HasField<Subscribe> for super::User {
         type Type = super::Boolean;
@@ -7976,9 +6324,7 @@ pub mod user_fields {
     pub struct CreatedAt;
     impl ::cynic::schema::Field for CreatedAt {
         type Type = super::DateTime;
-        fn name() -> &'static str {
-            "createdAt"
-        }
+        const NAME: &'static str = "createdAt";
     }
     impl ::cynic::schema::HasField<CreatedAt> for super::User {
         type Type = super::DateTime;
@@ -7986,68 +6332,44 @@ pub mod user_fields {
     pub struct UpdatedAt;
     impl ::cynic::schema::Field for UpdatedAt {
         type Type = super::DateTime;
-        fn name() -> &'static str {
-            "updatedAt"
-        }
+        const NAME: &'static str = "updatedAt";
     }
     impl ::cynic::schema::HasField<UpdatedAt> for super::User {
         type Type = super::DateTime;
     }
 }
 impl ::cynic::schema::NamedType for City {
-    fn name() -> &'static str {
-        "City"
-    }
+    const NAME: &'static str = "City";
 }
 impl ::cynic::schema::NamedType for Commitment {
-    fn name() -> &'static str {
-        "Commitment"
-    }
+    const NAME: &'static str = "Commitment";
 }
 impl ::cynic::schema::NamedType for Company {
-    fn name() -> &'static str {
-        "Company"
-    }
+    const NAME: &'static str = "Company";
 }
 impl ::cynic::schema::NamedType for Country {
-    fn name() -> &'static str {
-        "Country"
-    }
+    const NAME: &'static str = "Country";
 }
 impl ::cynic::schema::NamedType for Job {
-    fn name() -> &'static str {
-        "Job"
-    }
+    const NAME: &'static str = "Job";
 }
 impl ::cynic::schema::NamedType for Location {
-    fn name() -> &'static str {
-        "Location"
-    }
+    const NAME: &'static str = "Location";
 }
 impl ::cynic::schema::NamedType for Mutation {
-    fn name() -> &'static str {
-        "Mutation"
-    }
+    const NAME: &'static str = "Mutation";
 }
 impl ::cynic::schema::NamedType for Query {
-    fn name() -> &'static str {
-        "Query"
-    }
+    const NAME: &'static str = "Query";
 }
 impl ::cynic::schema::NamedType for Remote {
-    fn name() -> &'static str {
-        "Remote"
-    }
+    const NAME: &'static str = "Remote";
 }
 impl ::cynic::schema::NamedType for Tag {
-    fn name() -> &'static str {
-        "Tag"
-    }
+    const NAME: &'static str = "Tag";
 }
 impl ::cynic::schema::NamedType for User {
-    fn name() -> &'static str {
-        "User"
-    }
+    const NAME: &'static str = "User";
 }
 pub type Boolean = bool;
 pub type String = std::string::String;

--- a/cynic-codegen/tests/snapshots/use_schema__schema_file_2.snap
+++ b/cynic-codegen/tests/snapshots/use_schema__schema_file_2.snap
@@ -12,9 +12,7 @@ pub mod book_fields {
     pub struct Id;
     impl ::cynic::schema::Field for Id {
         type Type = super::String;
-        fn name() -> &'static str {
-            "id"
-        }
+        const NAME: &'static str = "id";
     }
     impl ::cynic::schema::HasField<Id> for super::Book {
         type Type = super::String;
@@ -22,9 +20,7 @@ pub mod book_fields {
     pub struct Name;
     impl ::cynic::schema::Field for Name {
         type Type = super::String;
-        fn name() -> &'static str {
-            "name"
-        }
+        const NAME: &'static str = "name";
     }
     impl ::cynic::schema::HasField<Name> for super::Book {
         type Type = super::String;
@@ -32,9 +28,7 @@ pub mod book_fields {
     pub struct Author;
     impl ::cynic::schema::Field for Author {
         type Type = super::String;
-        fn name() -> &'static str {
-            "author"
-        }
+        const NAME: &'static str = "author";
     }
     impl ::cynic::schema::HasField<Author> for super::Book {
         type Type = super::String;
@@ -45,9 +39,7 @@ pub mod book_changed_fields {
     pub struct MutationType;
     impl ::cynic::schema::Field for MutationType {
         type Type = super::MutationType;
-        fn name() -> &'static str {
-            "mutationType"
-        }
+        const NAME: &'static str = "mutationType";
     }
     impl ::cynic::schema::HasField<MutationType> for super::BookChanged {
         type Type = super::MutationType;
@@ -55,9 +47,7 @@ pub mod book_changed_fields {
     pub struct Id;
     impl ::cynic::schema::Field for Id {
         type Type = super::Id;
-        fn name() -> &'static str {
-            "id"
-        }
+        const NAME: &'static str = "id";
     }
     impl ::cynic::schema::HasField<Id> for super::BookChanged {
         type Type = super::Id;
@@ -65,9 +55,7 @@ pub mod book_changed_fields {
     pub struct Book;
     impl ::cynic::schema::Field for Book {
         type Type = Option<super::Book>;
-        fn name() -> &'static str {
-            "book"
-        }
+        const NAME: &'static str = "book";
     }
     impl ::cynic::schema::HasField<Book> for super::BookChanged {
         type Type = Option<super::Book>;
@@ -78,9 +66,7 @@ pub mod mutation_root_fields {
     pub struct CreateBook;
     impl ::cynic::schema::Field for CreateBook {
         type Type = super::Id;
-        fn name() -> &'static str {
-            "createBook"
-        }
+        const NAME: &'static str = "createBook";
     }
     impl ::cynic::schema::HasField<CreateBook> for super::MutationRoot {
         type Type = super::Id;
@@ -89,24 +75,18 @@ pub mod mutation_root_fields {
         pub struct Name;
         impl ::cynic::schema::HasArgument<Name> for super::CreateBook {
             type ArgumentType = super::super::String;
-            fn name() -> &'static str {
-                "name"
-            }
+            const NAME: &'static str = "name";
         }
         pub struct Author;
         impl ::cynic::schema::HasArgument<Author> for super::CreateBook {
             type ArgumentType = super::super::String;
-            fn name() -> &'static str {
-                "author"
-            }
+            const NAME: &'static str = "author";
         }
     }
     pub struct DeleteBook;
     impl ::cynic::schema::Field for DeleteBook {
         type Type = super::Boolean;
-        fn name() -> &'static str {
-            "deleteBook"
-        }
+        const NAME: &'static str = "deleteBook";
     }
     impl ::cynic::schema::HasField<DeleteBook> for super::MutationRoot {
         type Type = super::Boolean;
@@ -115,9 +95,7 @@ pub mod mutation_root_fields {
         pub struct Id;
         impl ::cynic::schema::HasArgument<Id> for super::DeleteBook {
             type ArgumentType = super::super::Id;
-            fn name() -> &'static str {
-                "id"
-            }
+            const NAME: &'static str = "id";
         }
     }
 }
@@ -127,9 +105,7 @@ pub mod query_root_fields {
     pub struct Books;
     impl ::cynic::schema::Field for Books {
         type Type = Vec<super::Book>;
-        fn name() -> &'static str {
-            "books"
-        }
+        const NAME: &'static str = "books";
     }
     impl ::cynic::schema::HasField<Books> for super::QueryRoot {
         type Type = Vec<super::Book>;
@@ -140,9 +116,7 @@ pub mod subscription_root_fields {
     pub struct Interval;
     impl ::cynic::schema::Field for Interval {
         type Type = super::Int;
-        fn name() -> &'static str {
-            "interval"
-        }
+        const NAME: &'static str = "interval";
     }
     impl ::cynic::schema::HasField<Interval> for super::SubscriptionRoot {
         type Type = super::Int;
@@ -151,17 +125,13 @@ pub mod subscription_root_fields {
         pub struct N;
         impl ::cynic::schema::HasArgument<N> for super::Interval {
             type ArgumentType = super::super::Int;
-            fn name() -> &'static str {
-                "n"
-            }
+            const NAME: &'static str = "n";
         }
     }
     pub struct Books;
     impl ::cynic::schema::Field for Books {
         type Type = super::BookChanged;
-        fn name() -> &'static str {
-            "books"
-        }
+        const NAME: &'static str = "books";
     }
     impl ::cynic::schema::HasField<Books> for super::SubscriptionRoot {
         type Type = super::BookChanged;
@@ -170,36 +140,24 @@ pub mod subscription_root_fields {
         pub struct MutationType;
         impl ::cynic::schema::HasArgument<MutationType> for super::Books {
             type ArgumentType = Option<super::super::MutationType>;
-            fn name() -> &'static str {
-                "mutationType"
-            }
+            const NAME: &'static str = "mutationType";
         }
     }
 }
 impl ::cynic::schema::NamedType for Book {
-    fn name() -> &'static str {
-        "Book"
-    }
+    const NAME: &'static str = "Book";
 }
 impl ::cynic::schema::NamedType for BookChanged {
-    fn name() -> &'static str {
-        "BookChanged"
-    }
+    const NAME: &'static str = "BookChanged";
 }
 impl ::cynic::schema::NamedType for MutationRoot {
-    fn name() -> &'static str {
-        "MutationRoot"
-    }
+    const NAME: &'static str = "MutationRoot";
 }
 impl ::cynic::schema::NamedType for QueryRoot {
-    fn name() -> &'static str {
-        "QueryRoot"
-    }
+    const NAME: &'static str = "QueryRoot";
 }
 impl ::cynic::schema::NamedType for SubscriptionRoot {
-    fn name() -> &'static str {
-        "SubscriptionRoot"
-    }
+    const NAME: &'static str = "SubscriptionRoot";
 }
 pub type Boolean = bool;
 pub type String = std::string::String;

--- a/cynic-codegen/tests/snapshots/use_schema__schema_file_3.snap
+++ b/cynic-codegen/tests/snapshots/use_schema__schema_file_3.snap
@@ -10,9 +10,7 @@ pub mod film_fields {
     pub struct Title;
     impl ::cynic::schema::Field for Title {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "title"
-        }
+        const NAME: &'static str = "title";
     }
     impl ::cynic::schema::HasField<Title> for super::Film {
         type Type = Option<super::String>;
@@ -20,9 +18,7 @@ pub mod film_fields {
     pub struct EpisodeId;
     impl ::cynic::schema::Field for EpisodeId {
         type Type = Option<super::Int>;
-        fn name() -> &'static str {
-            "episodeID"
-        }
+        const NAME: &'static str = "episodeID";
     }
     impl ::cynic::schema::HasField<EpisodeId> for super::Film {
         type Type = Option<super::Int>;
@@ -30,9 +26,7 @@ pub mod film_fields {
     pub struct OpeningCrawl;
     impl ::cynic::schema::Field for OpeningCrawl {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "openingCrawl"
-        }
+        const NAME: &'static str = "openingCrawl";
     }
     impl ::cynic::schema::HasField<OpeningCrawl> for super::Film {
         type Type = Option<super::String>;
@@ -40,9 +34,7 @@ pub mod film_fields {
     pub struct Director;
     impl ::cynic::schema::Field for Director {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "director"
-        }
+        const NAME: &'static str = "director";
     }
     impl ::cynic::schema::HasField<Director> for super::Film {
         type Type = Option<super::String>;
@@ -50,9 +42,7 @@ pub mod film_fields {
     pub struct Producers;
     impl ::cynic::schema::Field for Producers {
         type Type = Option<Vec<Option<super::String>>>;
-        fn name() -> &'static str {
-            "producers"
-        }
+        const NAME: &'static str = "producers";
     }
     impl ::cynic::schema::HasField<Producers> for super::Film {
         type Type = Option<Vec<Option<super::String>>>;
@@ -60,9 +50,7 @@ pub mod film_fields {
     pub struct ReleaseDate;
     impl ::cynic::schema::Field for ReleaseDate {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "releaseDate"
-        }
+        const NAME: &'static str = "releaseDate";
     }
     impl ::cynic::schema::HasField<ReleaseDate> for super::Film {
         type Type = Option<super::String>;
@@ -70,9 +58,7 @@ pub mod film_fields {
     pub struct SpeciesConnection;
     impl ::cynic::schema::Field for SpeciesConnection {
         type Type = Option<super::FilmSpeciesConnection>;
-        fn name() -> &'static str {
-            "speciesConnection"
-        }
+        const NAME: &'static str = "speciesConnection";
     }
     impl ::cynic::schema::HasField<SpeciesConnection> for super::Film {
         type Type = Option<super::FilmSpeciesConnection>;
@@ -81,38 +67,28 @@ pub mod film_fields {
         pub struct After;
         impl ::cynic::schema::HasArgument<After> for super::SpeciesConnection {
             type ArgumentType = Option<super::super::String>;
-            fn name() -> &'static str {
-                "after"
-            }
+            const NAME: &'static str = "after";
         }
         pub struct First;
         impl ::cynic::schema::HasArgument<First> for super::SpeciesConnection {
             type ArgumentType = Option<super::super::Int>;
-            fn name() -> &'static str {
-                "first"
-            }
+            const NAME: &'static str = "first";
         }
         pub struct Before;
         impl ::cynic::schema::HasArgument<Before> for super::SpeciesConnection {
             type ArgumentType = Option<super::super::String>;
-            fn name() -> &'static str {
-                "before"
-            }
+            const NAME: &'static str = "before";
         }
         pub struct Last;
         impl ::cynic::schema::HasArgument<Last> for super::SpeciesConnection {
             type ArgumentType = Option<super::super::Int>;
-            fn name() -> &'static str {
-                "last"
-            }
+            const NAME: &'static str = "last";
         }
     }
     pub struct StarshipConnection;
     impl ::cynic::schema::Field for StarshipConnection {
         type Type = Option<super::FilmStarshipsConnection>;
-        fn name() -> &'static str {
-            "starshipConnection"
-        }
+        const NAME: &'static str = "starshipConnection";
     }
     impl ::cynic::schema::HasField<StarshipConnection> for super::Film {
         type Type = Option<super::FilmStarshipsConnection>;
@@ -121,38 +97,28 @@ pub mod film_fields {
         pub struct After;
         impl ::cynic::schema::HasArgument<After> for super::StarshipConnection {
             type ArgumentType = Option<super::super::String>;
-            fn name() -> &'static str {
-                "after"
-            }
+            const NAME: &'static str = "after";
         }
         pub struct First;
         impl ::cynic::schema::HasArgument<First> for super::StarshipConnection {
             type ArgumentType = Option<super::super::Int>;
-            fn name() -> &'static str {
-                "first"
-            }
+            const NAME: &'static str = "first";
         }
         pub struct Before;
         impl ::cynic::schema::HasArgument<Before> for super::StarshipConnection {
             type ArgumentType = Option<super::super::String>;
-            fn name() -> &'static str {
-                "before"
-            }
+            const NAME: &'static str = "before";
         }
         pub struct Last;
         impl ::cynic::schema::HasArgument<Last> for super::StarshipConnection {
             type ArgumentType = Option<super::super::Int>;
-            fn name() -> &'static str {
-                "last"
-            }
+            const NAME: &'static str = "last";
         }
     }
     pub struct VehicleConnection;
     impl ::cynic::schema::Field for VehicleConnection {
         type Type = Option<super::FilmVehiclesConnection>;
-        fn name() -> &'static str {
-            "vehicleConnection"
-        }
+        const NAME: &'static str = "vehicleConnection";
     }
     impl ::cynic::schema::HasField<VehicleConnection> for super::Film {
         type Type = Option<super::FilmVehiclesConnection>;
@@ -161,38 +127,28 @@ pub mod film_fields {
         pub struct After;
         impl ::cynic::schema::HasArgument<After> for super::VehicleConnection {
             type ArgumentType = Option<super::super::String>;
-            fn name() -> &'static str {
-                "after"
-            }
+            const NAME: &'static str = "after";
         }
         pub struct First;
         impl ::cynic::schema::HasArgument<First> for super::VehicleConnection {
             type ArgumentType = Option<super::super::Int>;
-            fn name() -> &'static str {
-                "first"
-            }
+            const NAME: &'static str = "first";
         }
         pub struct Before;
         impl ::cynic::schema::HasArgument<Before> for super::VehicleConnection {
             type ArgumentType = Option<super::super::String>;
-            fn name() -> &'static str {
-                "before"
-            }
+            const NAME: &'static str = "before";
         }
         pub struct Last;
         impl ::cynic::schema::HasArgument<Last> for super::VehicleConnection {
             type ArgumentType = Option<super::super::Int>;
-            fn name() -> &'static str {
-                "last"
-            }
+            const NAME: &'static str = "last";
         }
     }
     pub struct CharacterConnection;
     impl ::cynic::schema::Field for CharacterConnection {
         type Type = Option<super::FilmCharactersConnection>;
-        fn name() -> &'static str {
-            "characterConnection"
-        }
+        const NAME: &'static str = "characterConnection";
     }
     impl ::cynic::schema::HasField<CharacterConnection> for super::Film {
         type Type = Option<super::FilmCharactersConnection>;
@@ -201,38 +157,28 @@ pub mod film_fields {
         pub struct After;
         impl ::cynic::schema::HasArgument<After> for super::CharacterConnection {
             type ArgumentType = Option<super::super::String>;
-            fn name() -> &'static str {
-                "after"
-            }
+            const NAME: &'static str = "after";
         }
         pub struct First;
         impl ::cynic::schema::HasArgument<First> for super::CharacterConnection {
             type ArgumentType = Option<super::super::Int>;
-            fn name() -> &'static str {
-                "first"
-            }
+            const NAME: &'static str = "first";
         }
         pub struct Before;
         impl ::cynic::schema::HasArgument<Before> for super::CharacterConnection {
             type ArgumentType = Option<super::super::String>;
-            fn name() -> &'static str {
-                "before"
-            }
+            const NAME: &'static str = "before";
         }
         pub struct Last;
         impl ::cynic::schema::HasArgument<Last> for super::CharacterConnection {
             type ArgumentType = Option<super::super::Int>;
-            fn name() -> &'static str {
-                "last"
-            }
+            const NAME: &'static str = "last";
         }
     }
     pub struct PlanetConnection;
     impl ::cynic::schema::Field for PlanetConnection {
         type Type = Option<super::FilmPlanetsConnection>;
-        fn name() -> &'static str {
-            "planetConnection"
-        }
+        const NAME: &'static str = "planetConnection";
     }
     impl ::cynic::schema::HasField<PlanetConnection> for super::Film {
         type Type = Option<super::FilmPlanetsConnection>;
@@ -241,38 +187,28 @@ pub mod film_fields {
         pub struct After;
         impl ::cynic::schema::HasArgument<After> for super::PlanetConnection {
             type ArgumentType = Option<super::super::String>;
-            fn name() -> &'static str {
-                "after"
-            }
+            const NAME: &'static str = "after";
         }
         pub struct First;
         impl ::cynic::schema::HasArgument<First> for super::PlanetConnection {
             type ArgumentType = Option<super::super::Int>;
-            fn name() -> &'static str {
-                "first"
-            }
+            const NAME: &'static str = "first";
         }
         pub struct Before;
         impl ::cynic::schema::HasArgument<Before> for super::PlanetConnection {
             type ArgumentType = Option<super::super::String>;
-            fn name() -> &'static str {
-                "before"
-            }
+            const NAME: &'static str = "before";
         }
         pub struct Last;
         impl ::cynic::schema::HasArgument<Last> for super::PlanetConnection {
             type ArgumentType = Option<super::super::Int>;
-            fn name() -> &'static str {
-                "last"
-            }
+            const NAME: &'static str = "last";
         }
     }
     pub struct Created;
     impl ::cynic::schema::Field for Created {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "created"
-        }
+        const NAME: &'static str = "created";
     }
     impl ::cynic::schema::HasField<Created> for super::Film {
         type Type = Option<super::String>;
@@ -280,9 +216,7 @@ pub mod film_fields {
     pub struct Edited;
     impl ::cynic::schema::Field for Edited {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "edited"
-        }
+        const NAME: &'static str = "edited";
     }
     impl ::cynic::schema::HasField<Edited> for super::Film {
         type Type = Option<super::String>;
@@ -290,9 +224,7 @@ pub mod film_fields {
     pub struct Id;
     impl ::cynic::schema::Field for Id {
         type Type = super::Id;
-        fn name() -> &'static str {
-            "id"
-        }
+        const NAME: &'static str = "id";
     }
     impl ::cynic::schema::HasField<Id> for super::Film {
         type Type = super::Id;
@@ -303,9 +235,7 @@ pub mod film_characters_connection_fields {
     pub struct PageInfo;
     impl ::cynic::schema::Field for PageInfo {
         type Type = super::PageInfo;
-        fn name() -> &'static str {
-            "pageInfo"
-        }
+        const NAME: &'static str = "pageInfo";
     }
     impl ::cynic::schema::HasField<PageInfo> for super::FilmCharactersConnection {
         type Type = super::PageInfo;
@@ -313,9 +243,7 @@ pub mod film_characters_connection_fields {
     pub struct Edges;
     impl ::cynic::schema::Field for Edges {
         type Type = Option<Vec<Option<super::FilmCharactersEdge>>>;
-        fn name() -> &'static str {
-            "edges"
-        }
+        const NAME: &'static str = "edges";
     }
     impl ::cynic::schema::HasField<Edges> for super::FilmCharactersConnection {
         type Type = Option<Vec<Option<super::FilmCharactersEdge>>>;
@@ -323,9 +251,7 @@ pub mod film_characters_connection_fields {
     pub struct TotalCount;
     impl ::cynic::schema::Field for TotalCount {
         type Type = Option<super::Int>;
-        fn name() -> &'static str {
-            "totalCount"
-        }
+        const NAME: &'static str = "totalCount";
     }
     impl ::cynic::schema::HasField<TotalCount> for super::FilmCharactersConnection {
         type Type = Option<super::Int>;
@@ -333,9 +259,7 @@ pub mod film_characters_connection_fields {
     pub struct Characters;
     impl ::cynic::schema::Field for Characters {
         type Type = Option<Vec<Option<super::Person>>>;
-        fn name() -> &'static str {
-            "characters"
-        }
+        const NAME: &'static str = "characters";
     }
     impl ::cynic::schema::HasField<Characters> for super::FilmCharactersConnection {
         type Type = Option<Vec<Option<super::Person>>>;
@@ -346,9 +270,7 @@ pub mod film_characters_edge_fields {
     pub struct Node;
     impl ::cynic::schema::Field for Node {
         type Type = Option<super::Person>;
-        fn name() -> &'static str {
-            "node"
-        }
+        const NAME: &'static str = "node";
     }
     impl ::cynic::schema::HasField<Node> for super::FilmCharactersEdge {
         type Type = Option<super::Person>;
@@ -356,9 +278,7 @@ pub mod film_characters_edge_fields {
     pub struct Cursor;
     impl ::cynic::schema::Field for Cursor {
         type Type = super::String;
-        fn name() -> &'static str {
-            "cursor"
-        }
+        const NAME: &'static str = "cursor";
     }
     impl ::cynic::schema::HasField<Cursor> for super::FilmCharactersEdge {
         type Type = super::String;
@@ -369,9 +289,7 @@ pub mod film_planets_connection_fields {
     pub struct PageInfo;
     impl ::cynic::schema::Field for PageInfo {
         type Type = super::PageInfo;
-        fn name() -> &'static str {
-            "pageInfo"
-        }
+        const NAME: &'static str = "pageInfo";
     }
     impl ::cynic::schema::HasField<PageInfo> for super::FilmPlanetsConnection {
         type Type = super::PageInfo;
@@ -379,9 +297,7 @@ pub mod film_planets_connection_fields {
     pub struct Edges;
     impl ::cynic::schema::Field for Edges {
         type Type = Option<Vec<Option<super::FilmPlanetsEdge>>>;
-        fn name() -> &'static str {
-            "edges"
-        }
+        const NAME: &'static str = "edges";
     }
     impl ::cynic::schema::HasField<Edges> for super::FilmPlanetsConnection {
         type Type = Option<Vec<Option<super::FilmPlanetsEdge>>>;
@@ -389,9 +305,7 @@ pub mod film_planets_connection_fields {
     pub struct TotalCount;
     impl ::cynic::schema::Field for TotalCount {
         type Type = Option<super::Int>;
-        fn name() -> &'static str {
-            "totalCount"
-        }
+        const NAME: &'static str = "totalCount";
     }
     impl ::cynic::schema::HasField<TotalCount> for super::FilmPlanetsConnection {
         type Type = Option<super::Int>;
@@ -399,9 +313,7 @@ pub mod film_planets_connection_fields {
     pub struct Planets;
     impl ::cynic::schema::Field for Planets {
         type Type = Option<Vec<Option<super::Planet>>>;
-        fn name() -> &'static str {
-            "planets"
-        }
+        const NAME: &'static str = "planets";
     }
     impl ::cynic::schema::HasField<Planets> for super::FilmPlanetsConnection {
         type Type = Option<Vec<Option<super::Planet>>>;
@@ -412,9 +324,7 @@ pub mod film_planets_edge_fields {
     pub struct Node;
     impl ::cynic::schema::Field for Node {
         type Type = Option<super::Planet>;
-        fn name() -> &'static str {
-            "node"
-        }
+        const NAME: &'static str = "node";
     }
     impl ::cynic::schema::HasField<Node> for super::FilmPlanetsEdge {
         type Type = Option<super::Planet>;
@@ -422,9 +332,7 @@ pub mod film_planets_edge_fields {
     pub struct Cursor;
     impl ::cynic::schema::Field for Cursor {
         type Type = super::String;
-        fn name() -> &'static str {
-            "cursor"
-        }
+        const NAME: &'static str = "cursor";
     }
     impl ::cynic::schema::HasField<Cursor> for super::FilmPlanetsEdge {
         type Type = super::String;
@@ -435,9 +343,7 @@ pub mod film_species_connection_fields {
     pub struct PageInfo;
     impl ::cynic::schema::Field for PageInfo {
         type Type = super::PageInfo;
-        fn name() -> &'static str {
-            "pageInfo"
-        }
+        const NAME: &'static str = "pageInfo";
     }
     impl ::cynic::schema::HasField<PageInfo> for super::FilmSpeciesConnection {
         type Type = super::PageInfo;
@@ -445,9 +351,7 @@ pub mod film_species_connection_fields {
     pub struct Edges;
     impl ::cynic::schema::Field for Edges {
         type Type = Option<Vec<Option<super::FilmSpeciesEdge>>>;
-        fn name() -> &'static str {
-            "edges"
-        }
+        const NAME: &'static str = "edges";
     }
     impl ::cynic::schema::HasField<Edges> for super::FilmSpeciesConnection {
         type Type = Option<Vec<Option<super::FilmSpeciesEdge>>>;
@@ -455,9 +359,7 @@ pub mod film_species_connection_fields {
     pub struct TotalCount;
     impl ::cynic::schema::Field for TotalCount {
         type Type = Option<super::Int>;
-        fn name() -> &'static str {
-            "totalCount"
-        }
+        const NAME: &'static str = "totalCount";
     }
     impl ::cynic::schema::HasField<TotalCount> for super::FilmSpeciesConnection {
         type Type = Option<super::Int>;
@@ -465,9 +367,7 @@ pub mod film_species_connection_fields {
     pub struct Species;
     impl ::cynic::schema::Field for Species {
         type Type = Option<Vec<Option<super::Species>>>;
-        fn name() -> &'static str {
-            "species"
-        }
+        const NAME: &'static str = "species";
     }
     impl ::cynic::schema::HasField<Species> for super::FilmSpeciesConnection {
         type Type = Option<Vec<Option<super::Species>>>;
@@ -478,9 +378,7 @@ pub mod film_species_edge_fields {
     pub struct Node;
     impl ::cynic::schema::Field for Node {
         type Type = Option<super::Species>;
-        fn name() -> &'static str {
-            "node"
-        }
+        const NAME: &'static str = "node";
     }
     impl ::cynic::schema::HasField<Node> for super::FilmSpeciesEdge {
         type Type = Option<super::Species>;
@@ -488,9 +386,7 @@ pub mod film_species_edge_fields {
     pub struct Cursor;
     impl ::cynic::schema::Field for Cursor {
         type Type = super::String;
-        fn name() -> &'static str {
-            "cursor"
-        }
+        const NAME: &'static str = "cursor";
     }
     impl ::cynic::schema::HasField<Cursor> for super::FilmSpeciesEdge {
         type Type = super::String;
@@ -501,9 +397,7 @@ pub mod film_starships_connection_fields {
     pub struct PageInfo;
     impl ::cynic::schema::Field for PageInfo {
         type Type = super::PageInfo;
-        fn name() -> &'static str {
-            "pageInfo"
-        }
+        const NAME: &'static str = "pageInfo";
     }
     impl ::cynic::schema::HasField<PageInfo> for super::FilmStarshipsConnection {
         type Type = super::PageInfo;
@@ -511,9 +405,7 @@ pub mod film_starships_connection_fields {
     pub struct Edges;
     impl ::cynic::schema::Field for Edges {
         type Type = Option<Vec<Option<super::FilmStarshipsEdge>>>;
-        fn name() -> &'static str {
-            "edges"
-        }
+        const NAME: &'static str = "edges";
     }
     impl ::cynic::schema::HasField<Edges> for super::FilmStarshipsConnection {
         type Type = Option<Vec<Option<super::FilmStarshipsEdge>>>;
@@ -521,9 +413,7 @@ pub mod film_starships_connection_fields {
     pub struct TotalCount;
     impl ::cynic::schema::Field for TotalCount {
         type Type = Option<super::Int>;
-        fn name() -> &'static str {
-            "totalCount"
-        }
+        const NAME: &'static str = "totalCount";
     }
     impl ::cynic::schema::HasField<TotalCount> for super::FilmStarshipsConnection {
         type Type = Option<super::Int>;
@@ -531,9 +421,7 @@ pub mod film_starships_connection_fields {
     pub struct Starships;
     impl ::cynic::schema::Field for Starships {
         type Type = Option<Vec<Option<super::Starship>>>;
-        fn name() -> &'static str {
-            "starships"
-        }
+        const NAME: &'static str = "starships";
     }
     impl ::cynic::schema::HasField<Starships> for super::FilmStarshipsConnection {
         type Type = Option<Vec<Option<super::Starship>>>;
@@ -544,9 +432,7 @@ pub mod film_starships_edge_fields {
     pub struct Node;
     impl ::cynic::schema::Field for Node {
         type Type = Option<super::Starship>;
-        fn name() -> &'static str {
-            "node"
-        }
+        const NAME: &'static str = "node";
     }
     impl ::cynic::schema::HasField<Node> for super::FilmStarshipsEdge {
         type Type = Option<super::Starship>;
@@ -554,9 +440,7 @@ pub mod film_starships_edge_fields {
     pub struct Cursor;
     impl ::cynic::schema::Field for Cursor {
         type Type = super::String;
-        fn name() -> &'static str {
-            "cursor"
-        }
+        const NAME: &'static str = "cursor";
     }
     impl ::cynic::schema::HasField<Cursor> for super::FilmStarshipsEdge {
         type Type = super::String;
@@ -567,9 +451,7 @@ pub mod film_vehicles_connection_fields {
     pub struct PageInfo;
     impl ::cynic::schema::Field for PageInfo {
         type Type = super::PageInfo;
-        fn name() -> &'static str {
-            "pageInfo"
-        }
+        const NAME: &'static str = "pageInfo";
     }
     impl ::cynic::schema::HasField<PageInfo> for super::FilmVehiclesConnection {
         type Type = super::PageInfo;
@@ -577,9 +459,7 @@ pub mod film_vehicles_connection_fields {
     pub struct Edges;
     impl ::cynic::schema::Field for Edges {
         type Type = Option<Vec<Option<super::FilmVehiclesEdge>>>;
-        fn name() -> &'static str {
-            "edges"
-        }
+        const NAME: &'static str = "edges";
     }
     impl ::cynic::schema::HasField<Edges> for super::FilmVehiclesConnection {
         type Type = Option<Vec<Option<super::FilmVehiclesEdge>>>;
@@ -587,9 +467,7 @@ pub mod film_vehicles_connection_fields {
     pub struct TotalCount;
     impl ::cynic::schema::Field for TotalCount {
         type Type = Option<super::Int>;
-        fn name() -> &'static str {
-            "totalCount"
-        }
+        const NAME: &'static str = "totalCount";
     }
     impl ::cynic::schema::HasField<TotalCount> for super::FilmVehiclesConnection {
         type Type = Option<super::Int>;
@@ -597,9 +475,7 @@ pub mod film_vehicles_connection_fields {
     pub struct Vehicles;
     impl ::cynic::schema::Field for Vehicles {
         type Type = Option<Vec<Option<super::Vehicle>>>;
-        fn name() -> &'static str {
-            "vehicles"
-        }
+        const NAME: &'static str = "vehicles";
     }
     impl ::cynic::schema::HasField<Vehicles> for super::FilmVehiclesConnection {
         type Type = Option<Vec<Option<super::Vehicle>>>;
@@ -610,9 +486,7 @@ pub mod film_vehicles_edge_fields {
     pub struct Node;
     impl ::cynic::schema::Field for Node {
         type Type = Option<super::Vehicle>;
-        fn name() -> &'static str {
-            "node"
-        }
+        const NAME: &'static str = "node";
     }
     impl ::cynic::schema::HasField<Node> for super::FilmVehiclesEdge {
         type Type = Option<super::Vehicle>;
@@ -620,9 +494,7 @@ pub mod film_vehicles_edge_fields {
     pub struct Cursor;
     impl ::cynic::schema::Field for Cursor {
         type Type = super::String;
-        fn name() -> &'static str {
-            "cursor"
-        }
+        const NAME: &'static str = "cursor";
     }
     impl ::cynic::schema::HasField<Cursor> for super::FilmVehiclesEdge {
         type Type = super::String;
@@ -633,9 +505,7 @@ pub mod films_connection_fields {
     pub struct PageInfo;
     impl ::cynic::schema::Field for PageInfo {
         type Type = super::PageInfo;
-        fn name() -> &'static str {
-            "pageInfo"
-        }
+        const NAME: &'static str = "pageInfo";
     }
     impl ::cynic::schema::HasField<PageInfo> for super::FilmsConnection {
         type Type = super::PageInfo;
@@ -643,9 +513,7 @@ pub mod films_connection_fields {
     pub struct Edges;
     impl ::cynic::schema::Field for Edges {
         type Type = Option<Vec<Option<super::FilmsEdge>>>;
-        fn name() -> &'static str {
-            "edges"
-        }
+        const NAME: &'static str = "edges";
     }
     impl ::cynic::schema::HasField<Edges> for super::FilmsConnection {
         type Type = Option<Vec<Option<super::FilmsEdge>>>;
@@ -653,9 +521,7 @@ pub mod films_connection_fields {
     pub struct TotalCount;
     impl ::cynic::schema::Field for TotalCount {
         type Type = Option<super::Int>;
-        fn name() -> &'static str {
-            "totalCount"
-        }
+        const NAME: &'static str = "totalCount";
     }
     impl ::cynic::schema::HasField<TotalCount> for super::FilmsConnection {
         type Type = Option<super::Int>;
@@ -663,9 +529,7 @@ pub mod films_connection_fields {
     pub struct Films;
     impl ::cynic::schema::Field for Films {
         type Type = Option<Vec<Option<super::Film>>>;
-        fn name() -> &'static str {
-            "films"
-        }
+        const NAME: &'static str = "films";
     }
     impl ::cynic::schema::HasField<Films> for super::FilmsConnection {
         type Type = Option<Vec<Option<super::Film>>>;
@@ -676,9 +540,7 @@ pub mod films_edge_fields {
     pub struct Node;
     impl ::cynic::schema::Field for Node {
         type Type = Option<super::Film>;
-        fn name() -> &'static str {
-            "node"
-        }
+        const NAME: &'static str = "node";
     }
     impl ::cynic::schema::HasField<Node> for super::FilmsEdge {
         type Type = Option<super::Film>;
@@ -686,9 +548,7 @@ pub mod films_edge_fields {
     pub struct Cursor;
     impl ::cynic::schema::Field for Cursor {
         type Type = super::String;
-        fn name() -> &'static str {
-            "cursor"
-        }
+        const NAME: &'static str = "cursor";
     }
     impl ::cynic::schema::HasField<Cursor> for super::FilmsEdge {
         type Type = super::String;
@@ -699,9 +559,7 @@ pub mod node_fields {
     pub struct Id;
     impl ::cynic::schema::Field for Id {
         type Type = super::Id;
-        fn name() -> &'static str {
-            "id"
-        }
+        const NAME: &'static str = "id";
     }
     impl ::cynic::schema::HasField<Id> for super::Node {
         type Type = super::Id;
@@ -712,9 +570,7 @@ pub mod page_info_fields {
     pub struct HasNextPage;
     impl ::cynic::schema::Field for HasNextPage {
         type Type = super::Boolean;
-        fn name() -> &'static str {
-            "hasNextPage"
-        }
+        const NAME: &'static str = "hasNextPage";
     }
     impl ::cynic::schema::HasField<HasNextPage> for super::PageInfo {
         type Type = super::Boolean;
@@ -722,9 +578,7 @@ pub mod page_info_fields {
     pub struct HasPreviousPage;
     impl ::cynic::schema::Field for HasPreviousPage {
         type Type = super::Boolean;
-        fn name() -> &'static str {
-            "hasPreviousPage"
-        }
+        const NAME: &'static str = "hasPreviousPage";
     }
     impl ::cynic::schema::HasField<HasPreviousPage> for super::PageInfo {
         type Type = super::Boolean;
@@ -732,9 +586,7 @@ pub mod page_info_fields {
     pub struct StartCursor;
     impl ::cynic::schema::Field for StartCursor {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "startCursor"
-        }
+        const NAME: &'static str = "startCursor";
     }
     impl ::cynic::schema::HasField<StartCursor> for super::PageInfo {
         type Type = Option<super::String>;
@@ -742,9 +594,7 @@ pub mod page_info_fields {
     pub struct EndCursor;
     impl ::cynic::schema::Field for EndCursor {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "endCursor"
-        }
+        const NAME: &'static str = "endCursor";
     }
     impl ::cynic::schema::HasField<EndCursor> for super::PageInfo {
         type Type = Option<super::String>;
@@ -755,9 +605,7 @@ pub mod people_connection_fields {
     pub struct PageInfo;
     impl ::cynic::schema::Field for PageInfo {
         type Type = super::PageInfo;
-        fn name() -> &'static str {
-            "pageInfo"
-        }
+        const NAME: &'static str = "pageInfo";
     }
     impl ::cynic::schema::HasField<PageInfo> for super::PeopleConnection {
         type Type = super::PageInfo;
@@ -765,9 +613,7 @@ pub mod people_connection_fields {
     pub struct Edges;
     impl ::cynic::schema::Field for Edges {
         type Type = Option<Vec<Option<super::PeopleEdge>>>;
-        fn name() -> &'static str {
-            "edges"
-        }
+        const NAME: &'static str = "edges";
     }
     impl ::cynic::schema::HasField<Edges> for super::PeopleConnection {
         type Type = Option<Vec<Option<super::PeopleEdge>>>;
@@ -775,9 +621,7 @@ pub mod people_connection_fields {
     pub struct TotalCount;
     impl ::cynic::schema::Field for TotalCount {
         type Type = Option<super::Int>;
-        fn name() -> &'static str {
-            "totalCount"
-        }
+        const NAME: &'static str = "totalCount";
     }
     impl ::cynic::schema::HasField<TotalCount> for super::PeopleConnection {
         type Type = Option<super::Int>;
@@ -785,9 +629,7 @@ pub mod people_connection_fields {
     pub struct People;
     impl ::cynic::schema::Field for People {
         type Type = Option<Vec<Option<super::Person>>>;
-        fn name() -> &'static str {
-            "people"
-        }
+        const NAME: &'static str = "people";
     }
     impl ::cynic::schema::HasField<People> for super::PeopleConnection {
         type Type = Option<Vec<Option<super::Person>>>;
@@ -798,9 +640,7 @@ pub mod people_edge_fields {
     pub struct Node;
     impl ::cynic::schema::Field for Node {
         type Type = Option<super::Person>;
-        fn name() -> &'static str {
-            "node"
-        }
+        const NAME: &'static str = "node";
     }
     impl ::cynic::schema::HasField<Node> for super::PeopleEdge {
         type Type = Option<super::Person>;
@@ -808,9 +648,7 @@ pub mod people_edge_fields {
     pub struct Cursor;
     impl ::cynic::schema::Field for Cursor {
         type Type = super::String;
-        fn name() -> &'static str {
-            "cursor"
-        }
+        const NAME: &'static str = "cursor";
     }
     impl ::cynic::schema::HasField<Cursor> for super::PeopleEdge {
         type Type = super::String;
@@ -821,9 +659,7 @@ pub mod person_fields {
     pub struct Name;
     impl ::cynic::schema::Field for Name {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "name"
-        }
+        const NAME: &'static str = "name";
     }
     impl ::cynic::schema::HasField<Name> for super::Person {
         type Type = Option<super::String>;
@@ -831,9 +667,7 @@ pub mod person_fields {
     pub struct BirthYear;
     impl ::cynic::schema::Field for BirthYear {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "birthYear"
-        }
+        const NAME: &'static str = "birthYear";
     }
     impl ::cynic::schema::HasField<BirthYear> for super::Person {
         type Type = Option<super::String>;
@@ -841,9 +675,7 @@ pub mod person_fields {
     pub struct EyeColor;
     impl ::cynic::schema::Field for EyeColor {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "eyeColor"
-        }
+        const NAME: &'static str = "eyeColor";
     }
     impl ::cynic::schema::HasField<EyeColor> for super::Person {
         type Type = Option<super::String>;
@@ -851,9 +683,7 @@ pub mod person_fields {
     pub struct Gender;
     impl ::cynic::schema::Field for Gender {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "gender"
-        }
+        const NAME: &'static str = "gender";
     }
     impl ::cynic::schema::HasField<Gender> for super::Person {
         type Type = Option<super::String>;
@@ -861,9 +691,7 @@ pub mod person_fields {
     pub struct HairColor;
     impl ::cynic::schema::Field for HairColor {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "hairColor"
-        }
+        const NAME: &'static str = "hairColor";
     }
     impl ::cynic::schema::HasField<HairColor> for super::Person {
         type Type = Option<super::String>;
@@ -871,9 +699,7 @@ pub mod person_fields {
     pub struct Height;
     impl ::cynic::schema::Field for Height {
         type Type = Option<super::Int>;
-        fn name() -> &'static str {
-            "height"
-        }
+        const NAME: &'static str = "height";
     }
     impl ::cynic::schema::HasField<Height> for super::Person {
         type Type = Option<super::Int>;
@@ -881,9 +707,7 @@ pub mod person_fields {
     pub struct Mass;
     impl ::cynic::schema::Field for Mass {
         type Type = Option<super::Float>;
-        fn name() -> &'static str {
-            "mass"
-        }
+        const NAME: &'static str = "mass";
     }
     impl ::cynic::schema::HasField<Mass> for super::Person {
         type Type = Option<super::Float>;
@@ -891,9 +715,7 @@ pub mod person_fields {
     pub struct SkinColor;
     impl ::cynic::schema::Field for SkinColor {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "skinColor"
-        }
+        const NAME: &'static str = "skinColor";
     }
     impl ::cynic::schema::HasField<SkinColor> for super::Person {
         type Type = Option<super::String>;
@@ -901,9 +723,7 @@ pub mod person_fields {
     pub struct Homeworld;
     impl ::cynic::schema::Field for Homeworld {
         type Type = Option<super::Planet>;
-        fn name() -> &'static str {
-            "homeworld"
-        }
+        const NAME: &'static str = "homeworld";
     }
     impl ::cynic::schema::HasField<Homeworld> for super::Person {
         type Type = Option<super::Planet>;
@@ -911,9 +731,7 @@ pub mod person_fields {
     pub struct FilmConnection;
     impl ::cynic::schema::Field for FilmConnection {
         type Type = Option<super::PersonFilmsConnection>;
-        fn name() -> &'static str {
-            "filmConnection"
-        }
+        const NAME: &'static str = "filmConnection";
     }
     impl ::cynic::schema::HasField<FilmConnection> for super::Person {
         type Type = Option<super::PersonFilmsConnection>;
@@ -922,38 +740,28 @@ pub mod person_fields {
         pub struct After;
         impl ::cynic::schema::HasArgument<After> for super::FilmConnection {
             type ArgumentType = Option<super::super::String>;
-            fn name() -> &'static str {
-                "after"
-            }
+            const NAME: &'static str = "after";
         }
         pub struct First;
         impl ::cynic::schema::HasArgument<First> for super::FilmConnection {
             type ArgumentType = Option<super::super::Int>;
-            fn name() -> &'static str {
-                "first"
-            }
+            const NAME: &'static str = "first";
         }
         pub struct Before;
         impl ::cynic::schema::HasArgument<Before> for super::FilmConnection {
             type ArgumentType = Option<super::super::String>;
-            fn name() -> &'static str {
-                "before"
-            }
+            const NAME: &'static str = "before";
         }
         pub struct Last;
         impl ::cynic::schema::HasArgument<Last> for super::FilmConnection {
             type ArgumentType = Option<super::super::Int>;
-            fn name() -> &'static str {
-                "last"
-            }
+            const NAME: &'static str = "last";
         }
     }
     pub struct Species;
     impl ::cynic::schema::Field for Species {
         type Type = Option<super::Species>;
-        fn name() -> &'static str {
-            "species"
-        }
+        const NAME: &'static str = "species";
     }
     impl ::cynic::schema::HasField<Species> for super::Person {
         type Type = Option<super::Species>;
@@ -961,9 +769,7 @@ pub mod person_fields {
     pub struct StarshipConnection;
     impl ::cynic::schema::Field for StarshipConnection {
         type Type = Option<super::PersonStarshipsConnection>;
-        fn name() -> &'static str {
-            "starshipConnection"
-        }
+        const NAME: &'static str = "starshipConnection";
     }
     impl ::cynic::schema::HasField<StarshipConnection> for super::Person {
         type Type = Option<super::PersonStarshipsConnection>;
@@ -972,38 +778,28 @@ pub mod person_fields {
         pub struct After;
         impl ::cynic::schema::HasArgument<After> for super::StarshipConnection {
             type ArgumentType = Option<super::super::String>;
-            fn name() -> &'static str {
-                "after"
-            }
+            const NAME: &'static str = "after";
         }
         pub struct First;
         impl ::cynic::schema::HasArgument<First> for super::StarshipConnection {
             type ArgumentType = Option<super::super::Int>;
-            fn name() -> &'static str {
-                "first"
-            }
+            const NAME: &'static str = "first";
         }
         pub struct Before;
         impl ::cynic::schema::HasArgument<Before> for super::StarshipConnection {
             type ArgumentType = Option<super::super::String>;
-            fn name() -> &'static str {
-                "before"
-            }
+            const NAME: &'static str = "before";
         }
         pub struct Last;
         impl ::cynic::schema::HasArgument<Last> for super::StarshipConnection {
             type ArgumentType = Option<super::super::Int>;
-            fn name() -> &'static str {
-                "last"
-            }
+            const NAME: &'static str = "last";
         }
     }
     pub struct VehicleConnection;
     impl ::cynic::schema::Field for VehicleConnection {
         type Type = Option<super::PersonVehiclesConnection>;
-        fn name() -> &'static str {
-            "vehicleConnection"
-        }
+        const NAME: &'static str = "vehicleConnection";
     }
     impl ::cynic::schema::HasField<VehicleConnection> for super::Person {
         type Type = Option<super::PersonVehiclesConnection>;
@@ -1012,38 +808,28 @@ pub mod person_fields {
         pub struct After;
         impl ::cynic::schema::HasArgument<After> for super::VehicleConnection {
             type ArgumentType = Option<super::super::String>;
-            fn name() -> &'static str {
-                "after"
-            }
+            const NAME: &'static str = "after";
         }
         pub struct First;
         impl ::cynic::schema::HasArgument<First> for super::VehicleConnection {
             type ArgumentType = Option<super::super::Int>;
-            fn name() -> &'static str {
-                "first"
-            }
+            const NAME: &'static str = "first";
         }
         pub struct Before;
         impl ::cynic::schema::HasArgument<Before> for super::VehicleConnection {
             type ArgumentType = Option<super::super::String>;
-            fn name() -> &'static str {
-                "before"
-            }
+            const NAME: &'static str = "before";
         }
         pub struct Last;
         impl ::cynic::schema::HasArgument<Last> for super::VehicleConnection {
             type ArgumentType = Option<super::super::Int>;
-            fn name() -> &'static str {
-                "last"
-            }
+            const NAME: &'static str = "last";
         }
     }
     pub struct Created;
     impl ::cynic::schema::Field for Created {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "created"
-        }
+        const NAME: &'static str = "created";
     }
     impl ::cynic::schema::HasField<Created> for super::Person {
         type Type = Option<super::String>;
@@ -1051,9 +837,7 @@ pub mod person_fields {
     pub struct Edited;
     impl ::cynic::schema::Field for Edited {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "edited"
-        }
+        const NAME: &'static str = "edited";
     }
     impl ::cynic::schema::HasField<Edited> for super::Person {
         type Type = Option<super::String>;
@@ -1061,9 +845,7 @@ pub mod person_fields {
     pub struct Id;
     impl ::cynic::schema::Field for Id {
         type Type = super::Id;
-        fn name() -> &'static str {
-            "id"
-        }
+        const NAME: &'static str = "id";
     }
     impl ::cynic::schema::HasField<Id> for super::Person {
         type Type = super::Id;
@@ -1074,9 +856,7 @@ pub mod person_films_connection_fields {
     pub struct PageInfo;
     impl ::cynic::schema::Field for PageInfo {
         type Type = super::PageInfo;
-        fn name() -> &'static str {
-            "pageInfo"
-        }
+        const NAME: &'static str = "pageInfo";
     }
     impl ::cynic::schema::HasField<PageInfo> for super::PersonFilmsConnection {
         type Type = super::PageInfo;
@@ -1084,9 +864,7 @@ pub mod person_films_connection_fields {
     pub struct Edges;
     impl ::cynic::schema::Field for Edges {
         type Type = Option<Vec<Option<super::PersonFilmsEdge>>>;
-        fn name() -> &'static str {
-            "edges"
-        }
+        const NAME: &'static str = "edges";
     }
     impl ::cynic::schema::HasField<Edges> for super::PersonFilmsConnection {
         type Type = Option<Vec<Option<super::PersonFilmsEdge>>>;
@@ -1094,9 +872,7 @@ pub mod person_films_connection_fields {
     pub struct TotalCount;
     impl ::cynic::schema::Field for TotalCount {
         type Type = Option<super::Int>;
-        fn name() -> &'static str {
-            "totalCount"
-        }
+        const NAME: &'static str = "totalCount";
     }
     impl ::cynic::schema::HasField<TotalCount> for super::PersonFilmsConnection {
         type Type = Option<super::Int>;
@@ -1104,9 +880,7 @@ pub mod person_films_connection_fields {
     pub struct Films;
     impl ::cynic::schema::Field for Films {
         type Type = Option<Vec<Option<super::Film>>>;
-        fn name() -> &'static str {
-            "films"
-        }
+        const NAME: &'static str = "films";
     }
     impl ::cynic::schema::HasField<Films> for super::PersonFilmsConnection {
         type Type = Option<Vec<Option<super::Film>>>;
@@ -1117,9 +891,7 @@ pub mod person_films_edge_fields {
     pub struct Node;
     impl ::cynic::schema::Field for Node {
         type Type = Option<super::Film>;
-        fn name() -> &'static str {
-            "node"
-        }
+        const NAME: &'static str = "node";
     }
     impl ::cynic::schema::HasField<Node> for super::PersonFilmsEdge {
         type Type = Option<super::Film>;
@@ -1127,9 +899,7 @@ pub mod person_films_edge_fields {
     pub struct Cursor;
     impl ::cynic::schema::Field for Cursor {
         type Type = super::String;
-        fn name() -> &'static str {
-            "cursor"
-        }
+        const NAME: &'static str = "cursor";
     }
     impl ::cynic::schema::HasField<Cursor> for super::PersonFilmsEdge {
         type Type = super::String;
@@ -1140,9 +910,7 @@ pub mod person_starships_connection_fields {
     pub struct PageInfo;
     impl ::cynic::schema::Field for PageInfo {
         type Type = super::PageInfo;
-        fn name() -> &'static str {
-            "pageInfo"
-        }
+        const NAME: &'static str = "pageInfo";
     }
     impl ::cynic::schema::HasField<PageInfo> for super::PersonStarshipsConnection {
         type Type = super::PageInfo;
@@ -1150,9 +918,7 @@ pub mod person_starships_connection_fields {
     pub struct Edges;
     impl ::cynic::schema::Field for Edges {
         type Type = Option<Vec<Option<super::PersonStarshipsEdge>>>;
-        fn name() -> &'static str {
-            "edges"
-        }
+        const NAME: &'static str = "edges";
     }
     impl ::cynic::schema::HasField<Edges> for super::PersonStarshipsConnection {
         type Type = Option<Vec<Option<super::PersonStarshipsEdge>>>;
@@ -1160,9 +926,7 @@ pub mod person_starships_connection_fields {
     pub struct TotalCount;
     impl ::cynic::schema::Field for TotalCount {
         type Type = Option<super::Int>;
-        fn name() -> &'static str {
-            "totalCount"
-        }
+        const NAME: &'static str = "totalCount";
     }
     impl ::cynic::schema::HasField<TotalCount> for super::PersonStarshipsConnection {
         type Type = Option<super::Int>;
@@ -1170,9 +934,7 @@ pub mod person_starships_connection_fields {
     pub struct Starships;
     impl ::cynic::schema::Field for Starships {
         type Type = Option<Vec<Option<super::Starship>>>;
-        fn name() -> &'static str {
-            "starships"
-        }
+        const NAME: &'static str = "starships";
     }
     impl ::cynic::schema::HasField<Starships> for super::PersonStarshipsConnection {
         type Type = Option<Vec<Option<super::Starship>>>;
@@ -1183,9 +945,7 @@ pub mod person_starships_edge_fields {
     pub struct Node;
     impl ::cynic::schema::Field for Node {
         type Type = Option<super::Starship>;
-        fn name() -> &'static str {
-            "node"
-        }
+        const NAME: &'static str = "node";
     }
     impl ::cynic::schema::HasField<Node> for super::PersonStarshipsEdge {
         type Type = Option<super::Starship>;
@@ -1193,9 +953,7 @@ pub mod person_starships_edge_fields {
     pub struct Cursor;
     impl ::cynic::schema::Field for Cursor {
         type Type = super::String;
-        fn name() -> &'static str {
-            "cursor"
-        }
+        const NAME: &'static str = "cursor";
     }
     impl ::cynic::schema::HasField<Cursor> for super::PersonStarshipsEdge {
         type Type = super::String;
@@ -1206,9 +964,7 @@ pub mod person_vehicles_connection_fields {
     pub struct PageInfo;
     impl ::cynic::schema::Field for PageInfo {
         type Type = super::PageInfo;
-        fn name() -> &'static str {
-            "pageInfo"
-        }
+        const NAME: &'static str = "pageInfo";
     }
     impl ::cynic::schema::HasField<PageInfo> for super::PersonVehiclesConnection {
         type Type = super::PageInfo;
@@ -1216,9 +972,7 @@ pub mod person_vehicles_connection_fields {
     pub struct Edges;
     impl ::cynic::schema::Field for Edges {
         type Type = Option<Vec<Option<super::PersonVehiclesEdge>>>;
-        fn name() -> &'static str {
-            "edges"
-        }
+        const NAME: &'static str = "edges";
     }
     impl ::cynic::schema::HasField<Edges> for super::PersonVehiclesConnection {
         type Type = Option<Vec<Option<super::PersonVehiclesEdge>>>;
@@ -1226,9 +980,7 @@ pub mod person_vehicles_connection_fields {
     pub struct TotalCount;
     impl ::cynic::schema::Field for TotalCount {
         type Type = Option<super::Int>;
-        fn name() -> &'static str {
-            "totalCount"
-        }
+        const NAME: &'static str = "totalCount";
     }
     impl ::cynic::schema::HasField<TotalCount> for super::PersonVehiclesConnection {
         type Type = Option<super::Int>;
@@ -1236,9 +988,7 @@ pub mod person_vehicles_connection_fields {
     pub struct Vehicles;
     impl ::cynic::schema::Field for Vehicles {
         type Type = Option<Vec<Option<super::Vehicle>>>;
-        fn name() -> &'static str {
-            "vehicles"
-        }
+        const NAME: &'static str = "vehicles";
     }
     impl ::cynic::schema::HasField<Vehicles> for super::PersonVehiclesConnection {
         type Type = Option<Vec<Option<super::Vehicle>>>;
@@ -1249,9 +999,7 @@ pub mod person_vehicles_edge_fields {
     pub struct Node;
     impl ::cynic::schema::Field for Node {
         type Type = Option<super::Vehicle>;
-        fn name() -> &'static str {
-            "node"
-        }
+        const NAME: &'static str = "node";
     }
     impl ::cynic::schema::HasField<Node> for super::PersonVehiclesEdge {
         type Type = Option<super::Vehicle>;
@@ -1259,9 +1007,7 @@ pub mod person_vehicles_edge_fields {
     pub struct Cursor;
     impl ::cynic::schema::Field for Cursor {
         type Type = super::String;
-        fn name() -> &'static str {
-            "cursor"
-        }
+        const NAME: &'static str = "cursor";
     }
     impl ::cynic::schema::HasField<Cursor> for super::PersonVehiclesEdge {
         type Type = super::String;
@@ -1272,9 +1018,7 @@ pub mod planet_fields {
     pub struct Name;
     impl ::cynic::schema::Field for Name {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "name"
-        }
+        const NAME: &'static str = "name";
     }
     impl ::cynic::schema::HasField<Name> for super::Planet {
         type Type = Option<super::String>;
@@ -1282,9 +1026,7 @@ pub mod planet_fields {
     pub struct Diameter;
     impl ::cynic::schema::Field for Diameter {
         type Type = Option<super::Int>;
-        fn name() -> &'static str {
-            "diameter"
-        }
+        const NAME: &'static str = "diameter";
     }
     impl ::cynic::schema::HasField<Diameter> for super::Planet {
         type Type = Option<super::Int>;
@@ -1292,9 +1034,7 @@ pub mod planet_fields {
     pub struct RotationPeriod;
     impl ::cynic::schema::Field for RotationPeriod {
         type Type = Option<super::Int>;
-        fn name() -> &'static str {
-            "rotationPeriod"
-        }
+        const NAME: &'static str = "rotationPeriod";
     }
     impl ::cynic::schema::HasField<RotationPeriod> for super::Planet {
         type Type = Option<super::Int>;
@@ -1302,9 +1042,7 @@ pub mod planet_fields {
     pub struct OrbitalPeriod;
     impl ::cynic::schema::Field for OrbitalPeriod {
         type Type = Option<super::Int>;
-        fn name() -> &'static str {
-            "orbitalPeriod"
-        }
+        const NAME: &'static str = "orbitalPeriod";
     }
     impl ::cynic::schema::HasField<OrbitalPeriod> for super::Planet {
         type Type = Option<super::Int>;
@@ -1312,9 +1050,7 @@ pub mod planet_fields {
     pub struct Gravity;
     impl ::cynic::schema::Field for Gravity {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "gravity"
-        }
+        const NAME: &'static str = "gravity";
     }
     impl ::cynic::schema::HasField<Gravity> for super::Planet {
         type Type = Option<super::String>;
@@ -1322,9 +1058,7 @@ pub mod planet_fields {
     pub struct Population;
     impl ::cynic::schema::Field for Population {
         type Type = Option<super::Float>;
-        fn name() -> &'static str {
-            "population"
-        }
+        const NAME: &'static str = "population";
     }
     impl ::cynic::schema::HasField<Population> for super::Planet {
         type Type = Option<super::Float>;
@@ -1332,9 +1066,7 @@ pub mod planet_fields {
     pub struct Climates;
     impl ::cynic::schema::Field for Climates {
         type Type = Option<Vec<Option<super::String>>>;
-        fn name() -> &'static str {
-            "climates"
-        }
+        const NAME: &'static str = "climates";
     }
     impl ::cynic::schema::HasField<Climates> for super::Planet {
         type Type = Option<Vec<Option<super::String>>>;
@@ -1342,9 +1074,7 @@ pub mod planet_fields {
     pub struct Terrains;
     impl ::cynic::schema::Field for Terrains {
         type Type = Option<Vec<Option<super::String>>>;
-        fn name() -> &'static str {
-            "terrains"
-        }
+        const NAME: &'static str = "terrains";
     }
     impl ::cynic::schema::HasField<Terrains> for super::Planet {
         type Type = Option<Vec<Option<super::String>>>;
@@ -1352,9 +1082,7 @@ pub mod planet_fields {
     pub struct SurfaceWater;
     impl ::cynic::schema::Field for SurfaceWater {
         type Type = Option<super::Float>;
-        fn name() -> &'static str {
-            "surfaceWater"
-        }
+        const NAME: &'static str = "surfaceWater";
     }
     impl ::cynic::schema::HasField<SurfaceWater> for super::Planet {
         type Type = Option<super::Float>;
@@ -1362,9 +1090,7 @@ pub mod planet_fields {
     pub struct ResidentConnection;
     impl ::cynic::schema::Field for ResidentConnection {
         type Type = Option<super::PlanetResidentsConnection>;
-        fn name() -> &'static str {
-            "residentConnection"
-        }
+        const NAME: &'static str = "residentConnection";
     }
     impl ::cynic::schema::HasField<ResidentConnection> for super::Planet {
         type Type = Option<super::PlanetResidentsConnection>;
@@ -1373,38 +1099,28 @@ pub mod planet_fields {
         pub struct After;
         impl ::cynic::schema::HasArgument<After> for super::ResidentConnection {
             type ArgumentType = Option<super::super::String>;
-            fn name() -> &'static str {
-                "after"
-            }
+            const NAME: &'static str = "after";
         }
         pub struct First;
         impl ::cynic::schema::HasArgument<First> for super::ResidentConnection {
             type ArgumentType = Option<super::super::Int>;
-            fn name() -> &'static str {
-                "first"
-            }
+            const NAME: &'static str = "first";
         }
         pub struct Before;
         impl ::cynic::schema::HasArgument<Before> for super::ResidentConnection {
             type ArgumentType = Option<super::super::String>;
-            fn name() -> &'static str {
-                "before"
-            }
+            const NAME: &'static str = "before";
         }
         pub struct Last;
         impl ::cynic::schema::HasArgument<Last> for super::ResidentConnection {
             type ArgumentType = Option<super::super::Int>;
-            fn name() -> &'static str {
-                "last"
-            }
+            const NAME: &'static str = "last";
         }
     }
     pub struct FilmConnection;
     impl ::cynic::schema::Field for FilmConnection {
         type Type = Option<super::PlanetFilmsConnection>;
-        fn name() -> &'static str {
-            "filmConnection"
-        }
+        const NAME: &'static str = "filmConnection";
     }
     impl ::cynic::schema::HasField<FilmConnection> for super::Planet {
         type Type = Option<super::PlanetFilmsConnection>;
@@ -1413,38 +1129,28 @@ pub mod planet_fields {
         pub struct After;
         impl ::cynic::schema::HasArgument<After> for super::FilmConnection {
             type ArgumentType = Option<super::super::String>;
-            fn name() -> &'static str {
-                "after"
-            }
+            const NAME: &'static str = "after";
         }
         pub struct First;
         impl ::cynic::schema::HasArgument<First> for super::FilmConnection {
             type ArgumentType = Option<super::super::Int>;
-            fn name() -> &'static str {
-                "first"
-            }
+            const NAME: &'static str = "first";
         }
         pub struct Before;
         impl ::cynic::schema::HasArgument<Before> for super::FilmConnection {
             type ArgumentType = Option<super::super::String>;
-            fn name() -> &'static str {
-                "before"
-            }
+            const NAME: &'static str = "before";
         }
         pub struct Last;
         impl ::cynic::schema::HasArgument<Last> for super::FilmConnection {
             type ArgumentType = Option<super::super::Int>;
-            fn name() -> &'static str {
-                "last"
-            }
+            const NAME: &'static str = "last";
         }
     }
     pub struct Created;
     impl ::cynic::schema::Field for Created {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "created"
-        }
+        const NAME: &'static str = "created";
     }
     impl ::cynic::schema::HasField<Created> for super::Planet {
         type Type = Option<super::String>;
@@ -1452,9 +1158,7 @@ pub mod planet_fields {
     pub struct Edited;
     impl ::cynic::schema::Field for Edited {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "edited"
-        }
+        const NAME: &'static str = "edited";
     }
     impl ::cynic::schema::HasField<Edited> for super::Planet {
         type Type = Option<super::String>;
@@ -1462,9 +1166,7 @@ pub mod planet_fields {
     pub struct Id;
     impl ::cynic::schema::Field for Id {
         type Type = super::Id;
-        fn name() -> &'static str {
-            "id"
-        }
+        const NAME: &'static str = "id";
     }
     impl ::cynic::schema::HasField<Id> for super::Planet {
         type Type = super::Id;
@@ -1475,9 +1177,7 @@ pub mod planet_films_connection_fields {
     pub struct PageInfo;
     impl ::cynic::schema::Field for PageInfo {
         type Type = super::PageInfo;
-        fn name() -> &'static str {
-            "pageInfo"
-        }
+        const NAME: &'static str = "pageInfo";
     }
     impl ::cynic::schema::HasField<PageInfo> for super::PlanetFilmsConnection {
         type Type = super::PageInfo;
@@ -1485,9 +1185,7 @@ pub mod planet_films_connection_fields {
     pub struct Edges;
     impl ::cynic::schema::Field for Edges {
         type Type = Option<Vec<Option<super::PlanetFilmsEdge>>>;
-        fn name() -> &'static str {
-            "edges"
-        }
+        const NAME: &'static str = "edges";
     }
     impl ::cynic::schema::HasField<Edges> for super::PlanetFilmsConnection {
         type Type = Option<Vec<Option<super::PlanetFilmsEdge>>>;
@@ -1495,9 +1193,7 @@ pub mod planet_films_connection_fields {
     pub struct TotalCount;
     impl ::cynic::schema::Field for TotalCount {
         type Type = Option<super::Int>;
-        fn name() -> &'static str {
-            "totalCount"
-        }
+        const NAME: &'static str = "totalCount";
     }
     impl ::cynic::schema::HasField<TotalCount> for super::PlanetFilmsConnection {
         type Type = Option<super::Int>;
@@ -1505,9 +1201,7 @@ pub mod planet_films_connection_fields {
     pub struct Films;
     impl ::cynic::schema::Field for Films {
         type Type = Option<Vec<Option<super::Film>>>;
-        fn name() -> &'static str {
-            "films"
-        }
+        const NAME: &'static str = "films";
     }
     impl ::cynic::schema::HasField<Films> for super::PlanetFilmsConnection {
         type Type = Option<Vec<Option<super::Film>>>;
@@ -1518,9 +1212,7 @@ pub mod planet_films_edge_fields {
     pub struct Node;
     impl ::cynic::schema::Field for Node {
         type Type = Option<super::Film>;
-        fn name() -> &'static str {
-            "node"
-        }
+        const NAME: &'static str = "node";
     }
     impl ::cynic::schema::HasField<Node> for super::PlanetFilmsEdge {
         type Type = Option<super::Film>;
@@ -1528,9 +1220,7 @@ pub mod planet_films_edge_fields {
     pub struct Cursor;
     impl ::cynic::schema::Field for Cursor {
         type Type = super::String;
-        fn name() -> &'static str {
-            "cursor"
-        }
+        const NAME: &'static str = "cursor";
     }
     impl ::cynic::schema::HasField<Cursor> for super::PlanetFilmsEdge {
         type Type = super::String;
@@ -1541,9 +1231,7 @@ pub mod planet_residents_connection_fields {
     pub struct PageInfo;
     impl ::cynic::schema::Field for PageInfo {
         type Type = super::PageInfo;
-        fn name() -> &'static str {
-            "pageInfo"
-        }
+        const NAME: &'static str = "pageInfo";
     }
     impl ::cynic::schema::HasField<PageInfo> for super::PlanetResidentsConnection {
         type Type = super::PageInfo;
@@ -1551,9 +1239,7 @@ pub mod planet_residents_connection_fields {
     pub struct Edges;
     impl ::cynic::schema::Field for Edges {
         type Type = Option<Vec<Option<super::PlanetResidentsEdge>>>;
-        fn name() -> &'static str {
-            "edges"
-        }
+        const NAME: &'static str = "edges";
     }
     impl ::cynic::schema::HasField<Edges> for super::PlanetResidentsConnection {
         type Type = Option<Vec<Option<super::PlanetResidentsEdge>>>;
@@ -1561,9 +1247,7 @@ pub mod planet_residents_connection_fields {
     pub struct TotalCount;
     impl ::cynic::schema::Field for TotalCount {
         type Type = Option<super::Int>;
-        fn name() -> &'static str {
-            "totalCount"
-        }
+        const NAME: &'static str = "totalCount";
     }
     impl ::cynic::schema::HasField<TotalCount> for super::PlanetResidentsConnection {
         type Type = Option<super::Int>;
@@ -1571,9 +1255,7 @@ pub mod planet_residents_connection_fields {
     pub struct Residents;
     impl ::cynic::schema::Field for Residents {
         type Type = Option<Vec<Option<super::Person>>>;
-        fn name() -> &'static str {
-            "residents"
-        }
+        const NAME: &'static str = "residents";
     }
     impl ::cynic::schema::HasField<Residents> for super::PlanetResidentsConnection {
         type Type = Option<Vec<Option<super::Person>>>;
@@ -1584,9 +1266,7 @@ pub mod planet_residents_edge_fields {
     pub struct Node;
     impl ::cynic::schema::Field for Node {
         type Type = Option<super::Person>;
-        fn name() -> &'static str {
-            "node"
-        }
+        const NAME: &'static str = "node";
     }
     impl ::cynic::schema::HasField<Node> for super::PlanetResidentsEdge {
         type Type = Option<super::Person>;
@@ -1594,9 +1274,7 @@ pub mod planet_residents_edge_fields {
     pub struct Cursor;
     impl ::cynic::schema::Field for Cursor {
         type Type = super::String;
-        fn name() -> &'static str {
-            "cursor"
-        }
+        const NAME: &'static str = "cursor";
     }
     impl ::cynic::schema::HasField<Cursor> for super::PlanetResidentsEdge {
         type Type = super::String;
@@ -1607,9 +1285,7 @@ pub mod planets_connection_fields {
     pub struct PageInfo;
     impl ::cynic::schema::Field for PageInfo {
         type Type = super::PageInfo;
-        fn name() -> &'static str {
-            "pageInfo"
-        }
+        const NAME: &'static str = "pageInfo";
     }
     impl ::cynic::schema::HasField<PageInfo> for super::PlanetsConnection {
         type Type = super::PageInfo;
@@ -1617,9 +1293,7 @@ pub mod planets_connection_fields {
     pub struct Edges;
     impl ::cynic::schema::Field for Edges {
         type Type = Option<Vec<Option<super::PlanetsEdge>>>;
-        fn name() -> &'static str {
-            "edges"
-        }
+        const NAME: &'static str = "edges";
     }
     impl ::cynic::schema::HasField<Edges> for super::PlanetsConnection {
         type Type = Option<Vec<Option<super::PlanetsEdge>>>;
@@ -1627,9 +1301,7 @@ pub mod planets_connection_fields {
     pub struct TotalCount;
     impl ::cynic::schema::Field for TotalCount {
         type Type = Option<super::Int>;
-        fn name() -> &'static str {
-            "totalCount"
-        }
+        const NAME: &'static str = "totalCount";
     }
     impl ::cynic::schema::HasField<TotalCount> for super::PlanetsConnection {
         type Type = Option<super::Int>;
@@ -1637,9 +1309,7 @@ pub mod planets_connection_fields {
     pub struct Planets;
     impl ::cynic::schema::Field for Planets {
         type Type = Option<Vec<Option<super::Planet>>>;
-        fn name() -> &'static str {
-            "planets"
-        }
+        const NAME: &'static str = "planets";
     }
     impl ::cynic::schema::HasField<Planets> for super::PlanetsConnection {
         type Type = Option<Vec<Option<super::Planet>>>;
@@ -1650,9 +1320,7 @@ pub mod planets_edge_fields {
     pub struct Node;
     impl ::cynic::schema::Field for Node {
         type Type = Option<super::Planet>;
-        fn name() -> &'static str {
-            "node"
-        }
+        const NAME: &'static str = "node";
     }
     impl ::cynic::schema::HasField<Node> for super::PlanetsEdge {
         type Type = Option<super::Planet>;
@@ -1660,9 +1328,7 @@ pub mod planets_edge_fields {
     pub struct Cursor;
     impl ::cynic::schema::Field for Cursor {
         type Type = super::String;
-        fn name() -> &'static str {
-            "cursor"
-        }
+        const NAME: &'static str = "cursor";
     }
     impl ::cynic::schema::HasField<Cursor> for super::PlanetsEdge {
         type Type = super::String;
@@ -1673,9 +1339,7 @@ pub mod root_fields {
     pub struct AllFilms;
     impl ::cynic::schema::Field for AllFilms {
         type Type = Option<super::FilmsConnection>;
-        fn name() -> &'static str {
-            "allFilms"
-        }
+        const NAME: &'static str = "allFilms";
     }
     impl ::cynic::schema::HasField<AllFilms> for super::Root {
         type Type = Option<super::FilmsConnection>;
@@ -1684,38 +1348,28 @@ pub mod root_fields {
         pub struct After;
         impl ::cynic::schema::HasArgument<After> for super::AllFilms {
             type ArgumentType = Option<super::super::String>;
-            fn name() -> &'static str {
-                "after"
-            }
+            const NAME: &'static str = "after";
         }
         pub struct First;
         impl ::cynic::schema::HasArgument<First> for super::AllFilms {
             type ArgumentType = Option<super::super::Int>;
-            fn name() -> &'static str {
-                "first"
-            }
+            const NAME: &'static str = "first";
         }
         pub struct Before;
         impl ::cynic::schema::HasArgument<Before> for super::AllFilms {
             type ArgumentType = Option<super::super::String>;
-            fn name() -> &'static str {
-                "before"
-            }
+            const NAME: &'static str = "before";
         }
         pub struct Last;
         impl ::cynic::schema::HasArgument<Last> for super::AllFilms {
             type ArgumentType = Option<super::super::Int>;
-            fn name() -> &'static str {
-                "last"
-            }
+            const NAME: &'static str = "last";
         }
     }
     pub struct Film;
     impl ::cynic::schema::Field for Film {
         type Type = Option<super::Film>;
-        fn name() -> &'static str {
-            "film"
-        }
+        const NAME: &'static str = "film";
     }
     impl ::cynic::schema::HasField<Film> for super::Root {
         type Type = Option<super::Film>;
@@ -1724,24 +1378,18 @@ pub mod root_fields {
         pub struct Id;
         impl ::cynic::schema::HasArgument<Id> for super::Film {
             type ArgumentType = Option<super::super::Id>;
-            fn name() -> &'static str {
-                "id"
-            }
+            const NAME: &'static str = "id";
         }
         pub struct FilmId;
         impl ::cynic::schema::HasArgument<FilmId> for super::Film {
             type ArgumentType = Option<super::super::Id>;
-            fn name() -> &'static str {
-                "filmID"
-            }
+            const NAME: &'static str = "filmID";
         }
     }
     pub struct AllPeople;
     impl ::cynic::schema::Field for AllPeople {
         type Type = Option<super::PeopleConnection>;
-        fn name() -> &'static str {
-            "allPeople"
-        }
+        const NAME: &'static str = "allPeople";
     }
     impl ::cynic::schema::HasField<AllPeople> for super::Root {
         type Type = Option<super::PeopleConnection>;
@@ -1750,38 +1398,28 @@ pub mod root_fields {
         pub struct After;
         impl ::cynic::schema::HasArgument<After> for super::AllPeople {
             type ArgumentType = Option<super::super::String>;
-            fn name() -> &'static str {
-                "after"
-            }
+            const NAME: &'static str = "after";
         }
         pub struct First;
         impl ::cynic::schema::HasArgument<First> for super::AllPeople {
             type ArgumentType = Option<super::super::Int>;
-            fn name() -> &'static str {
-                "first"
-            }
+            const NAME: &'static str = "first";
         }
         pub struct Before;
         impl ::cynic::schema::HasArgument<Before> for super::AllPeople {
             type ArgumentType = Option<super::super::String>;
-            fn name() -> &'static str {
-                "before"
-            }
+            const NAME: &'static str = "before";
         }
         pub struct Last;
         impl ::cynic::schema::HasArgument<Last> for super::AllPeople {
             type ArgumentType = Option<super::super::Int>;
-            fn name() -> &'static str {
-                "last"
-            }
+            const NAME: &'static str = "last";
         }
     }
     pub struct Person;
     impl ::cynic::schema::Field for Person {
         type Type = Option<super::Person>;
-        fn name() -> &'static str {
-            "person"
-        }
+        const NAME: &'static str = "person";
     }
     impl ::cynic::schema::HasField<Person> for super::Root {
         type Type = Option<super::Person>;
@@ -1790,24 +1428,18 @@ pub mod root_fields {
         pub struct Id;
         impl ::cynic::schema::HasArgument<Id> for super::Person {
             type ArgumentType = Option<super::super::Id>;
-            fn name() -> &'static str {
-                "id"
-            }
+            const NAME: &'static str = "id";
         }
         pub struct PersonId;
         impl ::cynic::schema::HasArgument<PersonId> for super::Person {
             type ArgumentType = Option<super::super::Id>;
-            fn name() -> &'static str {
-                "personID"
-            }
+            const NAME: &'static str = "personID";
         }
     }
     pub struct AllPlanets;
     impl ::cynic::schema::Field for AllPlanets {
         type Type = Option<super::PlanetsConnection>;
-        fn name() -> &'static str {
-            "allPlanets"
-        }
+        const NAME: &'static str = "allPlanets";
     }
     impl ::cynic::schema::HasField<AllPlanets> for super::Root {
         type Type = Option<super::PlanetsConnection>;
@@ -1816,38 +1448,28 @@ pub mod root_fields {
         pub struct After;
         impl ::cynic::schema::HasArgument<After> for super::AllPlanets {
             type ArgumentType = Option<super::super::String>;
-            fn name() -> &'static str {
-                "after"
-            }
+            const NAME: &'static str = "after";
         }
         pub struct First;
         impl ::cynic::schema::HasArgument<First> for super::AllPlanets {
             type ArgumentType = Option<super::super::Int>;
-            fn name() -> &'static str {
-                "first"
-            }
+            const NAME: &'static str = "first";
         }
         pub struct Before;
         impl ::cynic::schema::HasArgument<Before> for super::AllPlanets {
             type ArgumentType = Option<super::super::String>;
-            fn name() -> &'static str {
-                "before"
-            }
+            const NAME: &'static str = "before";
         }
         pub struct Last;
         impl ::cynic::schema::HasArgument<Last> for super::AllPlanets {
             type ArgumentType = Option<super::super::Int>;
-            fn name() -> &'static str {
-                "last"
-            }
+            const NAME: &'static str = "last";
         }
     }
     pub struct Planet;
     impl ::cynic::schema::Field for Planet {
         type Type = Option<super::Planet>;
-        fn name() -> &'static str {
-            "planet"
-        }
+        const NAME: &'static str = "planet";
     }
     impl ::cynic::schema::HasField<Planet> for super::Root {
         type Type = Option<super::Planet>;
@@ -1856,24 +1478,18 @@ pub mod root_fields {
         pub struct Id;
         impl ::cynic::schema::HasArgument<Id> for super::Planet {
             type ArgumentType = Option<super::super::Id>;
-            fn name() -> &'static str {
-                "id"
-            }
+            const NAME: &'static str = "id";
         }
         pub struct PlanetId;
         impl ::cynic::schema::HasArgument<PlanetId> for super::Planet {
             type ArgumentType = Option<super::super::Id>;
-            fn name() -> &'static str {
-                "planetID"
-            }
+            const NAME: &'static str = "planetID";
         }
     }
     pub struct AllSpecies;
     impl ::cynic::schema::Field for AllSpecies {
         type Type = Option<super::SpeciesConnection>;
-        fn name() -> &'static str {
-            "allSpecies"
-        }
+        const NAME: &'static str = "allSpecies";
     }
     impl ::cynic::schema::HasField<AllSpecies> for super::Root {
         type Type = Option<super::SpeciesConnection>;
@@ -1882,38 +1498,28 @@ pub mod root_fields {
         pub struct After;
         impl ::cynic::schema::HasArgument<After> for super::AllSpecies {
             type ArgumentType = Option<super::super::String>;
-            fn name() -> &'static str {
-                "after"
-            }
+            const NAME: &'static str = "after";
         }
         pub struct First;
         impl ::cynic::schema::HasArgument<First> for super::AllSpecies {
             type ArgumentType = Option<super::super::Int>;
-            fn name() -> &'static str {
-                "first"
-            }
+            const NAME: &'static str = "first";
         }
         pub struct Before;
         impl ::cynic::schema::HasArgument<Before> for super::AllSpecies {
             type ArgumentType = Option<super::super::String>;
-            fn name() -> &'static str {
-                "before"
-            }
+            const NAME: &'static str = "before";
         }
         pub struct Last;
         impl ::cynic::schema::HasArgument<Last> for super::AllSpecies {
             type ArgumentType = Option<super::super::Int>;
-            fn name() -> &'static str {
-                "last"
-            }
+            const NAME: &'static str = "last";
         }
     }
     pub struct Species;
     impl ::cynic::schema::Field for Species {
         type Type = Option<super::Species>;
-        fn name() -> &'static str {
-            "species"
-        }
+        const NAME: &'static str = "species";
     }
     impl ::cynic::schema::HasField<Species> for super::Root {
         type Type = Option<super::Species>;
@@ -1922,24 +1528,18 @@ pub mod root_fields {
         pub struct Id;
         impl ::cynic::schema::HasArgument<Id> for super::Species {
             type ArgumentType = Option<super::super::Id>;
-            fn name() -> &'static str {
-                "id"
-            }
+            const NAME: &'static str = "id";
         }
         pub struct SpeciesId;
         impl ::cynic::schema::HasArgument<SpeciesId> for super::Species {
             type ArgumentType = Option<super::super::Id>;
-            fn name() -> &'static str {
-                "speciesID"
-            }
+            const NAME: &'static str = "speciesID";
         }
     }
     pub struct AllStarships;
     impl ::cynic::schema::Field for AllStarships {
         type Type = Option<super::StarshipsConnection>;
-        fn name() -> &'static str {
-            "allStarships"
-        }
+        const NAME: &'static str = "allStarships";
     }
     impl ::cynic::schema::HasField<AllStarships> for super::Root {
         type Type = Option<super::StarshipsConnection>;
@@ -1948,38 +1548,28 @@ pub mod root_fields {
         pub struct After;
         impl ::cynic::schema::HasArgument<After> for super::AllStarships {
             type ArgumentType = Option<super::super::String>;
-            fn name() -> &'static str {
-                "after"
-            }
+            const NAME: &'static str = "after";
         }
         pub struct First;
         impl ::cynic::schema::HasArgument<First> for super::AllStarships {
             type ArgumentType = Option<super::super::Int>;
-            fn name() -> &'static str {
-                "first"
-            }
+            const NAME: &'static str = "first";
         }
         pub struct Before;
         impl ::cynic::schema::HasArgument<Before> for super::AllStarships {
             type ArgumentType = Option<super::super::String>;
-            fn name() -> &'static str {
-                "before"
-            }
+            const NAME: &'static str = "before";
         }
         pub struct Last;
         impl ::cynic::schema::HasArgument<Last> for super::AllStarships {
             type ArgumentType = Option<super::super::Int>;
-            fn name() -> &'static str {
-                "last"
-            }
+            const NAME: &'static str = "last";
         }
     }
     pub struct Starship;
     impl ::cynic::schema::Field for Starship {
         type Type = Option<super::Starship>;
-        fn name() -> &'static str {
-            "starship"
-        }
+        const NAME: &'static str = "starship";
     }
     impl ::cynic::schema::HasField<Starship> for super::Root {
         type Type = Option<super::Starship>;
@@ -1988,24 +1578,18 @@ pub mod root_fields {
         pub struct Id;
         impl ::cynic::schema::HasArgument<Id> for super::Starship {
             type ArgumentType = Option<super::super::Id>;
-            fn name() -> &'static str {
-                "id"
-            }
+            const NAME: &'static str = "id";
         }
         pub struct StarshipId;
         impl ::cynic::schema::HasArgument<StarshipId> for super::Starship {
             type ArgumentType = Option<super::super::Id>;
-            fn name() -> &'static str {
-                "starshipID"
-            }
+            const NAME: &'static str = "starshipID";
         }
     }
     pub struct AllVehicles;
     impl ::cynic::schema::Field for AllVehicles {
         type Type = Option<super::VehiclesConnection>;
-        fn name() -> &'static str {
-            "allVehicles"
-        }
+        const NAME: &'static str = "allVehicles";
     }
     impl ::cynic::schema::HasField<AllVehicles> for super::Root {
         type Type = Option<super::VehiclesConnection>;
@@ -2014,38 +1598,28 @@ pub mod root_fields {
         pub struct After;
         impl ::cynic::schema::HasArgument<After> for super::AllVehicles {
             type ArgumentType = Option<super::super::String>;
-            fn name() -> &'static str {
-                "after"
-            }
+            const NAME: &'static str = "after";
         }
         pub struct First;
         impl ::cynic::schema::HasArgument<First> for super::AllVehicles {
             type ArgumentType = Option<super::super::Int>;
-            fn name() -> &'static str {
-                "first"
-            }
+            const NAME: &'static str = "first";
         }
         pub struct Before;
         impl ::cynic::schema::HasArgument<Before> for super::AllVehicles {
             type ArgumentType = Option<super::super::String>;
-            fn name() -> &'static str {
-                "before"
-            }
+            const NAME: &'static str = "before";
         }
         pub struct Last;
         impl ::cynic::schema::HasArgument<Last> for super::AllVehicles {
             type ArgumentType = Option<super::super::Int>;
-            fn name() -> &'static str {
-                "last"
-            }
+            const NAME: &'static str = "last";
         }
     }
     pub struct Vehicle;
     impl ::cynic::schema::Field for Vehicle {
         type Type = Option<super::Vehicle>;
-        fn name() -> &'static str {
-            "vehicle"
-        }
+        const NAME: &'static str = "vehicle";
     }
     impl ::cynic::schema::HasField<Vehicle> for super::Root {
         type Type = Option<super::Vehicle>;
@@ -2054,24 +1628,18 @@ pub mod root_fields {
         pub struct Id;
         impl ::cynic::schema::HasArgument<Id> for super::Vehicle {
             type ArgumentType = Option<super::super::Id>;
-            fn name() -> &'static str {
-                "id"
-            }
+            const NAME: &'static str = "id";
         }
         pub struct VehicleId;
         impl ::cynic::schema::HasArgument<VehicleId> for super::Vehicle {
             type ArgumentType = Option<super::super::Id>;
-            fn name() -> &'static str {
-                "vehicleID"
-            }
+            const NAME: &'static str = "vehicleID";
         }
     }
     pub struct Node;
     impl ::cynic::schema::Field for Node {
         type Type = Option<super::Node>;
-        fn name() -> &'static str {
-            "node"
-        }
+        const NAME: &'static str = "node";
     }
     impl ::cynic::schema::HasField<Node> for super::Root {
         type Type = Option<super::Node>;
@@ -2080,9 +1648,7 @@ pub mod root_fields {
         pub struct Id;
         impl ::cynic::schema::HasArgument<Id> for super::Node {
             type ArgumentType = super::super::Id;
-            fn name() -> &'static str {
-                "id"
-            }
+            const NAME: &'static str = "id";
         }
     }
 }
@@ -2091,9 +1657,7 @@ pub mod species_fields {
     pub struct Name;
     impl ::cynic::schema::Field for Name {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "name"
-        }
+        const NAME: &'static str = "name";
     }
     impl ::cynic::schema::HasField<Name> for super::Species {
         type Type = Option<super::String>;
@@ -2101,9 +1665,7 @@ pub mod species_fields {
     pub struct Classification;
     impl ::cynic::schema::Field for Classification {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "classification"
-        }
+        const NAME: &'static str = "classification";
     }
     impl ::cynic::schema::HasField<Classification> for super::Species {
         type Type = Option<super::String>;
@@ -2111,9 +1673,7 @@ pub mod species_fields {
     pub struct Designation;
     impl ::cynic::schema::Field for Designation {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "designation"
-        }
+        const NAME: &'static str = "designation";
     }
     impl ::cynic::schema::HasField<Designation> for super::Species {
         type Type = Option<super::String>;
@@ -2121,9 +1681,7 @@ pub mod species_fields {
     pub struct AverageHeight;
     impl ::cynic::schema::Field for AverageHeight {
         type Type = Option<super::Float>;
-        fn name() -> &'static str {
-            "averageHeight"
-        }
+        const NAME: &'static str = "averageHeight";
     }
     impl ::cynic::schema::HasField<AverageHeight> for super::Species {
         type Type = Option<super::Float>;
@@ -2131,9 +1689,7 @@ pub mod species_fields {
     pub struct AverageLifespan;
     impl ::cynic::schema::Field for AverageLifespan {
         type Type = Option<super::Int>;
-        fn name() -> &'static str {
-            "averageLifespan"
-        }
+        const NAME: &'static str = "averageLifespan";
     }
     impl ::cynic::schema::HasField<AverageLifespan> for super::Species {
         type Type = Option<super::Int>;
@@ -2141,9 +1697,7 @@ pub mod species_fields {
     pub struct EyeColors;
     impl ::cynic::schema::Field for EyeColors {
         type Type = Option<Vec<Option<super::String>>>;
-        fn name() -> &'static str {
-            "eyeColors"
-        }
+        const NAME: &'static str = "eyeColors";
     }
     impl ::cynic::schema::HasField<EyeColors> for super::Species {
         type Type = Option<Vec<Option<super::String>>>;
@@ -2151,9 +1705,7 @@ pub mod species_fields {
     pub struct HairColors;
     impl ::cynic::schema::Field for HairColors {
         type Type = Option<Vec<Option<super::String>>>;
-        fn name() -> &'static str {
-            "hairColors"
-        }
+        const NAME: &'static str = "hairColors";
     }
     impl ::cynic::schema::HasField<HairColors> for super::Species {
         type Type = Option<Vec<Option<super::String>>>;
@@ -2161,9 +1713,7 @@ pub mod species_fields {
     pub struct SkinColors;
     impl ::cynic::schema::Field for SkinColors {
         type Type = Option<Vec<Option<super::String>>>;
-        fn name() -> &'static str {
-            "skinColors"
-        }
+        const NAME: &'static str = "skinColors";
     }
     impl ::cynic::schema::HasField<SkinColors> for super::Species {
         type Type = Option<Vec<Option<super::String>>>;
@@ -2171,9 +1721,7 @@ pub mod species_fields {
     pub struct Language;
     impl ::cynic::schema::Field for Language {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "language"
-        }
+        const NAME: &'static str = "language";
     }
     impl ::cynic::schema::HasField<Language> for super::Species {
         type Type = Option<super::String>;
@@ -2181,9 +1729,7 @@ pub mod species_fields {
     pub struct Homeworld;
     impl ::cynic::schema::Field for Homeworld {
         type Type = Option<super::Planet>;
-        fn name() -> &'static str {
-            "homeworld"
-        }
+        const NAME: &'static str = "homeworld";
     }
     impl ::cynic::schema::HasField<Homeworld> for super::Species {
         type Type = Option<super::Planet>;
@@ -2191,9 +1737,7 @@ pub mod species_fields {
     pub struct PersonConnection;
     impl ::cynic::schema::Field for PersonConnection {
         type Type = Option<super::SpeciesPeopleConnection>;
-        fn name() -> &'static str {
-            "personConnection"
-        }
+        const NAME: &'static str = "personConnection";
     }
     impl ::cynic::schema::HasField<PersonConnection> for super::Species {
         type Type = Option<super::SpeciesPeopleConnection>;
@@ -2202,38 +1746,28 @@ pub mod species_fields {
         pub struct After;
         impl ::cynic::schema::HasArgument<After> for super::PersonConnection {
             type ArgumentType = Option<super::super::String>;
-            fn name() -> &'static str {
-                "after"
-            }
+            const NAME: &'static str = "after";
         }
         pub struct First;
         impl ::cynic::schema::HasArgument<First> for super::PersonConnection {
             type ArgumentType = Option<super::super::Int>;
-            fn name() -> &'static str {
-                "first"
-            }
+            const NAME: &'static str = "first";
         }
         pub struct Before;
         impl ::cynic::schema::HasArgument<Before> for super::PersonConnection {
             type ArgumentType = Option<super::super::String>;
-            fn name() -> &'static str {
-                "before"
-            }
+            const NAME: &'static str = "before";
         }
         pub struct Last;
         impl ::cynic::schema::HasArgument<Last> for super::PersonConnection {
             type ArgumentType = Option<super::super::Int>;
-            fn name() -> &'static str {
-                "last"
-            }
+            const NAME: &'static str = "last";
         }
     }
     pub struct FilmConnection;
     impl ::cynic::schema::Field for FilmConnection {
         type Type = Option<super::SpeciesFilmsConnection>;
-        fn name() -> &'static str {
-            "filmConnection"
-        }
+        const NAME: &'static str = "filmConnection";
     }
     impl ::cynic::schema::HasField<FilmConnection> for super::Species {
         type Type = Option<super::SpeciesFilmsConnection>;
@@ -2242,38 +1776,28 @@ pub mod species_fields {
         pub struct After;
         impl ::cynic::schema::HasArgument<After> for super::FilmConnection {
             type ArgumentType = Option<super::super::String>;
-            fn name() -> &'static str {
-                "after"
-            }
+            const NAME: &'static str = "after";
         }
         pub struct First;
         impl ::cynic::schema::HasArgument<First> for super::FilmConnection {
             type ArgumentType = Option<super::super::Int>;
-            fn name() -> &'static str {
-                "first"
-            }
+            const NAME: &'static str = "first";
         }
         pub struct Before;
         impl ::cynic::schema::HasArgument<Before> for super::FilmConnection {
             type ArgumentType = Option<super::super::String>;
-            fn name() -> &'static str {
-                "before"
-            }
+            const NAME: &'static str = "before";
         }
         pub struct Last;
         impl ::cynic::schema::HasArgument<Last> for super::FilmConnection {
             type ArgumentType = Option<super::super::Int>;
-            fn name() -> &'static str {
-                "last"
-            }
+            const NAME: &'static str = "last";
         }
     }
     pub struct Created;
     impl ::cynic::schema::Field for Created {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "created"
-        }
+        const NAME: &'static str = "created";
     }
     impl ::cynic::schema::HasField<Created> for super::Species {
         type Type = Option<super::String>;
@@ -2281,9 +1805,7 @@ pub mod species_fields {
     pub struct Edited;
     impl ::cynic::schema::Field for Edited {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "edited"
-        }
+        const NAME: &'static str = "edited";
     }
     impl ::cynic::schema::HasField<Edited> for super::Species {
         type Type = Option<super::String>;
@@ -2291,9 +1813,7 @@ pub mod species_fields {
     pub struct Id;
     impl ::cynic::schema::Field for Id {
         type Type = super::Id;
-        fn name() -> &'static str {
-            "id"
-        }
+        const NAME: &'static str = "id";
     }
     impl ::cynic::schema::HasField<Id> for super::Species {
         type Type = super::Id;
@@ -2304,9 +1824,7 @@ pub mod species_connection_fields {
     pub struct PageInfo;
     impl ::cynic::schema::Field for PageInfo {
         type Type = super::PageInfo;
-        fn name() -> &'static str {
-            "pageInfo"
-        }
+        const NAME: &'static str = "pageInfo";
     }
     impl ::cynic::schema::HasField<PageInfo> for super::SpeciesConnection {
         type Type = super::PageInfo;
@@ -2314,9 +1832,7 @@ pub mod species_connection_fields {
     pub struct Edges;
     impl ::cynic::schema::Field for Edges {
         type Type = Option<Vec<Option<super::SpeciesEdge>>>;
-        fn name() -> &'static str {
-            "edges"
-        }
+        const NAME: &'static str = "edges";
     }
     impl ::cynic::schema::HasField<Edges> for super::SpeciesConnection {
         type Type = Option<Vec<Option<super::SpeciesEdge>>>;
@@ -2324,9 +1840,7 @@ pub mod species_connection_fields {
     pub struct TotalCount;
     impl ::cynic::schema::Field for TotalCount {
         type Type = Option<super::Int>;
-        fn name() -> &'static str {
-            "totalCount"
-        }
+        const NAME: &'static str = "totalCount";
     }
     impl ::cynic::schema::HasField<TotalCount> for super::SpeciesConnection {
         type Type = Option<super::Int>;
@@ -2334,9 +1848,7 @@ pub mod species_connection_fields {
     pub struct Species;
     impl ::cynic::schema::Field for Species {
         type Type = Option<Vec<Option<super::Species>>>;
-        fn name() -> &'static str {
-            "species"
-        }
+        const NAME: &'static str = "species";
     }
     impl ::cynic::schema::HasField<Species> for super::SpeciesConnection {
         type Type = Option<Vec<Option<super::Species>>>;
@@ -2347,9 +1859,7 @@ pub mod species_edge_fields {
     pub struct Node;
     impl ::cynic::schema::Field for Node {
         type Type = Option<super::Species>;
-        fn name() -> &'static str {
-            "node"
-        }
+        const NAME: &'static str = "node";
     }
     impl ::cynic::schema::HasField<Node> for super::SpeciesEdge {
         type Type = Option<super::Species>;
@@ -2357,9 +1867,7 @@ pub mod species_edge_fields {
     pub struct Cursor;
     impl ::cynic::schema::Field for Cursor {
         type Type = super::String;
-        fn name() -> &'static str {
-            "cursor"
-        }
+        const NAME: &'static str = "cursor";
     }
     impl ::cynic::schema::HasField<Cursor> for super::SpeciesEdge {
         type Type = super::String;
@@ -2370,9 +1878,7 @@ pub mod species_films_connection_fields {
     pub struct PageInfo;
     impl ::cynic::schema::Field for PageInfo {
         type Type = super::PageInfo;
-        fn name() -> &'static str {
-            "pageInfo"
-        }
+        const NAME: &'static str = "pageInfo";
     }
     impl ::cynic::schema::HasField<PageInfo> for super::SpeciesFilmsConnection {
         type Type = super::PageInfo;
@@ -2380,9 +1886,7 @@ pub mod species_films_connection_fields {
     pub struct Edges;
     impl ::cynic::schema::Field for Edges {
         type Type = Option<Vec<Option<super::SpeciesFilmsEdge>>>;
-        fn name() -> &'static str {
-            "edges"
-        }
+        const NAME: &'static str = "edges";
     }
     impl ::cynic::schema::HasField<Edges> for super::SpeciesFilmsConnection {
         type Type = Option<Vec<Option<super::SpeciesFilmsEdge>>>;
@@ -2390,9 +1894,7 @@ pub mod species_films_connection_fields {
     pub struct TotalCount;
     impl ::cynic::schema::Field for TotalCount {
         type Type = Option<super::Int>;
-        fn name() -> &'static str {
-            "totalCount"
-        }
+        const NAME: &'static str = "totalCount";
     }
     impl ::cynic::schema::HasField<TotalCount> for super::SpeciesFilmsConnection {
         type Type = Option<super::Int>;
@@ -2400,9 +1902,7 @@ pub mod species_films_connection_fields {
     pub struct Films;
     impl ::cynic::schema::Field for Films {
         type Type = Option<Vec<Option<super::Film>>>;
-        fn name() -> &'static str {
-            "films"
-        }
+        const NAME: &'static str = "films";
     }
     impl ::cynic::schema::HasField<Films> for super::SpeciesFilmsConnection {
         type Type = Option<Vec<Option<super::Film>>>;
@@ -2413,9 +1913,7 @@ pub mod species_films_edge_fields {
     pub struct Node;
     impl ::cynic::schema::Field for Node {
         type Type = Option<super::Film>;
-        fn name() -> &'static str {
-            "node"
-        }
+        const NAME: &'static str = "node";
     }
     impl ::cynic::schema::HasField<Node> for super::SpeciesFilmsEdge {
         type Type = Option<super::Film>;
@@ -2423,9 +1921,7 @@ pub mod species_films_edge_fields {
     pub struct Cursor;
     impl ::cynic::schema::Field for Cursor {
         type Type = super::String;
-        fn name() -> &'static str {
-            "cursor"
-        }
+        const NAME: &'static str = "cursor";
     }
     impl ::cynic::schema::HasField<Cursor> for super::SpeciesFilmsEdge {
         type Type = super::String;
@@ -2436,9 +1932,7 @@ pub mod species_people_connection_fields {
     pub struct PageInfo;
     impl ::cynic::schema::Field for PageInfo {
         type Type = super::PageInfo;
-        fn name() -> &'static str {
-            "pageInfo"
-        }
+        const NAME: &'static str = "pageInfo";
     }
     impl ::cynic::schema::HasField<PageInfo> for super::SpeciesPeopleConnection {
         type Type = super::PageInfo;
@@ -2446,9 +1940,7 @@ pub mod species_people_connection_fields {
     pub struct Edges;
     impl ::cynic::schema::Field for Edges {
         type Type = Option<Vec<Option<super::SpeciesPeopleEdge>>>;
-        fn name() -> &'static str {
-            "edges"
-        }
+        const NAME: &'static str = "edges";
     }
     impl ::cynic::schema::HasField<Edges> for super::SpeciesPeopleConnection {
         type Type = Option<Vec<Option<super::SpeciesPeopleEdge>>>;
@@ -2456,9 +1948,7 @@ pub mod species_people_connection_fields {
     pub struct TotalCount;
     impl ::cynic::schema::Field for TotalCount {
         type Type = Option<super::Int>;
-        fn name() -> &'static str {
-            "totalCount"
-        }
+        const NAME: &'static str = "totalCount";
     }
     impl ::cynic::schema::HasField<TotalCount> for super::SpeciesPeopleConnection {
         type Type = Option<super::Int>;
@@ -2466,9 +1956,7 @@ pub mod species_people_connection_fields {
     pub struct People;
     impl ::cynic::schema::Field for People {
         type Type = Option<Vec<Option<super::Person>>>;
-        fn name() -> &'static str {
-            "people"
-        }
+        const NAME: &'static str = "people";
     }
     impl ::cynic::schema::HasField<People> for super::SpeciesPeopleConnection {
         type Type = Option<Vec<Option<super::Person>>>;
@@ -2479,9 +1967,7 @@ pub mod species_people_edge_fields {
     pub struct Node;
     impl ::cynic::schema::Field for Node {
         type Type = Option<super::Person>;
-        fn name() -> &'static str {
-            "node"
-        }
+        const NAME: &'static str = "node";
     }
     impl ::cynic::schema::HasField<Node> for super::SpeciesPeopleEdge {
         type Type = Option<super::Person>;
@@ -2489,9 +1975,7 @@ pub mod species_people_edge_fields {
     pub struct Cursor;
     impl ::cynic::schema::Field for Cursor {
         type Type = super::String;
-        fn name() -> &'static str {
-            "cursor"
-        }
+        const NAME: &'static str = "cursor";
     }
     impl ::cynic::schema::HasField<Cursor> for super::SpeciesPeopleEdge {
         type Type = super::String;
@@ -2502,9 +1986,7 @@ pub mod starship_fields {
     pub struct Name;
     impl ::cynic::schema::Field for Name {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "name"
-        }
+        const NAME: &'static str = "name";
     }
     impl ::cynic::schema::HasField<Name> for super::Starship {
         type Type = Option<super::String>;
@@ -2512,9 +1994,7 @@ pub mod starship_fields {
     pub struct Model;
     impl ::cynic::schema::Field for Model {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "model"
-        }
+        const NAME: &'static str = "model";
     }
     impl ::cynic::schema::HasField<Model> for super::Starship {
         type Type = Option<super::String>;
@@ -2522,9 +2002,7 @@ pub mod starship_fields {
     pub struct StarshipClass;
     impl ::cynic::schema::Field for StarshipClass {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "starshipClass"
-        }
+        const NAME: &'static str = "starshipClass";
     }
     impl ::cynic::schema::HasField<StarshipClass> for super::Starship {
         type Type = Option<super::String>;
@@ -2532,9 +2010,7 @@ pub mod starship_fields {
     pub struct Manufacturers;
     impl ::cynic::schema::Field for Manufacturers {
         type Type = Option<Vec<Option<super::String>>>;
-        fn name() -> &'static str {
-            "manufacturers"
-        }
+        const NAME: &'static str = "manufacturers";
     }
     impl ::cynic::schema::HasField<Manufacturers> for super::Starship {
         type Type = Option<Vec<Option<super::String>>>;
@@ -2542,9 +2018,7 @@ pub mod starship_fields {
     pub struct CostInCredits;
     impl ::cynic::schema::Field for CostInCredits {
         type Type = Option<super::Float>;
-        fn name() -> &'static str {
-            "costInCredits"
-        }
+        const NAME: &'static str = "costInCredits";
     }
     impl ::cynic::schema::HasField<CostInCredits> for super::Starship {
         type Type = Option<super::Float>;
@@ -2552,9 +2026,7 @@ pub mod starship_fields {
     pub struct Length;
     impl ::cynic::schema::Field for Length {
         type Type = Option<super::Float>;
-        fn name() -> &'static str {
-            "length"
-        }
+        const NAME: &'static str = "length";
     }
     impl ::cynic::schema::HasField<Length> for super::Starship {
         type Type = Option<super::Float>;
@@ -2562,9 +2034,7 @@ pub mod starship_fields {
     pub struct Crew;
     impl ::cynic::schema::Field for Crew {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "crew"
-        }
+        const NAME: &'static str = "crew";
     }
     impl ::cynic::schema::HasField<Crew> for super::Starship {
         type Type = Option<super::String>;
@@ -2572,9 +2042,7 @@ pub mod starship_fields {
     pub struct Passengers;
     impl ::cynic::schema::Field for Passengers {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "passengers"
-        }
+        const NAME: &'static str = "passengers";
     }
     impl ::cynic::schema::HasField<Passengers> for super::Starship {
         type Type = Option<super::String>;
@@ -2582,9 +2050,7 @@ pub mod starship_fields {
     pub struct MaxAtmospheringSpeed;
     impl ::cynic::schema::Field for MaxAtmospheringSpeed {
         type Type = Option<super::Int>;
-        fn name() -> &'static str {
-            "maxAtmospheringSpeed"
-        }
+        const NAME: &'static str = "maxAtmospheringSpeed";
     }
     impl ::cynic::schema::HasField<MaxAtmospheringSpeed> for super::Starship {
         type Type = Option<super::Int>;
@@ -2592,9 +2058,7 @@ pub mod starship_fields {
     pub struct HyperdriveRating;
     impl ::cynic::schema::Field for HyperdriveRating {
         type Type = Option<super::Float>;
-        fn name() -> &'static str {
-            "hyperdriveRating"
-        }
+        const NAME: &'static str = "hyperdriveRating";
     }
     impl ::cynic::schema::HasField<HyperdriveRating> for super::Starship {
         type Type = Option<super::Float>;
@@ -2602,9 +2066,7 @@ pub mod starship_fields {
     pub struct Mglt;
     impl ::cynic::schema::Field for Mglt {
         type Type = Option<super::Int>;
-        fn name() -> &'static str {
-            "MGLT"
-        }
+        const NAME: &'static str = "MGLT";
     }
     impl ::cynic::schema::HasField<Mglt> for super::Starship {
         type Type = Option<super::Int>;
@@ -2612,9 +2074,7 @@ pub mod starship_fields {
     pub struct CargoCapacity;
     impl ::cynic::schema::Field for CargoCapacity {
         type Type = Option<super::Float>;
-        fn name() -> &'static str {
-            "cargoCapacity"
-        }
+        const NAME: &'static str = "cargoCapacity";
     }
     impl ::cynic::schema::HasField<CargoCapacity> for super::Starship {
         type Type = Option<super::Float>;
@@ -2622,9 +2082,7 @@ pub mod starship_fields {
     pub struct Consumables;
     impl ::cynic::schema::Field for Consumables {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "consumables"
-        }
+        const NAME: &'static str = "consumables";
     }
     impl ::cynic::schema::HasField<Consumables> for super::Starship {
         type Type = Option<super::String>;
@@ -2632,9 +2090,7 @@ pub mod starship_fields {
     pub struct PilotConnection;
     impl ::cynic::schema::Field for PilotConnection {
         type Type = Option<super::StarshipPilotsConnection>;
-        fn name() -> &'static str {
-            "pilotConnection"
-        }
+        const NAME: &'static str = "pilotConnection";
     }
     impl ::cynic::schema::HasField<PilotConnection> for super::Starship {
         type Type = Option<super::StarshipPilotsConnection>;
@@ -2643,38 +2099,28 @@ pub mod starship_fields {
         pub struct After;
         impl ::cynic::schema::HasArgument<After> for super::PilotConnection {
             type ArgumentType = Option<super::super::String>;
-            fn name() -> &'static str {
-                "after"
-            }
+            const NAME: &'static str = "after";
         }
         pub struct First;
         impl ::cynic::schema::HasArgument<First> for super::PilotConnection {
             type ArgumentType = Option<super::super::Int>;
-            fn name() -> &'static str {
-                "first"
-            }
+            const NAME: &'static str = "first";
         }
         pub struct Before;
         impl ::cynic::schema::HasArgument<Before> for super::PilotConnection {
             type ArgumentType = Option<super::super::String>;
-            fn name() -> &'static str {
-                "before"
-            }
+            const NAME: &'static str = "before";
         }
         pub struct Last;
         impl ::cynic::schema::HasArgument<Last> for super::PilotConnection {
             type ArgumentType = Option<super::super::Int>;
-            fn name() -> &'static str {
-                "last"
-            }
+            const NAME: &'static str = "last";
         }
     }
     pub struct FilmConnection;
     impl ::cynic::schema::Field for FilmConnection {
         type Type = Option<super::StarshipFilmsConnection>;
-        fn name() -> &'static str {
-            "filmConnection"
-        }
+        const NAME: &'static str = "filmConnection";
     }
     impl ::cynic::schema::HasField<FilmConnection> for super::Starship {
         type Type = Option<super::StarshipFilmsConnection>;
@@ -2683,38 +2129,28 @@ pub mod starship_fields {
         pub struct After;
         impl ::cynic::schema::HasArgument<After> for super::FilmConnection {
             type ArgumentType = Option<super::super::String>;
-            fn name() -> &'static str {
-                "after"
-            }
+            const NAME: &'static str = "after";
         }
         pub struct First;
         impl ::cynic::schema::HasArgument<First> for super::FilmConnection {
             type ArgumentType = Option<super::super::Int>;
-            fn name() -> &'static str {
-                "first"
-            }
+            const NAME: &'static str = "first";
         }
         pub struct Before;
         impl ::cynic::schema::HasArgument<Before> for super::FilmConnection {
             type ArgumentType = Option<super::super::String>;
-            fn name() -> &'static str {
-                "before"
-            }
+            const NAME: &'static str = "before";
         }
         pub struct Last;
         impl ::cynic::schema::HasArgument<Last> for super::FilmConnection {
             type ArgumentType = Option<super::super::Int>;
-            fn name() -> &'static str {
-                "last"
-            }
+            const NAME: &'static str = "last";
         }
     }
     pub struct Created;
     impl ::cynic::schema::Field for Created {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "created"
-        }
+        const NAME: &'static str = "created";
     }
     impl ::cynic::schema::HasField<Created> for super::Starship {
         type Type = Option<super::String>;
@@ -2722,9 +2158,7 @@ pub mod starship_fields {
     pub struct Edited;
     impl ::cynic::schema::Field for Edited {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "edited"
-        }
+        const NAME: &'static str = "edited";
     }
     impl ::cynic::schema::HasField<Edited> for super::Starship {
         type Type = Option<super::String>;
@@ -2732,9 +2166,7 @@ pub mod starship_fields {
     pub struct Id;
     impl ::cynic::schema::Field for Id {
         type Type = super::Id;
-        fn name() -> &'static str {
-            "id"
-        }
+        const NAME: &'static str = "id";
     }
     impl ::cynic::schema::HasField<Id> for super::Starship {
         type Type = super::Id;
@@ -2745,9 +2177,7 @@ pub mod starship_films_connection_fields {
     pub struct PageInfo;
     impl ::cynic::schema::Field for PageInfo {
         type Type = super::PageInfo;
-        fn name() -> &'static str {
-            "pageInfo"
-        }
+        const NAME: &'static str = "pageInfo";
     }
     impl ::cynic::schema::HasField<PageInfo> for super::StarshipFilmsConnection {
         type Type = super::PageInfo;
@@ -2755,9 +2185,7 @@ pub mod starship_films_connection_fields {
     pub struct Edges;
     impl ::cynic::schema::Field for Edges {
         type Type = Option<Vec<Option<super::StarshipFilmsEdge>>>;
-        fn name() -> &'static str {
-            "edges"
-        }
+        const NAME: &'static str = "edges";
     }
     impl ::cynic::schema::HasField<Edges> for super::StarshipFilmsConnection {
         type Type = Option<Vec<Option<super::StarshipFilmsEdge>>>;
@@ -2765,9 +2193,7 @@ pub mod starship_films_connection_fields {
     pub struct TotalCount;
     impl ::cynic::schema::Field for TotalCount {
         type Type = Option<super::Int>;
-        fn name() -> &'static str {
-            "totalCount"
-        }
+        const NAME: &'static str = "totalCount";
     }
     impl ::cynic::schema::HasField<TotalCount> for super::StarshipFilmsConnection {
         type Type = Option<super::Int>;
@@ -2775,9 +2201,7 @@ pub mod starship_films_connection_fields {
     pub struct Films;
     impl ::cynic::schema::Field for Films {
         type Type = Option<Vec<Option<super::Film>>>;
-        fn name() -> &'static str {
-            "films"
-        }
+        const NAME: &'static str = "films";
     }
     impl ::cynic::schema::HasField<Films> for super::StarshipFilmsConnection {
         type Type = Option<Vec<Option<super::Film>>>;
@@ -2788,9 +2212,7 @@ pub mod starship_films_edge_fields {
     pub struct Node;
     impl ::cynic::schema::Field for Node {
         type Type = Option<super::Film>;
-        fn name() -> &'static str {
-            "node"
-        }
+        const NAME: &'static str = "node";
     }
     impl ::cynic::schema::HasField<Node> for super::StarshipFilmsEdge {
         type Type = Option<super::Film>;
@@ -2798,9 +2220,7 @@ pub mod starship_films_edge_fields {
     pub struct Cursor;
     impl ::cynic::schema::Field for Cursor {
         type Type = super::String;
-        fn name() -> &'static str {
-            "cursor"
-        }
+        const NAME: &'static str = "cursor";
     }
     impl ::cynic::schema::HasField<Cursor> for super::StarshipFilmsEdge {
         type Type = super::String;
@@ -2811,9 +2231,7 @@ pub mod starship_pilots_connection_fields {
     pub struct PageInfo;
     impl ::cynic::schema::Field for PageInfo {
         type Type = super::PageInfo;
-        fn name() -> &'static str {
-            "pageInfo"
-        }
+        const NAME: &'static str = "pageInfo";
     }
     impl ::cynic::schema::HasField<PageInfo> for super::StarshipPilotsConnection {
         type Type = super::PageInfo;
@@ -2821,9 +2239,7 @@ pub mod starship_pilots_connection_fields {
     pub struct Edges;
     impl ::cynic::schema::Field for Edges {
         type Type = Option<Vec<Option<super::StarshipPilotsEdge>>>;
-        fn name() -> &'static str {
-            "edges"
-        }
+        const NAME: &'static str = "edges";
     }
     impl ::cynic::schema::HasField<Edges> for super::StarshipPilotsConnection {
         type Type = Option<Vec<Option<super::StarshipPilotsEdge>>>;
@@ -2831,9 +2247,7 @@ pub mod starship_pilots_connection_fields {
     pub struct TotalCount;
     impl ::cynic::schema::Field for TotalCount {
         type Type = Option<super::Int>;
-        fn name() -> &'static str {
-            "totalCount"
-        }
+        const NAME: &'static str = "totalCount";
     }
     impl ::cynic::schema::HasField<TotalCount> for super::StarshipPilotsConnection {
         type Type = Option<super::Int>;
@@ -2841,9 +2255,7 @@ pub mod starship_pilots_connection_fields {
     pub struct Pilots;
     impl ::cynic::schema::Field for Pilots {
         type Type = Option<Vec<Option<super::Person>>>;
-        fn name() -> &'static str {
-            "pilots"
-        }
+        const NAME: &'static str = "pilots";
     }
     impl ::cynic::schema::HasField<Pilots> for super::StarshipPilotsConnection {
         type Type = Option<Vec<Option<super::Person>>>;
@@ -2854,9 +2266,7 @@ pub mod starship_pilots_edge_fields {
     pub struct Node;
     impl ::cynic::schema::Field for Node {
         type Type = Option<super::Person>;
-        fn name() -> &'static str {
-            "node"
-        }
+        const NAME: &'static str = "node";
     }
     impl ::cynic::schema::HasField<Node> for super::StarshipPilotsEdge {
         type Type = Option<super::Person>;
@@ -2864,9 +2274,7 @@ pub mod starship_pilots_edge_fields {
     pub struct Cursor;
     impl ::cynic::schema::Field for Cursor {
         type Type = super::String;
-        fn name() -> &'static str {
-            "cursor"
-        }
+        const NAME: &'static str = "cursor";
     }
     impl ::cynic::schema::HasField<Cursor> for super::StarshipPilotsEdge {
         type Type = super::String;
@@ -2877,9 +2285,7 @@ pub mod starships_connection_fields {
     pub struct PageInfo;
     impl ::cynic::schema::Field for PageInfo {
         type Type = super::PageInfo;
-        fn name() -> &'static str {
-            "pageInfo"
-        }
+        const NAME: &'static str = "pageInfo";
     }
     impl ::cynic::schema::HasField<PageInfo> for super::StarshipsConnection {
         type Type = super::PageInfo;
@@ -2887,9 +2293,7 @@ pub mod starships_connection_fields {
     pub struct Edges;
     impl ::cynic::schema::Field for Edges {
         type Type = Option<Vec<Option<super::StarshipsEdge>>>;
-        fn name() -> &'static str {
-            "edges"
-        }
+        const NAME: &'static str = "edges";
     }
     impl ::cynic::schema::HasField<Edges> for super::StarshipsConnection {
         type Type = Option<Vec<Option<super::StarshipsEdge>>>;
@@ -2897,9 +2301,7 @@ pub mod starships_connection_fields {
     pub struct TotalCount;
     impl ::cynic::schema::Field for TotalCount {
         type Type = Option<super::Int>;
-        fn name() -> &'static str {
-            "totalCount"
-        }
+        const NAME: &'static str = "totalCount";
     }
     impl ::cynic::schema::HasField<TotalCount> for super::StarshipsConnection {
         type Type = Option<super::Int>;
@@ -2907,9 +2309,7 @@ pub mod starships_connection_fields {
     pub struct Starships;
     impl ::cynic::schema::Field for Starships {
         type Type = Option<Vec<Option<super::Starship>>>;
-        fn name() -> &'static str {
-            "starships"
-        }
+        const NAME: &'static str = "starships";
     }
     impl ::cynic::schema::HasField<Starships> for super::StarshipsConnection {
         type Type = Option<Vec<Option<super::Starship>>>;
@@ -2920,9 +2320,7 @@ pub mod starships_edge_fields {
     pub struct Node;
     impl ::cynic::schema::Field for Node {
         type Type = Option<super::Starship>;
-        fn name() -> &'static str {
-            "node"
-        }
+        const NAME: &'static str = "node";
     }
     impl ::cynic::schema::HasField<Node> for super::StarshipsEdge {
         type Type = Option<super::Starship>;
@@ -2930,9 +2328,7 @@ pub mod starships_edge_fields {
     pub struct Cursor;
     impl ::cynic::schema::Field for Cursor {
         type Type = super::String;
-        fn name() -> &'static str {
-            "cursor"
-        }
+        const NAME: &'static str = "cursor";
     }
     impl ::cynic::schema::HasField<Cursor> for super::StarshipsEdge {
         type Type = super::String;
@@ -2943,9 +2339,7 @@ pub mod vehicle_fields {
     pub struct Name;
     impl ::cynic::schema::Field for Name {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "name"
-        }
+        const NAME: &'static str = "name";
     }
     impl ::cynic::schema::HasField<Name> for super::Vehicle {
         type Type = Option<super::String>;
@@ -2953,9 +2347,7 @@ pub mod vehicle_fields {
     pub struct Model;
     impl ::cynic::schema::Field for Model {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "model"
-        }
+        const NAME: &'static str = "model";
     }
     impl ::cynic::schema::HasField<Model> for super::Vehicle {
         type Type = Option<super::String>;
@@ -2963,9 +2355,7 @@ pub mod vehicle_fields {
     pub struct VehicleClass;
     impl ::cynic::schema::Field for VehicleClass {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "vehicleClass"
-        }
+        const NAME: &'static str = "vehicleClass";
     }
     impl ::cynic::schema::HasField<VehicleClass> for super::Vehicle {
         type Type = Option<super::String>;
@@ -2973,9 +2363,7 @@ pub mod vehicle_fields {
     pub struct Manufacturers;
     impl ::cynic::schema::Field for Manufacturers {
         type Type = Option<Vec<Option<super::String>>>;
-        fn name() -> &'static str {
-            "manufacturers"
-        }
+        const NAME: &'static str = "manufacturers";
     }
     impl ::cynic::schema::HasField<Manufacturers> for super::Vehicle {
         type Type = Option<Vec<Option<super::String>>>;
@@ -2983,9 +2371,7 @@ pub mod vehicle_fields {
     pub struct CostInCredits;
     impl ::cynic::schema::Field for CostInCredits {
         type Type = Option<super::Float>;
-        fn name() -> &'static str {
-            "costInCredits"
-        }
+        const NAME: &'static str = "costInCredits";
     }
     impl ::cynic::schema::HasField<CostInCredits> for super::Vehicle {
         type Type = Option<super::Float>;
@@ -2993,9 +2379,7 @@ pub mod vehicle_fields {
     pub struct Length;
     impl ::cynic::schema::Field for Length {
         type Type = Option<super::Float>;
-        fn name() -> &'static str {
-            "length"
-        }
+        const NAME: &'static str = "length";
     }
     impl ::cynic::schema::HasField<Length> for super::Vehicle {
         type Type = Option<super::Float>;
@@ -3003,9 +2387,7 @@ pub mod vehicle_fields {
     pub struct Crew;
     impl ::cynic::schema::Field for Crew {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "crew"
-        }
+        const NAME: &'static str = "crew";
     }
     impl ::cynic::schema::HasField<Crew> for super::Vehicle {
         type Type = Option<super::String>;
@@ -3013,9 +2395,7 @@ pub mod vehicle_fields {
     pub struct Passengers;
     impl ::cynic::schema::Field for Passengers {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "passengers"
-        }
+        const NAME: &'static str = "passengers";
     }
     impl ::cynic::schema::HasField<Passengers> for super::Vehicle {
         type Type = Option<super::String>;
@@ -3023,9 +2403,7 @@ pub mod vehicle_fields {
     pub struct MaxAtmospheringSpeed;
     impl ::cynic::schema::Field for MaxAtmospheringSpeed {
         type Type = Option<super::Int>;
-        fn name() -> &'static str {
-            "maxAtmospheringSpeed"
-        }
+        const NAME: &'static str = "maxAtmospheringSpeed";
     }
     impl ::cynic::schema::HasField<MaxAtmospheringSpeed> for super::Vehicle {
         type Type = Option<super::Int>;
@@ -3033,9 +2411,7 @@ pub mod vehicle_fields {
     pub struct CargoCapacity;
     impl ::cynic::schema::Field for CargoCapacity {
         type Type = Option<super::Float>;
-        fn name() -> &'static str {
-            "cargoCapacity"
-        }
+        const NAME: &'static str = "cargoCapacity";
     }
     impl ::cynic::schema::HasField<CargoCapacity> for super::Vehicle {
         type Type = Option<super::Float>;
@@ -3043,9 +2419,7 @@ pub mod vehicle_fields {
     pub struct Consumables;
     impl ::cynic::schema::Field for Consumables {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "consumables"
-        }
+        const NAME: &'static str = "consumables";
     }
     impl ::cynic::schema::HasField<Consumables> for super::Vehicle {
         type Type = Option<super::String>;
@@ -3053,9 +2427,7 @@ pub mod vehicle_fields {
     pub struct PilotConnection;
     impl ::cynic::schema::Field for PilotConnection {
         type Type = Option<super::VehiclePilotsConnection>;
-        fn name() -> &'static str {
-            "pilotConnection"
-        }
+        const NAME: &'static str = "pilotConnection";
     }
     impl ::cynic::schema::HasField<PilotConnection> for super::Vehicle {
         type Type = Option<super::VehiclePilotsConnection>;
@@ -3064,38 +2436,28 @@ pub mod vehicle_fields {
         pub struct After;
         impl ::cynic::schema::HasArgument<After> for super::PilotConnection {
             type ArgumentType = Option<super::super::String>;
-            fn name() -> &'static str {
-                "after"
-            }
+            const NAME: &'static str = "after";
         }
         pub struct First;
         impl ::cynic::schema::HasArgument<First> for super::PilotConnection {
             type ArgumentType = Option<super::super::Int>;
-            fn name() -> &'static str {
-                "first"
-            }
+            const NAME: &'static str = "first";
         }
         pub struct Before;
         impl ::cynic::schema::HasArgument<Before> for super::PilotConnection {
             type ArgumentType = Option<super::super::String>;
-            fn name() -> &'static str {
-                "before"
-            }
+            const NAME: &'static str = "before";
         }
         pub struct Last;
         impl ::cynic::schema::HasArgument<Last> for super::PilotConnection {
             type ArgumentType = Option<super::super::Int>;
-            fn name() -> &'static str {
-                "last"
-            }
+            const NAME: &'static str = "last";
         }
     }
     pub struct FilmConnection;
     impl ::cynic::schema::Field for FilmConnection {
         type Type = Option<super::VehicleFilmsConnection>;
-        fn name() -> &'static str {
-            "filmConnection"
-        }
+        const NAME: &'static str = "filmConnection";
     }
     impl ::cynic::schema::HasField<FilmConnection> for super::Vehicle {
         type Type = Option<super::VehicleFilmsConnection>;
@@ -3104,38 +2466,28 @@ pub mod vehicle_fields {
         pub struct After;
         impl ::cynic::schema::HasArgument<After> for super::FilmConnection {
             type ArgumentType = Option<super::super::String>;
-            fn name() -> &'static str {
-                "after"
-            }
+            const NAME: &'static str = "after";
         }
         pub struct First;
         impl ::cynic::schema::HasArgument<First> for super::FilmConnection {
             type ArgumentType = Option<super::super::Int>;
-            fn name() -> &'static str {
-                "first"
-            }
+            const NAME: &'static str = "first";
         }
         pub struct Before;
         impl ::cynic::schema::HasArgument<Before> for super::FilmConnection {
             type ArgumentType = Option<super::super::String>;
-            fn name() -> &'static str {
-                "before"
-            }
+            const NAME: &'static str = "before";
         }
         pub struct Last;
         impl ::cynic::schema::HasArgument<Last> for super::FilmConnection {
             type ArgumentType = Option<super::super::Int>;
-            fn name() -> &'static str {
-                "last"
-            }
+            const NAME: &'static str = "last";
         }
     }
     pub struct Created;
     impl ::cynic::schema::Field for Created {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "created"
-        }
+        const NAME: &'static str = "created";
     }
     impl ::cynic::schema::HasField<Created> for super::Vehicle {
         type Type = Option<super::String>;
@@ -3143,9 +2495,7 @@ pub mod vehicle_fields {
     pub struct Edited;
     impl ::cynic::schema::Field for Edited {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "edited"
-        }
+        const NAME: &'static str = "edited";
     }
     impl ::cynic::schema::HasField<Edited> for super::Vehicle {
         type Type = Option<super::String>;
@@ -3153,9 +2503,7 @@ pub mod vehicle_fields {
     pub struct Id;
     impl ::cynic::schema::Field for Id {
         type Type = super::Id;
-        fn name() -> &'static str {
-            "id"
-        }
+        const NAME: &'static str = "id";
     }
     impl ::cynic::schema::HasField<Id> for super::Vehicle {
         type Type = super::Id;
@@ -3166,9 +2514,7 @@ pub mod vehicle_films_connection_fields {
     pub struct PageInfo;
     impl ::cynic::schema::Field for PageInfo {
         type Type = super::PageInfo;
-        fn name() -> &'static str {
-            "pageInfo"
-        }
+        const NAME: &'static str = "pageInfo";
     }
     impl ::cynic::schema::HasField<PageInfo> for super::VehicleFilmsConnection {
         type Type = super::PageInfo;
@@ -3176,9 +2522,7 @@ pub mod vehicle_films_connection_fields {
     pub struct Edges;
     impl ::cynic::schema::Field for Edges {
         type Type = Option<Vec<Option<super::VehicleFilmsEdge>>>;
-        fn name() -> &'static str {
-            "edges"
-        }
+        const NAME: &'static str = "edges";
     }
     impl ::cynic::schema::HasField<Edges> for super::VehicleFilmsConnection {
         type Type = Option<Vec<Option<super::VehicleFilmsEdge>>>;
@@ -3186,9 +2530,7 @@ pub mod vehicle_films_connection_fields {
     pub struct TotalCount;
     impl ::cynic::schema::Field for TotalCount {
         type Type = Option<super::Int>;
-        fn name() -> &'static str {
-            "totalCount"
-        }
+        const NAME: &'static str = "totalCount";
     }
     impl ::cynic::schema::HasField<TotalCount> for super::VehicleFilmsConnection {
         type Type = Option<super::Int>;
@@ -3196,9 +2538,7 @@ pub mod vehicle_films_connection_fields {
     pub struct Films;
     impl ::cynic::schema::Field for Films {
         type Type = Option<Vec<Option<super::Film>>>;
-        fn name() -> &'static str {
-            "films"
-        }
+        const NAME: &'static str = "films";
     }
     impl ::cynic::schema::HasField<Films> for super::VehicleFilmsConnection {
         type Type = Option<Vec<Option<super::Film>>>;
@@ -3209,9 +2549,7 @@ pub mod vehicle_films_edge_fields {
     pub struct Node;
     impl ::cynic::schema::Field for Node {
         type Type = Option<super::Film>;
-        fn name() -> &'static str {
-            "node"
-        }
+        const NAME: &'static str = "node";
     }
     impl ::cynic::schema::HasField<Node> for super::VehicleFilmsEdge {
         type Type = Option<super::Film>;
@@ -3219,9 +2557,7 @@ pub mod vehicle_films_edge_fields {
     pub struct Cursor;
     impl ::cynic::schema::Field for Cursor {
         type Type = super::String;
-        fn name() -> &'static str {
-            "cursor"
-        }
+        const NAME: &'static str = "cursor";
     }
     impl ::cynic::schema::HasField<Cursor> for super::VehicleFilmsEdge {
         type Type = super::String;
@@ -3232,9 +2568,7 @@ pub mod vehicle_pilots_connection_fields {
     pub struct PageInfo;
     impl ::cynic::schema::Field for PageInfo {
         type Type = super::PageInfo;
-        fn name() -> &'static str {
-            "pageInfo"
-        }
+        const NAME: &'static str = "pageInfo";
     }
     impl ::cynic::schema::HasField<PageInfo> for super::VehiclePilotsConnection {
         type Type = super::PageInfo;
@@ -3242,9 +2576,7 @@ pub mod vehicle_pilots_connection_fields {
     pub struct Edges;
     impl ::cynic::schema::Field for Edges {
         type Type = Option<Vec<Option<super::VehiclePilotsEdge>>>;
-        fn name() -> &'static str {
-            "edges"
-        }
+        const NAME: &'static str = "edges";
     }
     impl ::cynic::schema::HasField<Edges> for super::VehiclePilotsConnection {
         type Type = Option<Vec<Option<super::VehiclePilotsEdge>>>;
@@ -3252,9 +2584,7 @@ pub mod vehicle_pilots_connection_fields {
     pub struct TotalCount;
     impl ::cynic::schema::Field for TotalCount {
         type Type = Option<super::Int>;
-        fn name() -> &'static str {
-            "totalCount"
-        }
+        const NAME: &'static str = "totalCount";
     }
     impl ::cynic::schema::HasField<TotalCount> for super::VehiclePilotsConnection {
         type Type = Option<super::Int>;
@@ -3262,9 +2592,7 @@ pub mod vehicle_pilots_connection_fields {
     pub struct Pilots;
     impl ::cynic::schema::Field for Pilots {
         type Type = Option<Vec<Option<super::Person>>>;
-        fn name() -> &'static str {
-            "pilots"
-        }
+        const NAME: &'static str = "pilots";
     }
     impl ::cynic::schema::HasField<Pilots> for super::VehiclePilotsConnection {
         type Type = Option<Vec<Option<super::Person>>>;
@@ -3275,9 +2603,7 @@ pub mod vehicle_pilots_edge_fields {
     pub struct Node;
     impl ::cynic::schema::Field for Node {
         type Type = Option<super::Person>;
-        fn name() -> &'static str {
-            "node"
-        }
+        const NAME: &'static str = "node";
     }
     impl ::cynic::schema::HasField<Node> for super::VehiclePilotsEdge {
         type Type = Option<super::Person>;
@@ -3285,9 +2611,7 @@ pub mod vehicle_pilots_edge_fields {
     pub struct Cursor;
     impl ::cynic::schema::Field for Cursor {
         type Type = super::String;
-        fn name() -> &'static str {
-            "cursor"
-        }
+        const NAME: &'static str = "cursor";
     }
     impl ::cynic::schema::HasField<Cursor> for super::VehiclePilotsEdge {
         type Type = super::String;
@@ -3298,9 +2622,7 @@ pub mod vehicles_connection_fields {
     pub struct PageInfo;
     impl ::cynic::schema::Field for PageInfo {
         type Type = super::PageInfo;
-        fn name() -> &'static str {
-            "pageInfo"
-        }
+        const NAME: &'static str = "pageInfo";
     }
     impl ::cynic::schema::HasField<PageInfo> for super::VehiclesConnection {
         type Type = super::PageInfo;
@@ -3308,9 +2630,7 @@ pub mod vehicles_connection_fields {
     pub struct Edges;
     impl ::cynic::schema::Field for Edges {
         type Type = Option<Vec<Option<super::VehiclesEdge>>>;
-        fn name() -> &'static str {
-            "edges"
-        }
+        const NAME: &'static str = "edges";
     }
     impl ::cynic::schema::HasField<Edges> for super::VehiclesConnection {
         type Type = Option<Vec<Option<super::VehiclesEdge>>>;
@@ -3318,9 +2638,7 @@ pub mod vehicles_connection_fields {
     pub struct TotalCount;
     impl ::cynic::schema::Field for TotalCount {
         type Type = Option<super::Int>;
-        fn name() -> &'static str {
-            "totalCount"
-        }
+        const NAME: &'static str = "totalCount";
     }
     impl ::cynic::schema::HasField<TotalCount> for super::VehiclesConnection {
         type Type = Option<super::Int>;
@@ -3328,9 +2646,7 @@ pub mod vehicles_connection_fields {
     pub struct Vehicles;
     impl ::cynic::schema::Field for Vehicles {
         type Type = Option<Vec<Option<super::Vehicle>>>;
-        fn name() -> &'static str {
-            "vehicles"
-        }
+        const NAME: &'static str = "vehicles";
     }
     impl ::cynic::schema::HasField<Vehicles> for super::VehiclesConnection {
         type Type = Option<Vec<Option<super::Vehicle>>>;
@@ -3341,9 +2657,7 @@ pub mod vehicles_edge_fields {
     pub struct Node;
     impl ::cynic::schema::Field for Node {
         type Type = Option<super::Vehicle>;
-        fn name() -> &'static str {
-            "node"
-        }
+        const NAME: &'static str = "node";
     }
     impl ::cynic::schema::HasField<Node> for super::VehiclesEdge {
         type Type = Option<super::Vehicle>;
@@ -3351,9 +2665,7 @@ pub mod vehicles_edge_fields {
     pub struct Cursor;
     impl ::cynic::schema::Field for Cursor {
         type Type = super::String;
-        fn name() -> &'static str {
-            "cursor"
-        }
+        const NAME: &'static str = "cursor";
     }
     impl ::cynic::schema::HasField<Cursor> for super::VehiclesEdge {
         type Type = super::String;
@@ -3367,269 +2679,163 @@ impl ::cynic::schema::HasSubtype<Species> for Node {}
 impl ::cynic::schema::HasSubtype<Starship> for Node {}
 impl ::cynic::schema::HasSubtype<Vehicle> for Node {}
 impl ::cynic::schema::NamedType for Film {
-    fn name() -> &'static str {
-        "Film"
-    }
+    const NAME: &'static str = "Film";
 }
 impl ::cynic::schema::NamedType for FilmCharactersConnection {
-    fn name() -> &'static str {
-        "FilmCharactersConnection"
-    }
+    const NAME: &'static str = "FilmCharactersConnection";
 }
 impl ::cynic::schema::NamedType for FilmCharactersEdge {
-    fn name() -> &'static str {
-        "FilmCharactersEdge"
-    }
+    const NAME: &'static str = "FilmCharactersEdge";
 }
 impl ::cynic::schema::NamedType for FilmPlanetsConnection {
-    fn name() -> &'static str {
-        "FilmPlanetsConnection"
-    }
+    const NAME: &'static str = "FilmPlanetsConnection";
 }
 impl ::cynic::schema::NamedType for FilmPlanetsEdge {
-    fn name() -> &'static str {
-        "FilmPlanetsEdge"
-    }
+    const NAME: &'static str = "FilmPlanetsEdge";
 }
 impl ::cynic::schema::NamedType for FilmSpeciesConnection {
-    fn name() -> &'static str {
-        "FilmSpeciesConnection"
-    }
+    const NAME: &'static str = "FilmSpeciesConnection";
 }
 impl ::cynic::schema::NamedType for FilmSpeciesEdge {
-    fn name() -> &'static str {
-        "FilmSpeciesEdge"
-    }
+    const NAME: &'static str = "FilmSpeciesEdge";
 }
 impl ::cynic::schema::NamedType for FilmStarshipsConnection {
-    fn name() -> &'static str {
-        "FilmStarshipsConnection"
-    }
+    const NAME: &'static str = "FilmStarshipsConnection";
 }
 impl ::cynic::schema::NamedType for FilmStarshipsEdge {
-    fn name() -> &'static str {
-        "FilmStarshipsEdge"
-    }
+    const NAME: &'static str = "FilmStarshipsEdge";
 }
 impl ::cynic::schema::NamedType for FilmVehiclesConnection {
-    fn name() -> &'static str {
-        "FilmVehiclesConnection"
-    }
+    const NAME: &'static str = "FilmVehiclesConnection";
 }
 impl ::cynic::schema::NamedType for FilmVehiclesEdge {
-    fn name() -> &'static str {
-        "FilmVehiclesEdge"
-    }
+    const NAME: &'static str = "FilmVehiclesEdge";
 }
 impl ::cynic::schema::NamedType for FilmsConnection {
-    fn name() -> &'static str {
-        "FilmsConnection"
-    }
+    const NAME: &'static str = "FilmsConnection";
 }
 impl ::cynic::schema::NamedType for FilmsEdge {
-    fn name() -> &'static str {
-        "FilmsEdge"
-    }
+    const NAME: &'static str = "FilmsEdge";
 }
 impl ::cynic::schema::NamedType for Node {
-    fn name() -> &'static str {
-        "Node"
-    }
+    const NAME: &'static str = "Node";
 }
 impl ::cynic::schema::NamedType for PageInfo {
-    fn name() -> &'static str {
-        "PageInfo"
-    }
+    const NAME: &'static str = "PageInfo";
 }
 impl ::cynic::schema::NamedType for PeopleConnection {
-    fn name() -> &'static str {
-        "PeopleConnection"
-    }
+    const NAME: &'static str = "PeopleConnection";
 }
 impl ::cynic::schema::NamedType for PeopleEdge {
-    fn name() -> &'static str {
-        "PeopleEdge"
-    }
+    const NAME: &'static str = "PeopleEdge";
 }
 impl ::cynic::schema::NamedType for Person {
-    fn name() -> &'static str {
-        "Person"
-    }
+    const NAME: &'static str = "Person";
 }
 impl ::cynic::schema::NamedType for PersonFilmsConnection {
-    fn name() -> &'static str {
-        "PersonFilmsConnection"
-    }
+    const NAME: &'static str = "PersonFilmsConnection";
 }
 impl ::cynic::schema::NamedType for PersonFilmsEdge {
-    fn name() -> &'static str {
-        "PersonFilmsEdge"
-    }
+    const NAME: &'static str = "PersonFilmsEdge";
 }
 impl ::cynic::schema::NamedType for PersonStarshipsConnection {
-    fn name() -> &'static str {
-        "PersonStarshipsConnection"
-    }
+    const NAME: &'static str = "PersonStarshipsConnection";
 }
 impl ::cynic::schema::NamedType for PersonStarshipsEdge {
-    fn name() -> &'static str {
-        "PersonStarshipsEdge"
-    }
+    const NAME: &'static str = "PersonStarshipsEdge";
 }
 impl ::cynic::schema::NamedType for PersonVehiclesConnection {
-    fn name() -> &'static str {
-        "PersonVehiclesConnection"
-    }
+    const NAME: &'static str = "PersonVehiclesConnection";
 }
 impl ::cynic::schema::NamedType for PersonVehiclesEdge {
-    fn name() -> &'static str {
-        "PersonVehiclesEdge"
-    }
+    const NAME: &'static str = "PersonVehiclesEdge";
 }
 impl ::cynic::schema::NamedType for Planet {
-    fn name() -> &'static str {
-        "Planet"
-    }
+    const NAME: &'static str = "Planet";
 }
 impl ::cynic::schema::NamedType for PlanetFilmsConnection {
-    fn name() -> &'static str {
-        "PlanetFilmsConnection"
-    }
+    const NAME: &'static str = "PlanetFilmsConnection";
 }
 impl ::cynic::schema::NamedType for PlanetFilmsEdge {
-    fn name() -> &'static str {
-        "PlanetFilmsEdge"
-    }
+    const NAME: &'static str = "PlanetFilmsEdge";
 }
 impl ::cynic::schema::NamedType for PlanetResidentsConnection {
-    fn name() -> &'static str {
-        "PlanetResidentsConnection"
-    }
+    const NAME: &'static str = "PlanetResidentsConnection";
 }
 impl ::cynic::schema::NamedType for PlanetResidentsEdge {
-    fn name() -> &'static str {
-        "PlanetResidentsEdge"
-    }
+    const NAME: &'static str = "PlanetResidentsEdge";
 }
 impl ::cynic::schema::NamedType for PlanetsConnection {
-    fn name() -> &'static str {
-        "PlanetsConnection"
-    }
+    const NAME: &'static str = "PlanetsConnection";
 }
 impl ::cynic::schema::NamedType for PlanetsEdge {
-    fn name() -> &'static str {
-        "PlanetsEdge"
-    }
+    const NAME: &'static str = "PlanetsEdge";
 }
 impl ::cynic::schema::NamedType for Root {
-    fn name() -> &'static str {
-        "Root"
-    }
+    const NAME: &'static str = "Root";
 }
 impl ::cynic::schema::NamedType for Species {
-    fn name() -> &'static str {
-        "Species"
-    }
+    const NAME: &'static str = "Species";
 }
 impl ::cynic::schema::NamedType for SpeciesConnection {
-    fn name() -> &'static str {
-        "SpeciesConnection"
-    }
+    const NAME: &'static str = "SpeciesConnection";
 }
 impl ::cynic::schema::NamedType for SpeciesEdge {
-    fn name() -> &'static str {
-        "SpeciesEdge"
-    }
+    const NAME: &'static str = "SpeciesEdge";
 }
 impl ::cynic::schema::NamedType for SpeciesFilmsConnection {
-    fn name() -> &'static str {
-        "SpeciesFilmsConnection"
-    }
+    const NAME: &'static str = "SpeciesFilmsConnection";
 }
 impl ::cynic::schema::NamedType for SpeciesFilmsEdge {
-    fn name() -> &'static str {
-        "SpeciesFilmsEdge"
-    }
+    const NAME: &'static str = "SpeciesFilmsEdge";
 }
 impl ::cynic::schema::NamedType for SpeciesPeopleConnection {
-    fn name() -> &'static str {
-        "SpeciesPeopleConnection"
-    }
+    const NAME: &'static str = "SpeciesPeopleConnection";
 }
 impl ::cynic::schema::NamedType for SpeciesPeopleEdge {
-    fn name() -> &'static str {
-        "SpeciesPeopleEdge"
-    }
+    const NAME: &'static str = "SpeciesPeopleEdge";
 }
 impl ::cynic::schema::NamedType for Starship {
-    fn name() -> &'static str {
-        "Starship"
-    }
+    const NAME: &'static str = "Starship";
 }
 impl ::cynic::schema::NamedType for StarshipFilmsConnection {
-    fn name() -> &'static str {
-        "StarshipFilmsConnection"
-    }
+    const NAME: &'static str = "StarshipFilmsConnection";
 }
 impl ::cynic::schema::NamedType for StarshipFilmsEdge {
-    fn name() -> &'static str {
-        "StarshipFilmsEdge"
-    }
+    const NAME: &'static str = "StarshipFilmsEdge";
 }
 impl ::cynic::schema::NamedType for StarshipPilotsConnection {
-    fn name() -> &'static str {
-        "StarshipPilotsConnection"
-    }
+    const NAME: &'static str = "StarshipPilotsConnection";
 }
 impl ::cynic::schema::NamedType for StarshipPilotsEdge {
-    fn name() -> &'static str {
-        "StarshipPilotsEdge"
-    }
+    const NAME: &'static str = "StarshipPilotsEdge";
 }
 impl ::cynic::schema::NamedType for StarshipsConnection {
-    fn name() -> &'static str {
-        "StarshipsConnection"
-    }
+    const NAME: &'static str = "StarshipsConnection";
 }
 impl ::cynic::schema::NamedType for StarshipsEdge {
-    fn name() -> &'static str {
-        "StarshipsEdge"
-    }
+    const NAME: &'static str = "StarshipsEdge";
 }
 impl ::cynic::schema::NamedType for Vehicle {
-    fn name() -> &'static str {
-        "Vehicle"
-    }
+    const NAME: &'static str = "Vehicle";
 }
 impl ::cynic::schema::NamedType for VehicleFilmsConnection {
-    fn name() -> &'static str {
-        "VehicleFilmsConnection"
-    }
+    const NAME: &'static str = "VehicleFilmsConnection";
 }
 impl ::cynic::schema::NamedType for VehicleFilmsEdge {
-    fn name() -> &'static str {
-        "VehicleFilmsEdge"
-    }
+    const NAME: &'static str = "VehicleFilmsEdge";
 }
 impl ::cynic::schema::NamedType for VehiclePilotsConnection {
-    fn name() -> &'static str {
-        "VehiclePilotsConnection"
-    }
+    const NAME: &'static str = "VehiclePilotsConnection";
 }
 impl ::cynic::schema::NamedType for VehiclePilotsEdge {
-    fn name() -> &'static str {
-        "VehiclePilotsEdge"
-    }
+    const NAME: &'static str = "VehiclePilotsEdge";
 }
 impl ::cynic::schema::NamedType for VehiclesConnection {
-    fn name() -> &'static str {
-        "VehiclesConnection"
-    }
+    const NAME: &'static str = "VehiclesConnection";
 }
 impl ::cynic::schema::NamedType for VehiclesEdge {
-    fn name() -> &'static str {
-        "VehiclesEdge"
-    }
+    const NAME: &'static str = "VehiclesEdge";
 }
 pub type Boolean = bool;
 pub type String = std::string::String;

--- a/cynic-codegen/tests/snapshots/use_schema__schema_file_4.snap
+++ b/cynic-codegen/tests/snapshots/use_schema__schema_file_4.snap
@@ -10,9 +10,7 @@ pub mod bar_fields {
     pub struct Id;
     impl ::cynic::schema::Field for Id {
         type Type = super::Uuid;
-        fn name() -> &'static str {
-            "id"
-        }
+        const NAME: &'static str = "id";
     }
     impl ::cynic::schema::HasField<Id> for super::Bar {
         type Type = super::Uuid;
@@ -20,9 +18,7 @@ pub mod bar_fields {
     pub struct Name;
     impl ::cynic::schema::Field for Name {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "name"
-        }
+        const NAME: &'static str = "name";
     }
     impl ::cynic::schema::HasField<Name> for super::Bar {
         type Type = Option<super::String>;
@@ -33,9 +29,7 @@ pub mod foo_fields {
     pub struct _Underscore;
     impl ::cynic::schema::Field for _Underscore {
         type Type = Option<super::Boolean>;
-        fn name() -> &'static str {
-            "_"
-        }
+        const NAME: &'static str = "_";
     }
     impl ::cynic::schema::HasField<_Underscore> for super::Foo {
         type Type = Option<super::Boolean>;
@@ -43,9 +37,7 @@ pub mod foo_fields {
     pub struct Self_;
     impl ::cynic::schema::Field for Self_ {
         type Type = Option<super::Boolean>;
-        fn name() -> &'static str {
-            "self"
-        }
+        const NAME: &'static str = "self";
     }
     impl ::cynic::schema::HasField<Self_> for super::Foo {
         type Type = Option<super::Boolean>;
@@ -53,9 +45,7 @@ pub mod foo_fields {
     pub struct Super;
     impl ::cynic::schema::Field for Super {
         type Type = Option<super::Boolean>;
-        fn name() -> &'static str {
-            "super"
-        }
+        const NAME: &'static str = "super";
     }
     impl ::cynic::schema::HasField<Super> for super::Foo {
         type Type = Option<super::Boolean>;
@@ -63,9 +53,7 @@ pub mod foo_fields {
     pub struct Crate;
     impl ::cynic::schema::Field for Crate {
         type Type = Option<super::Boolean>;
-        fn name() -> &'static str {
-            "crate"
-        }
+        const NAME: &'static str = "crate";
     }
     impl ::cynic::schema::HasField<Crate> for super::Foo {
         type Type = Option<super::Boolean>;
@@ -73,9 +61,7 @@ pub mod foo_fields {
     pub struct Async;
     impl ::cynic::schema::Field for Async {
         type Type = Option<super::Boolean>;
-        fn name() -> &'static str {
-            "async"
-        }
+        const NAME: &'static str = "async";
     }
     impl ::cynic::schema::HasField<Async> for super::Foo {
         type Type = Option<super::Boolean>;
@@ -83,9 +69,7 @@ pub mod foo_fields {
     pub struct Bar;
     impl ::cynic::schema::Field for Bar {
         type Type = Option<super::Bar>;
-        fn name() -> &'static str {
-            "bar"
-        }
+        const NAME: &'static str = "bar";
     }
     impl ::cynic::schema::HasField<Bar> for super::Foo {
         type Type = Option<super::Bar>;
@@ -94,23 +78,17 @@ pub mod foo_fields {
         pub struct Id;
         impl ::cynic::schema::HasArgument<Id> for super::Bar {
             type ArgumentType = super::super::Uuid;
-            fn name() -> &'static str {
-                "id"
-            }
+            const NAME: &'static str = "id";
         }
     }
 }
 pub struct States {}
 pub struct Uuid {}
 impl ::cynic::schema::NamedType for Bar {
-    fn name() -> &'static str {
-        "Bar"
-    }
+    const NAME: &'static str = "Bar";
 }
 impl ::cynic::schema::NamedType for Foo {
-    fn name() -> &'static str {
-        "Foo"
-    }
+    const NAME: &'static str = "Foo";
 }
 pub type Boolean = bool;
 pub type String = std::string::String;

--- a/cynic-codegen/tests/snapshots/use_schema__schema_file_5.snap
+++ b/cynic-codegen/tests/snapshots/use_schema__schema_file_5.snap
@@ -11,9 +11,7 @@ pub mod an_input_type_fields {
     pub struct FavouriteDessert;
     impl ::cynic::schema::Field for FavouriteDessert {
         type Type = Option<super::Dessert>;
-        fn name() -> &'static str {
-            "favouriteDessert"
-        }
+        const NAME: &'static str = "favouriteDessert";
     }
     impl ::cynic::schema::HasInputField<FavouriteDessert, Option<super::Dessert>>
         for super::AnInputType
@@ -28,9 +26,7 @@ pub mod nested_fields {
     pub struct AString;
     impl ::cynic::schema::Field for AString {
         type Type = super::String;
-        fn name() -> &'static str {
-            "aString"
-        }
+        const NAME: &'static str = "aString";
     }
     impl ::cynic::schema::HasField<AString> for super::Nested {
         type Type = super::String;
@@ -38,9 +34,7 @@ pub mod nested_fields {
     pub struct OptString;
     impl ::cynic::schema::Field for OptString {
         type Type = Option<super::String>;
-        fn name() -> &'static str {
-            "optString"
-        }
+        const NAME: &'static str = "optString";
     }
     impl ::cynic::schema::HasField<OptString> for super::Nested {
         type Type = Option<super::String>;
@@ -51,9 +45,7 @@ pub mod query_fields {
     pub struct TestStruct;
     impl ::cynic::schema::Field for TestStruct {
         type Type = Option<super::TestStruct>;
-        fn name() -> &'static str {
-            "testStruct"
-        }
+        const NAME: &'static str = "testStruct";
     }
     impl ::cynic::schema::HasField<TestStruct> for super::Query {
         type Type = Option<super::TestStruct>;
@@ -61,9 +53,7 @@ pub mod query_fields {
     pub struct MyUnion;
     impl ::cynic::schema::Field for MyUnion {
         type Type = Option<super::MyUnionType>;
-        fn name() -> &'static str {
-            "myUnion"
-        }
+        const NAME: &'static str = "myUnion";
     }
     impl ::cynic::schema::HasField<MyUnion> for super::Query {
         type Type = Option<super::MyUnionType>;
@@ -74,9 +64,7 @@ pub mod test_struct_fields {
     pub struct FieldOne;
     impl ::cynic::schema::Field for FieldOne {
         type Type = super::String;
-        fn name() -> &'static str {
-            "fieldOne"
-        }
+        const NAME: &'static str = "fieldOne";
     }
     impl ::cynic::schema::HasField<FieldOne> for super::TestStruct {
         type Type = super::String;
@@ -85,24 +73,18 @@ pub mod test_struct_fields {
         pub struct X;
         impl ::cynic::schema::HasArgument<X> for super::FieldOne {
             type ArgumentType = Option<super::super::Int>;
-            fn name() -> &'static str {
-                "x"
-            }
+            const NAME: &'static str = "x";
         }
         pub struct Y;
         impl ::cynic::schema::HasArgument<Y> for super::FieldOne {
             type ArgumentType = Option<super::super::String>;
-            fn name() -> &'static str {
-                "y"
-            }
+            const NAME: &'static str = "y";
         }
     }
     pub struct TastyCakes;
     impl ::cynic::schema::Field for TastyCakes {
         type Type = super::Dessert;
-        fn name() -> &'static str {
-            "tastyCakes"
-        }
+        const NAME: &'static str = "tastyCakes";
     }
     impl ::cynic::schema::HasField<TastyCakes> for super::TestStruct {
         type Type = super::Dessert;
@@ -111,24 +93,18 @@ pub mod test_struct_fields {
         pub struct First;
         impl ::cynic::schema::HasArgument<First> for super::TastyCakes {
             type ArgumentType = super::super::Dessert;
-            fn name() -> &'static str {
-                "first"
-            }
+            const NAME: &'static str = "first";
         }
         pub struct Second;
         impl ::cynic::schema::HasArgument<Second> for super::TastyCakes {
             type ArgumentType = Option<super::super::Dessert>;
-            fn name() -> &'static str {
-                "second"
-            }
+            const NAME: &'static str = "second";
         }
     }
     pub struct FieldWithInput;
     impl ::cynic::schema::Field for FieldWithInput {
         type Type = super::Dessert;
-        fn name() -> &'static str {
-            "fieldWithInput"
-        }
+        const NAME: &'static str = "fieldWithInput";
     }
     impl ::cynic::schema::HasField<FieldWithInput> for super::TestStruct {
         type Type = super::Dessert;
@@ -137,17 +113,13 @@ pub mod test_struct_fields {
         pub struct Input;
         impl ::cynic::schema::HasArgument<Input> for super::FieldWithInput {
             type ArgumentType = super::super::AnInputType;
-            fn name() -> &'static str {
-                "input"
-            }
+            const NAME: &'static str = "input";
         }
     }
     pub struct Nested;
     impl ::cynic::schema::Field for Nested {
         type Type = super::Nested;
-        fn name() -> &'static str {
-            "nested"
-        }
+        const NAME: &'static str = "nested";
     }
     impl ::cynic::schema::HasField<Nested> for super::TestStruct {
         type Type = super::Nested;
@@ -155,9 +127,7 @@ pub mod test_struct_fields {
     pub struct OptNested;
     impl ::cynic::schema::Field for OptNested {
         type Type = Option<super::Nested>;
-        fn name() -> &'static str {
-            "optNested"
-        }
+        const NAME: &'static str = "optNested";
     }
     impl ::cynic::schema::HasField<OptNested> for super::TestStruct {
         type Type = Option<super::Nested>;
@@ -165,9 +135,7 @@ pub mod test_struct_fields {
     pub struct Dessert;
     impl ::cynic::schema::Field for Dessert {
         type Type = Option<super::Dessert>;
-        fn name() -> &'static str {
-            "dessert"
-        }
+        const NAME: &'static str = "dessert";
     }
     impl ::cynic::schema::HasField<Dessert> for super::TestStruct {
         type Type = Option<super::Dessert>;
@@ -175,9 +143,7 @@ pub mod test_struct_fields {
     pub struct Json;
     impl ::cynic::schema::Field for Json {
         type Type = Option<super::Json>;
-        fn name() -> &'static str {
-            "json"
-        }
+        const NAME: &'static str = "json";
     }
     impl ::cynic::schema::HasField<Json> for super::TestStruct {
         type Type = Option<super::Json>;
@@ -186,24 +152,16 @@ pub mod test_struct_fields {
 impl ::cynic::schema::HasSubtype<Nested> for MyUnionType {}
 impl ::cynic::schema::HasSubtype<TestStruct> for MyUnionType {}
 impl ::cynic::schema::NamedType for MyUnionType {
-    fn name() -> &'static str {
-        "MyUnionType"
-    }
+    const NAME: &'static str = "MyUnionType";
 }
 impl ::cynic::schema::NamedType for Nested {
-    fn name() -> &'static str {
-        "Nested"
-    }
+    const NAME: &'static str = "Nested";
 }
 impl ::cynic::schema::NamedType for Query {
-    fn name() -> &'static str {
-        "Query"
-    }
+    const NAME: &'static str = "Query";
 }
 impl ::cynic::schema::NamedType for TestStruct {
-    fn name() -> &'static str {
-        "TestStruct"
-    }
+    const NAME: &'static str = "TestStruct";
 }
 pub type Boolean = bool;
 pub type String = std::string::String;

--- a/cynic/src/queries/builders.rs
+++ b/cynic/src/queries/builders.rs
@@ -59,7 +59,7 @@ impl<'a, SchemaType, Variables> SelectionBuilder<'a, SchemaType, Variables> {
     {
         FieldSelectionBuilder {
             recurse_depth: self.recurse_depth,
-            field: self.push_selection(FieldMarker::name()),
+            field: self.push_selection(FieldMarker::NAME),
             phantom: PhantomData,
         }
     }
@@ -80,7 +80,7 @@ impl<'a, SchemaType, Variables> SelectionBuilder<'a, SchemaType, Variables> {
     {
         FieldSelectionBuilder {
             recurse_depth: self.recurse_depth,
-            field: self.push_selection(FieldMarker::name()),
+            field: self.push_selection(FieldMarker::NAME),
             phantom: PhantomData,
         }
     }
@@ -105,7 +105,7 @@ impl<'a, SchemaType, Variables> SelectionBuilder<'a, SchemaType, Variables> {
 
         Some(FieldSelectionBuilder {
             recurse_depth: Some(new_depth),
-            field: self.push_selection(FieldMarker::name()),
+            field: self.push_selection(FieldMarker::NAME),
             phantom: PhantomData,
         })
     }
@@ -172,7 +172,7 @@ impl<'a, Field, FieldSchemaType, Variables>
         Field: schema::HasArgument<ArgumentName>,
     {
         InputBuilder {
-            destination: InputLiteralContainer::object(Field::name(), &mut self.field.arguments),
+            destination: InputLiteralContainer::object(Field::NAME, &mut self.field.arguments),
             phantom: PhantomData,
         }
     }
@@ -208,7 +208,7 @@ impl<'a, SchemaType, Variables> InlineFragmentBuilder<'a, SchemaType, Variables>
         Subtype: crate::schema::NamedType,
         SchemaType: crate::schema::HasSubtype<Subtype>,
     {
-        self.inline_fragment.on_clause = Some(Subtype::name());
+        self.inline_fragment.on_clause = Some(Subtype::NAME);
         InlineFragmentBuilder {
             inline_fragment: self.inline_fragment,
             phantom: PhantomData,
@@ -300,7 +300,7 @@ impl<'a, SchemaType, ArgStruct> ObjectArgumentBuilder<'a, SchemaType, ArgStruct>
         F: FnOnce(InputBuilder<'_, FieldMarker::Type, ArgStruct>),
     {
         field_fn(InputBuilder {
-            destination: InputLiteralContainer::object(FieldMarker::name(), self.fields),
+            destination: InputLiteralContainer::object(FieldMarker::NAME, self.fields),
             phantom: PhantomData,
         });
 

--- a/cynic/src/schema.rs
+++ b/cynic/src/schema.rs
@@ -16,8 +16,8 @@ pub trait Field {
     /// The schema marker type of this field.
     type Type;
 
-    /// Returns the name of this field
-    fn name() -> &'static str;
+    /// the name of this field
+    const NAME: &'static str;
 }
 
 // TODO: Get the terminology straight in this file, it's a mess.
@@ -47,8 +47,8 @@ pub trait HasArgument<ArgumentMarker> {
     /// The schema marker type of this argument.
     type ArgumentType;
 
-    /// Returns the name of this field
-    fn name() -> &'static str;
+    /// The name of this argument
+    const NAME: &'static str;
 }
 
 /// Indicates that a type is a scalar that maps to the given schema scalar.
@@ -117,8 +117,8 @@ pub trait HasSubtype<Type> {}
 
 /// A marker type with a name.
 pub trait NamedType {
-    /// Gets the name of the marker
-    fn name() -> &'static str;
+    /// The name of this type
+    const NAME: &'static str;
 }
 
 /// Indicates that a type is an `InputObject`


### PR DESCRIPTION
#### Why are we making this change?

#391 updated cynic with some new traits for defining the schema.  It used
associated functions that return static strings for a lot of it's stuff.
However, these could just have been associated constants instead.

#### What effects does this change have?

Updates all of these to just be associated constants.