### PR TITLE
[Merged by Bors] - Remove `serde_json` dep, clean up `http`/`surf` features.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,8 +36,19 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 - `QueryBuilder::build`, `MutationBuilder::build` and
   `SubscriptionBuilder::build` now take their argument by value not by
   reference.
-- The `reqwest` feature no longer uses the `native-tls` feature. Users should
-  enable one of the `tls` features of `reqwest` themselves.
+- The `surf`, `reqwest` & `reqwest-blocking` features have been renamed to
+  `http-surf`, `http-reqwest` & `http-reqwest-blocking` respectively.
+- The `http-reqwest` feature no longer uses the `native-tls` feature. Users
+  should enable one of the `tls` features of `reqwest` themselves.
+- The `surf-h1-client`, `surf-curl-client`, `surf-wasm-client`,
+  `surf-middleware-logger` & `surf-encoding` features have been removed. If
+  users want to enable these features in surf they should do it in their own
+  `Cargo.toml`.
+- `cynic` no longer re-exports `serde_json`
+- The `GraphQlError` & `GraphQlResponse` structs no longer contain a
+  `serde_json::Value` for extensions.  They now have generic parameters that you
+  should provide if you care about error extensions.
+
 
 ### Deprecations
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,12 +76,6 @@ checksum = "28b2cd92db5cbd74e8e5028f7e27dd7aa3090e89e4f2a197cc7c8dfb69c7063b"
 
 [[package]]
 name = "arrayvec"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
-
-[[package]]
-name = "arrayvec"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
@@ -107,16 +101,6 @@ dependencies = [
  "concurrent-queue",
  "event-listener",
  "futures-core",
-]
-
-[[package]]
-name = "async-dup"
-version = "1.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7427a12b8dc09291528cfb1da2447059adb4a257388c2acd6497a79d55cf6f7c"
-dependencies = [
- "futures-io",
- "simple-mutex",
 ]
 
 [[package]]
@@ -147,24 +131,6 @@ dependencies = [
  "futures-lite",
  "num_cpus",
  "once_cell",
-]
-
-[[package]]
-name = "async-h1"
-version = "2.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc5142de15b549749cce62923a50714b0d7b77f5090ced141599e78899865451"
-dependencies = [
- "async-channel",
- "async-dup",
- "async-std",
- "byte-pool",
- "futures-core",
- "http-types",
- "httparse",
- "lazy_static",
- "log",
- "pin-project",
 ]
 
 [[package]]
@@ -203,18 +169,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479db852db25d9dbf6204e6cb6253698f175c15726470f78af0d918e99d6156e"
 dependencies = [
  "event-listener",
-]
-
-[[package]]
-name = "async-native-tls"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e9e7a929bd34c68a82d58a4de7f86fffdaf97fb2af850162a7bb19dd7269b33"
-dependencies = [
- "async-std",
- "native-tls",
- "thiserror",
- "url",
 ]
 
 [[package]]
@@ -321,16 +275,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63396b8a4b9de3f4fdfb320ab6080762242f66a8ef174c49d8e19b674db4cdbe"
 
 [[package]]
-name = "byte-pool"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8c7230ddbb427b1094d477d821a99f3f54d36333178eeb806e279bcdcecf0ca"
-dependencies = [
- "crossbeam-queue",
- "stable_deref_trait",
-]
-
-[[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -424,17 +368,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "config"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b076e143e1d9538dde65da30f8481c2a6c44040edb8e02b9bf1351edb92ce3"
-dependencies = [
- "lazy_static",
- "nom",
- "serde",
-]
-
-[[package]]
 name = "console"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -524,16 +457,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "738c290dfaea84fc1ca15ad9c168d083b05a714e1efddd8edaab678dc28d2836"
 dependencies = [
  "cfg-if 1.0.0",
-]
-
-[[package]]
-name = "crossbeam-queue"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f6cb3c7f5b8e51bc3ebb73a2327ad4abdbd119dc13223f14f961d2f38486756"
-dependencies = [
- "cfg-if 1.0.0",
- "crossbeam-utils",
 ]
 
 [[package]]
@@ -749,20 +672,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4677188513e0e9d7adced5997cf9a1e7a3c996c994f90093325c5332c1a8b221"
 dependencies = [
  "version_check 0.1.5",
-]
-
-[[package]]
-name = "deadpool"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d126179d86aee4556e54f5f3c6bf6d9884e7cc52cef82f77ee6f90a7747616d"
-dependencies = [
- "async-trait",
- "config",
- "crossbeam-queue",
- "num_cpus",
- "serde",
- "tokio",
 ]
 
 [[package]]
@@ -1186,21 +1095,13 @@ version = "6.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea880b03c18a7e981d7fb3608b8904a98425d53c440758fcebf7d934aa56547c"
 dependencies = [
- "async-h1",
- "async-native-tls",
  "async-std",
  "async-trait",
  "cfg-if 1.0.0",
  "dashmap",
- "deadpool",
- "futures",
  "http-types",
  "isahc",
- "js-sys",
  "log",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
 ]
 
 [[package]]
@@ -1397,19 +1298,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
-name = "lexical-core"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21f866863575d0e1d654fbeeabdc927292fdf862873dc3c96c6f753357e13374"
-dependencies = [
- "arrayvec 0.5.2",
- "bitflags",
- "cfg-if 1.0.0",
- "ryu",
- "static_assertions",
-]
-
-[[package]]
 name = "libc"
 version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1554,17 +1442,6 @@ checksum = "a19900e7eee95eb2b3c2e26d12a874cc80aaf750e31be6fcbe743ead369fa45d"
 dependencies = [
  "libc",
  "socket2 0.4.0",
-]
-
-[[package]]
-name = "nom"
-version = "5.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffb4262d26ed83a1c0a33a38fe2bb15797329c85770da05e6b828ddb782627af"
-dependencies = [
- "lexical-core",
- "memchr",
- "version_check 0.9.3",
 ]
 
 [[package]]
@@ -1974,7 +1851,7 @@ version = "1.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d37baa70cf8662d2ba1c1868c5983dda16ef32b105cce41fb5c47e72936a90b3"
 dependencies = [
- "arrayvec 0.7.2",
+ "arrayvec",
  "num-traits",
  "serde",
 ]
@@ -2210,15 +2087,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e24979f63a11545f5f2c60141afe249d4f19f84581ea2138065e400941d83d3"
 
 [[package]]
-name = "simple-mutex"
-version = "1.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38aabbeafa6f6dead8cebf246fe9fae1f9215c8d29b3a69f93bd62a9e4a3dcd6"
-dependencies = [
- "event-listener",
-]
-
-[[package]]
 name = "slab"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2270,12 +2138,6 @@ checksum = "8bd0ab6b8c375d2d963503b90d3770010d95bc3b5f98036f948dee24bf4e8879"
 dependencies = [
  "lock_api",
 ]
-
-[[package]]
-name = "stable_deref_trait"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "standback"
@@ -2359,7 +2221,6 @@ version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "718b1ae6b50351982dedff021db0def601677f2120938b070eadb10ba4038dd7"
 dependencies = [
- "async-native-tls",
  "async-std",
  "async-trait",
  "cfg-if 1.0.0",

--- a/cynic/Cargo.toml
+++ b/cynic/Cargo.toml
@@ -15,18 +15,15 @@ readme = "../README.md"
 
 [features]
 default = []
-all = ["surf", "reqwest", "reqwest-blocking"]
-reqwest-blocking = ["reqwest/blocking"]
-surf-h1-client = ["surf/h1-client"]
-surf-curl-client = ["surf/curl-client"]
-surf-wasm-client = ["surf/wasm-client"]
-surf-middleware-logger = ["surf/middleware-logger"]
-surf-encoding = ["surf/encoding"]
+all = ["http-surf", "http-reqwest", "http-reqwest-blocking"]
+http-surf = ["surf", "serde_json"]
+http-reqwest = ["reqwest"]
+http-reqwest-blocking = ["http-reqwest", "reqwest/blocking"]
 
 [dependencies]
 cynic-proc-macros = { path = "../cynic-proc-macros", version = "2.0.0-dev" }
 serde = { version = "1.0.130", features = [ "derive" ] }
-serde_json = "1.0"
+serde_json = { version = "1.0", optional = true }
 static_assertions = "1"
 thiserror = "1.0.30"
 
@@ -42,6 +39,7 @@ chrono = { version = "0.4.19", features = ["serde"] }
 insta = "1.9"
 maplit = "1.0.2"
 rstest = "0.12.0"
+serde_json = { version = "1.0" }
 
 [package.metadata.docs.rs]
 features = ["all"]

--- a/cynic/src/http.rs
+++ b/cynic/src/http.rs
@@ -3,19 +3,19 @@
 //! These are hidden behind feature flags by default as HTTP clients are quite
 //! heavy dependencies, and there's several options to choose from.
 
-#[cfg(feature = "surf")]
+#[cfg(feature = "http-surf")]
 #[cfg_attr(docsrs, doc(cfg(feature = "surf")))]
 pub use self::surf_ext::SurfExt;
 
-#[cfg(feature = "reqwest")]
+#[cfg(feature = "http-reqwest")]
 #[cfg_attr(docsrs, doc(cfg(feature = "reqwest")))]
 pub use reqwest_ext::ReqwestExt;
 
-#[cfg(feature = "reqwest-blocking")]
+#[cfg(feature = "http-reqwest-blocking")]
 #[cfg_attr(docsrs, doc(cfg(feature = "reqwest-blocking")))]
 pub use reqwest_blocking_ext::ReqwestBlockingExt;
 
-#[cfg(feature = "surf")]
+#[cfg(feature = "http-surf")]
 mod surf_ext {
     use serde_json::json;
     use std::{future::Future, pin::Pin};
@@ -70,7 +70,7 @@ mod surf_ext {
     /// );
     /// # };
     /// ```
-    #[cfg_attr(docsrs, doc(cfg(feature = "surf")))]
+    #[cfg_attr(docsrs, doc(cfg(feature = "http-surf")))]
     pub trait SurfExt {
         /// Runs a GraphQL query with the parameters in RequestBuilder, decodes
         /// the response and returns the result.
@@ -119,7 +119,7 @@ mod surf_ext {
 }
 
 /// The error type returned by `ReqwestExt` & `ReqwestBlockingExt`
-#[cfg(any(feature = "reqwest", feature = "reqwest-blocking"))]
+#[cfg(any(feature = "http-reqwest", feature = "http-reqwest-blocking"))]
 #[derive(thiserror::Error, Debug)]
 pub enum CynicReqwestError {
     /// An error from reqwest when making an HTTP request.
@@ -131,7 +131,7 @@ pub enum CynicReqwestError {
     ErrorResponse(reqwest::StatusCode, String),
 }
 
-#[cfg(feature = "reqwest")]
+#[cfg(feature = "http-reqwest")]
 mod reqwest_ext {
     use super::CynicReqwestError;
     use std::{future::Future, pin::Pin};
@@ -187,7 +187,7 @@ mod reqwest_ext {
     /// );
     /// # };
     /// ```
-    #[cfg_attr(docsrs, doc(cfg(feature = "reqwest")))]
+    #[cfg_attr(docsrs, doc(cfg(feature = "http-reqwest")))]
     pub trait ReqwestExt {
         /// Runs a GraphQL query with the parameters in RequestBuilder, decodes
         /// the and returns the result.
@@ -245,7 +245,7 @@ mod reqwest_ext {
     }
 }
 
-#[cfg(feature = "reqwest-blocking")]
+#[cfg(feature = "http-reqwest-blocking")]
 mod reqwest_blocking_ext {
     use super::CynicReqwestError;
 
@@ -295,7 +295,7 @@ mod reqwest_blocking_ext {
     ///         .unwrap()
     /// );
     /// ```
-    #[cfg_attr(docsrs, doc(cfg(feature = "reqwest-blocking")))]
+    #[cfg_attr(docsrs, doc(cfg(feature = "http-reqwest-blocking")))]
     pub trait ReqwestBlockingExt {
         /// Runs a GraphQL query with the parameters in RequestBuilder, decodes
         /// the and returns the result.

--- a/cynic/src/lib.rs
+++ b/cynic/src/lib.rs
@@ -196,11 +196,10 @@ pub use cynic_proc_macros::{
 
 pub use static_assertions::assert_impl_all as assert_impl;
 
-// We re-export serde_json as the output from a lot of our derive macros require it,
+// We re-export serde as the output from a lot of our derive macros require it,
 // and this way we can point at our copy rather than forcing users to add it to
 // their Cargo.toml
 pub use serde;
-pub use serde_json;
 
 /// Implements [`cynic::Scalar`] for a given type & type lock.
 ///

--- a/cynic/src/result.rs
+++ b/cynic/src/result.rs
@@ -1,34 +1,34 @@
 /// The response to a GraphQl operation
 #[derive(Debug, serde::Deserialize)]
-pub struct GraphQlResponse<T> {
+pub struct GraphQlResponse<T, ErrorExtensions = serde::de::IgnoredAny> {
     /// The operation data (if the operation was succesful)
     pub data: Option<T>,
 
     /// Any errors that occurred as part of this operation
-    pub errors: Option<Vec<GraphQlError>>,
+    pub errors: Option<Vec<GraphQlError<ErrorExtensions>>>,
 }
 
 /// A model describing an error which has taken place during execution.
 #[derive(Clone, Debug, Eq, PartialEq, serde::Deserialize, thiserror::Error)]
 #[error("{message}")]
-pub struct GraphQlError {
+pub struct GraphQlError<Extensions> {
     /// A description of the error which has taken place.
     pub message: String,
     /// Optional description of the locations where the errors have taken place.
     pub locations: Option<Vec<GraphQlErrorLocation>>,
     /// Optional path to the response field which experienced the associated error.
     pub path: Option<Vec<GraphQlErrorPathSegment>>,
-    /// Optional arbitrary JSON data describing the error in more detail.
-    pub extensions: Option<serde_json::Value>,
+    /// Optional arbitrary extra data describing the error in more detail.
+    pub extensions: Option<Extensions>,
 }
 
-impl GraphQlError {
+impl<ErrorExtensions> GraphQlError<ErrorExtensions> {
     /// Construct a new instance.
     pub fn new(
         message: String,
         locations: Option<Vec<GraphQlErrorLocation>>,
         path: Option<Vec<GraphQlErrorPathSegment>>,
-        extensions: Option<serde_json::Value>,
+        extensions: Option<ErrorExtensions>,
     ) -> Self {
         GraphQlError {
             message,
@@ -56,4 +56,41 @@ pub enum GraphQlErrorPathSegment {
     Field(String),
     /// A path segment representing an index offset, zero-based.
     Index(i32),
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn test_default_graphql_response_ignores_extensions() {
+        let response = json!({
+            "data": null,
+            "errors": [{
+                "message": "hello",
+                "locations": null,
+                "path": null,
+                "extensions": {"some": "string"}
+            }]
+        });
+        insta::assert_debug_snapshot!(serde_json::from_value::<GraphQlResponse<()>>(response).unwrap(), @r###"
+        GraphQlResponse {
+            data: None,
+            errors: Some(
+                [
+                    GraphQlError {
+                        message: "hello",
+                        locations: None,
+                        path: None,
+                        extensions: Some(
+                            IgnoredAny,
+                        ),
+                    },
+                ],
+            ),
+        }
+        "###);
+    }
 }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-cynic = { path = "../cynic", features = ["surf", "reqwest-blocking"] }
+cynic = { path = "../cynic", features = ["http-surf", "http-reqwest-blocking"] }
 cynic-codegen = { path = "../cynic-codegen" }
 
 # Reqwest example requirements


### PR DESCRIPTION
#### Why are we making this change?

#391 refactored `serde` so that it doesn't need to depend quite so heavily on
`serde_json`.  I've also decided on a new approach for handling features in the
`http` libraries we provide integrations with.

#### What effects does this change have?

1. Removes our dependency on `serde_json` unless neccesary.
2. Renames the http features (unfortunately I couldn't continue using just the
    names of the downstream crates as I needed to add additional features for
    some of them, which requires a different feature name to the crate name)
4. Removes most of the `surf` sub-features.

Fixes #414