### PR TITLE
Correct Typo in doc string related to reqwest feature flag

### DIFF
--- a/cynic/src/lib.rs
+++ b/cynic/src/lib.rs
@@ -152,9 +152,9 @@
 //!
 //! - `surf` adds integration with the [`surf`](https://github.com/http-rs/surf)
 //!   http client.
-//! - `rewest` adds async integration with the
+//! - `reqwest` adds async integration with the
 //!   [`reqwest`](https://github.com/seanmonstar/reqwest) http client.
-//! - `rewest-blocking` adds blocking integration with the
+//! - `reqwest-blocking` adds blocking integration with the
 //!   [`reqwest`](https://github.com/seanmonstar/reqwest) http client.
 //!
 //! It's worth noting that each of these features pulls in extra


### PR DESCRIPTION

#### Why are we making this change?

The doc string describing the available feature flags was missing a `q`
for the two `reqwest` related feature flags. These appear to be the only
two occurrences of the typo in the project.

#### What effects does this change have?

These changes are confined to a doc string and should have no effect (other than correcting the documentation when published).
