### PR TITLE
[Merged by Bors] - Dont recase schema types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 - The `GraphQlError` & `GraphQlResponse` structs no longer contain a
   `serde_json::Value` for extensions.  They now have generic parameters that you
   should provide if you care about error extensions.
+- The output of the `use_schema` macro is no longer re-cased.
 
 
 ### Deprecations
@@ -62,6 +63,8 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 - Fixed a case where the generator would output the incorrect casing for some
   occurrences of a custom scalar in the output (#346)
+- Cynic should now support schemas which have 2 similarly named but differently
+  cased scalars.
 
 ### Changes
 

--- a/cynic-codegen/src/fragment_derive/arguments/parsing.rs
+++ b/cynic-codegen/src/fragment_derive/arguments/parsing.rs
@@ -132,7 +132,7 @@ impl Parse for ArgumentLiteral {
                 return Ok(ArgumentLiteral::Null(ident.span()));
             }
 
-            return Ok(ArgumentLiteral::Enum(ident));
+            Ok(ArgumentLiteral::Enum(ident))
         } else {
             Err(lookahead.error())
         }

--- a/cynic-codegen/src/fragment_derive/fragment_derive_type.rs
+++ b/cynic-codegen/src/fragment_derive/fragment_derive_type.rs
@@ -1,5 +1,5 @@
 use crate::schema::{
-    markers::{FieldMarkerModule, MarkerIdent},
+    markers::{FieldMarkerModule, TypeMarkerIdent},
     types::{Field, Kind, Type},
     FieldName, SchemaError,
 };
@@ -7,7 +7,7 @@ use crate::schema::{
 pub struct FragmentDeriveType<'a> {
     pub fields: Vec<Field<'a>>,
     pub name: &'a str,
-    pub marker_ident: MarkerIdent<'a>,
+    pub marker_ident: TypeMarkerIdent<'a>,
     pub field_module: FieldMarkerModule<'a>,
 }
 

--- a/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__input_1.snap
+++ b/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__input_1.snap
@@ -1,6 +1,6 @@
 ---
 source: cynic-codegen/src/fragment_derive/tests.rs
-assertion_line: 85
+assertion_line: 94
 expression: "format_code(format!(\"{}\", tokens))"
 
 ---
@@ -11,14 +11,14 @@ impl<'de> ::cynic::QueryFragment<'de> for MyQuery {
     const TYPE: Option<&'static str> = Some("Query");
     fn query(mut builder: ::cynic::queries::SelectionBuilder<Self::SchemaType, Self::Variables>) {
         #![allow(unused_mut)]
-        let mut field_builder = builder . select_field :: < schema :: query_fields :: Post , < Option < BlogPostOutput > as :: cynic :: QueryFragment > :: SchemaType > () ;
+        let mut field_builder = builder . select_field :: < schema :: query_fields :: post , < Option < BlogPostOutput > as :: cynic :: QueryFragment > :: SchemaType > () ;
         {
             field_builder
-                .argument::<schema::query_fields::post_arguments::Id>()
+                .argument::<schema::query_fields::post_arguments::id>()
                 .literal("1234");
         }
         <Option<BlogPostOutput> as ::cynic::QueryFragment>::query(field_builder.select_children());
-        let mut field_builder = builder . select_field :: < schema :: query_fields :: AllPosts , < Vec < BlogPostOutput > as :: cynic :: QueryFragment > :: SchemaType > () ;
+        let mut field_builder = builder . select_field :: < schema :: query_fields :: allPosts , < Vec < BlogPostOutput > as :: cynic :: QueryFragment > :: SchemaType > () ;
         <Vec<BlogPostOutput> as ::cynic::QueryFragment>::query(field_builder.select_children());
     }
 }

--- a/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__input_2.snap
+++ b/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__input_2.snap
@@ -11,8 +11,8 @@ impl<'de> ::cynic::QueryFragment<'de> for BlogPostOutput {
     const TYPE: Option<&'static str> = Some("BlogPost");
     fn query(mut builder: ::cynic::queries::SelectionBuilder<Self::SchemaType, Self::Variables>) {
         #![allow(unused_mut)]
-        let mut field_builder = builder . select_field :: < schema :: blog_post_fields :: HasMetadata , < Option < bool > as :: cynic :: schema :: IsScalar < < schema :: blog_post_fields :: HasMetadata as :: cynic :: schema :: Field > :: Type >> :: SchemaType > () ;
-        let mut field_builder = builder . select_field :: < schema :: blog_post_fields :: Author , < AuthorOutput as :: cynic :: QueryFragment > :: SchemaType > () ;
+        let mut field_builder = builder . select_field :: < schema :: blog_post_fields :: hasMetadata , < Option < bool > as :: cynic :: schema :: IsScalar < < schema :: blog_post_fields :: hasMetadata as :: cynic :: schema :: Field > :: Type >> :: SchemaType > () ;
+        let mut field_builder = builder . select_field :: < schema :: blog_post_fields :: author , < AuthorOutput as :: cynic :: QueryFragment > :: SchemaType > () ;
         <AuthorOutput as ::cynic::QueryFragment>::query(field_builder.select_children());
     }
 }

--- a/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__input_3.snap
+++ b/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__input_3.snap
@@ -1,6 +1,6 @@
 ---
 source: cynic-codegen/src/fragment_derive/tests.rs
-assertion_line: 96
+assertion_line: 94
 expression: "format_code(format!(\"{}\", tokens))"
 
 ---
@@ -11,7 +11,7 @@ impl<'de> ::cynic::QueryFragment<'de> for MyQuery {
     const TYPE: Option<&'static str> = Some("Query");
     fn query(mut builder: ::cynic::queries::SelectionBuilder<Self::SchemaType, Self::Variables>) {
         #![allow(unused_mut)]
-        let mut field_builder = builder . select_field :: < schema :: query_fields :: FilteredPosts , < Vec < BlogPostOutput > as :: cynic :: QueryFragment > :: SchemaType > () ;
+        let mut field_builder = builder . select_field :: < schema :: query_fields :: filteredPosts , < Vec < BlogPostOutput > as :: cynic :: QueryFragment > :: SchemaType > () ;
         {
             struct PostStateDraft;
             impl ::cynic::serde::Serialize for PostStateDraft {
@@ -34,10 +34,10 @@ impl<'de> ::cynic::QueryFragment<'de> for MyQuery {
             }
             impl ::cynic::coercions::CoercesTo<schema::PostState> for PostStatePosted {};
             field_builder
-                .argument::<schema::query_fields::filtered_posts_arguments::Filters>()
+                .argument::<schema::query_fields::filtered_posts_arguments::filters>()
                 .value()
                 .object()
-                .field::<schema::post_filters_fields::States, _>(|builder| {
+                .field::<schema::post_filters_fields::states, _>(|builder| {
                     builder
                         .value()
                         .list()

--- a/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__input_4.snap
+++ b/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__input_4.snap
@@ -1,6 +1,6 @@
 ---
 source: cynic-codegen/src/fragment_derive/tests.rs
-assertion_line: 85
+assertion_line: 94
 expression: "format_code(format!(\"{}\", tokens))"
 
 ---
@@ -11,10 +11,10 @@ impl<'de> ::cynic::QueryFragment<'de> for MyQuery {
     const TYPE: Option<&'static str> = Some("Query");
     fn query(mut builder: ::cynic::queries::SelectionBuilder<Self::SchemaType, Self::Variables>) {
         #![allow(unused_mut)]
-        let mut field_builder = builder . select_field :: < schema :: query_fields :: FilteredPosts , < Vec < BlogPostOutput > as :: cynic :: QueryFragment > :: SchemaType > () ;
+        let mut field_builder = builder . select_field :: < schema :: query_fields :: filteredPosts , < Vec < BlogPostOutput > as :: cynic :: QueryFragment > :: SchemaType > () ;
         {
             field_builder
-                .argument::<schema::query_fields::filtered_posts_arguments::Filters>()
+                .argument::<schema::query_fields::filtered_posts_arguments::filters>()
                 .variable(<AnArgumentStruct as ::cynic::QueryVariables>::Fields::filters());
         }
         <Vec<BlogPostOutput> as ::cynic::QueryFragment>::query(field_builder.select_children());

--- a/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__input_6.snap
+++ b/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__input_6.snap
@@ -11,7 +11,7 @@ impl<'de> ::cynic::QueryFragment<'de> for Film {
     const TYPE: Option<&'static str> = Some("Film");
     fn query(mut builder: ::cynic::queries::SelectionBuilder<Self::SchemaType, Self::Variables>) {
         #![allow(unused_mut)]
-        let mut field_builder = builder . select_flattened_field :: < schema :: film_fields :: Producers , < String as :: cynic :: schema :: IsScalar < < schema :: film_fields :: Producers as :: cynic :: schema :: Field > :: Type >> :: SchemaType , < schema :: film_fields :: Producers as :: cynic :: schema :: Field > :: Type , > () ;
+        let mut field_builder = builder . select_flattened_field :: < schema :: film_fields :: producers , < String as :: cynic :: schema :: IsScalar < < schema :: film_fields :: producers as :: cynic :: schema :: Field > :: Type >> :: SchemaType , < schema :: film_fields :: producers as :: cynic :: schema :: Field > :: Type , > () ;
     }
 }
 #[automatically_derived]

--- a/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__input_7.snap
+++ b/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__input_7.snap
@@ -1,6 +1,6 @@
 ---
 source: cynic-codegen/src/fragment_derive/tests.rs
-assertion_line: 96
+assertion_line: 94
 expression: "format_code(format!(\"{}\", tokens))"
 
 ---
@@ -11,7 +11,7 @@ impl<'de> ::cynic::QueryFragment<'de> for MyQuery {
     const TYPE: Option<&'static str> = Some("Query");
     fn query(mut builder: ::cynic::queries::SelectionBuilder<Self::SchemaType, Self::Variables>) {
         #![allow(unused_mut)]
-        let mut field_builder = builder . select_field :: < schema :: query_fields :: FilteredPosts , < Vec < BlogPostOutput > as :: cynic :: QueryFragment > :: SchemaType > () ;
+        let mut field_builder = builder . select_field :: < schema :: query_fields :: filteredPosts , < Vec < BlogPostOutput > as :: cynic :: QueryFragment > :: SchemaType > () ;
         {
             struct PostStatePosted;
             impl ::cynic::serde::Serialize for PostStatePosted {
@@ -24,10 +24,10 @@ impl<'de> ::cynic::QueryFragment<'de> for MyQuery {
             }
             impl ::cynic::coercions::CoercesTo<schema::PostState> for PostStatePosted {};
             field_builder
-                .argument::<schema::query_fields::filtered_posts_arguments::Filters>()
+                .argument::<schema::query_fields::filtered_posts_arguments::filters>()
                 .value()
                 .object()
-                .field::<schema::post_filters_fields::States, _>(|builder| {
+                .field::<schema::post_filters_fields::states, _>(|builder| {
                     builder
                         .value()
                         .list()

--- a/cynic-codegen/src/input_object_derive/mod.rs
+++ b/cynic-codegen/src/input_object_derive/mod.rs
@@ -79,8 +79,7 @@ pub fn input_object_derive_impl(
 
         let errors = field_serializers
             .iter()
-            .map(|fs| fs.validate())
-            .flatten()
+            .filter_map(|fs| fs.validate())
             .collect::<Errors>();
 
         if !errors.is_empty() {
@@ -154,16 +153,15 @@ fn pair_fields<'a>(
         }
     }
 
-    let required_fields: HashSet<_>;
-    if require_all_fields {
-        required_fields = input_object_def.fields.iter().collect();
+    let required_fields = if require_all_fields {
+        input_object_def.fields.iter().collect::<HashSet<_>>()
     } else {
-        required_fields = input_object_def
+        input_object_def
             .fields
             .iter()
             .filter(|f| !matches!(f.value_type, TypeRef::Nullable(_)))
-            .collect();
-    }
+            .collect::<HashSet<_>>()
+    };
 
     let provided_fields = result
         .iter()

--- a/cynic-codegen/src/schema/markers.rs
+++ b/cynic-codegen/src/schema/markers.rs
@@ -71,6 +71,10 @@ impl<T> TypeRefMarker<'_, T> {
 }
 
 impl<'a> TypeMarkerIdent<'a> {
+    pub fn with_graphql_name(graphql_name: &'a str) -> Self {
+        TypeMarkerIdent { graphql_name }
+    }
+
     pub fn to_path(self, path_to_markers: &syn::Path) -> syn::Path {
         let mut path = path_to_markers.clone();
         path.push(proc_macro2::Ident::from(self));

--- a/cynic-codegen/src/schema_for_derives/utils.rs
+++ b/cynic-codegen/src/schema_for_derives/utils.rs
@@ -35,8 +35,7 @@ fn derive_from_attributes(attrs: &[Attribute]) -> Vec<Derive> {
     return meta_list
         .nested
         .iter()
-        .map(derive_for_nested_meta)
-        .flatten()
+        .filter_map(derive_for_nested_meta)
         .collect();
 }
 

--- a/cynic-codegen/src/use_schema/mod.rs
+++ b/cynic-codegen/src/use_schema/mod.rs
@@ -45,7 +45,7 @@ pub fn use_schema(input: UseSchemaParams) -> Result<TokenStream, Errors> {
 
         match definition {
             Type::Scalar(def) if !def.builtin => {
-                let ident = Ident::for_type(&def.name);
+                let ident = proc_macro2::Ident::from(def.marker_ident());
                 output.append_all(quote! {
                     pub struct #ident {}
                 });
@@ -70,7 +70,7 @@ pub fn use_schema(input: UseSchemaParams) -> Result<TokenStream, Errors> {
                 });
             }
             Type::Enum(def) => {
-                let ident = Ident::for_type(&def.name);
+                let ident = proc_macro2::Ident::from(def.marker_ident());
                 output.append_all(quote! {
                     pub struct #ident {}
                 });
@@ -89,7 +89,7 @@ pub fn use_schema(input: UseSchemaParams) -> Result<TokenStream, Errors> {
         pub type String = std::string::String;
         pub type Float = f64;
         pub type Int = i32;
-        pub type Id = ::cynic::Id;
+        pub type ID = ::cynic::Id;
 
         pub mod variable {
             use ::cynic::variables::VariableType;

--- a/cynic-codegen/src/use_schema/named_type.rs
+++ b/cynic-codegen/src/use_schema/named_type.rs
@@ -1,10 +1,10 @@
 use proc_macro2::TokenStream;
 
-use crate::{schema::markers::MarkerIdent, schema::types::Type};
+use crate::{schema::markers::TypeMarkerIdent, schema::types::Type};
 
 pub struct NamedType<'a> {
     graphql_name: &'a str,
-    marker_ident: MarkerIdent<'a>,
+    marker_ident: TypeMarkerIdent<'a>,
 }
 
 impl<'a> NamedType<'a> {

--- a/cynic-codegen/src/use_schema/subtype_markers.rs
+++ b/cynic-codegen/src/use_schema/subtype_markers.rs
@@ -1,12 +1,12 @@
 use proc_macro2::TokenStream;
 
-use crate::schema::{markers::MarkerIdent, types as schema};
+use crate::schema::{markers::TypeMarkerIdent, types as schema};
 
 /// Outputs `HasSubtype` implementations for the given types.
 #[derive(Debug)]
 pub struct SubtypeMarkers<'a> {
-    pub subtype: MarkerIdent<'a>,
-    pub supertypes: Vec<MarkerIdent<'a>>,
+    pub subtype: TypeMarkerIdent<'a>,
+    pub supertypes: Vec<TypeMarkerIdent<'a>>,
 }
 
 impl<'a> SubtypeMarkers<'a> {

--- a/cynic-codegen/tests/snapshots/use_schema__schema_file_1.snap
+++ b/cynic-codegen/tests/snapshots/use_schema__schema_file_1.snap
@@ -8,105 +8,105 @@ impl ::cynic::schema::QueryRoot for Query {}
 impl ::cynic::schema::MutationRoot for Mutation {}
 pub struct City;
 pub mod city_fields {
-    pub struct Id;
-    impl ::cynic::schema::Field for Id {
-        type Type = super::Id;
+    pub struct id;
+    impl ::cynic::schema::Field for id {
+        type Type = super::ID;
         const NAME: &'static str = "id";
     }
-    impl ::cynic::schema::HasField<Id> for super::City {
-        type Type = super::Id;
+    impl ::cynic::schema::HasField<id> for super::City {
+        type Type = super::ID;
     }
-    pub struct Name;
-    impl ::cynic::schema::Field for Name {
+    pub struct name;
+    impl ::cynic::schema::Field for name {
         type Type = super::String;
         const NAME: &'static str = "name";
     }
-    impl ::cynic::schema::HasField<Name> for super::City {
+    impl ::cynic::schema::HasField<name> for super::City {
         type Type = super::String;
     }
-    pub struct Slug;
-    impl ::cynic::schema::Field for Slug {
+    pub struct slug;
+    impl ::cynic::schema::Field for slug {
         type Type = super::String;
         const NAME: &'static str = "slug";
     }
-    impl ::cynic::schema::HasField<Slug> for super::City {
+    impl ::cynic::schema::HasField<slug> for super::City {
         type Type = super::String;
     }
-    pub struct Country;
-    impl ::cynic::schema::Field for Country {
+    pub struct country;
+    impl ::cynic::schema::Field for country {
         type Type = super::Country;
         const NAME: &'static str = "country";
     }
-    impl ::cynic::schema::HasField<Country> for super::City {
+    impl ::cynic::schema::HasField<country> for super::City {
         type Type = super::Country;
     }
-    pub struct Type;
-    impl ::cynic::schema::Field for Type {
+    pub struct r#type;
+    impl ::cynic::schema::Field for r#type {
         type Type = super::String;
         const NAME: &'static str = "type";
     }
-    impl ::cynic::schema::HasField<Type> for super::City {
+    impl ::cynic::schema::HasField<r#type> for super::City {
         type Type = super::String;
     }
-    pub struct Jobs;
-    impl ::cynic::schema::Field for Jobs {
+    pub struct jobs;
+    impl ::cynic::schema::Field for jobs {
         type Type = Option<Vec<super::Job>>;
         const NAME: &'static str = "jobs";
     }
-    impl ::cynic::schema::HasField<Jobs> for super::City {
+    impl ::cynic::schema::HasField<jobs> for super::City {
         type Type = Option<Vec<super::Job>>;
     }
     pub mod jobs_arguments {
-        pub struct Where;
-        impl ::cynic::schema::HasArgument<Where> for super::Jobs {
+        pub struct r#where;
+        impl ::cynic::schema::HasArgument<r#where> for super::jobs {
             type ArgumentType = Option<super::super::JobWhereInput>;
             const NAME: &'static str = "where";
         }
-        pub struct OrderBy;
-        impl ::cynic::schema::HasArgument<OrderBy> for super::Jobs {
+        pub struct orderBy;
+        impl ::cynic::schema::HasArgument<orderBy> for super::jobs {
             type ArgumentType = Option<super::super::JobOrderByInput>;
             const NAME: &'static str = "orderBy";
         }
-        pub struct Skip;
-        impl ::cynic::schema::HasArgument<Skip> for super::Jobs {
+        pub struct skip;
+        impl ::cynic::schema::HasArgument<skip> for super::jobs {
             type ArgumentType = Option<super::super::Int>;
             const NAME: &'static str = "skip";
         }
-        pub struct After;
-        impl ::cynic::schema::HasArgument<After> for super::Jobs {
+        pub struct after;
+        impl ::cynic::schema::HasArgument<after> for super::jobs {
             type ArgumentType = Option<super::super::String>;
             const NAME: &'static str = "after";
         }
-        pub struct Before;
-        impl ::cynic::schema::HasArgument<Before> for super::Jobs {
+        pub struct before;
+        impl ::cynic::schema::HasArgument<before> for super::jobs {
             type ArgumentType = Option<super::super::String>;
             const NAME: &'static str = "before";
         }
-        pub struct First;
-        impl ::cynic::schema::HasArgument<First> for super::Jobs {
+        pub struct first;
+        impl ::cynic::schema::HasArgument<first> for super::jobs {
             type ArgumentType = Option<super::super::Int>;
             const NAME: &'static str = "first";
         }
-        pub struct Last;
-        impl ::cynic::schema::HasArgument<Last> for super::Jobs {
+        pub struct last;
+        impl ::cynic::schema::HasArgument<last> for super::jobs {
             type ArgumentType = Option<super::super::Int>;
             const NAME: &'static str = "last";
         }
     }
-    pub struct CreatedAt;
-    impl ::cynic::schema::Field for CreatedAt {
+    pub struct createdAt;
+    impl ::cynic::schema::Field for createdAt {
         type Type = super::DateTime;
         const NAME: &'static str = "createdAt";
     }
-    impl ::cynic::schema::HasField<CreatedAt> for super::City {
+    impl ::cynic::schema::HasField<createdAt> for super::City {
         type Type = super::DateTime;
     }
-    pub struct UpdatedAt;
-    impl ::cynic::schema::Field for UpdatedAt {
+    pub struct updatedAt;
+    impl ::cynic::schema::Field for updatedAt {
         type Type = super::DateTime;
         const NAME: &'static str = "updatedAt";
     }
-    impl ::cynic::schema::HasField<UpdatedAt> for super::City {
+    impl ::cynic::schema::HasField<updatedAt> for super::City {
         type Type = super::DateTime;
     }
 }
@@ -114,2364 +114,2421 @@ pub struct CityOrderByInput {}
 pub struct CityWhereInput;
 impl ::cynic::schema::InputObjectMarker for CityWhereInput {}
 pub mod city_where_input_fields {
-    pub struct Id;
-    impl ::cynic::schema::Field for Id {
-        type Type = Option<super::Id>;
+    pub struct id;
+    impl ::cynic::schema::Field for id {
+        type Type = Option<super::ID>;
         const NAME: &'static str = "id";
     }
-    impl ::cynic::schema::HasInputField<Id, Option<super::Id>> for super::CityWhereInput {}
-    pub struct IdNot;
-    impl ::cynic::schema::Field for IdNot {
-        type Type = Option<super::Id>;
+    impl ::cynic::schema::HasInputField<id, Option<super::ID>> for super::CityWhereInput {}
+    pub struct id_not;
+    impl ::cynic::schema::Field for id_not {
+        type Type = Option<super::ID>;
         const NAME: &'static str = "id_not";
     }
-    impl ::cynic::schema::HasInputField<IdNot, Option<super::Id>> for super::CityWhereInput {}
-    pub struct IdIn;
-    impl ::cynic::schema::Field for IdIn {
-        type Type = Option<Vec<super::Id>>;
+    impl ::cynic::schema::HasInputField<id_not, Option<super::ID>> for super::CityWhereInput {}
+    pub struct id_in;
+    impl ::cynic::schema::Field for id_in {
+        type Type = Option<Vec<super::ID>>;
         const NAME: &'static str = "id_in";
     }
-    impl ::cynic::schema::HasInputField<IdIn, Option<Vec<super::Id>>> for super::CityWhereInput {}
-    pub struct IdNotIn;
-    impl ::cynic::schema::Field for IdNotIn {
-        type Type = Option<Vec<super::Id>>;
+    impl ::cynic::schema::HasInputField<id_in, Option<Vec<super::ID>>> for super::CityWhereInput {}
+    pub struct id_not_in;
+    impl ::cynic::schema::Field for id_not_in {
+        type Type = Option<Vec<super::ID>>;
         const NAME: &'static str = "id_not_in";
     }
-    impl ::cynic::schema::HasInputField<IdNotIn, Option<Vec<super::Id>>> for super::CityWhereInput {}
-    pub struct IdLt;
-    impl ::cynic::schema::Field for IdLt {
-        type Type = Option<super::Id>;
+    impl ::cynic::schema::HasInputField<id_not_in, Option<Vec<super::ID>>> for super::CityWhereInput {}
+    pub struct id_lt;
+    impl ::cynic::schema::Field for id_lt {
+        type Type = Option<super::ID>;
         const NAME: &'static str = "id_lt";
     }
-    impl ::cynic::schema::HasInputField<IdLt, Option<super::Id>> for super::CityWhereInput {}
-    pub struct IdLte;
-    impl ::cynic::schema::Field for IdLte {
-        type Type = Option<super::Id>;
+    impl ::cynic::schema::HasInputField<id_lt, Option<super::ID>> for super::CityWhereInput {}
+    pub struct id_lte;
+    impl ::cynic::schema::Field for id_lte {
+        type Type = Option<super::ID>;
         const NAME: &'static str = "id_lte";
     }
-    impl ::cynic::schema::HasInputField<IdLte, Option<super::Id>> for super::CityWhereInput {}
-    pub struct IdGt;
-    impl ::cynic::schema::Field for IdGt {
-        type Type = Option<super::Id>;
+    impl ::cynic::schema::HasInputField<id_lte, Option<super::ID>> for super::CityWhereInput {}
+    pub struct id_gt;
+    impl ::cynic::schema::Field for id_gt {
+        type Type = Option<super::ID>;
         const NAME: &'static str = "id_gt";
     }
-    impl ::cynic::schema::HasInputField<IdGt, Option<super::Id>> for super::CityWhereInput {}
-    pub struct IdGte;
-    impl ::cynic::schema::Field for IdGte {
-        type Type = Option<super::Id>;
+    impl ::cynic::schema::HasInputField<id_gt, Option<super::ID>> for super::CityWhereInput {}
+    pub struct id_gte;
+    impl ::cynic::schema::Field for id_gte {
+        type Type = Option<super::ID>;
         const NAME: &'static str = "id_gte";
     }
-    impl ::cynic::schema::HasInputField<IdGte, Option<super::Id>> for super::CityWhereInput {}
-    pub struct IdContains;
-    impl ::cynic::schema::Field for IdContains {
-        type Type = Option<super::Id>;
+    impl ::cynic::schema::HasInputField<id_gte, Option<super::ID>> for super::CityWhereInput {}
+    pub struct id_contains;
+    impl ::cynic::schema::Field for id_contains {
+        type Type = Option<super::ID>;
         const NAME: &'static str = "id_contains";
     }
-    impl ::cynic::schema::HasInputField<IdContains, Option<super::Id>> for super::CityWhereInput {}
-    pub struct IdNotContains;
-    impl ::cynic::schema::Field for IdNotContains {
-        type Type = Option<super::Id>;
+    impl ::cynic::schema::HasInputField<id_contains, Option<super::ID>> for super::CityWhereInput {}
+    pub struct id_not_contains;
+    impl ::cynic::schema::Field for id_not_contains {
+        type Type = Option<super::ID>;
         const NAME: &'static str = "id_not_contains";
     }
-    impl ::cynic::schema::HasInputField<IdNotContains, Option<super::Id>> for super::CityWhereInput {}
-    pub struct IdStartsWith;
-    impl ::cynic::schema::Field for IdStartsWith {
-        type Type = Option<super::Id>;
+    impl ::cynic::schema::HasInputField<id_not_contains, Option<super::ID>> for super::CityWhereInput {}
+    pub struct id_starts_with;
+    impl ::cynic::schema::Field for id_starts_with {
+        type Type = Option<super::ID>;
         const NAME: &'static str = "id_starts_with";
     }
-    impl ::cynic::schema::HasInputField<IdStartsWith, Option<super::Id>> for super::CityWhereInput {}
-    pub struct IdNotStartsWith;
-    impl ::cynic::schema::Field for IdNotStartsWith {
-        type Type = Option<super::Id>;
+    impl ::cynic::schema::HasInputField<id_starts_with, Option<super::ID>> for super::CityWhereInput {}
+    pub struct id_not_starts_with;
+    impl ::cynic::schema::Field for id_not_starts_with {
+        type Type = Option<super::ID>;
         const NAME: &'static str = "id_not_starts_with";
     }
-    impl ::cynic::schema::HasInputField<IdNotStartsWith, Option<super::Id>> for super::CityWhereInput {}
-    pub struct IdEndsWith;
-    impl ::cynic::schema::Field for IdEndsWith {
-        type Type = Option<super::Id>;
+    impl ::cynic::schema::HasInputField<id_not_starts_with, Option<super::ID>>
+        for super::CityWhereInput
+    {
+    }
+    pub struct id_ends_with;
+    impl ::cynic::schema::Field for id_ends_with {
+        type Type = Option<super::ID>;
         const NAME: &'static str = "id_ends_with";
     }
-    impl ::cynic::schema::HasInputField<IdEndsWith, Option<super::Id>> for super::CityWhereInput {}
-    pub struct IdNotEndsWith;
-    impl ::cynic::schema::Field for IdNotEndsWith {
-        type Type = Option<super::Id>;
+    impl ::cynic::schema::HasInputField<id_ends_with, Option<super::ID>> for super::CityWhereInput {}
+    pub struct id_not_ends_with;
+    impl ::cynic::schema::Field for id_not_ends_with {
+        type Type = Option<super::ID>;
         const NAME: &'static str = "id_not_ends_with";
     }
-    impl ::cynic::schema::HasInputField<IdNotEndsWith, Option<super::Id>> for super::CityWhereInput {}
-    pub struct Name;
-    impl ::cynic::schema::Field for Name {
+    impl ::cynic::schema::HasInputField<id_not_ends_with, Option<super::ID>> for super::CityWhereInput {}
+    pub struct name;
+    impl ::cynic::schema::Field for name {
         type Type = Option<super::String>;
         const NAME: &'static str = "name";
     }
-    impl ::cynic::schema::HasInputField<Name, Option<super::String>> for super::CityWhereInput {}
-    pub struct NameNot;
-    impl ::cynic::schema::Field for NameNot {
+    impl ::cynic::schema::HasInputField<name, Option<super::String>> for super::CityWhereInput {}
+    pub struct name_not;
+    impl ::cynic::schema::Field for name_not {
         type Type = Option<super::String>;
         const NAME: &'static str = "name_not";
     }
-    impl ::cynic::schema::HasInputField<NameNot, Option<super::String>> for super::CityWhereInput {}
-    pub struct NameIn;
-    impl ::cynic::schema::Field for NameIn {
+    impl ::cynic::schema::HasInputField<name_not, Option<super::String>> for super::CityWhereInput {}
+    pub struct name_in;
+    impl ::cynic::schema::Field for name_in {
         type Type = Option<Vec<super::String>>;
         const NAME: &'static str = "name_in";
     }
-    impl ::cynic::schema::HasInputField<NameIn, Option<Vec<super::String>>> for super::CityWhereInput {}
-    pub struct NameNotIn;
-    impl ::cynic::schema::Field for NameNotIn {
+    impl ::cynic::schema::HasInputField<name_in, Option<Vec<super::String>>> for super::CityWhereInput {}
+    pub struct name_not_in;
+    impl ::cynic::schema::Field for name_not_in {
         type Type = Option<Vec<super::String>>;
         const NAME: &'static str = "name_not_in";
     }
-    impl ::cynic::schema::HasInputField<NameNotIn, Option<Vec<super::String>>>
+    impl ::cynic::schema::HasInputField<name_not_in, Option<Vec<super::String>>>
         for super::CityWhereInput
     {
     }
-    pub struct NameLt;
-    impl ::cynic::schema::Field for NameLt {
+    pub struct name_lt;
+    impl ::cynic::schema::Field for name_lt {
         type Type = Option<super::String>;
         const NAME: &'static str = "name_lt";
     }
-    impl ::cynic::schema::HasInputField<NameLt, Option<super::String>> for super::CityWhereInput {}
-    pub struct NameLte;
-    impl ::cynic::schema::Field for NameLte {
+    impl ::cynic::schema::HasInputField<name_lt, Option<super::String>> for super::CityWhereInput {}
+    pub struct name_lte;
+    impl ::cynic::schema::Field for name_lte {
         type Type = Option<super::String>;
         const NAME: &'static str = "name_lte";
     }
-    impl ::cynic::schema::HasInputField<NameLte, Option<super::String>> for super::CityWhereInput {}
-    pub struct NameGt;
-    impl ::cynic::schema::Field for NameGt {
+    impl ::cynic::schema::HasInputField<name_lte, Option<super::String>> for super::CityWhereInput {}
+    pub struct name_gt;
+    impl ::cynic::schema::Field for name_gt {
         type Type = Option<super::String>;
         const NAME: &'static str = "name_gt";
     }
-    impl ::cynic::schema::HasInputField<NameGt, Option<super::String>> for super::CityWhereInput {}
-    pub struct NameGte;
-    impl ::cynic::schema::Field for NameGte {
+    impl ::cynic::schema::HasInputField<name_gt, Option<super::String>> for super::CityWhereInput {}
+    pub struct name_gte;
+    impl ::cynic::schema::Field for name_gte {
         type Type = Option<super::String>;
         const NAME: &'static str = "name_gte";
     }
-    impl ::cynic::schema::HasInputField<NameGte, Option<super::String>> for super::CityWhereInput {}
-    pub struct NameContains;
-    impl ::cynic::schema::Field for NameContains {
+    impl ::cynic::schema::HasInputField<name_gte, Option<super::String>> for super::CityWhereInput {}
+    pub struct name_contains;
+    impl ::cynic::schema::Field for name_contains {
         type Type = Option<super::String>;
         const NAME: &'static str = "name_contains";
     }
-    impl ::cynic::schema::HasInputField<NameContains, Option<super::String>> for super::CityWhereInput {}
-    pub struct NameNotContains;
-    impl ::cynic::schema::Field for NameNotContains {
+    impl ::cynic::schema::HasInputField<name_contains, Option<super::String>>
+        for super::CityWhereInput
+    {
+    }
+    pub struct name_not_contains;
+    impl ::cynic::schema::Field for name_not_contains {
         type Type = Option<super::String>;
         const NAME: &'static str = "name_not_contains";
     }
-    impl ::cynic::schema::HasInputField<NameNotContains, Option<super::String>>
+    impl ::cynic::schema::HasInputField<name_not_contains, Option<super::String>>
         for super::CityWhereInput
     {
     }
-    pub struct NameStartsWith;
-    impl ::cynic::schema::Field for NameStartsWith {
+    pub struct name_starts_with;
+    impl ::cynic::schema::Field for name_starts_with {
         type Type = Option<super::String>;
         const NAME: &'static str = "name_starts_with";
     }
-    impl ::cynic::schema::HasInputField<NameStartsWith, Option<super::String>>
+    impl ::cynic::schema::HasInputField<name_starts_with, Option<super::String>>
         for super::CityWhereInput
     {
     }
-    pub struct NameNotStartsWith;
-    impl ::cynic::schema::Field for NameNotStartsWith {
+    pub struct name_not_starts_with;
+    impl ::cynic::schema::Field for name_not_starts_with {
         type Type = Option<super::String>;
         const NAME: &'static str = "name_not_starts_with";
     }
-    impl ::cynic::schema::HasInputField<NameNotStartsWith, Option<super::String>>
+    impl ::cynic::schema::HasInputField<name_not_starts_with, Option<super::String>>
         for super::CityWhereInput
     {
     }
-    pub struct NameEndsWith;
-    impl ::cynic::schema::Field for NameEndsWith {
+    pub struct name_ends_with;
+    impl ::cynic::schema::Field for name_ends_with {
         type Type = Option<super::String>;
         const NAME: &'static str = "name_ends_with";
     }
-    impl ::cynic::schema::HasInputField<NameEndsWith, Option<super::String>> for super::CityWhereInput {}
-    pub struct NameNotEndsWith;
-    impl ::cynic::schema::Field for NameNotEndsWith {
+    impl ::cynic::schema::HasInputField<name_ends_with, Option<super::String>>
+        for super::CityWhereInput
+    {
+    }
+    pub struct name_not_ends_with;
+    impl ::cynic::schema::Field for name_not_ends_with {
         type Type = Option<super::String>;
         const NAME: &'static str = "name_not_ends_with";
     }
-    impl ::cynic::schema::HasInputField<NameNotEndsWith, Option<super::String>>
+    impl ::cynic::schema::HasInputField<name_not_ends_with, Option<super::String>>
         for super::CityWhereInput
     {
     }
-    pub struct Slug;
-    impl ::cynic::schema::Field for Slug {
+    pub struct slug;
+    impl ::cynic::schema::Field for slug {
         type Type = Option<super::String>;
         const NAME: &'static str = "slug";
     }
-    impl ::cynic::schema::HasInputField<Slug, Option<super::String>> for super::CityWhereInput {}
-    pub struct SlugNot;
-    impl ::cynic::schema::Field for SlugNot {
+    impl ::cynic::schema::HasInputField<slug, Option<super::String>> for super::CityWhereInput {}
+    pub struct slug_not;
+    impl ::cynic::schema::Field for slug_not {
         type Type = Option<super::String>;
         const NAME: &'static str = "slug_not";
     }
-    impl ::cynic::schema::HasInputField<SlugNot, Option<super::String>> for super::CityWhereInput {}
-    pub struct SlugIn;
-    impl ::cynic::schema::Field for SlugIn {
+    impl ::cynic::schema::HasInputField<slug_not, Option<super::String>> for super::CityWhereInput {}
+    pub struct slug_in;
+    impl ::cynic::schema::Field for slug_in {
         type Type = Option<Vec<super::String>>;
         const NAME: &'static str = "slug_in";
     }
-    impl ::cynic::schema::HasInputField<SlugIn, Option<Vec<super::String>>> for super::CityWhereInput {}
-    pub struct SlugNotIn;
-    impl ::cynic::schema::Field for SlugNotIn {
+    impl ::cynic::schema::HasInputField<slug_in, Option<Vec<super::String>>> for super::CityWhereInput {}
+    pub struct slug_not_in;
+    impl ::cynic::schema::Field for slug_not_in {
         type Type = Option<Vec<super::String>>;
         const NAME: &'static str = "slug_not_in";
     }
-    impl ::cynic::schema::HasInputField<SlugNotIn, Option<Vec<super::String>>>
+    impl ::cynic::schema::HasInputField<slug_not_in, Option<Vec<super::String>>>
         for super::CityWhereInput
     {
     }
-    pub struct SlugLt;
-    impl ::cynic::schema::Field for SlugLt {
+    pub struct slug_lt;
+    impl ::cynic::schema::Field for slug_lt {
         type Type = Option<super::String>;
         const NAME: &'static str = "slug_lt";
     }
-    impl ::cynic::schema::HasInputField<SlugLt, Option<super::String>> for super::CityWhereInput {}
-    pub struct SlugLte;
-    impl ::cynic::schema::Field for SlugLte {
+    impl ::cynic::schema::HasInputField<slug_lt, Option<super::String>> for super::CityWhereInput {}
+    pub struct slug_lte;
+    impl ::cynic::schema::Field for slug_lte {
         type Type = Option<super::String>;
         const NAME: &'static str = "slug_lte";
     }
-    impl ::cynic::schema::HasInputField<SlugLte, Option<super::String>> for super::CityWhereInput {}
-    pub struct SlugGt;
-    impl ::cynic::schema::Field for SlugGt {
+    impl ::cynic::schema::HasInputField<slug_lte, Option<super::String>> for super::CityWhereInput {}
+    pub struct slug_gt;
+    impl ::cynic::schema::Field for slug_gt {
         type Type = Option<super::String>;
         const NAME: &'static str = "slug_gt";
     }
-    impl ::cynic::schema::HasInputField<SlugGt, Option<super::String>> for super::CityWhereInput {}
-    pub struct SlugGte;
-    impl ::cynic::schema::Field for SlugGte {
+    impl ::cynic::schema::HasInputField<slug_gt, Option<super::String>> for super::CityWhereInput {}
+    pub struct slug_gte;
+    impl ::cynic::schema::Field for slug_gte {
         type Type = Option<super::String>;
         const NAME: &'static str = "slug_gte";
     }
-    impl ::cynic::schema::HasInputField<SlugGte, Option<super::String>> for super::CityWhereInput {}
-    pub struct SlugContains;
-    impl ::cynic::schema::Field for SlugContains {
+    impl ::cynic::schema::HasInputField<slug_gte, Option<super::String>> for super::CityWhereInput {}
+    pub struct slug_contains;
+    impl ::cynic::schema::Field for slug_contains {
         type Type = Option<super::String>;
         const NAME: &'static str = "slug_contains";
     }
-    impl ::cynic::schema::HasInputField<SlugContains, Option<super::String>> for super::CityWhereInput {}
-    pub struct SlugNotContains;
-    impl ::cynic::schema::Field for SlugNotContains {
+    impl ::cynic::schema::HasInputField<slug_contains, Option<super::String>>
+        for super::CityWhereInput
+    {
+    }
+    pub struct slug_not_contains;
+    impl ::cynic::schema::Field for slug_not_contains {
         type Type = Option<super::String>;
         const NAME: &'static str = "slug_not_contains";
     }
-    impl ::cynic::schema::HasInputField<SlugNotContains, Option<super::String>>
+    impl ::cynic::schema::HasInputField<slug_not_contains, Option<super::String>>
         for super::CityWhereInput
     {
     }
-    pub struct SlugStartsWith;
-    impl ::cynic::schema::Field for SlugStartsWith {
+    pub struct slug_starts_with;
+    impl ::cynic::schema::Field for slug_starts_with {
         type Type = Option<super::String>;
         const NAME: &'static str = "slug_starts_with";
     }
-    impl ::cynic::schema::HasInputField<SlugStartsWith, Option<super::String>>
+    impl ::cynic::schema::HasInputField<slug_starts_with, Option<super::String>>
         for super::CityWhereInput
     {
     }
-    pub struct SlugNotStartsWith;
-    impl ::cynic::schema::Field for SlugNotStartsWith {
+    pub struct slug_not_starts_with;
+    impl ::cynic::schema::Field for slug_not_starts_with {
         type Type = Option<super::String>;
         const NAME: &'static str = "slug_not_starts_with";
     }
-    impl ::cynic::schema::HasInputField<SlugNotStartsWith, Option<super::String>>
+    impl ::cynic::schema::HasInputField<slug_not_starts_with, Option<super::String>>
         for super::CityWhereInput
     {
     }
-    pub struct SlugEndsWith;
-    impl ::cynic::schema::Field for SlugEndsWith {
+    pub struct slug_ends_with;
+    impl ::cynic::schema::Field for slug_ends_with {
         type Type = Option<super::String>;
         const NAME: &'static str = "slug_ends_with";
     }
-    impl ::cynic::schema::HasInputField<SlugEndsWith, Option<super::String>> for super::CityWhereInput {}
-    pub struct SlugNotEndsWith;
-    impl ::cynic::schema::Field for SlugNotEndsWith {
+    impl ::cynic::schema::HasInputField<slug_ends_with, Option<super::String>>
+        for super::CityWhereInput
+    {
+    }
+    pub struct slug_not_ends_with;
+    impl ::cynic::schema::Field for slug_not_ends_with {
         type Type = Option<super::String>;
         const NAME: &'static str = "slug_not_ends_with";
     }
-    impl ::cynic::schema::HasInputField<SlugNotEndsWith, Option<super::String>>
+    impl ::cynic::schema::HasInputField<slug_not_ends_with, Option<super::String>>
         for super::CityWhereInput
     {
     }
-    pub struct Country;
-    impl ::cynic::schema::Field for Country {
+    pub struct country;
+    impl ::cynic::schema::Field for country {
         type Type = Option<super::CountryWhereInput>;
         const NAME: &'static str = "country";
     }
-    impl ::cynic::schema::HasInputField<Country, Option<super::CountryWhereInput>>
+    impl ::cynic::schema::HasInputField<country, Option<super::CountryWhereInput>>
         for super::CityWhereInput
     {
     }
-    pub struct Type;
-    impl ::cynic::schema::Field for Type {
+    pub struct r#type;
+    impl ::cynic::schema::Field for r#type {
         type Type = Option<super::String>;
         const NAME: &'static str = "type";
     }
-    impl ::cynic::schema::HasInputField<Type, Option<super::String>> for super::CityWhereInput {}
-    pub struct TypeNot;
-    impl ::cynic::schema::Field for TypeNot {
+    impl ::cynic::schema::HasInputField<r#type, Option<super::String>> for super::CityWhereInput {}
+    pub struct type_not;
+    impl ::cynic::schema::Field for type_not {
         type Type = Option<super::String>;
         const NAME: &'static str = "type_not";
     }
-    impl ::cynic::schema::HasInputField<TypeNot, Option<super::String>> for super::CityWhereInput {}
-    pub struct TypeIn;
-    impl ::cynic::schema::Field for TypeIn {
+    impl ::cynic::schema::HasInputField<type_not, Option<super::String>> for super::CityWhereInput {}
+    pub struct type_in;
+    impl ::cynic::schema::Field for type_in {
         type Type = Option<Vec<super::String>>;
         const NAME: &'static str = "type_in";
     }
-    impl ::cynic::schema::HasInputField<TypeIn, Option<Vec<super::String>>> for super::CityWhereInput {}
-    pub struct TypeNotIn;
-    impl ::cynic::schema::Field for TypeNotIn {
+    impl ::cynic::schema::HasInputField<type_in, Option<Vec<super::String>>> for super::CityWhereInput {}
+    pub struct type_not_in;
+    impl ::cynic::schema::Field for type_not_in {
         type Type = Option<Vec<super::String>>;
         const NAME: &'static str = "type_not_in";
     }
-    impl ::cynic::schema::HasInputField<TypeNotIn, Option<Vec<super::String>>>
+    impl ::cynic::schema::HasInputField<type_not_in, Option<Vec<super::String>>>
         for super::CityWhereInput
     {
     }
-    pub struct TypeLt;
-    impl ::cynic::schema::Field for TypeLt {
+    pub struct type_lt;
+    impl ::cynic::schema::Field for type_lt {
         type Type = Option<super::String>;
         const NAME: &'static str = "type_lt";
     }
-    impl ::cynic::schema::HasInputField<TypeLt, Option<super::String>> for super::CityWhereInput {}
-    pub struct TypeLte;
-    impl ::cynic::schema::Field for TypeLte {
+    impl ::cynic::schema::HasInputField<type_lt, Option<super::String>> for super::CityWhereInput {}
+    pub struct type_lte;
+    impl ::cynic::schema::Field for type_lte {
         type Type = Option<super::String>;
         const NAME: &'static str = "type_lte";
     }
-    impl ::cynic::schema::HasInputField<TypeLte, Option<super::String>> for super::CityWhereInput {}
-    pub struct TypeGt;
-    impl ::cynic::schema::Field for TypeGt {
+    impl ::cynic::schema::HasInputField<type_lte, Option<super::String>> for super::CityWhereInput {}
+    pub struct type_gt;
+    impl ::cynic::schema::Field for type_gt {
         type Type = Option<super::String>;
         const NAME: &'static str = "type_gt";
     }
-    impl ::cynic::schema::HasInputField<TypeGt, Option<super::String>> for super::CityWhereInput {}
-    pub struct TypeGte;
-    impl ::cynic::schema::Field for TypeGte {
+    impl ::cynic::schema::HasInputField<type_gt, Option<super::String>> for super::CityWhereInput {}
+    pub struct type_gte;
+    impl ::cynic::schema::Field for type_gte {
         type Type = Option<super::String>;
         const NAME: &'static str = "type_gte";
     }
-    impl ::cynic::schema::HasInputField<TypeGte, Option<super::String>> for super::CityWhereInput {}
-    pub struct TypeContains;
-    impl ::cynic::schema::Field for TypeContains {
+    impl ::cynic::schema::HasInputField<type_gte, Option<super::String>> for super::CityWhereInput {}
+    pub struct type_contains;
+    impl ::cynic::schema::Field for type_contains {
         type Type = Option<super::String>;
         const NAME: &'static str = "type_contains";
     }
-    impl ::cynic::schema::HasInputField<TypeContains, Option<super::String>> for super::CityWhereInput {}
-    pub struct TypeNotContains;
-    impl ::cynic::schema::Field for TypeNotContains {
+    impl ::cynic::schema::HasInputField<type_contains, Option<super::String>>
+        for super::CityWhereInput
+    {
+    }
+    pub struct type_not_contains;
+    impl ::cynic::schema::Field for type_not_contains {
         type Type = Option<super::String>;
         const NAME: &'static str = "type_not_contains";
     }
-    impl ::cynic::schema::HasInputField<TypeNotContains, Option<super::String>>
+    impl ::cynic::schema::HasInputField<type_not_contains, Option<super::String>>
         for super::CityWhereInput
     {
     }
-    pub struct TypeStartsWith;
-    impl ::cynic::schema::Field for TypeStartsWith {
+    pub struct type_starts_with;
+    impl ::cynic::schema::Field for type_starts_with {
         type Type = Option<super::String>;
         const NAME: &'static str = "type_starts_with";
     }
-    impl ::cynic::schema::HasInputField<TypeStartsWith, Option<super::String>>
+    impl ::cynic::schema::HasInputField<type_starts_with, Option<super::String>>
         for super::CityWhereInput
     {
     }
-    pub struct TypeNotStartsWith;
-    impl ::cynic::schema::Field for TypeNotStartsWith {
+    pub struct type_not_starts_with;
+    impl ::cynic::schema::Field for type_not_starts_with {
         type Type = Option<super::String>;
         const NAME: &'static str = "type_not_starts_with";
     }
-    impl ::cynic::schema::HasInputField<TypeNotStartsWith, Option<super::String>>
+    impl ::cynic::schema::HasInputField<type_not_starts_with, Option<super::String>>
         for super::CityWhereInput
     {
     }
-    pub struct TypeEndsWith;
-    impl ::cynic::schema::Field for TypeEndsWith {
+    pub struct type_ends_with;
+    impl ::cynic::schema::Field for type_ends_with {
         type Type = Option<super::String>;
         const NAME: &'static str = "type_ends_with";
     }
-    impl ::cynic::schema::HasInputField<TypeEndsWith, Option<super::String>> for super::CityWhereInput {}
-    pub struct TypeNotEndsWith;
-    impl ::cynic::schema::Field for TypeNotEndsWith {
+    impl ::cynic::schema::HasInputField<type_ends_with, Option<super::String>>
+        for super::CityWhereInput
+    {
+    }
+    pub struct type_not_ends_with;
+    impl ::cynic::schema::Field for type_not_ends_with {
         type Type = Option<super::String>;
         const NAME: &'static str = "type_not_ends_with";
     }
-    impl ::cynic::schema::HasInputField<TypeNotEndsWith, Option<super::String>>
+    impl ::cynic::schema::HasInputField<type_not_ends_with, Option<super::String>>
         for super::CityWhereInput
     {
     }
-    pub struct JobsEvery;
-    impl ::cynic::schema::Field for JobsEvery {
+    pub struct jobs_every;
+    impl ::cynic::schema::Field for jobs_every {
         type Type = Option<super::JobWhereInput>;
         const NAME: &'static str = "jobs_every";
     }
-    impl ::cynic::schema::HasInputField<JobsEvery, Option<super::JobWhereInput>>
+    impl ::cynic::schema::HasInputField<jobs_every, Option<super::JobWhereInput>>
         for super::CityWhereInput
     {
     }
-    pub struct JobsSome;
-    impl ::cynic::schema::Field for JobsSome {
+    pub struct jobs_some;
+    impl ::cynic::schema::Field for jobs_some {
         type Type = Option<super::JobWhereInput>;
         const NAME: &'static str = "jobs_some";
     }
-    impl ::cynic::schema::HasInputField<JobsSome, Option<super::JobWhereInput>>
+    impl ::cynic::schema::HasInputField<jobs_some, Option<super::JobWhereInput>>
         for super::CityWhereInput
     {
     }
-    pub struct JobsNone;
-    impl ::cynic::schema::Field for JobsNone {
+    pub struct jobs_none;
+    impl ::cynic::schema::Field for jobs_none {
         type Type = Option<super::JobWhereInput>;
         const NAME: &'static str = "jobs_none";
     }
-    impl ::cynic::schema::HasInputField<JobsNone, Option<super::JobWhereInput>>
+    impl ::cynic::schema::HasInputField<jobs_none, Option<super::JobWhereInput>>
         for super::CityWhereInput
     {
     }
-    pub struct CreatedAt;
-    impl ::cynic::schema::Field for CreatedAt {
+    pub struct createdAt;
+    impl ::cynic::schema::Field for createdAt {
         type Type = Option<super::DateTime>;
         const NAME: &'static str = "createdAt";
     }
-    impl ::cynic::schema::HasInputField<CreatedAt, Option<super::DateTime>> for super::CityWhereInput {}
-    pub struct CreatedAtNot;
-    impl ::cynic::schema::Field for CreatedAtNot {
+    impl ::cynic::schema::HasInputField<createdAt, Option<super::DateTime>> for super::CityWhereInput {}
+    pub struct createdAt_not;
+    impl ::cynic::schema::Field for createdAt_not {
         type Type = Option<super::DateTime>;
         const NAME: &'static str = "createdAt_not";
     }
-    impl ::cynic::schema::HasInputField<CreatedAtNot, Option<super::DateTime>>
+    impl ::cynic::schema::HasInputField<createdAt_not, Option<super::DateTime>>
         for super::CityWhereInput
     {
     }
-    pub struct CreatedAtIn;
-    impl ::cynic::schema::Field for CreatedAtIn {
+    pub struct createdAt_in;
+    impl ::cynic::schema::Field for createdAt_in {
         type Type = Option<Vec<super::DateTime>>;
         const NAME: &'static str = "createdAt_in";
     }
-    impl ::cynic::schema::HasInputField<CreatedAtIn, Option<Vec<super::DateTime>>>
+    impl ::cynic::schema::HasInputField<createdAt_in, Option<Vec<super::DateTime>>>
         for super::CityWhereInput
     {
     }
-    pub struct CreatedAtNotIn;
-    impl ::cynic::schema::Field for CreatedAtNotIn {
+    pub struct createdAt_not_in;
+    impl ::cynic::schema::Field for createdAt_not_in {
         type Type = Option<Vec<super::DateTime>>;
         const NAME: &'static str = "createdAt_not_in";
     }
-    impl ::cynic::schema::HasInputField<CreatedAtNotIn, Option<Vec<super::DateTime>>>
+    impl ::cynic::schema::HasInputField<createdAt_not_in, Option<Vec<super::DateTime>>>
         for super::CityWhereInput
     {
     }
-    pub struct CreatedAtLt;
-    impl ::cynic::schema::Field for CreatedAtLt {
+    pub struct createdAt_lt;
+    impl ::cynic::schema::Field for createdAt_lt {
         type Type = Option<super::DateTime>;
         const NAME: &'static str = "createdAt_lt";
     }
-    impl ::cynic::schema::HasInputField<CreatedAtLt, Option<super::DateTime>>
+    impl ::cynic::schema::HasInputField<createdAt_lt, Option<super::DateTime>>
         for super::CityWhereInput
     {
     }
-    pub struct CreatedAtLte;
-    impl ::cynic::schema::Field for CreatedAtLte {
+    pub struct createdAt_lte;
+    impl ::cynic::schema::Field for createdAt_lte {
         type Type = Option<super::DateTime>;
         const NAME: &'static str = "createdAt_lte";
     }
-    impl ::cynic::schema::HasInputField<CreatedAtLte, Option<super::DateTime>>
+    impl ::cynic::schema::HasInputField<createdAt_lte, Option<super::DateTime>>
         for super::CityWhereInput
     {
     }
-    pub struct CreatedAtGt;
-    impl ::cynic::schema::Field for CreatedAtGt {
+    pub struct createdAt_gt;
+    impl ::cynic::schema::Field for createdAt_gt {
         type Type = Option<super::DateTime>;
         const NAME: &'static str = "createdAt_gt";
     }
-    impl ::cynic::schema::HasInputField<CreatedAtGt, Option<super::DateTime>>
+    impl ::cynic::schema::HasInputField<createdAt_gt, Option<super::DateTime>>
         for super::CityWhereInput
     {
     }
-    pub struct CreatedAtGte;
-    impl ::cynic::schema::Field for CreatedAtGte {
+    pub struct createdAt_gte;
+    impl ::cynic::schema::Field for createdAt_gte {
         type Type = Option<super::DateTime>;
         const NAME: &'static str = "createdAt_gte";
     }
-    impl ::cynic::schema::HasInputField<CreatedAtGte, Option<super::DateTime>>
+    impl ::cynic::schema::HasInputField<createdAt_gte, Option<super::DateTime>>
         for super::CityWhereInput
     {
     }
-    pub struct UpdatedAt;
-    impl ::cynic::schema::Field for UpdatedAt {
+    pub struct updatedAt;
+    impl ::cynic::schema::Field for updatedAt {
         type Type = Option<super::DateTime>;
         const NAME: &'static str = "updatedAt";
     }
-    impl ::cynic::schema::HasInputField<UpdatedAt, Option<super::DateTime>> for super::CityWhereInput {}
-    pub struct UpdatedAtNot;
-    impl ::cynic::schema::Field for UpdatedAtNot {
+    impl ::cynic::schema::HasInputField<updatedAt, Option<super::DateTime>> for super::CityWhereInput {}
+    pub struct updatedAt_not;
+    impl ::cynic::schema::Field for updatedAt_not {
         type Type = Option<super::DateTime>;
         const NAME: &'static str = "updatedAt_not";
     }
-    impl ::cynic::schema::HasInputField<UpdatedAtNot, Option<super::DateTime>>
+    impl ::cynic::schema::HasInputField<updatedAt_not, Option<super::DateTime>>
         for super::CityWhereInput
     {
     }
-    pub struct UpdatedAtIn;
-    impl ::cynic::schema::Field for UpdatedAtIn {
+    pub struct updatedAt_in;
+    impl ::cynic::schema::Field for updatedAt_in {
         type Type = Option<Vec<super::DateTime>>;
         const NAME: &'static str = "updatedAt_in";
     }
-    impl ::cynic::schema::HasInputField<UpdatedAtIn, Option<Vec<super::DateTime>>>
+    impl ::cynic::schema::HasInputField<updatedAt_in, Option<Vec<super::DateTime>>>
         for super::CityWhereInput
     {
     }
-    pub struct UpdatedAtNotIn;
-    impl ::cynic::schema::Field for UpdatedAtNotIn {
+    pub struct updatedAt_not_in;
+    impl ::cynic::schema::Field for updatedAt_not_in {
         type Type = Option<Vec<super::DateTime>>;
         const NAME: &'static str = "updatedAt_not_in";
     }
-    impl ::cynic::schema::HasInputField<UpdatedAtNotIn, Option<Vec<super::DateTime>>>
+    impl ::cynic::schema::HasInputField<updatedAt_not_in, Option<Vec<super::DateTime>>>
         for super::CityWhereInput
     {
     }
-    pub struct UpdatedAtLt;
-    impl ::cynic::schema::Field for UpdatedAtLt {
+    pub struct updatedAt_lt;
+    impl ::cynic::schema::Field for updatedAt_lt {
         type Type = Option<super::DateTime>;
         const NAME: &'static str = "updatedAt_lt";
     }
-    impl ::cynic::schema::HasInputField<UpdatedAtLt, Option<super::DateTime>>
+    impl ::cynic::schema::HasInputField<updatedAt_lt, Option<super::DateTime>>
         for super::CityWhereInput
     {
     }
-    pub struct UpdatedAtLte;
-    impl ::cynic::schema::Field for UpdatedAtLte {
+    pub struct updatedAt_lte;
+    impl ::cynic::schema::Field for updatedAt_lte {
         type Type = Option<super::DateTime>;
         const NAME: &'static str = "updatedAt_lte";
     }
-    impl ::cynic::schema::HasInputField<UpdatedAtLte, Option<super::DateTime>>
+    impl ::cynic::schema::HasInputField<updatedAt_lte, Option<super::DateTime>>
         for super::CityWhereInput
     {
     }
-    pub struct UpdatedAtGt;
-    impl ::cynic::schema::Field for UpdatedAtGt {
+    pub struct updatedAt_gt;
+    impl ::cynic::schema::Field for updatedAt_gt {
         type Type = Option<super::DateTime>;
         const NAME: &'static str = "updatedAt_gt";
     }
-    impl ::cynic::schema::HasInputField<UpdatedAtGt, Option<super::DateTime>>
+    impl ::cynic::schema::HasInputField<updatedAt_gt, Option<super::DateTime>>
         for super::CityWhereInput
     {
     }
-    pub struct UpdatedAtGte;
-    impl ::cynic::schema::Field for UpdatedAtGte {
+    pub struct updatedAt_gte;
+    impl ::cynic::schema::Field for updatedAt_gte {
         type Type = Option<super::DateTime>;
         const NAME: &'static str = "updatedAt_gte";
     }
-    impl ::cynic::schema::HasInputField<UpdatedAtGte, Option<super::DateTime>>
+    impl ::cynic::schema::HasInputField<updatedAt_gte, Option<super::DateTime>>
         for super::CityWhereInput
     {
     }
-    pub struct And;
-    impl ::cynic::schema::Field for And {
+    pub struct AND;
+    impl ::cynic::schema::Field for AND {
         type Type = Option<Vec<super::CityWhereInput>>;
         const NAME: &'static str = "AND";
     }
-    impl ::cynic::schema::HasInputField<And, Option<Vec<super::CityWhereInput>>>
+    impl ::cynic::schema::HasInputField<AND, Option<Vec<super::CityWhereInput>>>
         for super::CityWhereInput
     {
     }
-    pub struct Or;
-    impl ::cynic::schema::Field for Or {
+    pub struct OR;
+    impl ::cynic::schema::Field for OR {
         type Type = Option<Vec<super::CityWhereInput>>;
         const NAME: &'static str = "OR";
     }
-    impl ::cynic::schema::HasInputField<Or, Option<Vec<super::CityWhereInput>>>
+    impl ::cynic::schema::HasInputField<OR, Option<Vec<super::CityWhereInput>>>
         for super::CityWhereInput
     {
     }
-    pub struct Not;
-    impl ::cynic::schema::Field for Not {
+    pub struct NOT;
+    impl ::cynic::schema::Field for NOT {
         type Type = Option<Vec<super::CityWhereInput>>;
         const NAME: &'static str = "NOT";
     }
-    impl ::cynic::schema::HasInputField<Not, Option<Vec<super::CityWhereInput>>>
+    impl ::cynic::schema::HasInputField<NOT, Option<Vec<super::CityWhereInput>>>
         for super::CityWhereInput
     {
     }
 }
 pub struct Commitment;
 pub mod commitment_fields {
-    pub struct Id;
-    impl ::cynic::schema::Field for Id {
-        type Type = super::Id;
+    pub struct id;
+    impl ::cynic::schema::Field for id {
+        type Type = super::ID;
         const NAME: &'static str = "id";
     }
-    impl ::cynic::schema::HasField<Id> for super::Commitment {
-        type Type = super::Id;
+    impl ::cynic::schema::HasField<id> for super::Commitment {
+        type Type = super::ID;
     }
-    pub struct Title;
-    impl ::cynic::schema::Field for Title {
+    pub struct title;
+    impl ::cynic::schema::Field for title {
         type Type = super::String;
         const NAME: &'static str = "title";
     }
-    impl ::cynic::schema::HasField<Title> for super::Commitment {
+    impl ::cynic::schema::HasField<title> for super::Commitment {
         type Type = super::String;
     }
-    pub struct Slug;
-    impl ::cynic::schema::Field for Slug {
+    pub struct slug;
+    impl ::cynic::schema::Field for slug {
         type Type = super::String;
         const NAME: &'static str = "slug";
     }
-    impl ::cynic::schema::HasField<Slug> for super::Commitment {
+    impl ::cynic::schema::HasField<slug> for super::Commitment {
         type Type = super::String;
     }
-    pub struct Jobs;
-    impl ::cynic::schema::Field for Jobs {
+    pub struct jobs;
+    impl ::cynic::schema::Field for jobs {
         type Type = Option<Vec<super::Job>>;
         const NAME: &'static str = "jobs";
     }
-    impl ::cynic::schema::HasField<Jobs> for super::Commitment {
+    impl ::cynic::schema::HasField<jobs> for super::Commitment {
         type Type = Option<Vec<super::Job>>;
     }
     pub mod jobs_arguments {
-        pub struct Where;
-        impl ::cynic::schema::HasArgument<Where> for super::Jobs {
+        pub struct r#where;
+        impl ::cynic::schema::HasArgument<r#where> for super::jobs {
             type ArgumentType = Option<super::super::JobWhereInput>;
             const NAME: &'static str = "where";
         }
-        pub struct OrderBy;
-        impl ::cynic::schema::HasArgument<OrderBy> for super::Jobs {
+        pub struct orderBy;
+        impl ::cynic::schema::HasArgument<orderBy> for super::jobs {
             type ArgumentType = Option<super::super::JobOrderByInput>;
             const NAME: &'static str = "orderBy";
         }
-        pub struct Skip;
-        impl ::cynic::schema::HasArgument<Skip> for super::Jobs {
+        pub struct skip;
+        impl ::cynic::schema::HasArgument<skip> for super::jobs {
             type ArgumentType = Option<super::super::Int>;
             const NAME: &'static str = "skip";
         }
-        pub struct After;
-        impl ::cynic::schema::HasArgument<After> for super::Jobs {
+        pub struct after;
+        impl ::cynic::schema::HasArgument<after> for super::jobs {
             type ArgumentType = Option<super::super::String>;
             const NAME: &'static str = "after";
         }
-        pub struct Before;
-        impl ::cynic::schema::HasArgument<Before> for super::Jobs {
+        pub struct before;
+        impl ::cynic::schema::HasArgument<before> for super::jobs {
             type ArgumentType = Option<super::super::String>;
             const NAME: &'static str = "before";
         }
-        pub struct First;
-        impl ::cynic::schema::HasArgument<First> for super::Jobs {
+        pub struct first;
+        impl ::cynic::schema::HasArgument<first> for super::jobs {
             type ArgumentType = Option<super::super::Int>;
             const NAME: &'static str = "first";
         }
-        pub struct Last;
-        impl ::cynic::schema::HasArgument<Last> for super::Jobs {
+        pub struct last;
+        impl ::cynic::schema::HasArgument<last> for super::jobs {
             type ArgumentType = Option<super::super::Int>;
             const NAME: &'static str = "last";
         }
     }
-    pub struct CreatedAt;
-    impl ::cynic::schema::Field for CreatedAt {
+    pub struct createdAt;
+    impl ::cynic::schema::Field for createdAt {
         type Type = super::DateTime;
         const NAME: &'static str = "createdAt";
     }
-    impl ::cynic::schema::HasField<CreatedAt> for super::Commitment {
+    impl ::cynic::schema::HasField<createdAt> for super::Commitment {
         type Type = super::DateTime;
     }
-    pub struct UpdatedAt;
-    impl ::cynic::schema::Field for UpdatedAt {
+    pub struct updatedAt;
+    impl ::cynic::schema::Field for updatedAt {
         type Type = super::DateTime;
         const NAME: &'static str = "updatedAt";
     }
-    impl ::cynic::schema::HasField<UpdatedAt> for super::Commitment {
+    impl ::cynic::schema::HasField<updatedAt> for super::Commitment {
         type Type = super::DateTime;
     }
 }
 pub struct CommitmentWhereInput;
 impl ::cynic::schema::InputObjectMarker for CommitmentWhereInput {}
 pub mod commitment_where_input_fields {
-    pub struct Id;
-    impl ::cynic::schema::Field for Id {
-        type Type = Option<super::Id>;
+    pub struct id;
+    impl ::cynic::schema::Field for id {
+        type Type = Option<super::ID>;
         const NAME: &'static str = "id";
     }
-    impl ::cynic::schema::HasInputField<Id, Option<super::Id>> for super::CommitmentWhereInput {}
-    pub struct IdNot;
-    impl ::cynic::schema::Field for IdNot {
-        type Type = Option<super::Id>;
+    impl ::cynic::schema::HasInputField<id, Option<super::ID>> for super::CommitmentWhereInput {}
+    pub struct id_not;
+    impl ::cynic::schema::Field for id_not {
+        type Type = Option<super::ID>;
         const NAME: &'static str = "id_not";
     }
-    impl ::cynic::schema::HasInputField<IdNot, Option<super::Id>> for super::CommitmentWhereInput {}
-    pub struct IdIn;
-    impl ::cynic::schema::Field for IdIn {
-        type Type = Option<Vec<super::Id>>;
+    impl ::cynic::schema::HasInputField<id_not, Option<super::ID>> for super::CommitmentWhereInput {}
+    pub struct id_in;
+    impl ::cynic::schema::Field for id_in {
+        type Type = Option<Vec<super::ID>>;
         const NAME: &'static str = "id_in";
     }
-    impl ::cynic::schema::HasInputField<IdIn, Option<Vec<super::Id>>> for super::CommitmentWhereInput {}
-    pub struct IdNotIn;
-    impl ::cynic::schema::Field for IdNotIn {
-        type Type = Option<Vec<super::Id>>;
+    impl ::cynic::schema::HasInputField<id_in, Option<Vec<super::ID>>> for super::CommitmentWhereInput {}
+    pub struct id_not_in;
+    impl ::cynic::schema::Field for id_not_in {
+        type Type = Option<Vec<super::ID>>;
         const NAME: &'static str = "id_not_in";
     }
-    impl ::cynic::schema::HasInputField<IdNotIn, Option<Vec<super::Id>>>
+    impl ::cynic::schema::HasInputField<id_not_in, Option<Vec<super::ID>>>
         for super::CommitmentWhereInput
     {
     }
-    pub struct IdLt;
-    impl ::cynic::schema::Field for IdLt {
-        type Type = Option<super::Id>;
+    pub struct id_lt;
+    impl ::cynic::schema::Field for id_lt {
+        type Type = Option<super::ID>;
         const NAME: &'static str = "id_lt";
     }
-    impl ::cynic::schema::HasInputField<IdLt, Option<super::Id>> for super::CommitmentWhereInput {}
-    pub struct IdLte;
-    impl ::cynic::schema::Field for IdLte {
-        type Type = Option<super::Id>;
+    impl ::cynic::schema::HasInputField<id_lt, Option<super::ID>> for super::CommitmentWhereInput {}
+    pub struct id_lte;
+    impl ::cynic::schema::Field for id_lte {
+        type Type = Option<super::ID>;
         const NAME: &'static str = "id_lte";
     }
-    impl ::cynic::schema::HasInputField<IdLte, Option<super::Id>> for super::CommitmentWhereInput {}
-    pub struct IdGt;
-    impl ::cynic::schema::Field for IdGt {
-        type Type = Option<super::Id>;
+    impl ::cynic::schema::HasInputField<id_lte, Option<super::ID>> for super::CommitmentWhereInput {}
+    pub struct id_gt;
+    impl ::cynic::schema::Field for id_gt {
+        type Type = Option<super::ID>;
         const NAME: &'static str = "id_gt";
     }
-    impl ::cynic::schema::HasInputField<IdGt, Option<super::Id>> for super::CommitmentWhereInput {}
-    pub struct IdGte;
-    impl ::cynic::schema::Field for IdGte {
-        type Type = Option<super::Id>;
+    impl ::cynic::schema::HasInputField<id_gt, Option<super::ID>> for super::CommitmentWhereInput {}
+    pub struct id_gte;
+    impl ::cynic::schema::Field for id_gte {
+        type Type = Option<super::ID>;
         const NAME: &'static str = "id_gte";
     }
-    impl ::cynic::schema::HasInputField<IdGte, Option<super::Id>> for super::CommitmentWhereInput {}
-    pub struct IdContains;
-    impl ::cynic::schema::Field for IdContains {
-        type Type = Option<super::Id>;
+    impl ::cynic::schema::HasInputField<id_gte, Option<super::ID>> for super::CommitmentWhereInput {}
+    pub struct id_contains;
+    impl ::cynic::schema::Field for id_contains {
+        type Type = Option<super::ID>;
         const NAME: &'static str = "id_contains";
     }
-    impl ::cynic::schema::HasInputField<IdContains, Option<super::Id>> for super::CommitmentWhereInput {}
-    pub struct IdNotContains;
-    impl ::cynic::schema::Field for IdNotContains {
-        type Type = Option<super::Id>;
+    impl ::cynic::schema::HasInputField<id_contains, Option<super::ID>>
+        for super::CommitmentWhereInput
+    {
+    }
+    pub struct id_not_contains;
+    impl ::cynic::schema::Field for id_not_contains {
+        type Type = Option<super::ID>;
         const NAME: &'static str = "id_not_contains";
     }
-    impl ::cynic::schema::HasInputField<IdNotContains, Option<super::Id>>
+    impl ::cynic::schema::HasInputField<id_not_contains, Option<super::ID>>
         for super::CommitmentWhereInput
     {
     }
-    pub struct IdStartsWith;
-    impl ::cynic::schema::Field for IdStartsWith {
-        type Type = Option<super::Id>;
+    pub struct id_starts_with;
+    impl ::cynic::schema::Field for id_starts_with {
+        type Type = Option<super::ID>;
         const NAME: &'static str = "id_starts_with";
     }
-    impl ::cynic::schema::HasInputField<IdStartsWith, Option<super::Id>>
+    impl ::cynic::schema::HasInputField<id_starts_with, Option<super::ID>>
         for super::CommitmentWhereInput
     {
     }
-    pub struct IdNotStartsWith;
-    impl ::cynic::schema::Field for IdNotStartsWith {
-        type Type = Option<super::Id>;
+    pub struct id_not_starts_with;
+    impl ::cynic::schema::Field for id_not_starts_with {
+        type Type = Option<super::ID>;
         const NAME: &'static str = "id_not_starts_with";
     }
-    impl ::cynic::schema::HasInputField<IdNotStartsWith, Option<super::Id>>
+    impl ::cynic::schema::HasInputField<id_not_starts_with, Option<super::ID>>
         for super::CommitmentWhereInput
     {
     }
-    pub struct IdEndsWith;
-    impl ::cynic::schema::Field for IdEndsWith {
-        type Type = Option<super::Id>;
+    pub struct id_ends_with;
+    impl ::cynic::schema::Field for id_ends_with {
+        type Type = Option<super::ID>;
         const NAME: &'static str = "id_ends_with";
     }
-    impl ::cynic::schema::HasInputField<IdEndsWith, Option<super::Id>> for super::CommitmentWhereInput {}
-    pub struct IdNotEndsWith;
-    impl ::cynic::schema::Field for IdNotEndsWith {
-        type Type = Option<super::Id>;
-        const NAME: &'static str = "id_not_ends_with";
-    }
-    impl ::cynic::schema::HasInputField<IdNotEndsWith, Option<super::Id>>
+    impl ::cynic::schema::HasInputField<id_ends_with, Option<super::ID>>
         for super::CommitmentWhereInput
     {
     }
-    pub struct Title;
-    impl ::cynic::schema::Field for Title {
+    pub struct id_not_ends_with;
+    impl ::cynic::schema::Field for id_not_ends_with {
+        type Type = Option<super::ID>;
+        const NAME: &'static str = "id_not_ends_with";
+    }
+    impl ::cynic::schema::HasInputField<id_not_ends_with, Option<super::ID>>
+        for super::CommitmentWhereInput
+    {
+    }
+    pub struct title;
+    impl ::cynic::schema::Field for title {
         type Type = Option<super::String>;
         const NAME: &'static str = "title";
     }
-    impl ::cynic::schema::HasInputField<Title, Option<super::String>> for super::CommitmentWhereInput {}
-    pub struct TitleNot;
-    impl ::cynic::schema::Field for TitleNot {
+    impl ::cynic::schema::HasInputField<title, Option<super::String>> for super::CommitmentWhereInput {}
+    pub struct title_not;
+    impl ::cynic::schema::Field for title_not {
         type Type = Option<super::String>;
         const NAME: &'static str = "title_not";
     }
-    impl ::cynic::schema::HasInputField<TitleNot, Option<super::String>>
+    impl ::cynic::schema::HasInputField<title_not, Option<super::String>>
         for super::CommitmentWhereInput
     {
     }
-    pub struct TitleIn;
-    impl ::cynic::schema::Field for TitleIn {
+    pub struct title_in;
+    impl ::cynic::schema::Field for title_in {
         type Type = Option<Vec<super::String>>;
         const NAME: &'static str = "title_in";
     }
-    impl ::cynic::schema::HasInputField<TitleIn, Option<Vec<super::String>>>
+    impl ::cynic::schema::HasInputField<title_in, Option<Vec<super::String>>>
         for super::CommitmentWhereInput
     {
     }
-    pub struct TitleNotIn;
-    impl ::cynic::schema::Field for TitleNotIn {
+    pub struct title_not_in;
+    impl ::cynic::schema::Field for title_not_in {
         type Type = Option<Vec<super::String>>;
         const NAME: &'static str = "title_not_in";
     }
-    impl ::cynic::schema::HasInputField<TitleNotIn, Option<Vec<super::String>>>
+    impl ::cynic::schema::HasInputField<title_not_in, Option<Vec<super::String>>>
         for super::CommitmentWhereInput
     {
     }
-    pub struct TitleLt;
-    impl ::cynic::schema::Field for TitleLt {
+    pub struct title_lt;
+    impl ::cynic::schema::Field for title_lt {
         type Type = Option<super::String>;
         const NAME: &'static str = "title_lt";
     }
-    impl ::cynic::schema::HasInputField<TitleLt, Option<super::String>>
+    impl ::cynic::schema::HasInputField<title_lt, Option<super::String>>
         for super::CommitmentWhereInput
     {
     }
-    pub struct TitleLte;
-    impl ::cynic::schema::Field for TitleLte {
+    pub struct title_lte;
+    impl ::cynic::schema::Field for title_lte {
         type Type = Option<super::String>;
         const NAME: &'static str = "title_lte";
     }
-    impl ::cynic::schema::HasInputField<TitleLte, Option<super::String>>
+    impl ::cynic::schema::HasInputField<title_lte, Option<super::String>>
         for super::CommitmentWhereInput
     {
     }
-    pub struct TitleGt;
-    impl ::cynic::schema::Field for TitleGt {
+    pub struct title_gt;
+    impl ::cynic::schema::Field for title_gt {
         type Type = Option<super::String>;
         const NAME: &'static str = "title_gt";
     }
-    impl ::cynic::schema::HasInputField<TitleGt, Option<super::String>>
+    impl ::cynic::schema::HasInputField<title_gt, Option<super::String>>
         for super::CommitmentWhereInput
     {
     }
-    pub struct TitleGte;
-    impl ::cynic::schema::Field for TitleGte {
+    pub struct title_gte;
+    impl ::cynic::schema::Field for title_gte {
         type Type = Option<super::String>;
         const NAME: &'static str = "title_gte";
     }
-    impl ::cynic::schema::HasInputField<TitleGte, Option<super::String>>
+    impl ::cynic::schema::HasInputField<title_gte, Option<super::String>>
         for super::CommitmentWhereInput
     {
     }
-    pub struct TitleContains;
-    impl ::cynic::schema::Field for TitleContains {
+    pub struct title_contains;
+    impl ::cynic::schema::Field for title_contains {
         type Type = Option<super::String>;
         const NAME: &'static str = "title_contains";
     }
-    impl ::cynic::schema::HasInputField<TitleContains, Option<super::String>>
+    impl ::cynic::schema::HasInputField<title_contains, Option<super::String>>
         for super::CommitmentWhereInput
     {
     }
-    pub struct TitleNotContains;
-    impl ::cynic::schema::Field for TitleNotContains {
+    pub struct title_not_contains;
+    impl ::cynic::schema::Field for title_not_contains {
         type Type = Option<super::String>;
         const NAME: &'static str = "title_not_contains";
     }
-    impl ::cynic::schema::HasInputField<TitleNotContains, Option<super::String>>
+    impl ::cynic::schema::HasInputField<title_not_contains, Option<super::String>>
         for super::CommitmentWhereInput
     {
     }
-    pub struct TitleStartsWith;
-    impl ::cynic::schema::Field for TitleStartsWith {
+    pub struct title_starts_with;
+    impl ::cynic::schema::Field for title_starts_with {
         type Type = Option<super::String>;
         const NAME: &'static str = "title_starts_with";
     }
-    impl ::cynic::schema::HasInputField<TitleStartsWith, Option<super::String>>
+    impl ::cynic::schema::HasInputField<title_starts_with, Option<super::String>>
         for super::CommitmentWhereInput
     {
     }
-    pub struct TitleNotStartsWith;
-    impl ::cynic::schema::Field for TitleNotStartsWith {
+    pub struct title_not_starts_with;
+    impl ::cynic::schema::Field for title_not_starts_with {
         type Type = Option<super::String>;
         const NAME: &'static str = "title_not_starts_with";
     }
-    impl ::cynic::schema::HasInputField<TitleNotStartsWith, Option<super::String>>
+    impl ::cynic::schema::HasInputField<title_not_starts_with, Option<super::String>>
         for super::CommitmentWhereInput
     {
     }
-    pub struct TitleEndsWith;
-    impl ::cynic::schema::Field for TitleEndsWith {
+    pub struct title_ends_with;
+    impl ::cynic::schema::Field for title_ends_with {
         type Type = Option<super::String>;
         const NAME: &'static str = "title_ends_with";
     }
-    impl ::cynic::schema::HasInputField<TitleEndsWith, Option<super::String>>
+    impl ::cynic::schema::HasInputField<title_ends_with, Option<super::String>>
         for super::CommitmentWhereInput
     {
     }
-    pub struct TitleNotEndsWith;
-    impl ::cynic::schema::Field for TitleNotEndsWith {
+    pub struct title_not_ends_with;
+    impl ::cynic::schema::Field for title_not_ends_with {
         type Type = Option<super::String>;
         const NAME: &'static str = "title_not_ends_with";
     }
-    impl ::cynic::schema::HasInputField<TitleNotEndsWith, Option<super::String>>
+    impl ::cynic::schema::HasInputField<title_not_ends_with, Option<super::String>>
         for super::CommitmentWhereInput
     {
     }
-    pub struct Slug;
-    impl ::cynic::schema::Field for Slug {
+    pub struct slug;
+    impl ::cynic::schema::Field for slug {
         type Type = Option<super::String>;
         const NAME: &'static str = "slug";
     }
-    impl ::cynic::schema::HasInputField<Slug, Option<super::String>> for super::CommitmentWhereInput {}
-    pub struct SlugNot;
-    impl ::cynic::schema::Field for SlugNot {
+    impl ::cynic::schema::HasInputField<slug, Option<super::String>> for super::CommitmentWhereInput {}
+    pub struct slug_not;
+    impl ::cynic::schema::Field for slug_not {
         type Type = Option<super::String>;
         const NAME: &'static str = "slug_not";
     }
-    impl ::cynic::schema::HasInputField<SlugNot, Option<super::String>>
+    impl ::cynic::schema::HasInputField<slug_not, Option<super::String>>
         for super::CommitmentWhereInput
     {
     }
-    pub struct SlugIn;
-    impl ::cynic::schema::Field for SlugIn {
+    pub struct slug_in;
+    impl ::cynic::schema::Field for slug_in {
         type Type = Option<Vec<super::String>>;
         const NAME: &'static str = "slug_in";
     }
-    impl ::cynic::schema::HasInputField<SlugIn, Option<Vec<super::String>>>
+    impl ::cynic::schema::HasInputField<slug_in, Option<Vec<super::String>>>
         for super::CommitmentWhereInput
     {
     }
-    pub struct SlugNotIn;
-    impl ::cynic::schema::Field for SlugNotIn {
+    pub struct slug_not_in;
+    impl ::cynic::schema::Field for slug_not_in {
         type Type = Option<Vec<super::String>>;
         const NAME: &'static str = "slug_not_in";
     }
-    impl ::cynic::schema::HasInputField<SlugNotIn, Option<Vec<super::String>>>
+    impl ::cynic::schema::HasInputField<slug_not_in, Option<Vec<super::String>>>
         for super::CommitmentWhereInput
     {
     }
-    pub struct SlugLt;
-    impl ::cynic::schema::Field for SlugLt {
+    pub struct slug_lt;
+    impl ::cynic::schema::Field for slug_lt {
         type Type = Option<super::String>;
         const NAME: &'static str = "slug_lt";
     }
-    impl ::cynic::schema::HasInputField<SlugLt, Option<super::String>> for super::CommitmentWhereInput {}
-    pub struct SlugLte;
-    impl ::cynic::schema::Field for SlugLte {
+    impl ::cynic::schema::HasInputField<slug_lt, Option<super::String>>
+        for super::CommitmentWhereInput
+    {
+    }
+    pub struct slug_lte;
+    impl ::cynic::schema::Field for slug_lte {
         type Type = Option<super::String>;
         const NAME: &'static str = "slug_lte";
     }
-    impl ::cynic::schema::HasInputField<SlugLte, Option<super::String>>
+    impl ::cynic::schema::HasInputField<slug_lte, Option<super::String>>
         for super::CommitmentWhereInput
     {
     }
-    pub struct SlugGt;
-    impl ::cynic::schema::Field for SlugGt {
+    pub struct slug_gt;
+    impl ::cynic::schema::Field for slug_gt {
         type Type = Option<super::String>;
         const NAME: &'static str = "slug_gt";
     }
-    impl ::cynic::schema::HasInputField<SlugGt, Option<super::String>> for super::CommitmentWhereInput {}
-    pub struct SlugGte;
-    impl ::cynic::schema::Field for SlugGte {
+    impl ::cynic::schema::HasInputField<slug_gt, Option<super::String>>
+        for super::CommitmentWhereInput
+    {
+    }
+    pub struct slug_gte;
+    impl ::cynic::schema::Field for slug_gte {
         type Type = Option<super::String>;
         const NAME: &'static str = "slug_gte";
     }
-    impl ::cynic::schema::HasInputField<SlugGte, Option<super::String>>
+    impl ::cynic::schema::HasInputField<slug_gte, Option<super::String>>
         for super::CommitmentWhereInput
     {
     }
-    pub struct SlugContains;
-    impl ::cynic::schema::Field for SlugContains {
+    pub struct slug_contains;
+    impl ::cynic::schema::Field for slug_contains {
         type Type = Option<super::String>;
         const NAME: &'static str = "slug_contains";
     }
-    impl ::cynic::schema::HasInputField<SlugContains, Option<super::String>>
+    impl ::cynic::schema::HasInputField<slug_contains, Option<super::String>>
         for super::CommitmentWhereInput
     {
     }
-    pub struct SlugNotContains;
-    impl ::cynic::schema::Field for SlugNotContains {
+    pub struct slug_not_contains;
+    impl ::cynic::schema::Field for slug_not_contains {
         type Type = Option<super::String>;
         const NAME: &'static str = "slug_not_contains";
     }
-    impl ::cynic::schema::HasInputField<SlugNotContains, Option<super::String>>
+    impl ::cynic::schema::HasInputField<slug_not_contains, Option<super::String>>
         for super::CommitmentWhereInput
     {
     }
-    pub struct SlugStartsWith;
-    impl ::cynic::schema::Field for SlugStartsWith {
+    pub struct slug_starts_with;
+    impl ::cynic::schema::Field for slug_starts_with {
         type Type = Option<super::String>;
         const NAME: &'static str = "slug_starts_with";
     }
-    impl ::cynic::schema::HasInputField<SlugStartsWith, Option<super::String>>
+    impl ::cynic::schema::HasInputField<slug_starts_with, Option<super::String>>
         for super::CommitmentWhereInput
     {
     }
-    pub struct SlugNotStartsWith;
-    impl ::cynic::schema::Field for SlugNotStartsWith {
+    pub struct slug_not_starts_with;
+    impl ::cynic::schema::Field for slug_not_starts_with {
         type Type = Option<super::String>;
         const NAME: &'static str = "slug_not_starts_with";
     }
-    impl ::cynic::schema::HasInputField<SlugNotStartsWith, Option<super::String>>
+    impl ::cynic::schema::HasInputField<slug_not_starts_with, Option<super::String>>
         for super::CommitmentWhereInput
     {
     }
-    pub struct SlugEndsWith;
-    impl ::cynic::schema::Field for SlugEndsWith {
+    pub struct slug_ends_with;
+    impl ::cynic::schema::Field for slug_ends_with {
         type Type = Option<super::String>;
         const NAME: &'static str = "slug_ends_with";
     }
-    impl ::cynic::schema::HasInputField<SlugEndsWith, Option<super::String>>
+    impl ::cynic::schema::HasInputField<slug_ends_with, Option<super::String>>
         for super::CommitmentWhereInput
     {
     }
-    pub struct SlugNotEndsWith;
-    impl ::cynic::schema::Field for SlugNotEndsWith {
+    pub struct slug_not_ends_with;
+    impl ::cynic::schema::Field for slug_not_ends_with {
         type Type = Option<super::String>;
         const NAME: &'static str = "slug_not_ends_with";
     }
-    impl ::cynic::schema::HasInputField<SlugNotEndsWith, Option<super::String>>
+    impl ::cynic::schema::HasInputField<slug_not_ends_with, Option<super::String>>
         for super::CommitmentWhereInput
     {
     }
-    pub struct JobsEvery;
-    impl ::cynic::schema::Field for JobsEvery {
+    pub struct jobs_every;
+    impl ::cynic::schema::Field for jobs_every {
         type Type = Option<super::JobWhereInput>;
         const NAME: &'static str = "jobs_every";
     }
-    impl ::cynic::schema::HasInputField<JobsEvery, Option<super::JobWhereInput>>
+    impl ::cynic::schema::HasInputField<jobs_every, Option<super::JobWhereInput>>
         for super::CommitmentWhereInput
     {
     }
-    pub struct JobsSome;
-    impl ::cynic::schema::Field for JobsSome {
+    pub struct jobs_some;
+    impl ::cynic::schema::Field for jobs_some {
         type Type = Option<super::JobWhereInput>;
         const NAME: &'static str = "jobs_some";
     }
-    impl ::cynic::schema::HasInputField<JobsSome, Option<super::JobWhereInput>>
+    impl ::cynic::schema::HasInputField<jobs_some, Option<super::JobWhereInput>>
         for super::CommitmentWhereInput
     {
     }
-    pub struct JobsNone;
-    impl ::cynic::schema::Field for JobsNone {
+    pub struct jobs_none;
+    impl ::cynic::schema::Field for jobs_none {
         type Type = Option<super::JobWhereInput>;
         const NAME: &'static str = "jobs_none";
     }
-    impl ::cynic::schema::HasInputField<JobsNone, Option<super::JobWhereInput>>
+    impl ::cynic::schema::HasInputField<jobs_none, Option<super::JobWhereInput>>
         for super::CommitmentWhereInput
     {
     }
-    pub struct CreatedAt;
-    impl ::cynic::schema::Field for CreatedAt {
+    pub struct createdAt;
+    impl ::cynic::schema::Field for createdAt {
         type Type = Option<super::DateTime>;
         const NAME: &'static str = "createdAt";
     }
-    impl ::cynic::schema::HasInputField<CreatedAt, Option<super::DateTime>>
+    impl ::cynic::schema::HasInputField<createdAt, Option<super::DateTime>>
         for super::CommitmentWhereInput
     {
     }
-    pub struct CreatedAtNot;
-    impl ::cynic::schema::Field for CreatedAtNot {
+    pub struct createdAt_not;
+    impl ::cynic::schema::Field for createdAt_not {
         type Type = Option<super::DateTime>;
         const NAME: &'static str = "createdAt_not";
     }
-    impl ::cynic::schema::HasInputField<CreatedAtNot, Option<super::DateTime>>
+    impl ::cynic::schema::HasInputField<createdAt_not, Option<super::DateTime>>
         for super::CommitmentWhereInput
     {
     }
-    pub struct CreatedAtIn;
-    impl ::cynic::schema::Field for CreatedAtIn {
+    pub struct createdAt_in;
+    impl ::cynic::schema::Field for createdAt_in {
         type Type = Option<Vec<super::DateTime>>;
         const NAME: &'static str = "createdAt_in";
     }
-    impl ::cynic::schema::HasInputField<CreatedAtIn, Option<Vec<super::DateTime>>>
+    impl ::cynic::schema::HasInputField<createdAt_in, Option<Vec<super::DateTime>>>
         for super::CommitmentWhereInput
     {
     }
-    pub struct CreatedAtNotIn;
-    impl ::cynic::schema::Field for CreatedAtNotIn {
+    pub struct createdAt_not_in;
+    impl ::cynic::schema::Field for createdAt_not_in {
         type Type = Option<Vec<super::DateTime>>;
         const NAME: &'static str = "createdAt_not_in";
     }
-    impl ::cynic::schema::HasInputField<CreatedAtNotIn, Option<Vec<super::DateTime>>>
+    impl ::cynic::schema::HasInputField<createdAt_not_in, Option<Vec<super::DateTime>>>
         for super::CommitmentWhereInput
     {
     }
-    pub struct CreatedAtLt;
-    impl ::cynic::schema::Field for CreatedAtLt {
+    pub struct createdAt_lt;
+    impl ::cynic::schema::Field for createdAt_lt {
         type Type = Option<super::DateTime>;
         const NAME: &'static str = "createdAt_lt";
     }
-    impl ::cynic::schema::HasInputField<CreatedAtLt, Option<super::DateTime>>
+    impl ::cynic::schema::HasInputField<createdAt_lt, Option<super::DateTime>>
         for super::CommitmentWhereInput
     {
     }
-    pub struct CreatedAtLte;
-    impl ::cynic::schema::Field for CreatedAtLte {
+    pub struct createdAt_lte;
+    impl ::cynic::schema::Field for createdAt_lte {
         type Type = Option<super::DateTime>;
         const NAME: &'static str = "createdAt_lte";
     }
-    impl ::cynic::schema::HasInputField<CreatedAtLte, Option<super::DateTime>>
+    impl ::cynic::schema::HasInputField<createdAt_lte, Option<super::DateTime>>
         for super::CommitmentWhereInput
     {
     }
-    pub struct CreatedAtGt;
-    impl ::cynic::schema::Field for CreatedAtGt {
+    pub struct createdAt_gt;
+    impl ::cynic::schema::Field for createdAt_gt {
         type Type = Option<super::DateTime>;
         const NAME: &'static str = "createdAt_gt";
     }
-    impl ::cynic::schema::HasInputField<CreatedAtGt, Option<super::DateTime>>
+    impl ::cynic::schema::HasInputField<createdAt_gt, Option<super::DateTime>>
         for super::CommitmentWhereInput
     {
     }
-    pub struct CreatedAtGte;
-    impl ::cynic::schema::Field for CreatedAtGte {
+    pub struct createdAt_gte;
+    impl ::cynic::schema::Field for createdAt_gte {
         type Type = Option<super::DateTime>;
         const NAME: &'static str = "createdAt_gte";
     }
-    impl ::cynic::schema::HasInputField<CreatedAtGte, Option<super::DateTime>>
+    impl ::cynic::schema::HasInputField<createdAt_gte, Option<super::DateTime>>
         for super::CommitmentWhereInput
     {
     }
-    pub struct UpdatedAt;
-    impl ::cynic::schema::Field for UpdatedAt {
+    pub struct updatedAt;
+    impl ::cynic::schema::Field for updatedAt {
         type Type = Option<super::DateTime>;
         const NAME: &'static str = "updatedAt";
     }
-    impl ::cynic::schema::HasInputField<UpdatedAt, Option<super::DateTime>>
+    impl ::cynic::schema::HasInputField<updatedAt, Option<super::DateTime>>
         for super::CommitmentWhereInput
     {
     }
-    pub struct UpdatedAtNot;
-    impl ::cynic::schema::Field for UpdatedAtNot {
+    pub struct updatedAt_not;
+    impl ::cynic::schema::Field for updatedAt_not {
         type Type = Option<super::DateTime>;
         const NAME: &'static str = "updatedAt_not";
     }
-    impl ::cynic::schema::HasInputField<UpdatedAtNot, Option<super::DateTime>>
+    impl ::cynic::schema::HasInputField<updatedAt_not, Option<super::DateTime>>
         for super::CommitmentWhereInput
     {
     }
-    pub struct UpdatedAtIn;
-    impl ::cynic::schema::Field for UpdatedAtIn {
+    pub struct updatedAt_in;
+    impl ::cynic::schema::Field for updatedAt_in {
         type Type = Option<Vec<super::DateTime>>;
         const NAME: &'static str = "updatedAt_in";
     }
-    impl ::cynic::schema::HasInputField<UpdatedAtIn, Option<Vec<super::DateTime>>>
+    impl ::cynic::schema::HasInputField<updatedAt_in, Option<Vec<super::DateTime>>>
         for super::CommitmentWhereInput
     {
     }
-    pub struct UpdatedAtNotIn;
-    impl ::cynic::schema::Field for UpdatedAtNotIn {
+    pub struct updatedAt_not_in;
+    impl ::cynic::schema::Field for updatedAt_not_in {
         type Type = Option<Vec<super::DateTime>>;
         const NAME: &'static str = "updatedAt_not_in";
     }
-    impl ::cynic::schema::HasInputField<UpdatedAtNotIn, Option<Vec<super::DateTime>>>
+    impl ::cynic::schema::HasInputField<updatedAt_not_in, Option<Vec<super::DateTime>>>
         for super::CommitmentWhereInput
     {
     }
-    pub struct UpdatedAtLt;
-    impl ::cynic::schema::Field for UpdatedAtLt {
+    pub struct updatedAt_lt;
+    impl ::cynic::schema::Field for updatedAt_lt {
         type Type = Option<super::DateTime>;
         const NAME: &'static str = "updatedAt_lt";
     }
-    impl ::cynic::schema::HasInputField<UpdatedAtLt, Option<super::DateTime>>
+    impl ::cynic::schema::HasInputField<updatedAt_lt, Option<super::DateTime>>
         for super::CommitmentWhereInput
     {
     }
-    pub struct UpdatedAtLte;
-    impl ::cynic::schema::Field for UpdatedAtLte {
+    pub struct updatedAt_lte;
+    impl ::cynic::schema::Field for updatedAt_lte {
         type Type = Option<super::DateTime>;
         const NAME: &'static str = "updatedAt_lte";
     }
-    impl ::cynic::schema::HasInputField<UpdatedAtLte, Option<super::DateTime>>
+    impl ::cynic::schema::HasInputField<updatedAt_lte, Option<super::DateTime>>
         for super::CommitmentWhereInput
     {
     }
-    pub struct UpdatedAtGt;
-    impl ::cynic::schema::Field for UpdatedAtGt {
+    pub struct updatedAt_gt;
+    impl ::cynic::schema::Field for updatedAt_gt {
         type Type = Option<super::DateTime>;
         const NAME: &'static str = "updatedAt_gt";
     }
-    impl ::cynic::schema::HasInputField<UpdatedAtGt, Option<super::DateTime>>
+    impl ::cynic::schema::HasInputField<updatedAt_gt, Option<super::DateTime>>
         for super::CommitmentWhereInput
     {
     }
-    pub struct UpdatedAtGte;
-    impl ::cynic::schema::Field for UpdatedAtGte {
+    pub struct updatedAt_gte;
+    impl ::cynic::schema::Field for updatedAt_gte {
         type Type = Option<super::DateTime>;
         const NAME: &'static str = "updatedAt_gte";
     }
-    impl ::cynic::schema::HasInputField<UpdatedAtGte, Option<super::DateTime>>
+    impl ::cynic::schema::HasInputField<updatedAt_gte, Option<super::DateTime>>
         for super::CommitmentWhereInput
     {
     }
-    pub struct And;
-    impl ::cynic::schema::Field for And {
+    pub struct AND;
+    impl ::cynic::schema::Field for AND {
         type Type = Option<Vec<super::CommitmentWhereInput>>;
         const NAME: &'static str = "AND";
     }
-    impl ::cynic::schema::HasInputField<And, Option<Vec<super::CommitmentWhereInput>>>
+    impl ::cynic::schema::HasInputField<AND, Option<Vec<super::CommitmentWhereInput>>>
         for super::CommitmentWhereInput
     {
     }
-    pub struct Or;
-    impl ::cynic::schema::Field for Or {
+    pub struct OR;
+    impl ::cynic::schema::Field for OR {
         type Type = Option<Vec<super::CommitmentWhereInput>>;
         const NAME: &'static str = "OR";
     }
-    impl ::cynic::schema::HasInputField<Or, Option<Vec<super::CommitmentWhereInput>>>
+    impl ::cynic::schema::HasInputField<OR, Option<Vec<super::CommitmentWhereInput>>>
         for super::CommitmentWhereInput
     {
     }
-    pub struct Not;
-    impl ::cynic::schema::Field for Not {
+    pub struct NOT;
+    impl ::cynic::schema::Field for NOT {
         type Type = Option<Vec<super::CommitmentWhereInput>>;
         const NAME: &'static str = "NOT";
     }
-    impl ::cynic::schema::HasInputField<Not, Option<Vec<super::CommitmentWhereInput>>>
+    impl ::cynic::schema::HasInputField<NOT, Option<Vec<super::CommitmentWhereInput>>>
         for super::CommitmentWhereInput
     {
     }
 }
 pub struct Company;
 pub mod company_fields {
-    pub struct Id;
-    impl ::cynic::schema::Field for Id {
-        type Type = super::Id;
+    pub struct id;
+    impl ::cynic::schema::Field for id {
+        type Type = super::ID;
         const NAME: &'static str = "id";
     }
-    impl ::cynic::schema::HasField<Id> for super::Company {
-        type Type = super::Id;
+    impl ::cynic::schema::HasField<id> for super::Company {
+        type Type = super::ID;
     }
-    pub struct Name;
-    impl ::cynic::schema::Field for Name {
+    pub struct name;
+    impl ::cynic::schema::Field for name {
         type Type = super::String;
         const NAME: &'static str = "name";
     }
-    impl ::cynic::schema::HasField<Name> for super::Company {
+    impl ::cynic::schema::HasField<name> for super::Company {
         type Type = super::String;
     }
-    pub struct Slug;
-    impl ::cynic::schema::Field for Slug {
+    pub struct slug;
+    impl ::cynic::schema::Field for slug {
         type Type = super::String;
         const NAME: &'static str = "slug";
     }
-    impl ::cynic::schema::HasField<Slug> for super::Company {
+    impl ::cynic::schema::HasField<slug> for super::Company {
         type Type = super::String;
     }
-    pub struct WebsiteUrl;
-    impl ::cynic::schema::Field for WebsiteUrl {
+    pub struct websiteUrl;
+    impl ::cynic::schema::Field for websiteUrl {
         type Type = super::String;
         const NAME: &'static str = "websiteUrl";
     }
-    impl ::cynic::schema::HasField<WebsiteUrl> for super::Company {
+    impl ::cynic::schema::HasField<websiteUrl> for super::Company {
         type Type = super::String;
     }
-    pub struct LogoUrl;
-    impl ::cynic::schema::Field for LogoUrl {
+    pub struct logoUrl;
+    impl ::cynic::schema::Field for logoUrl {
         type Type = Option<super::String>;
         const NAME: &'static str = "logoUrl";
     }
-    impl ::cynic::schema::HasField<LogoUrl> for super::Company {
+    impl ::cynic::schema::HasField<logoUrl> for super::Company {
         type Type = Option<super::String>;
     }
-    pub struct Jobs;
-    impl ::cynic::schema::Field for Jobs {
+    pub struct jobs;
+    impl ::cynic::schema::Field for jobs {
         type Type = Option<Vec<super::Job>>;
         const NAME: &'static str = "jobs";
     }
-    impl ::cynic::schema::HasField<Jobs> for super::Company {
+    impl ::cynic::schema::HasField<jobs> for super::Company {
         type Type = Option<Vec<super::Job>>;
     }
     pub mod jobs_arguments {
-        pub struct Where;
-        impl ::cynic::schema::HasArgument<Where> for super::Jobs {
+        pub struct r#where;
+        impl ::cynic::schema::HasArgument<r#where> for super::jobs {
             type ArgumentType = Option<super::super::JobWhereInput>;
             const NAME: &'static str = "where";
         }
-        pub struct OrderBy;
-        impl ::cynic::schema::HasArgument<OrderBy> for super::Jobs {
+        pub struct orderBy;
+        impl ::cynic::schema::HasArgument<orderBy> for super::jobs {
             type ArgumentType = Option<super::super::JobOrderByInput>;
             const NAME: &'static str = "orderBy";
         }
-        pub struct Skip;
-        impl ::cynic::schema::HasArgument<Skip> for super::Jobs {
+        pub struct skip;
+        impl ::cynic::schema::HasArgument<skip> for super::jobs {
             type ArgumentType = Option<super::super::Int>;
             const NAME: &'static str = "skip";
         }
-        pub struct After;
-        impl ::cynic::schema::HasArgument<After> for super::Jobs {
+        pub struct after;
+        impl ::cynic::schema::HasArgument<after> for super::jobs {
             type ArgumentType = Option<super::super::String>;
             const NAME: &'static str = "after";
         }
-        pub struct Before;
-        impl ::cynic::schema::HasArgument<Before> for super::Jobs {
+        pub struct before;
+        impl ::cynic::schema::HasArgument<before> for super::jobs {
             type ArgumentType = Option<super::super::String>;
             const NAME: &'static str = "before";
         }
-        pub struct First;
-        impl ::cynic::schema::HasArgument<First> for super::Jobs {
+        pub struct first;
+        impl ::cynic::schema::HasArgument<first> for super::jobs {
             type ArgumentType = Option<super::super::Int>;
             const NAME: &'static str = "first";
         }
-        pub struct Last;
-        impl ::cynic::schema::HasArgument<Last> for super::Jobs {
+        pub struct last;
+        impl ::cynic::schema::HasArgument<last> for super::jobs {
             type ArgumentType = Option<super::super::Int>;
             const NAME: &'static str = "last";
         }
     }
-    pub struct Twitter;
-    impl ::cynic::schema::Field for Twitter {
+    pub struct twitter;
+    impl ::cynic::schema::Field for twitter {
         type Type = Option<super::String>;
         const NAME: &'static str = "twitter";
     }
-    impl ::cynic::schema::HasField<Twitter> for super::Company {
+    impl ::cynic::schema::HasField<twitter> for super::Company {
         type Type = Option<super::String>;
     }
-    pub struct Emailed;
-    impl ::cynic::schema::Field for Emailed {
+    pub struct emailed;
+    impl ::cynic::schema::Field for emailed {
         type Type = Option<super::Boolean>;
         const NAME: &'static str = "emailed";
     }
-    impl ::cynic::schema::HasField<Emailed> for super::Company {
+    impl ::cynic::schema::HasField<emailed> for super::Company {
         type Type = Option<super::Boolean>;
     }
-    pub struct CreatedAt;
-    impl ::cynic::schema::Field for CreatedAt {
+    pub struct createdAt;
+    impl ::cynic::schema::Field for createdAt {
         type Type = super::DateTime;
         const NAME: &'static str = "createdAt";
     }
-    impl ::cynic::schema::HasField<CreatedAt> for super::Company {
+    impl ::cynic::schema::HasField<createdAt> for super::Company {
         type Type = super::DateTime;
     }
-    pub struct UpdatedAt;
-    impl ::cynic::schema::Field for UpdatedAt {
+    pub struct updatedAt;
+    impl ::cynic::schema::Field for updatedAt {
         type Type = super::DateTime;
         const NAME: &'static str = "updatedAt";
     }
-    impl ::cynic::schema::HasField<UpdatedAt> for super::Company {
+    impl ::cynic::schema::HasField<updatedAt> for super::Company {
         type Type = super::DateTime;
     }
 }
 pub struct CompanyWhereInput;
 impl ::cynic::schema::InputObjectMarker for CompanyWhereInput {}
 pub mod company_where_input_fields {
-    pub struct Id;
-    impl ::cynic::schema::Field for Id {
-        type Type = Option<super::Id>;
+    pub struct id;
+    impl ::cynic::schema::Field for id {
+        type Type = Option<super::ID>;
         const NAME: &'static str = "id";
     }
-    impl ::cynic::schema::HasInputField<Id, Option<super::Id>> for super::CompanyWhereInput {}
-    pub struct IdNot;
-    impl ::cynic::schema::Field for IdNot {
-        type Type = Option<super::Id>;
+    impl ::cynic::schema::HasInputField<id, Option<super::ID>> for super::CompanyWhereInput {}
+    pub struct id_not;
+    impl ::cynic::schema::Field for id_not {
+        type Type = Option<super::ID>;
         const NAME: &'static str = "id_not";
     }
-    impl ::cynic::schema::HasInputField<IdNot, Option<super::Id>> for super::CompanyWhereInput {}
-    pub struct IdIn;
-    impl ::cynic::schema::Field for IdIn {
-        type Type = Option<Vec<super::Id>>;
+    impl ::cynic::schema::HasInputField<id_not, Option<super::ID>> for super::CompanyWhereInput {}
+    pub struct id_in;
+    impl ::cynic::schema::Field for id_in {
+        type Type = Option<Vec<super::ID>>;
         const NAME: &'static str = "id_in";
     }
-    impl ::cynic::schema::HasInputField<IdIn, Option<Vec<super::Id>>> for super::CompanyWhereInput {}
-    pub struct IdNotIn;
-    impl ::cynic::schema::Field for IdNotIn {
-        type Type = Option<Vec<super::Id>>;
+    impl ::cynic::schema::HasInputField<id_in, Option<Vec<super::ID>>> for super::CompanyWhereInput {}
+    pub struct id_not_in;
+    impl ::cynic::schema::Field for id_not_in {
+        type Type = Option<Vec<super::ID>>;
         const NAME: &'static str = "id_not_in";
     }
-    impl ::cynic::schema::HasInputField<IdNotIn, Option<Vec<super::Id>>> for super::CompanyWhereInput {}
-    pub struct IdLt;
-    impl ::cynic::schema::Field for IdLt {
-        type Type = Option<super::Id>;
-        const NAME: &'static str = "id_lt";
-    }
-    impl ::cynic::schema::HasInputField<IdLt, Option<super::Id>> for super::CompanyWhereInput {}
-    pub struct IdLte;
-    impl ::cynic::schema::Field for IdLte {
-        type Type = Option<super::Id>;
-        const NAME: &'static str = "id_lte";
-    }
-    impl ::cynic::schema::HasInputField<IdLte, Option<super::Id>> for super::CompanyWhereInput {}
-    pub struct IdGt;
-    impl ::cynic::schema::Field for IdGt {
-        type Type = Option<super::Id>;
-        const NAME: &'static str = "id_gt";
-    }
-    impl ::cynic::schema::HasInputField<IdGt, Option<super::Id>> for super::CompanyWhereInput {}
-    pub struct IdGte;
-    impl ::cynic::schema::Field for IdGte {
-        type Type = Option<super::Id>;
-        const NAME: &'static str = "id_gte";
-    }
-    impl ::cynic::schema::HasInputField<IdGte, Option<super::Id>> for super::CompanyWhereInput {}
-    pub struct IdContains;
-    impl ::cynic::schema::Field for IdContains {
-        type Type = Option<super::Id>;
-        const NAME: &'static str = "id_contains";
-    }
-    impl ::cynic::schema::HasInputField<IdContains, Option<super::Id>> for super::CompanyWhereInput {}
-    pub struct IdNotContains;
-    impl ::cynic::schema::Field for IdNotContains {
-        type Type = Option<super::Id>;
-        const NAME: &'static str = "id_not_contains";
-    }
-    impl ::cynic::schema::HasInputField<IdNotContains, Option<super::Id>> for super::CompanyWhereInput {}
-    pub struct IdStartsWith;
-    impl ::cynic::schema::Field for IdStartsWith {
-        type Type = Option<super::Id>;
-        const NAME: &'static str = "id_starts_with";
-    }
-    impl ::cynic::schema::HasInputField<IdStartsWith, Option<super::Id>> for super::CompanyWhereInput {}
-    pub struct IdNotStartsWith;
-    impl ::cynic::schema::Field for IdNotStartsWith {
-        type Type = Option<super::Id>;
-        const NAME: &'static str = "id_not_starts_with";
-    }
-    impl ::cynic::schema::HasInputField<IdNotStartsWith, Option<super::Id>>
+    impl ::cynic::schema::HasInputField<id_not_in, Option<Vec<super::ID>>>
         for super::CompanyWhereInput
     {
     }
-    pub struct IdEndsWith;
-    impl ::cynic::schema::Field for IdEndsWith {
-        type Type = Option<super::Id>;
+    pub struct id_lt;
+    impl ::cynic::schema::Field for id_lt {
+        type Type = Option<super::ID>;
+        const NAME: &'static str = "id_lt";
+    }
+    impl ::cynic::schema::HasInputField<id_lt, Option<super::ID>> for super::CompanyWhereInput {}
+    pub struct id_lte;
+    impl ::cynic::schema::Field for id_lte {
+        type Type = Option<super::ID>;
+        const NAME: &'static str = "id_lte";
+    }
+    impl ::cynic::schema::HasInputField<id_lte, Option<super::ID>> for super::CompanyWhereInput {}
+    pub struct id_gt;
+    impl ::cynic::schema::Field for id_gt {
+        type Type = Option<super::ID>;
+        const NAME: &'static str = "id_gt";
+    }
+    impl ::cynic::schema::HasInputField<id_gt, Option<super::ID>> for super::CompanyWhereInput {}
+    pub struct id_gte;
+    impl ::cynic::schema::Field for id_gte {
+        type Type = Option<super::ID>;
+        const NAME: &'static str = "id_gte";
+    }
+    impl ::cynic::schema::HasInputField<id_gte, Option<super::ID>> for super::CompanyWhereInput {}
+    pub struct id_contains;
+    impl ::cynic::schema::Field for id_contains {
+        type Type = Option<super::ID>;
+        const NAME: &'static str = "id_contains";
+    }
+    impl ::cynic::schema::HasInputField<id_contains, Option<super::ID>> for super::CompanyWhereInput {}
+    pub struct id_not_contains;
+    impl ::cynic::schema::Field for id_not_contains {
+        type Type = Option<super::ID>;
+        const NAME: &'static str = "id_not_contains";
+    }
+    impl ::cynic::schema::HasInputField<id_not_contains, Option<super::ID>>
+        for super::CompanyWhereInput
+    {
+    }
+    pub struct id_starts_with;
+    impl ::cynic::schema::Field for id_starts_with {
+        type Type = Option<super::ID>;
+        const NAME: &'static str = "id_starts_with";
+    }
+    impl ::cynic::schema::HasInputField<id_starts_with, Option<super::ID>>
+        for super::CompanyWhereInput
+    {
+    }
+    pub struct id_not_starts_with;
+    impl ::cynic::schema::Field for id_not_starts_with {
+        type Type = Option<super::ID>;
+        const NAME: &'static str = "id_not_starts_with";
+    }
+    impl ::cynic::schema::HasInputField<id_not_starts_with, Option<super::ID>>
+        for super::CompanyWhereInput
+    {
+    }
+    pub struct id_ends_with;
+    impl ::cynic::schema::Field for id_ends_with {
+        type Type = Option<super::ID>;
         const NAME: &'static str = "id_ends_with";
     }
-    impl ::cynic::schema::HasInputField<IdEndsWith, Option<super::Id>> for super::CompanyWhereInput {}
-    pub struct IdNotEndsWith;
-    impl ::cynic::schema::Field for IdNotEndsWith {
-        type Type = Option<super::Id>;
+    impl ::cynic::schema::HasInputField<id_ends_with, Option<super::ID>> for super::CompanyWhereInput {}
+    pub struct id_not_ends_with;
+    impl ::cynic::schema::Field for id_not_ends_with {
+        type Type = Option<super::ID>;
         const NAME: &'static str = "id_not_ends_with";
     }
-    impl ::cynic::schema::HasInputField<IdNotEndsWith, Option<super::Id>> for super::CompanyWhereInput {}
-    pub struct Name;
-    impl ::cynic::schema::Field for Name {
+    impl ::cynic::schema::HasInputField<id_not_ends_with, Option<super::ID>>
+        for super::CompanyWhereInput
+    {
+    }
+    pub struct name;
+    impl ::cynic::schema::Field for name {
         type Type = Option<super::String>;
         const NAME: &'static str = "name";
     }
-    impl ::cynic::schema::HasInputField<Name, Option<super::String>> for super::CompanyWhereInput {}
-    pub struct NameNot;
-    impl ::cynic::schema::Field for NameNot {
+    impl ::cynic::schema::HasInputField<name, Option<super::String>> for super::CompanyWhereInput {}
+    pub struct name_not;
+    impl ::cynic::schema::Field for name_not {
         type Type = Option<super::String>;
         const NAME: &'static str = "name_not";
     }
-    impl ::cynic::schema::HasInputField<NameNot, Option<super::String>> for super::CompanyWhereInput {}
-    pub struct NameIn;
-    impl ::cynic::schema::Field for NameIn {
+    impl ::cynic::schema::HasInputField<name_not, Option<super::String>> for super::CompanyWhereInput {}
+    pub struct name_in;
+    impl ::cynic::schema::Field for name_in {
         type Type = Option<Vec<super::String>>;
         const NAME: &'static str = "name_in";
     }
-    impl ::cynic::schema::HasInputField<NameIn, Option<Vec<super::String>>>
+    impl ::cynic::schema::HasInputField<name_in, Option<Vec<super::String>>>
         for super::CompanyWhereInput
     {
     }
-    pub struct NameNotIn;
-    impl ::cynic::schema::Field for NameNotIn {
+    pub struct name_not_in;
+    impl ::cynic::schema::Field for name_not_in {
         type Type = Option<Vec<super::String>>;
         const NAME: &'static str = "name_not_in";
     }
-    impl ::cynic::schema::HasInputField<NameNotIn, Option<Vec<super::String>>>
+    impl ::cynic::schema::HasInputField<name_not_in, Option<Vec<super::String>>>
         for super::CompanyWhereInput
     {
     }
-    pub struct NameLt;
-    impl ::cynic::schema::Field for NameLt {
+    pub struct name_lt;
+    impl ::cynic::schema::Field for name_lt {
         type Type = Option<super::String>;
         const NAME: &'static str = "name_lt";
     }
-    impl ::cynic::schema::HasInputField<NameLt, Option<super::String>> for super::CompanyWhereInput {}
-    pub struct NameLte;
-    impl ::cynic::schema::Field for NameLte {
+    impl ::cynic::schema::HasInputField<name_lt, Option<super::String>> for super::CompanyWhereInput {}
+    pub struct name_lte;
+    impl ::cynic::schema::Field for name_lte {
         type Type = Option<super::String>;
         const NAME: &'static str = "name_lte";
     }
-    impl ::cynic::schema::HasInputField<NameLte, Option<super::String>> for super::CompanyWhereInput {}
-    pub struct NameGt;
-    impl ::cynic::schema::Field for NameGt {
+    impl ::cynic::schema::HasInputField<name_lte, Option<super::String>> for super::CompanyWhereInput {}
+    pub struct name_gt;
+    impl ::cynic::schema::Field for name_gt {
         type Type = Option<super::String>;
         const NAME: &'static str = "name_gt";
     }
-    impl ::cynic::schema::HasInputField<NameGt, Option<super::String>> for super::CompanyWhereInput {}
-    pub struct NameGte;
-    impl ::cynic::schema::Field for NameGte {
+    impl ::cynic::schema::HasInputField<name_gt, Option<super::String>> for super::CompanyWhereInput {}
+    pub struct name_gte;
+    impl ::cynic::schema::Field for name_gte {
         type Type = Option<super::String>;
         const NAME: &'static str = "name_gte";
     }
-    impl ::cynic::schema::HasInputField<NameGte, Option<super::String>> for super::CompanyWhereInput {}
-    pub struct NameContains;
-    impl ::cynic::schema::Field for NameContains {
+    impl ::cynic::schema::HasInputField<name_gte, Option<super::String>> for super::CompanyWhereInput {}
+    pub struct name_contains;
+    impl ::cynic::schema::Field for name_contains {
         type Type = Option<super::String>;
         const NAME: &'static str = "name_contains";
     }
-    impl ::cynic::schema::HasInputField<NameContains, Option<super::String>>
+    impl ::cynic::schema::HasInputField<name_contains, Option<super::String>>
         for super::CompanyWhereInput
     {
     }
-    pub struct NameNotContains;
-    impl ::cynic::schema::Field for NameNotContains {
+    pub struct name_not_contains;
+    impl ::cynic::schema::Field for name_not_contains {
         type Type = Option<super::String>;
         const NAME: &'static str = "name_not_contains";
     }
-    impl ::cynic::schema::HasInputField<NameNotContains, Option<super::String>>
+    impl ::cynic::schema::HasInputField<name_not_contains, Option<super::String>>
         for super::CompanyWhereInput
     {
     }
-    pub struct NameStartsWith;
-    impl ::cynic::schema::Field for NameStartsWith {
+    pub struct name_starts_with;
+    impl ::cynic::schema::Field for name_starts_with {
         type Type = Option<super::String>;
         const NAME: &'static str = "name_starts_with";
     }
-    impl ::cynic::schema::HasInputField<NameStartsWith, Option<super::String>>
+    impl ::cynic::schema::HasInputField<name_starts_with, Option<super::String>>
         for super::CompanyWhereInput
     {
     }
-    pub struct NameNotStartsWith;
-    impl ::cynic::schema::Field for NameNotStartsWith {
+    pub struct name_not_starts_with;
+    impl ::cynic::schema::Field for name_not_starts_with {
         type Type = Option<super::String>;
         const NAME: &'static str = "name_not_starts_with";
     }
-    impl ::cynic::schema::HasInputField<NameNotStartsWith, Option<super::String>>
+    impl ::cynic::schema::HasInputField<name_not_starts_with, Option<super::String>>
         for super::CompanyWhereInput
     {
     }
-    pub struct NameEndsWith;
-    impl ::cynic::schema::Field for NameEndsWith {
+    pub struct name_ends_with;
+    impl ::cynic::schema::Field for name_ends_with {
         type Type = Option<super::String>;
         const NAME: &'static str = "name_ends_with";
     }
-    impl ::cynic::schema::HasInputField<NameEndsWith, Option<super::String>>
+    impl ::cynic::schema::HasInputField<name_ends_with, Option<super::String>>
         for super::CompanyWhereInput
     {
     }
-    pub struct NameNotEndsWith;
-    impl ::cynic::schema::Field for NameNotEndsWith {
+    pub struct name_not_ends_with;
+    impl ::cynic::schema::Field for name_not_ends_with {
         type Type = Option<super::String>;
         const NAME: &'static str = "name_not_ends_with";
     }
-    impl ::cynic::schema::HasInputField<NameNotEndsWith, Option<super::String>>
+    impl ::cynic::schema::HasInputField<name_not_ends_with, Option<super::String>>
         for super::CompanyWhereInput
     {
     }
-    pub struct Slug;
-    impl ::cynic::schema::Field for Slug {
+    pub struct slug;
+    impl ::cynic::schema::Field for slug {
         type Type = Option<super::String>;
         const NAME: &'static str = "slug";
     }
-    impl ::cynic::schema::HasInputField<Slug, Option<super::String>> for super::CompanyWhereInput {}
-    pub struct SlugNot;
-    impl ::cynic::schema::Field for SlugNot {
+    impl ::cynic::schema::HasInputField<slug, Option<super::String>> for super::CompanyWhereInput {}
+    pub struct slug_not;
+    impl ::cynic::schema::Field for slug_not {
         type Type = Option<super::String>;
         const NAME: &'static str = "slug_not";
     }
-    impl ::cynic::schema::HasInputField<SlugNot, Option<super::String>> for super::CompanyWhereInput {}
-    pub struct SlugIn;
-    impl ::cynic::schema::Field for SlugIn {
+    impl ::cynic::schema::HasInputField<slug_not, Option<super::String>> for super::CompanyWhereInput {}
+    pub struct slug_in;
+    impl ::cynic::schema::Field for slug_in {
         type Type = Option<Vec<super::String>>;
         const NAME: &'static str = "slug_in";
     }
-    impl ::cynic::schema::HasInputField<SlugIn, Option<Vec<super::String>>>
+    impl ::cynic::schema::HasInputField<slug_in, Option<Vec<super::String>>>
         for super::CompanyWhereInput
     {
     }
-    pub struct SlugNotIn;
-    impl ::cynic::schema::Field for SlugNotIn {
+    pub struct slug_not_in;
+    impl ::cynic::schema::Field for slug_not_in {
         type Type = Option<Vec<super::String>>;
         const NAME: &'static str = "slug_not_in";
     }
-    impl ::cynic::schema::HasInputField<SlugNotIn, Option<Vec<super::String>>>
+    impl ::cynic::schema::HasInputField<slug_not_in, Option<Vec<super::String>>>
         for super::CompanyWhereInput
     {
     }
-    pub struct SlugLt;
-    impl ::cynic::schema::Field for SlugLt {
+    pub struct slug_lt;
+    impl ::cynic::schema::Field for slug_lt {
         type Type = Option<super::String>;
         const NAME: &'static str = "slug_lt";
     }
-    impl ::cynic::schema::HasInputField<SlugLt, Option<super::String>> for super::CompanyWhereInput {}
-    pub struct SlugLte;
-    impl ::cynic::schema::Field for SlugLte {
+    impl ::cynic::schema::HasInputField<slug_lt, Option<super::String>> for super::CompanyWhereInput {}
+    pub struct slug_lte;
+    impl ::cynic::schema::Field for slug_lte {
         type Type = Option<super::String>;
         const NAME: &'static str = "slug_lte";
     }
-    impl ::cynic::schema::HasInputField<SlugLte, Option<super::String>> for super::CompanyWhereInput {}
-    pub struct SlugGt;
-    impl ::cynic::schema::Field for SlugGt {
+    impl ::cynic::schema::HasInputField<slug_lte, Option<super::String>> for super::CompanyWhereInput {}
+    pub struct slug_gt;
+    impl ::cynic::schema::Field for slug_gt {
         type Type = Option<super::String>;
         const NAME: &'static str = "slug_gt";
     }
-    impl ::cynic::schema::HasInputField<SlugGt, Option<super::String>> for super::CompanyWhereInput {}
-    pub struct SlugGte;
-    impl ::cynic::schema::Field for SlugGte {
+    impl ::cynic::schema::HasInputField<slug_gt, Option<super::String>> for super::CompanyWhereInput {}
+    pub struct slug_gte;
+    impl ::cynic::schema::Field for slug_gte {
         type Type = Option<super::String>;
         const NAME: &'static str = "slug_gte";
     }
-    impl ::cynic::schema::HasInputField<SlugGte, Option<super::String>> for super::CompanyWhereInput {}
-    pub struct SlugContains;
-    impl ::cynic::schema::Field for SlugContains {
+    impl ::cynic::schema::HasInputField<slug_gte, Option<super::String>> for super::CompanyWhereInput {}
+    pub struct slug_contains;
+    impl ::cynic::schema::Field for slug_contains {
         type Type = Option<super::String>;
         const NAME: &'static str = "slug_contains";
     }
-    impl ::cynic::schema::HasInputField<SlugContains, Option<super::String>>
+    impl ::cynic::schema::HasInputField<slug_contains, Option<super::String>>
         for super::CompanyWhereInput
     {
     }
-    pub struct SlugNotContains;
-    impl ::cynic::schema::Field for SlugNotContains {
+    pub struct slug_not_contains;
+    impl ::cynic::schema::Field for slug_not_contains {
         type Type = Option<super::String>;
         const NAME: &'static str = "slug_not_contains";
     }
-    impl ::cynic::schema::HasInputField<SlugNotContains, Option<super::String>>
+    impl ::cynic::schema::HasInputField<slug_not_contains, Option<super::String>>
         for super::CompanyWhereInput
     {
     }
-    pub struct SlugStartsWith;
-    impl ::cynic::schema::Field for SlugStartsWith {
+    pub struct slug_starts_with;
+    impl ::cynic::schema::Field for slug_starts_with {
         type Type = Option<super::String>;
         const NAME: &'static str = "slug_starts_with";
     }
-    impl ::cynic::schema::HasInputField<SlugStartsWith, Option<super::String>>
+    impl ::cynic::schema::HasInputField<slug_starts_with, Option<super::String>>
         for super::CompanyWhereInput
     {
     }
-    pub struct SlugNotStartsWith;
-    impl ::cynic::schema::Field for SlugNotStartsWith {
+    pub struct slug_not_starts_with;
+    impl ::cynic::schema::Field for slug_not_starts_with {
         type Type = Option<super::String>;
         const NAME: &'static str = "slug_not_starts_with";
     }
-    impl ::cynic::schema::HasInputField<SlugNotStartsWith, Option<super::String>>
+    impl ::cynic::schema::HasInputField<slug_not_starts_with, Option<super::String>>
         for super::CompanyWhereInput
     {
     }
-    pub struct SlugEndsWith;
-    impl ::cynic::schema::Field for SlugEndsWith {
+    pub struct slug_ends_with;
+    impl ::cynic::schema::Field for slug_ends_with {
         type Type = Option<super::String>;
         const NAME: &'static str = "slug_ends_with";
     }
-    impl ::cynic::schema::HasInputField<SlugEndsWith, Option<super::String>>
+    impl ::cynic::schema::HasInputField<slug_ends_with, Option<super::String>>
         for super::CompanyWhereInput
     {
     }
-    pub struct SlugNotEndsWith;
-    impl ::cynic::schema::Field for SlugNotEndsWith {
+    pub struct slug_not_ends_with;
+    impl ::cynic::schema::Field for slug_not_ends_with {
         type Type = Option<super::String>;
         const NAME: &'static str = "slug_not_ends_with";
     }
-    impl ::cynic::schema::HasInputField<SlugNotEndsWith, Option<super::String>>
+    impl ::cynic::schema::HasInputField<slug_not_ends_with, Option<super::String>>
         for super::CompanyWhereInput
     {
     }
-    pub struct WebsiteUrl;
-    impl ::cynic::schema::Field for WebsiteUrl {
+    pub struct websiteUrl;
+    impl ::cynic::schema::Field for websiteUrl {
         type Type = Option<super::String>;
         const NAME: &'static str = "websiteUrl";
     }
-    impl ::cynic::schema::HasInputField<WebsiteUrl, Option<super::String>>
+    impl ::cynic::schema::HasInputField<websiteUrl, Option<super::String>>
         for super::CompanyWhereInput
     {
     }
-    pub struct WebsiteUrlNot;
-    impl ::cynic::schema::Field for WebsiteUrlNot {
+    pub struct websiteUrl_not;
+    impl ::cynic::schema::Field for websiteUrl_not {
         type Type = Option<super::String>;
         const NAME: &'static str = "websiteUrl_not";
     }
-    impl ::cynic::schema::HasInputField<WebsiteUrlNot, Option<super::String>>
+    impl ::cynic::schema::HasInputField<websiteUrl_not, Option<super::String>>
         for super::CompanyWhereInput
     {
     }
-    pub struct WebsiteUrlIn;
-    impl ::cynic::schema::Field for WebsiteUrlIn {
+    pub struct websiteUrl_in;
+    impl ::cynic::schema::Field for websiteUrl_in {
         type Type = Option<Vec<super::String>>;
         const NAME: &'static str = "websiteUrl_in";
     }
-    impl ::cynic::schema::HasInputField<WebsiteUrlIn, Option<Vec<super::String>>>
+    impl ::cynic::schema::HasInputField<websiteUrl_in, Option<Vec<super::String>>>
         for super::CompanyWhereInput
     {
     }
-    pub struct WebsiteUrlNotIn;
-    impl ::cynic::schema::Field for WebsiteUrlNotIn {
+    pub struct websiteUrl_not_in;
+    impl ::cynic::schema::Field for websiteUrl_not_in {
         type Type = Option<Vec<super::String>>;
         const NAME: &'static str = "websiteUrl_not_in";
     }
-    impl ::cynic::schema::HasInputField<WebsiteUrlNotIn, Option<Vec<super::String>>>
+    impl ::cynic::schema::HasInputField<websiteUrl_not_in, Option<Vec<super::String>>>
         for super::CompanyWhereInput
     {
     }
-    pub struct WebsiteUrlLt;
-    impl ::cynic::schema::Field for WebsiteUrlLt {
+    pub struct websiteUrl_lt;
+    impl ::cynic::schema::Field for websiteUrl_lt {
         type Type = Option<super::String>;
         const NAME: &'static str = "websiteUrl_lt";
     }
-    impl ::cynic::schema::HasInputField<WebsiteUrlLt, Option<super::String>>
+    impl ::cynic::schema::HasInputField<websiteUrl_lt, Option<super::String>>
         for super::CompanyWhereInput
     {
     }
-    pub struct WebsiteUrlLte;
-    impl ::cynic::schema::Field for WebsiteUrlLte {
+    pub struct websiteUrl_lte;
+    impl ::cynic::schema::Field for websiteUrl_lte {
         type Type = Option<super::String>;
         const NAME: &'static str = "websiteUrl_lte";
     }
-    impl ::cynic::schema::HasInputField<WebsiteUrlLte, Option<super::String>>
+    impl ::cynic::schema::HasInputField<websiteUrl_lte, Option<super::String>>
         for super::CompanyWhereInput
     {
     }
-    pub struct WebsiteUrlGt;
-    impl ::cynic::schema::Field for WebsiteUrlGt {
+    pub struct websiteUrl_gt;
+    impl ::cynic::schema::Field for websiteUrl_gt {
         type Type = Option<super::String>;
         const NAME: &'static str = "websiteUrl_gt";
     }
-    impl ::cynic::schema::HasInputField<WebsiteUrlGt, Option<super::String>>
+    impl ::cynic::schema::HasInputField<websiteUrl_gt, Option<super::String>>
         for super::CompanyWhereInput
     {
     }
-    pub struct WebsiteUrlGte;
-    impl ::cynic::schema::Field for WebsiteUrlGte {
+    pub struct websiteUrl_gte;
+    impl ::cynic::schema::Field for websiteUrl_gte {
         type Type = Option<super::String>;
         const NAME: &'static str = "websiteUrl_gte";
     }
-    impl ::cynic::schema::HasInputField<WebsiteUrlGte, Option<super::String>>
+    impl ::cynic::schema::HasInputField<websiteUrl_gte, Option<super::String>>
         for super::CompanyWhereInput
     {
     }
-    pub struct WebsiteUrlContains;
-    impl ::cynic::schema::Field for WebsiteUrlContains {
+    pub struct websiteUrl_contains;
+    impl ::cynic::schema::Field for websiteUrl_contains {
         type Type = Option<super::String>;
         const NAME: &'static str = "websiteUrl_contains";
     }
-    impl ::cynic::schema::HasInputField<WebsiteUrlContains, Option<super::String>>
+    impl ::cynic::schema::HasInputField<websiteUrl_contains, Option<super::String>>
         for super::CompanyWhereInput
     {
     }
-    pub struct WebsiteUrlNotContains;
-    impl ::cynic::schema::Field for WebsiteUrlNotContains {
+    pub struct websiteUrl_not_contains;
+    impl ::cynic::schema::Field for websiteUrl_not_contains {
         type Type = Option<super::String>;
         const NAME: &'static str = "websiteUrl_not_contains";
     }
-    impl ::cynic::schema::HasInputField<WebsiteUrlNotContains, Option<super::String>>
+    impl ::cynic::schema::HasInputField<websiteUrl_not_contains, Option<super::String>>
         for super::CompanyWhereInput
     {
     }
-    pub struct WebsiteUrlStartsWith;
-    impl ::cynic::schema::Field for WebsiteUrlStartsWith {
+    pub struct websiteUrl_starts_with;
+    impl ::cynic::schema::Field for websiteUrl_starts_with {
         type Type = Option<super::String>;
         const NAME: &'static str = "websiteUrl_starts_with";
     }
-    impl ::cynic::schema::HasInputField<WebsiteUrlStartsWith, Option<super::String>>
+    impl ::cynic::schema::HasInputField<websiteUrl_starts_with, Option<super::String>>
         for super::CompanyWhereInput
     {
     }
-    pub struct WebsiteUrlNotStartsWith;
-    impl ::cynic::schema::Field for WebsiteUrlNotStartsWith {
+    pub struct websiteUrl_not_starts_with;
+    impl ::cynic::schema::Field for websiteUrl_not_starts_with {
         type Type = Option<super::String>;
         const NAME: &'static str = "websiteUrl_not_starts_with";
     }
-    impl ::cynic::schema::HasInputField<WebsiteUrlNotStartsWith, Option<super::String>>
+    impl ::cynic::schema::HasInputField<websiteUrl_not_starts_with, Option<super::String>>
         for super::CompanyWhereInput
     {
     }
-    pub struct WebsiteUrlEndsWith;
-    impl ::cynic::schema::Field for WebsiteUrlEndsWith {
+    pub struct websiteUrl_ends_with;
+    impl ::cynic::schema::Field for websiteUrl_ends_with {
         type Type = Option<super::String>;
         const NAME: &'static str = "websiteUrl_ends_with";
     }
-    impl ::cynic::schema::HasInputField<WebsiteUrlEndsWith, Option<super::String>>
+    impl ::cynic::schema::HasInputField<websiteUrl_ends_with, Option<super::String>>
         for super::CompanyWhereInput
     {
     }
-    pub struct WebsiteUrlNotEndsWith;
-    impl ::cynic::schema::Field for WebsiteUrlNotEndsWith {
+    pub struct websiteUrl_not_ends_with;
+    impl ::cynic::schema::Field for websiteUrl_not_ends_with {
         type Type = Option<super::String>;
         const NAME: &'static str = "websiteUrl_not_ends_with";
     }
-    impl ::cynic::schema::HasInputField<WebsiteUrlNotEndsWith, Option<super::String>>
+    impl ::cynic::schema::HasInputField<websiteUrl_not_ends_with, Option<super::String>>
         for super::CompanyWhereInput
     {
     }
-    pub struct LogoUrl;
-    impl ::cynic::schema::Field for LogoUrl {
+    pub struct logoUrl;
+    impl ::cynic::schema::Field for logoUrl {
         type Type = Option<super::String>;
         const NAME: &'static str = "logoUrl";
     }
-    impl ::cynic::schema::HasInputField<LogoUrl, Option<super::String>> for super::CompanyWhereInput {}
-    pub struct LogoUrlNot;
-    impl ::cynic::schema::Field for LogoUrlNot {
+    impl ::cynic::schema::HasInputField<logoUrl, Option<super::String>> for super::CompanyWhereInput {}
+    pub struct logoUrl_not;
+    impl ::cynic::schema::Field for logoUrl_not {
         type Type = Option<super::String>;
         const NAME: &'static str = "logoUrl_not";
     }
-    impl ::cynic::schema::HasInputField<LogoUrlNot, Option<super::String>>
+    impl ::cynic::schema::HasInputField<logoUrl_not, Option<super::String>>
         for super::CompanyWhereInput
     {
     }
-    pub struct LogoUrlIn;
-    impl ::cynic::schema::Field for LogoUrlIn {
+    pub struct logoUrl_in;
+    impl ::cynic::schema::Field for logoUrl_in {
         type Type = Option<Vec<super::String>>;
         const NAME: &'static str = "logoUrl_in";
     }
-    impl ::cynic::schema::HasInputField<LogoUrlIn, Option<Vec<super::String>>>
+    impl ::cynic::schema::HasInputField<logoUrl_in, Option<Vec<super::String>>>
         for super::CompanyWhereInput
     {
     }
-    pub struct LogoUrlNotIn;
-    impl ::cynic::schema::Field for LogoUrlNotIn {
+    pub struct logoUrl_not_in;
+    impl ::cynic::schema::Field for logoUrl_not_in {
         type Type = Option<Vec<super::String>>;
         const NAME: &'static str = "logoUrl_not_in";
     }
-    impl ::cynic::schema::HasInputField<LogoUrlNotIn, Option<Vec<super::String>>>
+    impl ::cynic::schema::HasInputField<logoUrl_not_in, Option<Vec<super::String>>>
         for super::CompanyWhereInput
     {
     }
-    pub struct LogoUrlLt;
-    impl ::cynic::schema::Field for LogoUrlLt {
+    pub struct logoUrl_lt;
+    impl ::cynic::schema::Field for logoUrl_lt {
         type Type = Option<super::String>;
         const NAME: &'static str = "logoUrl_lt";
     }
-    impl ::cynic::schema::HasInputField<LogoUrlLt, Option<super::String>> for super::CompanyWhereInput {}
-    pub struct LogoUrlLte;
-    impl ::cynic::schema::Field for LogoUrlLte {
+    impl ::cynic::schema::HasInputField<logoUrl_lt, Option<super::String>>
+        for super::CompanyWhereInput
+    {
+    }
+    pub struct logoUrl_lte;
+    impl ::cynic::schema::Field for logoUrl_lte {
         type Type = Option<super::String>;
         const NAME: &'static str = "logoUrl_lte";
     }
-    impl ::cynic::schema::HasInputField<LogoUrlLte, Option<super::String>>
+    impl ::cynic::schema::HasInputField<logoUrl_lte, Option<super::String>>
         for super::CompanyWhereInput
     {
     }
-    pub struct LogoUrlGt;
-    impl ::cynic::schema::Field for LogoUrlGt {
+    pub struct logoUrl_gt;
+    impl ::cynic::schema::Field for logoUrl_gt {
         type Type = Option<super::String>;
         const NAME: &'static str = "logoUrl_gt";
     }
-    impl ::cynic::schema::HasInputField<LogoUrlGt, Option<super::String>> for super::CompanyWhereInput {}
-    pub struct LogoUrlGte;
-    impl ::cynic::schema::Field for LogoUrlGte {
+    impl ::cynic::schema::HasInputField<logoUrl_gt, Option<super::String>>
+        for super::CompanyWhereInput
+    {
+    }
+    pub struct logoUrl_gte;
+    impl ::cynic::schema::Field for logoUrl_gte {
         type Type = Option<super::String>;
         const NAME: &'static str = "logoUrl_gte";
     }
-    impl ::cynic::schema::HasInputField<LogoUrlGte, Option<super::String>>
+    impl ::cynic::schema::HasInputField<logoUrl_gte, Option<super::String>>
         for super::CompanyWhereInput
     {
     }
-    pub struct LogoUrlContains;
-    impl ::cynic::schema::Field for LogoUrlContains {
+    pub struct logoUrl_contains;
+    impl ::cynic::schema::Field for logoUrl_contains {
         type Type = Option<super::String>;
         const NAME: &'static str = "logoUrl_contains";
     }
-    impl ::cynic::schema::HasInputField<LogoUrlContains, Option<super::String>>
+    impl ::cynic::schema::HasInputField<logoUrl_contains, Option<super::String>>
         for super::CompanyWhereInput
     {
     }
-    pub struct LogoUrlNotContains;
-    impl ::cynic::schema::Field for LogoUrlNotContains {
+    pub struct logoUrl_not_contains;
+    impl ::cynic::schema::Field for logoUrl_not_contains {
         type Type = Option<super::String>;
         const NAME: &'static str = "logoUrl_not_contains";
     }
-    impl ::cynic::schema::HasInputField<LogoUrlNotContains, Option<super::String>>
+    impl ::cynic::schema::HasInputField<logoUrl_not_contains, Option<super::String>>
         for super::CompanyWhereInput
     {
     }
-    pub struct LogoUrlStartsWith;
-    impl ::cynic::schema::Field for LogoUrlStartsWith {
+    pub struct logoUrl_starts_with;
+    impl ::cynic::schema::Field for logoUrl_starts_with {
         type Type = Option<super::String>;
         const NAME: &'static str = "logoUrl_starts_with";
     }
-    impl ::cynic::schema::HasInputField<LogoUrlStartsWith, Option<super::String>>
+    impl ::cynic::schema::HasInputField<logoUrl_starts_with, Option<super::String>>
         for super::CompanyWhereInput
     {
     }
-    pub struct LogoUrlNotStartsWith;
-    impl ::cynic::schema::Field for LogoUrlNotStartsWith {
+    pub struct logoUrl_not_starts_with;
+    impl ::cynic::schema::Field for logoUrl_not_starts_with {
         type Type = Option<super::String>;
         const NAME: &'static str = "logoUrl_not_starts_with";
     }
-    impl ::cynic::schema::HasInputField<LogoUrlNotStartsWith, Option<super::String>>
+    impl ::cynic::schema::HasInputField<logoUrl_not_starts_with, Option<super::String>>
         for super::CompanyWhereInput
     {
     }
-    pub struct LogoUrlEndsWith;
-    impl ::cynic::schema::Field for LogoUrlEndsWith {
+    pub struct logoUrl_ends_with;
+    impl ::cynic::schema::Field for logoUrl_ends_with {
         type Type = Option<super::String>;
         const NAME: &'static str = "logoUrl_ends_with";
     }
-    impl ::cynic::schema::HasInputField<LogoUrlEndsWith, Option<super::String>>
+    impl ::cynic::schema::HasInputField<logoUrl_ends_with, Option<super::String>>
         for super::CompanyWhereInput
     {
     }
-    pub struct LogoUrlNotEndsWith;
-    impl ::cynic::schema::Field for LogoUrlNotEndsWith {
+    pub struct logoUrl_not_ends_with;
+    impl ::cynic::schema::Field for logoUrl_not_ends_with {
         type Type = Option<super::String>;
         const NAME: &'static str = "logoUrl_not_ends_with";
     }
-    impl ::cynic::schema::HasInputField<LogoUrlNotEndsWith, Option<super::String>>
+    impl ::cynic::schema::HasInputField<logoUrl_not_ends_with, Option<super::String>>
         for super::CompanyWhereInput
     {
     }
-    pub struct JobsEvery;
-    impl ::cynic::schema::Field for JobsEvery {
+    pub struct jobs_every;
+    impl ::cynic::schema::Field for jobs_every {
         type Type = Option<super::JobWhereInput>;
         const NAME: &'static str = "jobs_every";
     }
-    impl ::cynic::schema::HasInputField<JobsEvery, Option<super::JobWhereInput>>
+    impl ::cynic::schema::HasInputField<jobs_every, Option<super::JobWhereInput>>
         for super::CompanyWhereInput
     {
     }
-    pub struct JobsSome;
-    impl ::cynic::schema::Field for JobsSome {
+    pub struct jobs_some;
+    impl ::cynic::schema::Field for jobs_some {
         type Type = Option<super::JobWhereInput>;
         const NAME: &'static str = "jobs_some";
     }
-    impl ::cynic::schema::HasInputField<JobsSome, Option<super::JobWhereInput>>
+    impl ::cynic::schema::HasInputField<jobs_some, Option<super::JobWhereInput>>
         for super::CompanyWhereInput
     {
     }
-    pub struct JobsNone;
-    impl ::cynic::schema::Field for JobsNone {
+    pub struct jobs_none;
+    impl ::cynic::schema::Field for jobs_none {
         type Type = Option<super::JobWhereInput>;
         const NAME: &'static str = "jobs_none";
     }
-    impl ::cynic::schema::HasInputField<JobsNone, Option<super::JobWhereInput>>
+    impl ::cynic::schema::HasInputField<jobs_none, Option<super::JobWhereInput>>
         for super::CompanyWhereInput
     {
     }
-    pub struct Twitter;
-    impl ::cynic::schema::Field for Twitter {
+    pub struct twitter;
+    impl ::cynic::schema::Field for twitter {
         type Type = Option<super::String>;
         const NAME: &'static str = "twitter";
     }
-    impl ::cynic::schema::HasInputField<Twitter, Option<super::String>> for super::CompanyWhereInput {}
-    pub struct TwitterNot;
-    impl ::cynic::schema::Field for TwitterNot {
+    impl ::cynic::schema::HasInputField<twitter, Option<super::String>> for super::CompanyWhereInput {}
+    pub struct twitter_not;
+    impl ::cynic::schema::Field for twitter_not {
         type Type = Option<super::String>;
         const NAME: &'static str = "twitter_not";
     }
-    impl ::cynic::schema::HasInputField<TwitterNot, Option<super::String>>
+    impl ::cynic::schema::HasInputField<twitter_not, Option<super::String>>
         for super::CompanyWhereInput
     {
     }
-    pub struct TwitterIn;
-    impl ::cynic::schema::Field for TwitterIn {
+    pub struct twitter_in;
+    impl ::cynic::schema::Field for twitter_in {
         type Type = Option<Vec<super::String>>;
         const NAME: &'static str = "twitter_in";
     }
-    impl ::cynic::schema::HasInputField<TwitterIn, Option<Vec<super::String>>>
+    impl ::cynic::schema::HasInputField<twitter_in, Option<Vec<super::String>>>
         for super::CompanyWhereInput
     {
     }
-    pub struct TwitterNotIn;
-    impl ::cynic::schema::Field for TwitterNotIn {
+    pub struct twitter_not_in;
+    impl ::cynic::schema::Field for twitter_not_in {
         type Type = Option<Vec<super::String>>;
         const NAME: &'static str = "twitter_not_in";
     }
-    impl ::cynic::schema::HasInputField<TwitterNotIn, Option<Vec<super::String>>>
+    impl ::cynic::schema::HasInputField<twitter_not_in, Option<Vec<super::String>>>
         for super::CompanyWhereInput
     {
     }
-    pub struct TwitterLt;
-    impl ::cynic::schema::Field for TwitterLt {
+    pub struct twitter_lt;
+    impl ::cynic::schema::Field for twitter_lt {
         type Type = Option<super::String>;
         const NAME: &'static str = "twitter_lt";
     }
-    impl ::cynic::schema::HasInputField<TwitterLt, Option<super::String>> for super::CompanyWhereInput {}
-    pub struct TwitterLte;
-    impl ::cynic::schema::Field for TwitterLte {
+    impl ::cynic::schema::HasInputField<twitter_lt, Option<super::String>>
+        for super::CompanyWhereInput
+    {
+    }
+    pub struct twitter_lte;
+    impl ::cynic::schema::Field for twitter_lte {
         type Type = Option<super::String>;
         const NAME: &'static str = "twitter_lte";
     }
-    impl ::cynic::schema::HasInputField<TwitterLte, Option<super::String>>
+    impl ::cynic::schema::HasInputField<twitter_lte, Option<super::String>>
         for super::CompanyWhereInput
     {
     }
-    pub struct TwitterGt;
-    impl ::cynic::schema::Field for TwitterGt {
+    pub struct twitter_gt;
+    impl ::cynic::schema::Field for twitter_gt {
         type Type = Option<super::String>;
         const NAME: &'static str = "twitter_gt";
     }
-    impl ::cynic::schema::HasInputField<TwitterGt, Option<super::String>> for super::CompanyWhereInput {}
-    pub struct TwitterGte;
-    impl ::cynic::schema::Field for TwitterGte {
+    impl ::cynic::schema::HasInputField<twitter_gt, Option<super::String>>
+        for super::CompanyWhereInput
+    {
+    }
+    pub struct twitter_gte;
+    impl ::cynic::schema::Field for twitter_gte {
         type Type = Option<super::String>;
         const NAME: &'static str = "twitter_gte";
     }
-    impl ::cynic::schema::HasInputField<TwitterGte, Option<super::String>>
+    impl ::cynic::schema::HasInputField<twitter_gte, Option<super::String>>
         for super::CompanyWhereInput
     {
     }
-    pub struct TwitterContains;
-    impl ::cynic::schema::Field for TwitterContains {
+    pub struct twitter_contains;
+    impl ::cynic::schema::Field for twitter_contains {
         type Type = Option<super::String>;
         const NAME: &'static str = "twitter_contains";
     }
-    impl ::cynic::schema::HasInputField<TwitterContains, Option<super::String>>
+    impl ::cynic::schema::HasInputField<twitter_contains, Option<super::String>>
         for super::CompanyWhereInput
     {
     }
-    pub struct TwitterNotContains;
-    impl ::cynic::schema::Field for TwitterNotContains {
+    pub struct twitter_not_contains;
+    impl ::cynic::schema::Field for twitter_not_contains {
         type Type = Option<super::String>;
         const NAME: &'static str = "twitter_not_contains";
     }
-    impl ::cynic::schema::HasInputField<TwitterNotContains, Option<super::String>>
+    impl ::cynic::schema::HasInputField<twitter_not_contains, Option<super::String>>
         for super::CompanyWhereInput
     {
     }
-    pub struct TwitterStartsWith;
-    impl ::cynic::schema::Field for TwitterStartsWith {
+    pub struct twitter_starts_with;
+    impl ::cynic::schema::Field for twitter_starts_with {
         type Type = Option<super::String>;
         const NAME: &'static str = "twitter_starts_with";
     }
-    impl ::cynic::schema::HasInputField<TwitterStartsWith, Option<super::String>>
+    impl ::cynic::schema::HasInputField<twitter_starts_with, Option<super::String>>
         for super::CompanyWhereInput
     {
     }
-    pub struct TwitterNotStartsWith;
-    impl ::cynic::schema::Field for TwitterNotStartsWith {
+    pub struct twitter_not_starts_with;
+    impl ::cynic::schema::Field for twitter_not_starts_with {
         type Type = Option<super::String>;
         const NAME: &'static str = "twitter_not_starts_with";
     }
-    impl ::cynic::schema::HasInputField<TwitterNotStartsWith, Option<super::String>>
+    impl ::cynic::schema::HasInputField<twitter_not_starts_with, Option<super::String>>
         for super::CompanyWhereInput
     {
     }
-    pub struct TwitterEndsWith;
-    impl ::cynic::schema::Field for TwitterEndsWith {
+    pub struct twitter_ends_with;
+    impl ::cynic::schema::Field for twitter_ends_with {
         type Type = Option<super::String>;
         const NAME: &'static str = "twitter_ends_with";
     }
-    impl ::cynic::schema::HasInputField<TwitterEndsWith, Option<super::String>>
+    impl ::cynic::schema::HasInputField<twitter_ends_with, Option<super::String>>
         for super::CompanyWhereInput
     {
     }
-    pub struct TwitterNotEndsWith;
-    impl ::cynic::schema::Field for TwitterNotEndsWith {
+    pub struct twitter_not_ends_with;
+    impl ::cynic::schema::Field for twitter_not_ends_with {
         type Type = Option<super::String>;
         const NAME: &'static str = "twitter_not_ends_with";
     }
-    impl ::cynic::schema::HasInputField<TwitterNotEndsWith, Option<super::String>>
+    impl ::cynic::schema::HasInputField<twitter_not_ends_with, Option<super::String>>
         for super::CompanyWhereInput
     {
     }
-    pub struct Emailed;
-    impl ::cynic::schema::Field for Emailed {
+    pub struct emailed;
+    impl ::cynic::schema::Field for emailed {
         type Type = Option<super::Boolean>;
         const NAME: &'static str = "emailed";
     }
-    impl ::cynic::schema::HasInputField<Emailed, Option<super::Boolean>> for super::CompanyWhereInput {}
-    pub struct EmailedNot;
-    impl ::cynic::schema::Field for EmailedNot {
+    impl ::cynic::schema::HasInputField<emailed, Option<super::Boolean>> for super::CompanyWhereInput {}
+    pub struct emailed_not;
+    impl ::cynic::schema::Field for emailed_not {
         type Type = Option<super::Boolean>;
         const NAME: &'static str = "emailed_not";
     }
-    impl ::cynic::schema::HasInputField<EmailedNot, Option<super::Boolean>>
+    impl ::cynic::schema::HasInputField<emailed_not, Option<super::Boolean>>
         for super::CompanyWhereInput
     {
     }
-    pub struct CreatedAt;
-    impl ::cynic::schema::Field for CreatedAt {
+    pub struct createdAt;
+    impl ::cynic::schema::Field for createdAt {
         type Type = Option<super::DateTime>;
         const NAME: &'static str = "createdAt";
     }
-    impl ::cynic::schema::HasInputField<CreatedAt, Option<super::DateTime>>
+    impl ::cynic::schema::HasInputField<createdAt, Option<super::DateTime>>
         for super::CompanyWhereInput
     {
     }
-    pub struct CreatedAtNot;
-    impl ::cynic::schema::Field for CreatedAtNot {
+    pub struct createdAt_not;
+    impl ::cynic::schema::Field for createdAt_not {
         type Type = Option<super::DateTime>;
         const NAME: &'static str = "createdAt_not";
     }
-    impl ::cynic::schema::HasInputField<CreatedAtNot, Option<super::DateTime>>
+    impl ::cynic::schema::HasInputField<createdAt_not, Option<super::DateTime>>
         for super::CompanyWhereInput
     {
     }
-    pub struct CreatedAtIn;
-    impl ::cynic::schema::Field for CreatedAtIn {
+    pub struct createdAt_in;
+    impl ::cynic::schema::Field for createdAt_in {
         type Type = Option<Vec<super::DateTime>>;
         const NAME: &'static str = "createdAt_in";
     }
-    impl ::cynic::schema::HasInputField<CreatedAtIn, Option<Vec<super::DateTime>>>
+    impl ::cynic::schema::HasInputField<createdAt_in, Option<Vec<super::DateTime>>>
         for super::CompanyWhereInput
     {
     }
-    pub struct CreatedAtNotIn;
-    impl ::cynic::schema::Field for CreatedAtNotIn {
+    pub struct createdAt_not_in;
+    impl ::cynic::schema::Field for createdAt_not_in {
         type Type = Option<Vec<super::DateTime>>;
         const NAME: &'static str = "createdAt_not_in";
     }
-    impl ::cynic::schema::HasInputField<CreatedAtNotIn, Option<Vec<super::DateTime>>>
+    impl ::cynic::schema::HasInputField<createdAt_not_in, Option<Vec<super::DateTime>>>
         for super::CompanyWhereInput
     {
     }
-    pub struct CreatedAtLt;
-    impl ::cynic::schema::Field for CreatedAtLt {
+    pub struct createdAt_lt;
+    impl ::cynic::schema::Field for createdAt_lt {
         type Type = Option<super::DateTime>;
         const NAME: &'static str = "createdAt_lt";
     }
-    impl ::cynic::schema::HasInputField<CreatedAtLt, Option<super::DateTime>>
+    impl ::cynic::schema::HasInputField<createdAt_lt, Option<super::DateTime>>
         for super::CompanyWhereInput
     {
     }
-    pub struct CreatedAtLte;
-    impl ::cynic::schema::Field for CreatedAtLte {
+    pub struct createdAt_lte;
+    impl ::cynic::schema::Field for createdAt_lte {
         type Type = Option<super::DateTime>;
         const NAME: &'static str = "createdAt_lte";
     }
-    impl ::cynic::schema::HasInputField<CreatedAtLte, Option<super::DateTime>>
+    impl ::cynic::schema::HasInputField<createdAt_lte, Option<super::DateTime>>
         for super::CompanyWhereInput
     {
     }
-    pub struct CreatedAtGt;
-    impl ::cynic::schema::Field for CreatedAtGt {
+    pub struct createdAt_gt;
+    impl ::cynic::schema::Field for createdAt_gt {
         type Type = Option<super::DateTime>;
         const NAME: &'static str = "createdAt_gt";
     }
-    impl ::cynic::schema::HasInputField<CreatedAtGt, Option<super::DateTime>>
+    impl ::cynic::schema::HasInputField<createdAt_gt, Option<super::DateTime>>
         for super::CompanyWhereInput
     {
     }
-    pub struct CreatedAtGte;
-    impl ::cynic::schema::Field for CreatedAtGte {
+    pub struct createdAt_gte;
+    impl ::cynic::schema::Field for createdAt_gte {
         type Type = Option<super::DateTime>;
         const NAME: &'static str = "createdAt_gte";
     }
-    impl ::cynic::schema::HasInputField<CreatedAtGte, Option<super::DateTime>>
+    impl ::cynic::schema::HasInputField<createdAt_gte, Option<super::DateTime>>
         for super::CompanyWhereInput
     {
     }
-    pub struct UpdatedAt;
-    impl ::cynic::schema::Field for UpdatedAt {
+    pub struct updatedAt;
+    impl ::cynic::schema::Field for updatedAt {
         type Type = Option<super::DateTime>;
         const NAME: &'static str = "updatedAt";
     }
-    impl ::cynic::schema::HasInputField<UpdatedAt, Option<super::DateTime>>
+    impl ::cynic::schema::HasInputField<updatedAt, Option<super::DateTime>>
         for super::CompanyWhereInput
     {
     }
-    pub struct UpdatedAtNot;
-    impl ::cynic::schema::Field for UpdatedAtNot {
+    pub struct updatedAt_not;
+    impl ::cynic::schema::Field for updatedAt_not {
         type Type = Option<super::DateTime>;
         const NAME: &'static str = "updatedAt_not";
     }
-    impl ::cynic::schema::HasInputField<UpdatedAtNot, Option<super::DateTime>>
+    impl ::cynic::schema::HasInputField<updatedAt_not, Option<super::DateTime>>
         for super::CompanyWhereInput
     {
     }
-    pub struct UpdatedAtIn;
-    impl ::cynic::schema::Field for UpdatedAtIn {
+    pub struct updatedAt_in;
+    impl ::cynic::schema::Field for updatedAt_in {
         type Type = Option<Vec<super::DateTime>>;
         const NAME: &'static str = "updatedAt_in";
     }
-    impl ::cynic::schema::HasInputField<UpdatedAtIn, Option<Vec<super::DateTime>>>
+    impl ::cynic::schema::HasInputField<updatedAt_in, Option<Vec<super::DateTime>>>
         for super::CompanyWhereInput
     {
     }
-    pub struct UpdatedAtNotIn;
-    impl ::cynic::schema::Field for UpdatedAtNotIn {
+    pub struct updatedAt_not_in;
+    impl ::cynic::schema::Field for updatedAt_not_in {
         type Type = Option<Vec<super::DateTime>>;
         const NAME: &'static str = "updatedAt_not_in";
     }
-    impl ::cynic::schema::HasInputField<UpdatedAtNotIn, Option<Vec<super::DateTime>>>
+    impl ::cynic::schema::HasInputField<updatedAt_not_in, Option<Vec<super::DateTime>>>
         for super::CompanyWhereInput
     {
     }
-    pub struct UpdatedAtLt;
-    impl ::cynic::schema::Field for UpdatedAtLt {
+    pub struct updatedAt_lt;
+    impl ::cynic::schema::Field for updatedAt_lt {
         type Type = Option<super::DateTime>;
         const NAME: &'static str = "updatedAt_lt";
     }
-    impl ::cynic::schema::HasInputField<UpdatedAtLt, Option<super::DateTime>>
+    impl ::cynic::schema::HasInputField<updatedAt_lt, Option<super::DateTime>>
         for super::CompanyWhereInput
     {
     }
-    pub struct UpdatedAtLte;
-    impl ::cynic::schema::Field for UpdatedAtLte {
+    pub struct updatedAt_lte;
+    impl ::cynic::schema::Field for updatedAt_lte {
         type Type = Option<super::DateTime>;
         const NAME: &'static str = "updatedAt_lte";
     }
-    impl ::cynic::schema::HasInputField<UpdatedAtLte, Option<super::DateTime>>
+    impl ::cynic::schema::HasInputField<updatedAt_lte, Option<super::DateTime>>
         for super::CompanyWhereInput
     {
     }
-    pub struct UpdatedAtGt;
-    impl ::cynic::schema::Field for UpdatedAtGt {
+    pub struct updatedAt_gt;
+    impl ::cynic::schema::Field for updatedAt_gt {
         type Type = Option<super::DateTime>;
         const NAME: &'static str = "updatedAt_gt";
     }
-    impl ::cynic::schema::HasInputField<UpdatedAtGt, Option<super::DateTime>>
+    impl ::cynic::schema::HasInputField<updatedAt_gt, Option<super::DateTime>>
         for super::CompanyWhereInput
     {
     }
-    pub struct UpdatedAtGte;
-    impl ::cynic::schema::Field for UpdatedAtGte {
+    pub struct updatedAt_gte;
+    impl ::cynic::schema::Field for updatedAt_gte {
         type Type = Option<super::DateTime>;
         const NAME: &'static str = "updatedAt_gte";
     }
-    impl ::cynic::schema::HasInputField<UpdatedAtGte, Option<super::DateTime>>
+    impl ::cynic::schema::HasInputField<updatedAt_gte, Option<super::DateTime>>
         for super::CompanyWhereInput
     {
     }
-    pub struct And;
-    impl ::cynic::schema::Field for And {
+    pub struct AND;
+    impl ::cynic::schema::Field for AND {
         type Type = Option<Vec<super::CompanyWhereInput>>;
         const NAME: &'static str = "AND";
     }
-    impl ::cynic::schema::HasInputField<And, Option<Vec<super::CompanyWhereInput>>>
+    impl ::cynic::schema::HasInputField<AND, Option<Vec<super::CompanyWhereInput>>>
         for super::CompanyWhereInput
     {
     }
-    pub struct Or;
-    impl ::cynic::schema::Field for Or {
+    pub struct OR;
+    impl ::cynic::schema::Field for OR {
         type Type = Option<Vec<super::CompanyWhereInput>>;
         const NAME: &'static str = "OR";
     }
-    impl ::cynic::schema::HasInputField<Or, Option<Vec<super::CompanyWhereInput>>>
+    impl ::cynic::schema::HasInputField<OR, Option<Vec<super::CompanyWhereInput>>>
         for super::CompanyWhereInput
     {
     }
-    pub struct Not;
-    impl ::cynic::schema::Field for Not {
+    pub struct NOT;
+    impl ::cynic::schema::Field for NOT {
         type Type = Option<Vec<super::CompanyWhereInput>>;
         const NAME: &'static str = "NOT";
     }
-    impl ::cynic::schema::HasInputField<Not, Option<Vec<super::CompanyWhereInput>>>
+    impl ::cynic::schema::HasInputField<NOT, Option<Vec<super::CompanyWhereInput>>>
         for super::CompanyWhereInput
     {
     }
 }
 pub struct Country;
 pub mod country_fields {
-    pub struct Id;
-    impl ::cynic::schema::Field for Id {
-        type Type = super::Id;
+    pub struct id;
+    impl ::cynic::schema::Field for id {
+        type Type = super::ID;
         const NAME: &'static str = "id";
     }
-    impl ::cynic::schema::HasField<Id> for super::Country {
-        type Type = super::Id;
+    impl ::cynic::schema::HasField<id> for super::Country {
+        type Type = super::ID;
     }
-    pub struct Name;
-    impl ::cynic::schema::Field for Name {
+    pub struct name;
+    impl ::cynic::schema::Field for name {
         type Type = super::String;
         const NAME: &'static str = "name";
     }
-    impl ::cynic::schema::HasField<Name> for super::Country {
+    impl ::cynic::schema::HasField<name> for super::Country {
         type Type = super::String;
     }
-    pub struct Slug;
-    impl ::cynic::schema::Field for Slug {
+    pub struct slug;
+    impl ::cynic::schema::Field for slug {
         type Type = super::String;
         const NAME: &'static str = "slug";
     }
-    impl ::cynic::schema::HasField<Slug> for super::Country {
+    impl ::cynic::schema::HasField<slug> for super::Country {
         type Type = super::String;
     }
-    pub struct Type;
-    impl ::cynic::schema::Field for Type {
+    pub struct r#type;
+    impl ::cynic::schema::Field for r#type {
         type Type = super::String;
         const NAME: &'static str = "type";
     }
-    impl ::cynic::schema::HasField<Type> for super::Country {
+    impl ::cynic::schema::HasField<r#type> for super::Country {
         type Type = super::String;
     }
-    pub struct IsoCode;
-    impl ::cynic::schema::Field for IsoCode {
+    pub struct isoCode;
+    impl ::cynic::schema::Field for isoCode {
         type Type = Option<super::String>;
         const NAME: &'static str = "isoCode";
     }
-    impl ::cynic::schema::HasField<IsoCode> for super::Country {
+    impl ::cynic::schema::HasField<isoCode> for super::Country {
         type Type = Option<super::String>;
     }
-    pub struct Cities;
-    impl ::cynic::schema::Field for Cities {
+    pub struct cities;
+    impl ::cynic::schema::Field for cities {
         type Type = Option<Vec<super::City>>;
         const NAME: &'static str = "cities";
     }
-    impl ::cynic::schema::HasField<Cities> for super::Country {
+    impl ::cynic::schema::HasField<cities> for super::Country {
         type Type = Option<Vec<super::City>>;
     }
     pub mod cities_arguments {
-        pub struct Where;
-        impl ::cynic::schema::HasArgument<Where> for super::Cities {
+        pub struct r#where;
+        impl ::cynic::schema::HasArgument<r#where> for super::cities {
             type ArgumentType = Option<super::super::CityWhereInput>;
             const NAME: &'static str = "where";
         }
-        pub struct OrderBy;
-        impl ::cynic::schema::HasArgument<OrderBy> for super::Cities {
+        pub struct orderBy;
+        impl ::cynic::schema::HasArgument<orderBy> for super::cities {
             type ArgumentType = Option<super::super::CityOrderByInput>;
             const NAME: &'static str = "orderBy";
         }
-        pub struct Skip;
-        impl ::cynic::schema::HasArgument<Skip> for super::Cities {
+        pub struct skip;
+        impl ::cynic::schema::HasArgument<skip> for super::cities {
             type ArgumentType = Option<super::super::Int>;
             const NAME: &'static str = "skip";
         }
-        pub struct After;
-        impl ::cynic::schema::HasArgument<After> for super::Cities {
+        pub struct after;
+        impl ::cynic::schema::HasArgument<after> for super::cities {
             type ArgumentType = Option<super::super::String>;
             const NAME: &'static str = "after";
         }
-        pub struct Before;
-        impl ::cynic::schema::HasArgument<Before> for super::Cities {
+        pub struct before;
+        impl ::cynic::schema::HasArgument<before> for super::cities {
             type ArgumentType = Option<super::super::String>;
             const NAME: &'static str = "before";
         }
-        pub struct First;
-        impl ::cynic::schema::HasArgument<First> for super::Cities {
+        pub struct first;
+        impl ::cynic::schema::HasArgument<first> for super::cities {
             type ArgumentType = Option<super::super::Int>;
             const NAME: &'static str = "first";
         }
-        pub struct Last;
-        impl ::cynic::schema::HasArgument<Last> for super::Cities {
+        pub struct last;
+        impl ::cynic::schema::HasArgument<last> for super::cities {
             type ArgumentType = Option<super::super::Int>;
             const NAME: &'static str = "last";
         }
     }
-    pub struct Jobs;
-    impl ::cynic::schema::Field for Jobs {
+    pub struct jobs;
+    impl ::cynic::schema::Field for jobs {
         type Type = Option<Vec<super::Job>>;
         const NAME: &'static str = "jobs";
     }
-    impl ::cynic::schema::HasField<Jobs> for super::Country {
+    impl ::cynic::schema::HasField<jobs> for super::Country {
         type Type = Option<Vec<super::Job>>;
     }
     pub mod jobs_arguments {
-        pub struct Where;
-        impl ::cynic::schema::HasArgument<Where> for super::Jobs {
+        pub struct r#where;
+        impl ::cynic::schema::HasArgument<r#where> for super::jobs {
             type ArgumentType = Option<super::super::JobWhereInput>;
             const NAME: &'static str = "where";
         }
-        pub struct OrderBy;
-        impl ::cynic::schema::HasArgument<OrderBy> for super::Jobs {
+        pub struct orderBy;
+        impl ::cynic::schema::HasArgument<orderBy> for super::jobs {
             type ArgumentType = Option<super::super::JobOrderByInput>;
             const NAME: &'static str = "orderBy";
         }
-        pub struct Skip;
-        impl ::cynic::schema::HasArgument<Skip> for super::Jobs {
+        pub struct skip;
+        impl ::cynic::schema::HasArgument<skip> for super::jobs {
             type ArgumentType = Option<super::super::Int>;
             const NAME: &'static str = "skip";
         }
-        pub struct After;
-        impl ::cynic::schema::HasArgument<After> for super::Jobs {
+        pub struct after;
+        impl ::cynic::schema::HasArgument<after> for super::jobs {
             type ArgumentType = Option<super::super::String>;
             const NAME: &'static str = "after";
         }
-        pub struct Before;
-        impl ::cynic::schema::HasArgument<Before> for super::Jobs {
+        pub struct before;
+        impl ::cynic::schema::HasArgument<before> for super::jobs {
             type ArgumentType = Option<super::super::String>;
             const NAME: &'static str = "before";
         }
-        pub struct First;
-        impl ::cynic::schema::HasArgument<First> for super::Jobs {
+        pub struct first;
+        impl ::cynic::schema::HasArgument<first> for super::jobs {
             type ArgumentType = Option<super::super::Int>;
             const NAME: &'static str = "first";
         }
-        pub struct Last;
-        impl ::cynic::schema::HasArgument<Last> for super::Jobs {
+        pub struct last;
+        impl ::cynic::schema::HasArgument<last> for super::jobs {
             type ArgumentType = Option<super::super::Int>;
             const NAME: &'static str = "last";
         }
     }
-    pub struct CreatedAt;
-    impl ::cynic::schema::Field for CreatedAt {
+    pub struct createdAt;
+    impl ::cynic::schema::Field for createdAt {
         type Type = super::DateTime;
         const NAME: &'static str = "createdAt";
     }
-    impl ::cynic::schema::HasField<CreatedAt> for super::Country {
+    impl ::cynic::schema::HasField<createdAt> for super::Country {
         type Type = super::DateTime;
     }
-    pub struct UpdatedAt;
-    impl ::cynic::schema::Field for UpdatedAt {
+    pub struct updatedAt;
+    impl ::cynic::schema::Field for updatedAt {
         type Type = super::DateTime;
         const NAME: &'static str = "updatedAt";
     }
-    impl ::cynic::schema::HasField<UpdatedAt> for super::Country {
+    impl ::cynic::schema::HasField<updatedAt> for super::Country {
         type Type = super::DateTime;
     }
 }
@@ -2479,756 +2536,774 @@ pub struct CountryOrderByInput {}
 pub struct CountryWhereInput;
 impl ::cynic::schema::InputObjectMarker for CountryWhereInput {}
 pub mod country_where_input_fields {
-    pub struct Id;
-    impl ::cynic::schema::Field for Id {
-        type Type = Option<super::Id>;
+    pub struct id;
+    impl ::cynic::schema::Field for id {
+        type Type = Option<super::ID>;
         const NAME: &'static str = "id";
     }
-    impl ::cynic::schema::HasInputField<Id, Option<super::Id>> for super::CountryWhereInput {}
-    pub struct IdNot;
-    impl ::cynic::schema::Field for IdNot {
-        type Type = Option<super::Id>;
+    impl ::cynic::schema::HasInputField<id, Option<super::ID>> for super::CountryWhereInput {}
+    pub struct id_not;
+    impl ::cynic::schema::Field for id_not {
+        type Type = Option<super::ID>;
         const NAME: &'static str = "id_not";
     }
-    impl ::cynic::schema::HasInputField<IdNot, Option<super::Id>> for super::CountryWhereInput {}
-    pub struct IdIn;
-    impl ::cynic::schema::Field for IdIn {
-        type Type = Option<Vec<super::Id>>;
+    impl ::cynic::schema::HasInputField<id_not, Option<super::ID>> for super::CountryWhereInput {}
+    pub struct id_in;
+    impl ::cynic::schema::Field for id_in {
+        type Type = Option<Vec<super::ID>>;
         const NAME: &'static str = "id_in";
     }
-    impl ::cynic::schema::HasInputField<IdIn, Option<Vec<super::Id>>> for super::CountryWhereInput {}
-    pub struct IdNotIn;
-    impl ::cynic::schema::Field for IdNotIn {
-        type Type = Option<Vec<super::Id>>;
+    impl ::cynic::schema::HasInputField<id_in, Option<Vec<super::ID>>> for super::CountryWhereInput {}
+    pub struct id_not_in;
+    impl ::cynic::schema::Field for id_not_in {
+        type Type = Option<Vec<super::ID>>;
         const NAME: &'static str = "id_not_in";
     }
-    impl ::cynic::schema::HasInputField<IdNotIn, Option<Vec<super::Id>>> for super::CountryWhereInput {}
-    pub struct IdLt;
-    impl ::cynic::schema::Field for IdLt {
-        type Type = Option<super::Id>;
-        const NAME: &'static str = "id_lt";
-    }
-    impl ::cynic::schema::HasInputField<IdLt, Option<super::Id>> for super::CountryWhereInput {}
-    pub struct IdLte;
-    impl ::cynic::schema::Field for IdLte {
-        type Type = Option<super::Id>;
-        const NAME: &'static str = "id_lte";
-    }
-    impl ::cynic::schema::HasInputField<IdLte, Option<super::Id>> for super::CountryWhereInput {}
-    pub struct IdGt;
-    impl ::cynic::schema::Field for IdGt {
-        type Type = Option<super::Id>;
-        const NAME: &'static str = "id_gt";
-    }
-    impl ::cynic::schema::HasInputField<IdGt, Option<super::Id>> for super::CountryWhereInput {}
-    pub struct IdGte;
-    impl ::cynic::schema::Field for IdGte {
-        type Type = Option<super::Id>;
-        const NAME: &'static str = "id_gte";
-    }
-    impl ::cynic::schema::HasInputField<IdGte, Option<super::Id>> for super::CountryWhereInput {}
-    pub struct IdContains;
-    impl ::cynic::schema::Field for IdContains {
-        type Type = Option<super::Id>;
-        const NAME: &'static str = "id_contains";
-    }
-    impl ::cynic::schema::HasInputField<IdContains, Option<super::Id>> for super::CountryWhereInput {}
-    pub struct IdNotContains;
-    impl ::cynic::schema::Field for IdNotContains {
-        type Type = Option<super::Id>;
-        const NAME: &'static str = "id_not_contains";
-    }
-    impl ::cynic::schema::HasInputField<IdNotContains, Option<super::Id>> for super::CountryWhereInput {}
-    pub struct IdStartsWith;
-    impl ::cynic::schema::Field for IdStartsWith {
-        type Type = Option<super::Id>;
-        const NAME: &'static str = "id_starts_with";
-    }
-    impl ::cynic::schema::HasInputField<IdStartsWith, Option<super::Id>> for super::CountryWhereInput {}
-    pub struct IdNotStartsWith;
-    impl ::cynic::schema::Field for IdNotStartsWith {
-        type Type = Option<super::Id>;
-        const NAME: &'static str = "id_not_starts_with";
-    }
-    impl ::cynic::schema::HasInputField<IdNotStartsWith, Option<super::Id>>
+    impl ::cynic::schema::HasInputField<id_not_in, Option<Vec<super::ID>>>
         for super::CountryWhereInput
     {
     }
-    pub struct IdEndsWith;
-    impl ::cynic::schema::Field for IdEndsWith {
-        type Type = Option<super::Id>;
+    pub struct id_lt;
+    impl ::cynic::schema::Field for id_lt {
+        type Type = Option<super::ID>;
+        const NAME: &'static str = "id_lt";
+    }
+    impl ::cynic::schema::HasInputField<id_lt, Option<super::ID>> for super::CountryWhereInput {}
+    pub struct id_lte;
+    impl ::cynic::schema::Field for id_lte {
+        type Type = Option<super::ID>;
+        const NAME: &'static str = "id_lte";
+    }
+    impl ::cynic::schema::HasInputField<id_lte, Option<super::ID>> for super::CountryWhereInput {}
+    pub struct id_gt;
+    impl ::cynic::schema::Field for id_gt {
+        type Type = Option<super::ID>;
+        const NAME: &'static str = "id_gt";
+    }
+    impl ::cynic::schema::HasInputField<id_gt, Option<super::ID>> for super::CountryWhereInput {}
+    pub struct id_gte;
+    impl ::cynic::schema::Field for id_gte {
+        type Type = Option<super::ID>;
+        const NAME: &'static str = "id_gte";
+    }
+    impl ::cynic::schema::HasInputField<id_gte, Option<super::ID>> for super::CountryWhereInput {}
+    pub struct id_contains;
+    impl ::cynic::schema::Field for id_contains {
+        type Type = Option<super::ID>;
+        const NAME: &'static str = "id_contains";
+    }
+    impl ::cynic::schema::HasInputField<id_contains, Option<super::ID>> for super::CountryWhereInput {}
+    pub struct id_not_contains;
+    impl ::cynic::schema::Field for id_not_contains {
+        type Type = Option<super::ID>;
+        const NAME: &'static str = "id_not_contains";
+    }
+    impl ::cynic::schema::HasInputField<id_not_contains, Option<super::ID>>
+        for super::CountryWhereInput
+    {
+    }
+    pub struct id_starts_with;
+    impl ::cynic::schema::Field for id_starts_with {
+        type Type = Option<super::ID>;
+        const NAME: &'static str = "id_starts_with";
+    }
+    impl ::cynic::schema::HasInputField<id_starts_with, Option<super::ID>>
+        for super::CountryWhereInput
+    {
+    }
+    pub struct id_not_starts_with;
+    impl ::cynic::schema::Field for id_not_starts_with {
+        type Type = Option<super::ID>;
+        const NAME: &'static str = "id_not_starts_with";
+    }
+    impl ::cynic::schema::HasInputField<id_not_starts_with, Option<super::ID>>
+        for super::CountryWhereInput
+    {
+    }
+    pub struct id_ends_with;
+    impl ::cynic::schema::Field for id_ends_with {
+        type Type = Option<super::ID>;
         const NAME: &'static str = "id_ends_with";
     }
-    impl ::cynic::schema::HasInputField<IdEndsWith, Option<super::Id>> for super::CountryWhereInput {}
-    pub struct IdNotEndsWith;
-    impl ::cynic::schema::Field for IdNotEndsWith {
-        type Type = Option<super::Id>;
+    impl ::cynic::schema::HasInputField<id_ends_with, Option<super::ID>> for super::CountryWhereInput {}
+    pub struct id_not_ends_with;
+    impl ::cynic::schema::Field for id_not_ends_with {
+        type Type = Option<super::ID>;
         const NAME: &'static str = "id_not_ends_with";
     }
-    impl ::cynic::schema::HasInputField<IdNotEndsWith, Option<super::Id>> for super::CountryWhereInput {}
-    pub struct Name;
-    impl ::cynic::schema::Field for Name {
+    impl ::cynic::schema::HasInputField<id_not_ends_with, Option<super::ID>>
+        for super::CountryWhereInput
+    {
+    }
+    pub struct name;
+    impl ::cynic::schema::Field for name {
         type Type = Option<super::String>;
         const NAME: &'static str = "name";
     }
-    impl ::cynic::schema::HasInputField<Name, Option<super::String>> for super::CountryWhereInput {}
-    pub struct NameNot;
-    impl ::cynic::schema::Field for NameNot {
+    impl ::cynic::schema::HasInputField<name, Option<super::String>> for super::CountryWhereInput {}
+    pub struct name_not;
+    impl ::cynic::schema::Field for name_not {
         type Type = Option<super::String>;
         const NAME: &'static str = "name_not";
     }
-    impl ::cynic::schema::HasInputField<NameNot, Option<super::String>> for super::CountryWhereInput {}
-    pub struct NameIn;
-    impl ::cynic::schema::Field for NameIn {
+    impl ::cynic::schema::HasInputField<name_not, Option<super::String>> for super::CountryWhereInput {}
+    pub struct name_in;
+    impl ::cynic::schema::Field for name_in {
         type Type = Option<Vec<super::String>>;
         const NAME: &'static str = "name_in";
     }
-    impl ::cynic::schema::HasInputField<NameIn, Option<Vec<super::String>>>
+    impl ::cynic::schema::HasInputField<name_in, Option<Vec<super::String>>>
         for super::CountryWhereInput
     {
     }
-    pub struct NameNotIn;
-    impl ::cynic::schema::Field for NameNotIn {
+    pub struct name_not_in;
+    impl ::cynic::schema::Field for name_not_in {
         type Type = Option<Vec<super::String>>;
         const NAME: &'static str = "name_not_in";
     }
-    impl ::cynic::schema::HasInputField<NameNotIn, Option<Vec<super::String>>>
+    impl ::cynic::schema::HasInputField<name_not_in, Option<Vec<super::String>>>
         for super::CountryWhereInput
     {
     }
-    pub struct NameLt;
-    impl ::cynic::schema::Field for NameLt {
+    pub struct name_lt;
+    impl ::cynic::schema::Field for name_lt {
         type Type = Option<super::String>;
         const NAME: &'static str = "name_lt";
     }
-    impl ::cynic::schema::HasInputField<NameLt, Option<super::String>> for super::CountryWhereInput {}
-    pub struct NameLte;
-    impl ::cynic::schema::Field for NameLte {
+    impl ::cynic::schema::HasInputField<name_lt, Option<super::String>> for super::CountryWhereInput {}
+    pub struct name_lte;
+    impl ::cynic::schema::Field for name_lte {
         type Type = Option<super::String>;
         const NAME: &'static str = "name_lte";
     }
-    impl ::cynic::schema::HasInputField<NameLte, Option<super::String>> for super::CountryWhereInput {}
-    pub struct NameGt;
-    impl ::cynic::schema::Field for NameGt {
+    impl ::cynic::schema::HasInputField<name_lte, Option<super::String>> for super::CountryWhereInput {}
+    pub struct name_gt;
+    impl ::cynic::schema::Field for name_gt {
         type Type = Option<super::String>;
         const NAME: &'static str = "name_gt";
     }
-    impl ::cynic::schema::HasInputField<NameGt, Option<super::String>> for super::CountryWhereInput {}
-    pub struct NameGte;
-    impl ::cynic::schema::Field for NameGte {
+    impl ::cynic::schema::HasInputField<name_gt, Option<super::String>> for super::CountryWhereInput {}
+    pub struct name_gte;
+    impl ::cynic::schema::Field for name_gte {
         type Type = Option<super::String>;
         const NAME: &'static str = "name_gte";
     }
-    impl ::cynic::schema::HasInputField<NameGte, Option<super::String>> for super::CountryWhereInput {}
-    pub struct NameContains;
-    impl ::cynic::schema::Field for NameContains {
+    impl ::cynic::schema::HasInputField<name_gte, Option<super::String>> for super::CountryWhereInput {}
+    pub struct name_contains;
+    impl ::cynic::schema::Field for name_contains {
         type Type = Option<super::String>;
         const NAME: &'static str = "name_contains";
     }
-    impl ::cynic::schema::HasInputField<NameContains, Option<super::String>>
+    impl ::cynic::schema::HasInputField<name_contains, Option<super::String>>
         for super::CountryWhereInput
     {
     }
-    pub struct NameNotContains;
-    impl ::cynic::schema::Field for NameNotContains {
+    pub struct name_not_contains;
+    impl ::cynic::schema::Field for name_not_contains {
         type Type = Option<super::String>;
         const NAME: &'static str = "name_not_contains";
     }
-    impl ::cynic::schema::HasInputField<NameNotContains, Option<super::String>>
+    impl ::cynic::schema::HasInputField<name_not_contains, Option<super::String>>
         for super::CountryWhereInput
     {
     }
-    pub struct NameStartsWith;
-    impl ::cynic::schema::Field for NameStartsWith {
+    pub struct name_starts_with;
+    impl ::cynic::schema::Field for name_starts_with {
         type Type = Option<super::String>;
         const NAME: &'static str = "name_starts_with";
     }
-    impl ::cynic::schema::HasInputField<NameStartsWith, Option<super::String>>
+    impl ::cynic::schema::HasInputField<name_starts_with, Option<super::String>>
         for super::CountryWhereInput
     {
     }
-    pub struct NameNotStartsWith;
-    impl ::cynic::schema::Field for NameNotStartsWith {
+    pub struct name_not_starts_with;
+    impl ::cynic::schema::Field for name_not_starts_with {
         type Type = Option<super::String>;
         const NAME: &'static str = "name_not_starts_with";
     }
-    impl ::cynic::schema::HasInputField<NameNotStartsWith, Option<super::String>>
+    impl ::cynic::schema::HasInputField<name_not_starts_with, Option<super::String>>
         for super::CountryWhereInput
     {
     }
-    pub struct NameEndsWith;
-    impl ::cynic::schema::Field for NameEndsWith {
+    pub struct name_ends_with;
+    impl ::cynic::schema::Field for name_ends_with {
         type Type = Option<super::String>;
         const NAME: &'static str = "name_ends_with";
     }
-    impl ::cynic::schema::HasInputField<NameEndsWith, Option<super::String>>
+    impl ::cynic::schema::HasInputField<name_ends_with, Option<super::String>>
         for super::CountryWhereInput
     {
     }
-    pub struct NameNotEndsWith;
-    impl ::cynic::schema::Field for NameNotEndsWith {
+    pub struct name_not_ends_with;
+    impl ::cynic::schema::Field for name_not_ends_with {
         type Type = Option<super::String>;
         const NAME: &'static str = "name_not_ends_with";
     }
-    impl ::cynic::schema::HasInputField<NameNotEndsWith, Option<super::String>>
+    impl ::cynic::schema::HasInputField<name_not_ends_with, Option<super::String>>
         for super::CountryWhereInput
     {
     }
-    pub struct Slug;
-    impl ::cynic::schema::Field for Slug {
+    pub struct slug;
+    impl ::cynic::schema::Field for slug {
         type Type = Option<super::String>;
         const NAME: &'static str = "slug";
     }
-    impl ::cynic::schema::HasInputField<Slug, Option<super::String>> for super::CountryWhereInput {}
-    pub struct SlugNot;
-    impl ::cynic::schema::Field for SlugNot {
+    impl ::cynic::schema::HasInputField<slug, Option<super::String>> for super::CountryWhereInput {}
+    pub struct slug_not;
+    impl ::cynic::schema::Field for slug_not {
         type Type = Option<super::String>;
         const NAME: &'static str = "slug_not";
     }
-    impl ::cynic::schema::HasInputField<SlugNot, Option<super::String>> for super::CountryWhereInput {}
-    pub struct SlugIn;
-    impl ::cynic::schema::Field for SlugIn {
+    impl ::cynic::schema::HasInputField<slug_not, Option<super::String>> for super::CountryWhereInput {}
+    pub struct slug_in;
+    impl ::cynic::schema::Field for slug_in {
         type Type = Option<Vec<super::String>>;
         const NAME: &'static str = "slug_in";
     }
-    impl ::cynic::schema::HasInputField<SlugIn, Option<Vec<super::String>>>
+    impl ::cynic::schema::HasInputField<slug_in, Option<Vec<super::String>>>
         for super::CountryWhereInput
     {
     }
-    pub struct SlugNotIn;
-    impl ::cynic::schema::Field for SlugNotIn {
+    pub struct slug_not_in;
+    impl ::cynic::schema::Field for slug_not_in {
         type Type = Option<Vec<super::String>>;
         const NAME: &'static str = "slug_not_in";
     }
-    impl ::cynic::schema::HasInputField<SlugNotIn, Option<Vec<super::String>>>
+    impl ::cynic::schema::HasInputField<slug_not_in, Option<Vec<super::String>>>
         for super::CountryWhereInput
     {
     }
-    pub struct SlugLt;
-    impl ::cynic::schema::Field for SlugLt {
+    pub struct slug_lt;
+    impl ::cynic::schema::Field for slug_lt {
         type Type = Option<super::String>;
         const NAME: &'static str = "slug_lt";
     }
-    impl ::cynic::schema::HasInputField<SlugLt, Option<super::String>> for super::CountryWhereInput {}
-    pub struct SlugLte;
-    impl ::cynic::schema::Field for SlugLte {
+    impl ::cynic::schema::HasInputField<slug_lt, Option<super::String>> for super::CountryWhereInput {}
+    pub struct slug_lte;
+    impl ::cynic::schema::Field for slug_lte {
         type Type = Option<super::String>;
         const NAME: &'static str = "slug_lte";
     }
-    impl ::cynic::schema::HasInputField<SlugLte, Option<super::String>> for super::CountryWhereInput {}
-    pub struct SlugGt;
-    impl ::cynic::schema::Field for SlugGt {
+    impl ::cynic::schema::HasInputField<slug_lte, Option<super::String>> for super::CountryWhereInput {}
+    pub struct slug_gt;
+    impl ::cynic::schema::Field for slug_gt {
         type Type = Option<super::String>;
         const NAME: &'static str = "slug_gt";
     }
-    impl ::cynic::schema::HasInputField<SlugGt, Option<super::String>> for super::CountryWhereInput {}
-    pub struct SlugGte;
-    impl ::cynic::schema::Field for SlugGte {
+    impl ::cynic::schema::HasInputField<slug_gt, Option<super::String>> for super::CountryWhereInput {}
+    pub struct slug_gte;
+    impl ::cynic::schema::Field for slug_gte {
         type Type = Option<super::String>;
         const NAME: &'static str = "slug_gte";
     }
-    impl ::cynic::schema::HasInputField<SlugGte, Option<super::String>> for super::CountryWhereInput {}
-    pub struct SlugContains;
-    impl ::cynic::schema::Field for SlugContains {
+    impl ::cynic::schema::HasInputField<slug_gte, Option<super::String>> for super::CountryWhereInput {}
+    pub struct slug_contains;
+    impl ::cynic::schema::Field for slug_contains {
         type Type = Option<super::String>;
         const NAME: &'static str = "slug_contains";
     }
-    impl ::cynic::schema::HasInputField<SlugContains, Option<super::String>>
+    impl ::cynic::schema::HasInputField<slug_contains, Option<super::String>>
         for super::CountryWhereInput
     {
     }
-    pub struct SlugNotContains;
-    impl ::cynic::schema::Field for SlugNotContains {
+    pub struct slug_not_contains;
+    impl ::cynic::schema::Field for slug_not_contains {
         type Type = Option<super::String>;
         const NAME: &'static str = "slug_not_contains";
     }
-    impl ::cynic::schema::HasInputField<SlugNotContains, Option<super::String>>
+    impl ::cynic::schema::HasInputField<slug_not_contains, Option<super::String>>
         for super::CountryWhereInput
     {
     }
-    pub struct SlugStartsWith;
-    impl ::cynic::schema::Field for SlugStartsWith {
+    pub struct slug_starts_with;
+    impl ::cynic::schema::Field for slug_starts_with {
         type Type = Option<super::String>;
         const NAME: &'static str = "slug_starts_with";
     }
-    impl ::cynic::schema::HasInputField<SlugStartsWith, Option<super::String>>
+    impl ::cynic::schema::HasInputField<slug_starts_with, Option<super::String>>
         for super::CountryWhereInput
     {
     }
-    pub struct SlugNotStartsWith;
-    impl ::cynic::schema::Field for SlugNotStartsWith {
+    pub struct slug_not_starts_with;
+    impl ::cynic::schema::Field for slug_not_starts_with {
         type Type = Option<super::String>;
         const NAME: &'static str = "slug_not_starts_with";
     }
-    impl ::cynic::schema::HasInputField<SlugNotStartsWith, Option<super::String>>
+    impl ::cynic::schema::HasInputField<slug_not_starts_with, Option<super::String>>
         for super::CountryWhereInput
     {
     }
-    pub struct SlugEndsWith;
-    impl ::cynic::schema::Field for SlugEndsWith {
+    pub struct slug_ends_with;
+    impl ::cynic::schema::Field for slug_ends_with {
         type Type = Option<super::String>;
         const NAME: &'static str = "slug_ends_with";
     }
-    impl ::cynic::schema::HasInputField<SlugEndsWith, Option<super::String>>
+    impl ::cynic::schema::HasInputField<slug_ends_with, Option<super::String>>
         for super::CountryWhereInput
     {
     }
-    pub struct SlugNotEndsWith;
-    impl ::cynic::schema::Field for SlugNotEndsWith {
+    pub struct slug_not_ends_with;
+    impl ::cynic::schema::Field for slug_not_ends_with {
         type Type = Option<super::String>;
         const NAME: &'static str = "slug_not_ends_with";
     }
-    impl ::cynic::schema::HasInputField<SlugNotEndsWith, Option<super::String>>
+    impl ::cynic::schema::HasInputField<slug_not_ends_with, Option<super::String>>
         for super::CountryWhereInput
     {
     }
-    pub struct Type;
-    impl ::cynic::schema::Field for Type {
+    pub struct r#type;
+    impl ::cynic::schema::Field for r#type {
         type Type = Option<super::String>;
         const NAME: &'static str = "type";
     }
-    impl ::cynic::schema::HasInputField<Type, Option<super::String>> for super::CountryWhereInput {}
-    pub struct TypeNot;
-    impl ::cynic::schema::Field for TypeNot {
+    impl ::cynic::schema::HasInputField<r#type, Option<super::String>> for super::CountryWhereInput {}
+    pub struct type_not;
+    impl ::cynic::schema::Field for type_not {
         type Type = Option<super::String>;
         const NAME: &'static str = "type_not";
     }
-    impl ::cynic::schema::HasInputField<TypeNot, Option<super::String>> for super::CountryWhereInput {}
-    pub struct TypeIn;
-    impl ::cynic::schema::Field for TypeIn {
+    impl ::cynic::schema::HasInputField<type_not, Option<super::String>> for super::CountryWhereInput {}
+    pub struct type_in;
+    impl ::cynic::schema::Field for type_in {
         type Type = Option<Vec<super::String>>;
         const NAME: &'static str = "type_in";
     }
-    impl ::cynic::schema::HasInputField<TypeIn, Option<Vec<super::String>>>
+    impl ::cynic::schema::HasInputField<type_in, Option<Vec<super::String>>>
         for super::CountryWhereInput
     {
     }
-    pub struct TypeNotIn;
-    impl ::cynic::schema::Field for TypeNotIn {
+    pub struct type_not_in;
+    impl ::cynic::schema::Field for type_not_in {
         type Type = Option<Vec<super::String>>;
         const NAME: &'static str = "type_not_in";
     }
-    impl ::cynic::schema::HasInputField<TypeNotIn, Option<Vec<super::String>>>
+    impl ::cynic::schema::HasInputField<type_not_in, Option<Vec<super::String>>>
         for super::CountryWhereInput
     {
     }
-    pub struct TypeLt;
-    impl ::cynic::schema::Field for TypeLt {
+    pub struct type_lt;
+    impl ::cynic::schema::Field for type_lt {
         type Type = Option<super::String>;
         const NAME: &'static str = "type_lt";
     }
-    impl ::cynic::schema::HasInputField<TypeLt, Option<super::String>> for super::CountryWhereInput {}
-    pub struct TypeLte;
-    impl ::cynic::schema::Field for TypeLte {
+    impl ::cynic::schema::HasInputField<type_lt, Option<super::String>> for super::CountryWhereInput {}
+    pub struct type_lte;
+    impl ::cynic::schema::Field for type_lte {
         type Type = Option<super::String>;
         const NAME: &'static str = "type_lte";
     }
-    impl ::cynic::schema::HasInputField<TypeLte, Option<super::String>> for super::CountryWhereInput {}
-    pub struct TypeGt;
-    impl ::cynic::schema::Field for TypeGt {
+    impl ::cynic::schema::HasInputField<type_lte, Option<super::String>> for super::CountryWhereInput {}
+    pub struct type_gt;
+    impl ::cynic::schema::Field for type_gt {
         type Type = Option<super::String>;
         const NAME: &'static str = "type_gt";
     }
-    impl ::cynic::schema::HasInputField<TypeGt, Option<super::String>> for super::CountryWhereInput {}
-    pub struct TypeGte;
-    impl ::cynic::schema::Field for TypeGte {
+    impl ::cynic::schema::HasInputField<type_gt, Option<super::String>> for super::CountryWhereInput {}
+    pub struct type_gte;
+    impl ::cynic::schema::Field for type_gte {
         type Type = Option<super::String>;
         const NAME: &'static str = "type_gte";
     }
-    impl ::cynic::schema::HasInputField<TypeGte, Option<super::String>> for super::CountryWhereInput {}
-    pub struct TypeContains;
-    impl ::cynic::schema::Field for TypeContains {
+    impl ::cynic::schema::HasInputField<type_gte, Option<super::String>> for super::CountryWhereInput {}
+    pub struct type_contains;
+    impl ::cynic::schema::Field for type_contains {
         type Type = Option<super::String>;
         const NAME: &'static str = "type_contains";
     }
-    impl ::cynic::schema::HasInputField<TypeContains, Option<super::String>>
+    impl ::cynic::schema::HasInputField<type_contains, Option<super::String>>
         for super::CountryWhereInput
     {
     }
-    pub struct TypeNotContains;
-    impl ::cynic::schema::Field for TypeNotContains {
+    pub struct type_not_contains;
+    impl ::cynic::schema::Field for type_not_contains {
         type Type = Option<super::String>;
         const NAME: &'static str = "type_not_contains";
     }
-    impl ::cynic::schema::HasInputField<TypeNotContains, Option<super::String>>
+    impl ::cynic::schema::HasInputField<type_not_contains, Option<super::String>>
         for super::CountryWhereInput
     {
     }
-    pub struct TypeStartsWith;
-    impl ::cynic::schema::Field for TypeStartsWith {
+    pub struct type_starts_with;
+    impl ::cynic::schema::Field for type_starts_with {
         type Type = Option<super::String>;
         const NAME: &'static str = "type_starts_with";
     }
-    impl ::cynic::schema::HasInputField<TypeStartsWith, Option<super::String>>
+    impl ::cynic::schema::HasInputField<type_starts_with, Option<super::String>>
         for super::CountryWhereInput
     {
     }
-    pub struct TypeNotStartsWith;
-    impl ::cynic::schema::Field for TypeNotStartsWith {
+    pub struct type_not_starts_with;
+    impl ::cynic::schema::Field for type_not_starts_with {
         type Type = Option<super::String>;
         const NAME: &'static str = "type_not_starts_with";
     }
-    impl ::cynic::schema::HasInputField<TypeNotStartsWith, Option<super::String>>
+    impl ::cynic::schema::HasInputField<type_not_starts_with, Option<super::String>>
         for super::CountryWhereInput
     {
     }
-    pub struct TypeEndsWith;
-    impl ::cynic::schema::Field for TypeEndsWith {
+    pub struct type_ends_with;
+    impl ::cynic::schema::Field for type_ends_with {
         type Type = Option<super::String>;
         const NAME: &'static str = "type_ends_with";
     }
-    impl ::cynic::schema::HasInputField<TypeEndsWith, Option<super::String>>
+    impl ::cynic::schema::HasInputField<type_ends_with, Option<super::String>>
         for super::CountryWhereInput
     {
     }
-    pub struct TypeNotEndsWith;
-    impl ::cynic::schema::Field for TypeNotEndsWith {
+    pub struct type_not_ends_with;
+    impl ::cynic::schema::Field for type_not_ends_with {
         type Type = Option<super::String>;
         const NAME: &'static str = "type_not_ends_with";
     }
-    impl ::cynic::schema::HasInputField<TypeNotEndsWith, Option<super::String>>
+    impl ::cynic::schema::HasInputField<type_not_ends_with, Option<super::String>>
         for super::CountryWhereInput
     {
     }
-    pub struct IsoCode;
-    impl ::cynic::schema::Field for IsoCode {
+    pub struct isoCode;
+    impl ::cynic::schema::Field for isoCode {
         type Type = Option<super::String>;
         const NAME: &'static str = "isoCode";
     }
-    impl ::cynic::schema::HasInputField<IsoCode, Option<super::String>> for super::CountryWhereInput {}
-    pub struct IsoCodeNot;
-    impl ::cynic::schema::Field for IsoCodeNot {
+    impl ::cynic::schema::HasInputField<isoCode, Option<super::String>> for super::CountryWhereInput {}
+    pub struct isoCode_not;
+    impl ::cynic::schema::Field for isoCode_not {
         type Type = Option<super::String>;
         const NAME: &'static str = "isoCode_not";
     }
-    impl ::cynic::schema::HasInputField<IsoCodeNot, Option<super::String>>
+    impl ::cynic::schema::HasInputField<isoCode_not, Option<super::String>>
         for super::CountryWhereInput
     {
     }
-    pub struct IsoCodeIn;
-    impl ::cynic::schema::Field for IsoCodeIn {
+    pub struct isoCode_in;
+    impl ::cynic::schema::Field for isoCode_in {
         type Type = Option<Vec<super::String>>;
         const NAME: &'static str = "isoCode_in";
     }
-    impl ::cynic::schema::HasInputField<IsoCodeIn, Option<Vec<super::String>>>
+    impl ::cynic::schema::HasInputField<isoCode_in, Option<Vec<super::String>>>
         for super::CountryWhereInput
     {
     }
-    pub struct IsoCodeNotIn;
-    impl ::cynic::schema::Field for IsoCodeNotIn {
+    pub struct isoCode_not_in;
+    impl ::cynic::schema::Field for isoCode_not_in {
         type Type = Option<Vec<super::String>>;
         const NAME: &'static str = "isoCode_not_in";
     }
-    impl ::cynic::schema::HasInputField<IsoCodeNotIn, Option<Vec<super::String>>>
+    impl ::cynic::schema::HasInputField<isoCode_not_in, Option<Vec<super::String>>>
         for super::CountryWhereInput
     {
     }
-    pub struct IsoCodeLt;
-    impl ::cynic::schema::Field for IsoCodeLt {
+    pub struct isoCode_lt;
+    impl ::cynic::schema::Field for isoCode_lt {
         type Type = Option<super::String>;
         const NAME: &'static str = "isoCode_lt";
     }
-    impl ::cynic::schema::HasInputField<IsoCodeLt, Option<super::String>> for super::CountryWhereInput {}
-    pub struct IsoCodeLte;
-    impl ::cynic::schema::Field for IsoCodeLte {
+    impl ::cynic::schema::HasInputField<isoCode_lt, Option<super::String>>
+        for super::CountryWhereInput
+    {
+    }
+    pub struct isoCode_lte;
+    impl ::cynic::schema::Field for isoCode_lte {
         type Type = Option<super::String>;
         const NAME: &'static str = "isoCode_lte";
     }
-    impl ::cynic::schema::HasInputField<IsoCodeLte, Option<super::String>>
+    impl ::cynic::schema::HasInputField<isoCode_lte, Option<super::String>>
         for super::CountryWhereInput
     {
     }
-    pub struct IsoCodeGt;
-    impl ::cynic::schema::Field for IsoCodeGt {
+    pub struct isoCode_gt;
+    impl ::cynic::schema::Field for isoCode_gt {
         type Type = Option<super::String>;
         const NAME: &'static str = "isoCode_gt";
     }
-    impl ::cynic::schema::HasInputField<IsoCodeGt, Option<super::String>> for super::CountryWhereInput {}
-    pub struct IsoCodeGte;
-    impl ::cynic::schema::Field for IsoCodeGte {
+    impl ::cynic::schema::HasInputField<isoCode_gt, Option<super::String>>
+        for super::CountryWhereInput
+    {
+    }
+    pub struct isoCode_gte;
+    impl ::cynic::schema::Field for isoCode_gte {
         type Type = Option<super::String>;
         const NAME: &'static str = "isoCode_gte";
     }
-    impl ::cynic::schema::HasInputField<IsoCodeGte, Option<super::String>>
+    impl ::cynic::schema::HasInputField<isoCode_gte, Option<super::String>>
         for super::CountryWhereInput
     {
     }
-    pub struct IsoCodeContains;
-    impl ::cynic::schema::Field for IsoCodeContains {
+    pub struct isoCode_contains;
+    impl ::cynic::schema::Field for isoCode_contains {
         type Type = Option<super::String>;
         const NAME: &'static str = "isoCode_contains";
     }
-    impl ::cynic::schema::HasInputField<IsoCodeContains, Option<super::String>>
+    impl ::cynic::schema::HasInputField<isoCode_contains, Option<super::String>>
         for super::CountryWhereInput
     {
     }
-    pub struct IsoCodeNotContains;
-    impl ::cynic::schema::Field for IsoCodeNotContains {
+    pub struct isoCode_not_contains;
+    impl ::cynic::schema::Field for isoCode_not_contains {
         type Type = Option<super::String>;
         const NAME: &'static str = "isoCode_not_contains";
     }
-    impl ::cynic::schema::HasInputField<IsoCodeNotContains, Option<super::String>>
+    impl ::cynic::schema::HasInputField<isoCode_not_contains, Option<super::String>>
         for super::CountryWhereInput
     {
     }
-    pub struct IsoCodeStartsWith;
-    impl ::cynic::schema::Field for IsoCodeStartsWith {
+    pub struct isoCode_starts_with;
+    impl ::cynic::schema::Field for isoCode_starts_with {
         type Type = Option<super::String>;
         const NAME: &'static str = "isoCode_starts_with";
     }
-    impl ::cynic::schema::HasInputField<IsoCodeStartsWith, Option<super::String>>
+    impl ::cynic::schema::HasInputField<isoCode_starts_with, Option<super::String>>
         for super::CountryWhereInput
     {
     }
-    pub struct IsoCodeNotStartsWith;
-    impl ::cynic::schema::Field for IsoCodeNotStartsWith {
+    pub struct isoCode_not_starts_with;
+    impl ::cynic::schema::Field for isoCode_not_starts_with {
         type Type = Option<super::String>;
         const NAME: &'static str = "isoCode_not_starts_with";
     }
-    impl ::cynic::schema::HasInputField<IsoCodeNotStartsWith, Option<super::String>>
+    impl ::cynic::schema::HasInputField<isoCode_not_starts_with, Option<super::String>>
         for super::CountryWhereInput
     {
     }
-    pub struct IsoCodeEndsWith;
-    impl ::cynic::schema::Field for IsoCodeEndsWith {
+    pub struct isoCode_ends_with;
+    impl ::cynic::schema::Field for isoCode_ends_with {
         type Type = Option<super::String>;
         const NAME: &'static str = "isoCode_ends_with";
     }
-    impl ::cynic::schema::HasInputField<IsoCodeEndsWith, Option<super::String>>
+    impl ::cynic::schema::HasInputField<isoCode_ends_with, Option<super::String>>
         for super::CountryWhereInput
     {
     }
-    pub struct IsoCodeNotEndsWith;
-    impl ::cynic::schema::Field for IsoCodeNotEndsWith {
+    pub struct isoCode_not_ends_with;
+    impl ::cynic::schema::Field for isoCode_not_ends_with {
         type Type = Option<super::String>;
         const NAME: &'static str = "isoCode_not_ends_with";
     }
-    impl ::cynic::schema::HasInputField<IsoCodeNotEndsWith, Option<super::String>>
+    impl ::cynic::schema::HasInputField<isoCode_not_ends_with, Option<super::String>>
         for super::CountryWhereInput
     {
     }
-    pub struct CitiesEvery;
-    impl ::cynic::schema::Field for CitiesEvery {
+    pub struct cities_every;
+    impl ::cynic::schema::Field for cities_every {
         type Type = Option<super::CityWhereInput>;
         const NAME: &'static str = "cities_every";
     }
-    impl ::cynic::schema::HasInputField<CitiesEvery, Option<super::CityWhereInput>>
+    impl ::cynic::schema::HasInputField<cities_every, Option<super::CityWhereInput>>
         for super::CountryWhereInput
     {
     }
-    pub struct CitiesSome;
-    impl ::cynic::schema::Field for CitiesSome {
+    pub struct cities_some;
+    impl ::cynic::schema::Field for cities_some {
         type Type = Option<super::CityWhereInput>;
         const NAME: &'static str = "cities_some";
     }
-    impl ::cynic::schema::HasInputField<CitiesSome, Option<super::CityWhereInput>>
+    impl ::cynic::schema::HasInputField<cities_some, Option<super::CityWhereInput>>
         for super::CountryWhereInput
     {
     }
-    pub struct CitiesNone;
-    impl ::cynic::schema::Field for CitiesNone {
+    pub struct cities_none;
+    impl ::cynic::schema::Field for cities_none {
         type Type = Option<super::CityWhereInput>;
         const NAME: &'static str = "cities_none";
     }
-    impl ::cynic::schema::HasInputField<CitiesNone, Option<super::CityWhereInput>>
+    impl ::cynic::schema::HasInputField<cities_none, Option<super::CityWhereInput>>
         for super::CountryWhereInput
     {
     }
-    pub struct JobsEvery;
-    impl ::cynic::schema::Field for JobsEvery {
+    pub struct jobs_every;
+    impl ::cynic::schema::Field for jobs_every {
         type Type = Option<super::JobWhereInput>;
         const NAME: &'static str = "jobs_every";
     }
-    impl ::cynic::schema::HasInputField<JobsEvery, Option<super::JobWhereInput>>
+    impl ::cynic::schema::HasInputField<jobs_every, Option<super::JobWhereInput>>
         for super::CountryWhereInput
     {
     }
-    pub struct JobsSome;
-    impl ::cynic::schema::Field for JobsSome {
+    pub struct jobs_some;
+    impl ::cynic::schema::Field for jobs_some {
         type Type = Option<super::JobWhereInput>;
         const NAME: &'static str = "jobs_some";
     }
-    impl ::cynic::schema::HasInputField<JobsSome, Option<super::JobWhereInput>>
+    impl ::cynic::schema::HasInputField<jobs_some, Option<super::JobWhereInput>>
         for super::CountryWhereInput
     {
     }
-    pub struct JobsNone;
-    impl ::cynic::schema::Field for JobsNone {
+    pub struct jobs_none;
+    impl ::cynic::schema::Field for jobs_none {
         type Type = Option<super::JobWhereInput>;
         const NAME: &'static str = "jobs_none";
     }
-    impl ::cynic::schema::HasInputField<JobsNone, Option<super::JobWhereInput>>
+    impl ::cynic::schema::HasInputField<jobs_none, Option<super::JobWhereInput>>
         for super::CountryWhereInput
     {
     }
-    pub struct CreatedAt;
-    impl ::cynic::schema::Field for CreatedAt {
+    pub struct createdAt;
+    impl ::cynic::schema::Field for createdAt {
         type Type = Option<super::DateTime>;
         const NAME: &'static str = "createdAt";
     }
-    impl ::cynic::schema::HasInputField<CreatedAt, Option<super::DateTime>>
+    impl ::cynic::schema::HasInputField<createdAt, Option<super::DateTime>>
         for super::CountryWhereInput
     {
     }
-    pub struct CreatedAtNot;
-    impl ::cynic::schema::Field for CreatedAtNot {
+    pub struct createdAt_not;
+    impl ::cynic::schema::Field for createdAt_not {
         type Type = Option<super::DateTime>;
         const NAME: &'static str = "createdAt_not";
     }
-    impl ::cynic::schema::HasInputField<CreatedAtNot, Option<super::DateTime>>
+    impl ::cynic::schema::HasInputField<createdAt_not, Option<super::DateTime>>
         for super::CountryWhereInput
     {
     }
-    pub struct CreatedAtIn;
-    impl ::cynic::schema::Field for CreatedAtIn {
+    pub struct createdAt_in;
+    impl ::cynic::schema::Field for createdAt_in {
         type Type = Option<Vec<super::DateTime>>;
         const NAME: &'static str = "createdAt_in";
     }
-    impl ::cynic::schema::HasInputField<CreatedAtIn, Option<Vec<super::DateTime>>>
+    impl ::cynic::schema::HasInputField<createdAt_in, Option<Vec<super::DateTime>>>
         for super::CountryWhereInput
     {
     }
-    pub struct CreatedAtNotIn;
-    impl ::cynic::schema::Field for CreatedAtNotIn {
+    pub struct createdAt_not_in;
+    impl ::cynic::schema::Field for createdAt_not_in {
         type Type = Option<Vec<super::DateTime>>;
         const NAME: &'static str = "createdAt_not_in";
     }
-    impl ::cynic::schema::HasInputField<CreatedAtNotIn, Option<Vec<super::DateTime>>>
+    impl ::cynic::schema::HasInputField<createdAt_not_in, Option<Vec<super::DateTime>>>
         for super::CountryWhereInput
     {
     }
-    pub struct CreatedAtLt;
-    impl ::cynic::schema::Field for CreatedAtLt {
+    pub struct createdAt_lt;
+    impl ::cynic::schema::Field for createdAt_lt {
         type Type = Option<super::DateTime>;
         const NAME: &'static str = "createdAt_lt";
     }
-    impl ::cynic::schema::HasInputField<CreatedAtLt, Option<super::DateTime>>
+    impl ::cynic::schema::HasInputField<createdAt_lt, Option<super::DateTime>>
         for super::CountryWhereInput
     {
     }
-    pub struct CreatedAtLte;
-    impl ::cynic::schema::Field for CreatedAtLte {
+    pub struct createdAt_lte;
+    impl ::cynic::schema::Field for createdAt_lte {
         type Type = Option<super::DateTime>;
         const NAME: &'static str = "createdAt_lte";
     }
-    impl ::cynic::schema::HasInputField<CreatedAtLte, Option<super::DateTime>>
+    impl ::cynic::schema::HasInputField<createdAt_lte, Option<super::DateTime>>
         for super::CountryWhereInput
     {
     }
-    pub struct CreatedAtGt;
-    impl ::cynic::schema::Field for CreatedAtGt {
+    pub struct createdAt_gt;
+    impl ::cynic::schema::Field for createdAt_gt {
         type Type = Option<super::DateTime>;
         const NAME: &'static str = "createdAt_gt";
     }
-    impl ::cynic::schema::HasInputField<CreatedAtGt, Option<super::DateTime>>
+    impl ::cynic::schema::HasInputField<createdAt_gt, Option<super::DateTime>>
         for super::CountryWhereInput
     {
     }
-    pub struct CreatedAtGte;
-    impl ::cynic::schema::Field for CreatedAtGte {
+    pub struct createdAt_gte;
+    impl ::cynic::schema::Field for createdAt_gte {
         type Type = Option<super::DateTime>;
         const NAME: &'static str = "createdAt_gte";
     }
-    impl ::cynic::schema::HasInputField<CreatedAtGte, Option<super::DateTime>>
+    impl ::cynic::schema::HasInputField<createdAt_gte, Option<super::DateTime>>
         for super::CountryWhereInput
     {
     }
-    pub struct UpdatedAt;
-    impl ::cynic::schema::Field for UpdatedAt {
+    pub struct updatedAt;
+    impl ::cynic::schema::Field for updatedAt {
         type Type = Option<super::DateTime>;
         const NAME: &'static str = "updatedAt";
     }
-    impl ::cynic::schema::HasInputField<UpdatedAt, Option<super::DateTime>>
+    impl ::cynic::schema::HasInputField<updatedAt, Option<super::DateTime>>
         for super::CountryWhereInput
     {
     }
-    pub struct UpdatedAtNot;
-    impl ::cynic::schema::Field for UpdatedAtNot {
+    pub struct updatedAt_not;
+    impl ::cynic::schema::Field for updatedAt_not {
         type Type = Option<super::DateTime>;
         const NAME: &'static str = "updatedAt_not";
     }
-    impl ::cynic::schema::HasInputField<UpdatedAtNot, Option<super::DateTime>>
+    impl ::cynic::schema::HasInputField<updatedAt_not, Option<super::DateTime>>
         for super::CountryWhereInput
     {
     }
-    pub struct UpdatedAtIn;
-    impl ::cynic::schema::Field for UpdatedAtIn {
+    pub struct updatedAt_in;
+    impl ::cynic::schema::Field for updatedAt_in {
         type Type = Option<Vec<super::DateTime>>;
         const NAME: &'static str = "updatedAt_in";
     }
-    impl ::cynic::schema::HasInputField<UpdatedAtIn, Option<Vec<super::DateTime>>>
+    impl ::cynic::schema::HasInputField<updatedAt_in, Option<Vec<super::DateTime>>>
         for super::CountryWhereInput
     {
     }
-    pub struct UpdatedAtNotIn;
-    impl ::cynic::schema::Field for UpdatedAtNotIn {
+    pub struct updatedAt_not_in;
+    impl ::cynic::schema::Field for updatedAt_not_in {
         type Type = Option<Vec<super::DateTime>>;
         const NAME: &'static str = "updatedAt_not_in";
     }
-    impl ::cynic::schema::HasInputField<UpdatedAtNotIn, Option<Vec<super::DateTime>>>
+    impl ::cynic::schema::HasInputField<updatedAt_not_in, Option<Vec<super::DateTime>>>
         for super::CountryWhereInput
     {
     }
-    pub struct UpdatedAtLt;
-    impl ::cynic::schema::Field for UpdatedAtLt {
+    pub struct updatedAt_lt;
+    impl ::cynic::schema::Field for updatedAt_lt {
         type Type = Option<super::DateTime>;
         const NAME: &'static str = "updatedAt_lt";
     }
-    impl ::cynic::schema::HasInputField<UpdatedAtLt, Option<super::DateTime>>
+    impl ::cynic::schema::HasInputField<updatedAt_lt, Option<super::DateTime>>
         for super::CountryWhereInput
     {
     }
-    pub struct UpdatedAtLte;
-    impl ::cynic::schema::Field for UpdatedAtLte {
+    pub struct updatedAt_lte;
+    impl ::cynic::schema::Field for updatedAt_lte {
         type Type = Option<super::DateTime>;
         const NAME: &'static str = "updatedAt_lte";
     }
-    impl ::cynic::schema::HasInputField<UpdatedAtLte, Option<super::DateTime>>
+    impl ::cynic::schema::HasInputField<updatedAt_lte, Option<super::DateTime>>
         for super::CountryWhereInput
     {
     }
-    pub struct UpdatedAtGt;
-    impl ::cynic::schema::Field for UpdatedAtGt {
+    pub struct updatedAt_gt;
+    impl ::cynic::schema::Field for updatedAt_gt {
         type Type = Option<super::DateTime>;
         const NAME: &'static str = "updatedAt_gt";
     }
-    impl ::cynic::schema::HasInputField<UpdatedAtGt, Option<super::DateTime>>
+    impl ::cynic::schema::HasInputField<updatedAt_gt, Option<super::DateTime>>
         for super::CountryWhereInput
     {
     }
-    pub struct UpdatedAtGte;
-    impl ::cynic::schema::Field for UpdatedAtGte {
+    pub struct updatedAt_gte;
+    impl ::cynic::schema::Field for updatedAt_gte {
         type Type = Option<super::DateTime>;
         const NAME: &'static str = "updatedAt_gte";
     }
-    impl ::cynic::schema::HasInputField<UpdatedAtGte, Option<super::DateTime>>
+    impl ::cynic::schema::HasInputField<updatedAt_gte, Option<super::DateTime>>
         for super::CountryWhereInput
     {
     }
-    pub struct And;
-    impl ::cynic::schema::Field for And {
+    pub struct AND;
+    impl ::cynic::schema::Field for AND {
         type Type = Option<Vec<super::CountryWhereInput>>;
         const NAME: &'static str = "AND";
     }
-    impl ::cynic::schema::HasInputField<And, Option<Vec<super::CountryWhereInput>>>
+    impl ::cynic::schema::HasInputField<AND, Option<Vec<super::CountryWhereInput>>>
         for super::CountryWhereInput
     {
     }
-    pub struct Or;
-    impl ::cynic::schema::Field for Or {
+    pub struct OR;
+    impl ::cynic::schema::Field for OR {
         type Type = Option<Vec<super::CountryWhereInput>>;
         const NAME: &'static str = "OR";
     }
-    impl ::cynic::schema::HasInputField<Or, Option<Vec<super::CountryWhereInput>>>
+    impl ::cynic::schema::HasInputField<OR, Option<Vec<super::CountryWhereInput>>>
         for super::CountryWhereInput
     {
     }
-    pub struct Not;
-    impl ::cynic::schema::Field for Not {
+    pub struct NOT;
+    impl ::cynic::schema::Field for NOT {
         type Type = Option<Vec<super::CountryWhereInput>>;
         const NAME: &'static str = "NOT";
     }
-    impl ::cynic::schema::HasInputField<Not, Option<Vec<super::CountryWhereInput>>>
+    impl ::cynic::schema::HasInputField<NOT, Option<Vec<super::CountryWhereInput>>>
         for super::CountryWhereInput
     {
     }
@@ -3236,1417 +3311,1456 @@ pub mod country_where_input_fields {
 pub struct DateTime {}
 pub struct Job;
 pub mod job_fields {
-    pub struct Id;
-    impl ::cynic::schema::Field for Id {
-        type Type = super::Id;
+    pub struct id;
+    impl ::cynic::schema::Field for id {
+        type Type = super::ID;
         const NAME: &'static str = "id";
     }
-    impl ::cynic::schema::HasField<Id> for super::Job {
-        type Type = super::Id;
+    impl ::cynic::schema::HasField<id> for super::Job {
+        type Type = super::ID;
     }
-    pub struct Title;
-    impl ::cynic::schema::Field for Title {
+    pub struct title;
+    impl ::cynic::schema::Field for title {
         type Type = super::String;
         const NAME: &'static str = "title";
     }
-    impl ::cynic::schema::HasField<Title> for super::Job {
+    impl ::cynic::schema::HasField<title> for super::Job {
         type Type = super::String;
     }
-    pub struct Slug;
-    impl ::cynic::schema::Field for Slug {
+    pub struct slug;
+    impl ::cynic::schema::Field for slug {
         type Type = super::String;
         const NAME: &'static str = "slug";
     }
-    impl ::cynic::schema::HasField<Slug> for super::Job {
+    impl ::cynic::schema::HasField<slug> for super::Job {
         type Type = super::String;
     }
-    pub struct Commitment;
-    impl ::cynic::schema::Field for Commitment {
+    pub struct commitment;
+    impl ::cynic::schema::Field for commitment {
         type Type = super::Commitment;
         const NAME: &'static str = "commitment";
     }
-    impl ::cynic::schema::HasField<Commitment> for super::Job {
+    impl ::cynic::schema::HasField<commitment> for super::Job {
         type Type = super::Commitment;
     }
-    pub struct Cities;
-    impl ::cynic::schema::Field for Cities {
+    pub struct cities;
+    impl ::cynic::schema::Field for cities {
         type Type = Option<Vec<super::City>>;
         const NAME: &'static str = "cities";
     }
-    impl ::cynic::schema::HasField<Cities> for super::Job {
+    impl ::cynic::schema::HasField<cities> for super::Job {
         type Type = Option<Vec<super::City>>;
     }
     pub mod cities_arguments {
-        pub struct Where;
-        impl ::cynic::schema::HasArgument<Where> for super::Cities {
+        pub struct r#where;
+        impl ::cynic::schema::HasArgument<r#where> for super::cities {
             type ArgumentType = Option<super::super::CityWhereInput>;
             const NAME: &'static str = "where";
         }
-        pub struct OrderBy;
-        impl ::cynic::schema::HasArgument<OrderBy> for super::Cities {
+        pub struct orderBy;
+        impl ::cynic::schema::HasArgument<orderBy> for super::cities {
             type ArgumentType = Option<super::super::CityOrderByInput>;
             const NAME: &'static str = "orderBy";
         }
-        pub struct Skip;
-        impl ::cynic::schema::HasArgument<Skip> for super::Cities {
+        pub struct skip;
+        impl ::cynic::schema::HasArgument<skip> for super::cities {
             type ArgumentType = Option<super::super::Int>;
             const NAME: &'static str = "skip";
         }
-        pub struct After;
-        impl ::cynic::schema::HasArgument<After> for super::Cities {
+        pub struct after;
+        impl ::cynic::schema::HasArgument<after> for super::cities {
             type ArgumentType = Option<super::super::String>;
             const NAME: &'static str = "after";
         }
-        pub struct Before;
-        impl ::cynic::schema::HasArgument<Before> for super::Cities {
+        pub struct before;
+        impl ::cynic::schema::HasArgument<before> for super::cities {
             type ArgumentType = Option<super::super::String>;
             const NAME: &'static str = "before";
         }
-        pub struct First;
-        impl ::cynic::schema::HasArgument<First> for super::Cities {
+        pub struct first;
+        impl ::cynic::schema::HasArgument<first> for super::cities {
             type ArgumentType = Option<super::super::Int>;
             const NAME: &'static str = "first";
         }
-        pub struct Last;
-        impl ::cynic::schema::HasArgument<Last> for super::Cities {
+        pub struct last;
+        impl ::cynic::schema::HasArgument<last> for super::cities {
             type ArgumentType = Option<super::super::Int>;
             const NAME: &'static str = "last";
         }
     }
-    pub struct Countries;
-    impl ::cynic::schema::Field for Countries {
+    pub struct countries;
+    impl ::cynic::schema::Field for countries {
         type Type = Option<Vec<super::Country>>;
         const NAME: &'static str = "countries";
     }
-    impl ::cynic::schema::HasField<Countries> for super::Job {
+    impl ::cynic::schema::HasField<countries> for super::Job {
         type Type = Option<Vec<super::Country>>;
     }
     pub mod countries_arguments {
-        pub struct Where;
-        impl ::cynic::schema::HasArgument<Where> for super::Countries {
+        pub struct r#where;
+        impl ::cynic::schema::HasArgument<r#where> for super::countries {
             type ArgumentType = Option<super::super::CountryWhereInput>;
             const NAME: &'static str = "where";
         }
-        pub struct OrderBy;
-        impl ::cynic::schema::HasArgument<OrderBy> for super::Countries {
+        pub struct orderBy;
+        impl ::cynic::schema::HasArgument<orderBy> for super::countries {
             type ArgumentType = Option<super::super::CountryOrderByInput>;
             const NAME: &'static str = "orderBy";
         }
-        pub struct Skip;
-        impl ::cynic::schema::HasArgument<Skip> for super::Countries {
+        pub struct skip;
+        impl ::cynic::schema::HasArgument<skip> for super::countries {
             type ArgumentType = Option<super::super::Int>;
             const NAME: &'static str = "skip";
         }
-        pub struct After;
-        impl ::cynic::schema::HasArgument<After> for super::Countries {
+        pub struct after;
+        impl ::cynic::schema::HasArgument<after> for super::countries {
             type ArgumentType = Option<super::super::String>;
             const NAME: &'static str = "after";
         }
-        pub struct Before;
-        impl ::cynic::schema::HasArgument<Before> for super::Countries {
+        pub struct before;
+        impl ::cynic::schema::HasArgument<before> for super::countries {
             type ArgumentType = Option<super::super::String>;
             const NAME: &'static str = "before";
         }
-        pub struct First;
-        impl ::cynic::schema::HasArgument<First> for super::Countries {
+        pub struct first;
+        impl ::cynic::schema::HasArgument<first> for super::countries {
             type ArgumentType = Option<super::super::Int>;
             const NAME: &'static str = "first";
         }
-        pub struct Last;
-        impl ::cynic::schema::HasArgument<Last> for super::Countries {
+        pub struct last;
+        impl ::cynic::schema::HasArgument<last> for super::countries {
             type ArgumentType = Option<super::super::Int>;
             const NAME: &'static str = "last";
         }
     }
-    pub struct Remotes;
-    impl ::cynic::schema::Field for Remotes {
+    pub struct remotes;
+    impl ::cynic::schema::Field for remotes {
         type Type = Option<Vec<super::Remote>>;
         const NAME: &'static str = "remotes";
     }
-    impl ::cynic::schema::HasField<Remotes> for super::Job {
+    impl ::cynic::schema::HasField<remotes> for super::Job {
         type Type = Option<Vec<super::Remote>>;
     }
     pub mod remotes_arguments {
-        pub struct Where;
-        impl ::cynic::schema::HasArgument<Where> for super::Remotes {
+        pub struct r#where;
+        impl ::cynic::schema::HasArgument<r#where> for super::remotes {
             type ArgumentType = Option<super::super::RemoteWhereInput>;
             const NAME: &'static str = "where";
         }
-        pub struct OrderBy;
-        impl ::cynic::schema::HasArgument<OrderBy> for super::Remotes {
+        pub struct orderBy;
+        impl ::cynic::schema::HasArgument<orderBy> for super::remotes {
             type ArgumentType = Option<super::super::RemoteOrderByInput>;
             const NAME: &'static str = "orderBy";
         }
-        pub struct Skip;
-        impl ::cynic::schema::HasArgument<Skip> for super::Remotes {
+        pub struct skip;
+        impl ::cynic::schema::HasArgument<skip> for super::remotes {
             type ArgumentType = Option<super::super::Int>;
             const NAME: &'static str = "skip";
         }
-        pub struct After;
-        impl ::cynic::schema::HasArgument<After> for super::Remotes {
+        pub struct after;
+        impl ::cynic::schema::HasArgument<after> for super::remotes {
             type ArgumentType = Option<super::super::String>;
             const NAME: &'static str = "after";
         }
-        pub struct Before;
-        impl ::cynic::schema::HasArgument<Before> for super::Remotes {
+        pub struct before;
+        impl ::cynic::schema::HasArgument<before> for super::remotes {
             type ArgumentType = Option<super::super::String>;
             const NAME: &'static str = "before";
         }
-        pub struct First;
-        impl ::cynic::schema::HasArgument<First> for super::Remotes {
+        pub struct first;
+        impl ::cynic::schema::HasArgument<first> for super::remotes {
             type ArgumentType = Option<super::super::Int>;
             const NAME: &'static str = "first";
         }
-        pub struct Last;
-        impl ::cynic::schema::HasArgument<Last> for super::Remotes {
+        pub struct last;
+        impl ::cynic::schema::HasArgument<last> for super::remotes {
             type ArgumentType = Option<super::super::Int>;
             const NAME: &'static str = "last";
         }
     }
-    pub struct Description;
-    impl ::cynic::schema::Field for Description {
+    pub struct description;
+    impl ::cynic::schema::Field for description {
         type Type = Option<super::String>;
         const NAME: &'static str = "description";
     }
-    impl ::cynic::schema::HasField<Description> for super::Job {
+    impl ::cynic::schema::HasField<description> for super::Job {
         type Type = Option<super::String>;
     }
-    pub struct ApplyUrl;
-    impl ::cynic::schema::Field for ApplyUrl {
+    pub struct applyUrl;
+    impl ::cynic::schema::Field for applyUrl {
         type Type = Option<super::String>;
         const NAME: &'static str = "applyUrl";
     }
-    impl ::cynic::schema::HasField<ApplyUrl> for super::Job {
+    impl ::cynic::schema::HasField<applyUrl> for super::Job {
         type Type = Option<super::String>;
     }
-    pub struct Company;
-    impl ::cynic::schema::Field for Company {
+    pub struct company;
+    impl ::cynic::schema::Field for company {
         type Type = Option<super::Company>;
         const NAME: &'static str = "company";
     }
-    impl ::cynic::schema::HasField<Company> for super::Job {
+    impl ::cynic::schema::HasField<company> for super::Job {
         type Type = Option<super::Company>;
     }
-    pub struct Tags;
-    impl ::cynic::schema::Field for Tags {
+    pub struct tags;
+    impl ::cynic::schema::Field for tags {
         type Type = Option<Vec<super::Tag>>;
         const NAME: &'static str = "tags";
     }
-    impl ::cynic::schema::HasField<Tags> for super::Job {
+    impl ::cynic::schema::HasField<tags> for super::Job {
         type Type = Option<Vec<super::Tag>>;
     }
     pub mod tags_arguments {
-        pub struct Where;
-        impl ::cynic::schema::HasArgument<Where> for super::Tags {
+        pub struct r#where;
+        impl ::cynic::schema::HasArgument<r#where> for super::tags {
             type ArgumentType = Option<super::super::TagWhereInput>;
             const NAME: &'static str = "where";
         }
-        pub struct OrderBy;
-        impl ::cynic::schema::HasArgument<OrderBy> for super::Tags {
+        pub struct orderBy;
+        impl ::cynic::schema::HasArgument<orderBy> for super::tags {
             type ArgumentType = Option<super::super::TagOrderByInput>;
             const NAME: &'static str = "orderBy";
         }
-        pub struct Skip;
-        impl ::cynic::schema::HasArgument<Skip> for super::Tags {
+        pub struct skip;
+        impl ::cynic::schema::HasArgument<skip> for super::tags {
             type ArgumentType = Option<super::super::Int>;
             const NAME: &'static str = "skip";
         }
-        pub struct After;
-        impl ::cynic::schema::HasArgument<After> for super::Tags {
+        pub struct after;
+        impl ::cynic::schema::HasArgument<after> for super::tags {
             type ArgumentType = Option<super::super::String>;
             const NAME: &'static str = "after";
         }
-        pub struct Before;
-        impl ::cynic::schema::HasArgument<Before> for super::Tags {
+        pub struct before;
+        impl ::cynic::schema::HasArgument<before> for super::tags {
             type ArgumentType = Option<super::super::String>;
             const NAME: &'static str = "before";
         }
-        pub struct First;
-        impl ::cynic::schema::HasArgument<First> for super::Tags {
+        pub struct first;
+        impl ::cynic::schema::HasArgument<first> for super::tags {
             type ArgumentType = Option<super::super::Int>;
             const NAME: &'static str = "first";
         }
-        pub struct Last;
-        impl ::cynic::schema::HasArgument<Last> for super::Tags {
+        pub struct last;
+        impl ::cynic::schema::HasArgument<last> for super::tags {
             type ArgumentType = Option<super::super::Int>;
             const NAME: &'static str = "last";
         }
     }
-    pub struct IsPublished;
-    impl ::cynic::schema::Field for IsPublished {
+    pub struct isPublished;
+    impl ::cynic::schema::Field for isPublished {
         type Type = Option<super::Boolean>;
         const NAME: &'static str = "isPublished";
     }
-    impl ::cynic::schema::HasField<IsPublished> for super::Job {
+    impl ::cynic::schema::HasField<isPublished> for super::Job {
         type Type = Option<super::Boolean>;
     }
-    pub struct IsFeatured;
-    impl ::cynic::schema::Field for IsFeatured {
+    pub struct isFeatured;
+    impl ::cynic::schema::Field for isFeatured {
         type Type = Option<super::Boolean>;
         const NAME: &'static str = "isFeatured";
     }
-    impl ::cynic::schema::HasField<IsFeatured> for super::Job {
+    impl ::cynic::schema::HasField<isFeatured> for super::Job {
         type Type = Option<super::Boolean>;
     }
-    pub struct LocationNames;
-    impl ::cynic::schema::Field for LocationNames {
+    pub struct locationNames;
+    impl ::cynic::schema::Field for locationNames {
         type Type = Option<super::String>;
         const NAME: &'static str = "locationNames";
     }
-    impl ::cynic::schema::HasField<LocationNames> for super::Job {
+    impl ::cynic::schema::HasField<locationNames> for super::Job {
         type Type = Option<super::String>;
     }
-    pub struct UserEmail;
-    impl ::cynic::schema::Field for UserEmail {
+    pub struct userEmail;
+    impl ::cynic::schema::Field for userEmail {
         type Type = Option<super::String>;
         const NAME: &'static str = "userEmail";
     }
-    impl ::cynic::schema::HasField<UserEmail> for super::Job {
+    impl ::cynic::schema::HasField<userEmail> for super::Job {
         type Type = Option<super::String>;
     }
-    pub struct PostedAt;
-    impl ::cynic::schema::Field for PostedAt {
+    pub struct postedAt;
+    impl ::cynic::schema::Field for postedAt {
         type Type = super::DateTime;
         const NAME: &'static str = "postedAt";
     }
-    impl ::cynic::schema::HasField<PostedAt> for super::Job {
+    impl ::cynic::schema::HasField<postedAt> for super::Job {
         type Type = super::DateTime;
     }
-    pub struct CreatedAt;
-    impl ::cynic::schema::Field for CreatedAt {
+    pub struct createdAt;
+    impl ::cynic::schema::Field for createdAt {
         type Type = super::DateTime;
         const NAME: &'static str = "createdAt";
     }
-    impl ::cynic::schema::HasField<CreatedAt> for super::Job {
+    impl ::cynic::schema::HasField<createdAt> for super::Job {
         type Type = super::DateTime;
     }
-    pub struct UpdatedAt;
-    impl ::cynic::schema::Field for UpdatedAt {
+    pub struct updatedAt;
+    impl ::cynic::schema::Field for updatedAt {
         type Type = super::DateTime;
         const NAME: &'static str = "updatedAt";
     }
-    impl ::cynic::schema::HasField<UpdatedAt> for super::Job {
+    impl ::cynic::schema::HasField<updatedAt> for super::Job {
         type Type = super::DateTime;
     }
 }
 pub struct JobInput;
 impl ::cynic::schema::InputObjectMarker for JobInput {}
 pub mod job_input_fields {
-    pub struct CompanySlug;
-    impl ::cynic::schema::Field for CompanySlug {
+    pub struct companySlug;
+    impl ::cynic::schema::Field for companySlug {
         type Type = super::String;
         const NAME: &'static str = "companySlug";
     }
-    impl ::cynic::schema::HasInputField<CompanySlug, super::String> for super::JobInput {}
-    pub struct JobSlug;
-    impl ::cynic::schema::Field for JobSlug {
+    impl ::cynic::schema::HasInputField<companySlug, super::String> for super::JobInput {}
+    pub struct jobSlug;
+    impl ::cynic::schema::Field for jobSlug {
         type Type = super::String;
         const NAME: &'static str = "jobSlug";
     }
-    impl ::cynic::schema::HasInputField<JobSlug, super::String> for super::JobInput {}
+    impl ::cynic::schema::HasInputField<jobSlug, super::String> for super::JobInput {}
 }
 pub struct JobOrderByInput {}
 pub struct JobWhereInput;
 impl ::cynic::schema::InputObjectMarker for JobWhereInput {}
 pub mod job_where_input_fields {
-    pub struct Id;
-    impl ::cynic::schema::Field for Id {
-        type Type = Option<super::Id>;
+    pub struct id;
+    impl ::cynic::schema::Field for id {
+        type Type = Option<super::ID>;
         const NAME: &'static str = "id";
     }
-    impl ::cynic::schema::HasInputField<Id, Option<super::Id>> for super::JobWhereInput {}
-    pub struct IdNot;
-    impl ::cynic::schema::Field for IdNot {
-        type Type = Option<super::Id>;
+    impl ::cynic::schema::HasInputField<id, Option<super::ID>> for super::JobWhereInput {}
+    pub struct id_not;
+    impl ::cynic::schema::Field for id_not {
+        type Type = Option<super::ID>;
         const NAME: &'static str = "id_not";
     }
-    impl ::cynic::schema::HasInputField<IdNot, Option<super::Id>> for super::JobWhereInput {}
-    pub struct IdIn;
-    impl ::cynic::schema::Field for IdIn {
-        type Type = Option<Vec<super::Id>>;
+    impl ::cynic::schema::HasInputField<id_not, Option<super::ID>> for super::JobWhereInput {}
+    pub struct id_in;
+    impl ::cynic::schema::Field for id_in {
+        type Type = Option<Vec<super::ID>>;
         const NAME: &'static str = "id_in";
     }
-    impl ::cynic::schema::HasInputField<IdIn, Option<Vec<super::Id>>> for super::JobWhereInput {}
-    pub struct IdNotIn;
-    impl ::cynic::schema::Field for IdNotIn {
-        type Type = Option<Vec<super::Id>>;
+    impl ::cynic::schema::HasInputField<id_in, Option<Vec<super::ID>>> for super::JobWhereInput {}
+    pub struct id_not_in;
+    impl ::cynic::schema::Field for id_not_in {
+        type Type = Option<Vec<super::ID>>;
         const NAME: &'static str = "id_not_in";
     }
-    impl ::cynic::schema::HasInputField<IdNotIn, Option<Vec<super::Id>>> for super::JobWhereInput {}
-    pub struct IdLt;
-    impl ::cynic::schema::Field for IdLt {
-        type Type = Option<super::Id>;
+    impl ::cynic::schema::HasInputField<id_not_in, Option<Vec<super::ID>>> for super::JobWhereInput {}
+    pub struct id_lt;
+    impl ::cynic::schema::Field for id_lt {
+        type Type = Option<super::ID>;
         const NAME: &'static str = "id_lt";
     }
-    impl ::cynic::schema::HasInputField<IdLt, Option<super::Id>> for super::JobWhereInput {}
-    pub struct IdLte;
-    impl ::cynic::schema::Field for IdLte {
-        type Type = Option<super::Id>;
+    impl ::cynic::schema::HasInputField<id_lt, Option<super::ID>> for super::JobWhereInput {}
+    pub struct id_lte;
+    impl ::cynic::schema::Field for id_lte {
+        type Type = Option<super::ID>;
         const NAME: &'static str = "id_lte";
     }
-    impl ::cynic::schema::HasInputField<IdLte, Option<super::Id>> for super::JobWhereInput {}
-    pub struct IdGt;
-    impl ::cynic::schema::Field for IdGt {
-        type Type = Option<super::Id>;
+    impl ::cynic::schema::HasInputField<id_lte, Option<super::ID>> for super::JobWhereInput {}
+    pub struct id_gt;
+    impl ::cynic::schema::Field for id_gt {
+        type Type = Option<super::ID>;
         const NAME: &'static str = "id_gt";
     }
-    impl ::cynic::schema::HasInputField<IdGt, Option<super::Id>> for super::JobWhereInput {}
-    pub struct IdGte;
-    impl ::cynic::schema::Field for IdGte {
-        type Type = Option<super::Id>;
+    impl ::cynic::schema::HasInputField<id_gt, Option<super::ID>> for super::JobWhereInput {}
+    pub struct id_gte;
+    impl ::cynic::schema::Field for id_gte {
+        type Type = Option<super::ID>;
         const NAME: &'static str = "id_gte";
     }
-    impl ::cynic::schema::HasInputField<IdGte, Option<super::Id>> for super::JobWhereInput {}
-    pub struct IdContains;
-    impl ::cynic::schema::Field for IdContains {
-        type Type = Option<super::Id>;
+    impl ::cynic::schema::HasInputField<id_gte, Option<super::ID>> for super::JobWhereInput {}
+    pub struct id_contains;
+    impl ::cynic::schema::Field for id_contains {
+        type Type = Option<super::ID>;
         const NAME: &'static str = "id_contains";
     }
-    impl ::cynic::schema::HasInputField<IdContains, Option<super::Id>> for super::JobWhereInput {}
-    pub struct IdNotContains;
-    impl ::cynic::schema::Field for IdNotContains {
-        type Type = Option<super::Id>;
+    impl ::cynic::schema::HasInputField<id_contains, Option<super::ID>> for super::JobWhereInput {}
+    pub struct id_not_contains;
+    impl ::cynic::schema::Field for id_not_contains {
+        type Type = Option<super::ID>;
         const NAME: &'static str = "id_not_contains";
     }
-    impl ::cynic::schema::HasInputField<IdNotContains, Option<super::Id>> for super::JobWhereInput {}
-    pub struct IdStartsWith;
-    impl ::cynic::schema::Field for IdStartsWith {
-        type Type = Option<super::Id>;
+    impl ::cynic::schema::HasInputField<id_not_contains, Option<super::ID>> for super::JobWhereInput {}
+    pub struct id_starts_with;
+    impl ::cynic::schema::Field for id_starts_with {
+        type Type = Option<super::ID>;
         const NAME: &'static str = "id_starts_with";
     }
-    impl ::cynic::schema::HasInputField<IdStartsWith, Option<super::Id>> for super::JobWhereInput {}
-    pub struct IdNotStartsWith;
-    impl ::cynic::schema::Field for IdNotStartsWith {
-        type Type = Option<super::Id>;
+    impl ::cynic::schema::HasInputField<id_starts_with, Option<super::ID>> for super::JobWhereInput {}
+    pub struct id_not_starts_with;
+    impl ::cynic::schema::Field for id_not_starts_with {
+        type Type = Option<super::ID>;
         const NAME: &'static str = "id_not_starts_with";
     }
-    impl ::cynic::schema::HasInputField<IdNotStartsWith, Option<super::Id>> for super::JobWhereInput {}
-    pub struct IdEndsWith;
-    impl ::cynic::schema::Field for IdEndsWith {
-        type Type = Option<super::Id>;
+    impl ::cynic::schema::HasInputField<id_not_starts_with, Option<super::ID>>
+        for super::JobWhereInput
+    {
+    }
+    pub struct id_ends_with;
+    impl ::cynic::schema::Field for id_ends_with {
+        type Type = Option<super::ID>;
         const NAME: &'static str = "id_ends_with";
     }
-    impl ::cynic::schema::HasInputField<IdEndsWith, Option<super::Id>> for super::JobWhereInput {}
-    pub struct IdNotEndsWith;
-    impl ::cynic::schema::Field for IdNotEndsWith {
-        type Type = Option<super::Id>;
+    impl ::cynic::schema::HasInputField<id_ends_with, Option<super::ID>> for super::JobWhereInput {}
+    pub struct id_not_ends_with;
+    impl ::cynic::schema::Field for id_not_ends_with {
+        type Type = Option<super::ID>;
         const NAME: &'static str = "id_not_ends_with";
     }
-    impl ::cynic::schema::HasInputField<IdNotEndsWith, Option<super::Id>> for super::JobWhereInput {}
-    pub struct Title;
-    impl ::cynic::schema::Field for Title {
+    impl ::cynic::schema::HasInputField<id_not_ends_with, Option<super::ID>> for super::JobWhereInput {}
+    pub struct title;
+    impl ::cynic::schema::Field for title {
         type Type = Option<super::String>;
         const NAME: &'static str = "title";
     }
-    impl ::cynic::schema::HasInputField<Title, Option<super::String>> for super::JobWhereInput {}
-    pub struct TitleNot;
-    impl ::cynic::schema::Field for TitleNot {
+    impl ::cynic::schema::HasInputField<title, Option<super::String>> for super::JobWhereInput {}
+    pub struct title_not;
+    impl ::cynic::schema::Field for title_not {
         type Type = Option<super::String>;
         const NAME: &'static str = "title_not";
     }
-    impl ::cynic::schema::HasInputField<TitleNot, Option<super::String>> for super::JobWhereInput {}
-    pub struct TitleIn;
-    impl ::cynic::schema::Field for TitleIn {
+    impl ::cynic::schema::HasInputField<title_not, Option<super::String>> for super::JobWhereInput {}
+    pub struct title_in;
+    impl ::cynic::schema::Field for title_in {
         type Type = Option<Vec<super::String>>;
         const NAME: &'static str = "title_in";
     }
-    impl ::cynic::schema::HasInputField<TitleIn, Option<Vec<super::String>>> for super::JobWhereInput {}
-    pub struct TitleNotIn;
-    impl ::cynic::schema::Field for TitleNotIn {
+    impl ::cynic::schema::HasInputField<title_in, Option<Vec<super::String>>> for super::JobWhereInput {}
+    pub struct title_not_in;
+    impl ::cynic::schema::Field for title_not_in {
         type Type = Option<Vec<super::String>>;
         const NAME: &'static str = "title_not_in";
     }
-    impl ::cynic::schema::HasInputField<TitleNotIn, Option<Vec<super::String>>>
+    impl ::cynic::schema::HasInputField<title_not_in, Option<Vec<super::String>>>
         for super::JobWhereInput
     {
     }
-    pub struct TitleLt;
-    impl ::cynic::schema::Field for TitleLt {
+    pub struct title_lt;
+    impl ::cynic::schema::Field for title_lt {
         type Type = Option<super::String>;
         const NAME: &'static str = "title_lt";
     }
-    impl ::cynic::schema::HasInputField<TitleLt, Option<super::String>> for super::JobWhereInput {}
-    pub struct TitleLte;
-    impl ::cynic::schema::Field for TitleLte {
+    impl ::cynic::schema::HasInputField<title_lt, Option<super::String>> for super::JobWhereInput {}
+    pub struct title_lte;
+    impl ::cynic::schema::Field for title_lte {
         type Type = Option<super::String>;
         const NAME: &'static str = "title_lte";
     }
-    impl ::cynic::schema::HasInputField<TitleLte, Option<super::String>> for super::JobWhereInput {}
-    pub struct TitleGt;
-    impl ::cynic::schema::Field for TitleGt {
+    impl ::cynic::schema::HasInputField<title_lte, Option<super::String>> for super::JobWhereInput {}
+    pub struct title_gt;
+    impl ::cynic::schema::Field for title_gt {
         type Type = Option<super::String>;
         const NAME: &'static str = "title_gt";
     }
-    impl ::cynic::schema::HasInputField<TitleGt, Option<super::String>> for super::JobWhereInput {}
-    pub struct TitleGte;
-    impl ::cynic::schema::Field for TitleGte {
+    impl ::cynic::schema::HasInputField<title_gt, Option<super::String>> for super::JobWhereInput {}
+    pub struct title_gte;
+    impl ::cynic::schema::Field for title_gte {
         type Type = Option<super::String>;
         const NAME: &'static str = "title_gte";
     }
-    impl ::cynic::schema::HasInputField<TitleGte, Option<super::String>> for super::JobWhereInput {}
-    pub struct TitleContains;
-    impl ::cynic::schema::Field for TitleContains {
+    impl ::cynic::schema::HasInputField<title_gte, Option<super::String>> for super::JobWhereInput {}
+    pub struct title_contains;
+    impl ::cynic::schema::Field for title_contains {
         type Type = Option<super::String>;
         const NAME: &'static str = "title_contains";
     }
-    impl ::cynic::schema::HasInputField<TitleContains, Option<super::String>> for super::JobWhereInput {}
-    pub struct TitleNotContains;
-    impl ::cynic::schema::Field for TitleNotContains {
+    impl ::cynic::schema::HasInputField<title_contains, Option<super::String>>
+        for super::JobWhereInput
+    {
+    }
+    pub struct title_not_contains;
+    impl ::cynic::schema::Field for title_not_contains {
         type Type = Option<super::String>;
         const NAME: &'static str = "title_not_contains";
     }
-    impl ::cynic::schema::HasInputField<TitleNotContains, Option<super::String>>
+    impl ::cynic::schema::HasInputField<title_not_contains, Option<super::String>>
         for super::JobWhereInput
     {
     }
-    pub struct TitleStartsWith;
-    impl ::cynic::schema::Field for TitleStartsWith {
+    pub struct title_starts_with;
+    impl ::cynic::schema::Field for title_starts_with {
         type Type = Option<super::String>;
         const NAME: &'static str = "title_starts_with";
     }
-    impl ::cynic::schema::HasInputField<TitleStartsWith, Option<super::String>>
+    impl ::cynic::schema::HasInputField<title_starts_with, Option<super::String>>
         for super::JobWhereInput
     {
     }
-    pub struct TitleNotStartsWith;
-    impl ::cynic::schema::Field for TitleNotStartsWith {
+    pub struct title_not_starts_with;
+    impl ::cynic::schema::Field for title_not_starts_with {
         type Type = Option<super::String>;
         const NAME: &'static str = "title_not_starts_with";
     }
-    impl ::cynic::schema::HasInputField<TitleNotStartsWith, Option<super::String>>
+    impl ::cynic::schema::HasInputField<title_not_starts_with, Option<super::String>>
         for super::JobWhereInput
     {
     }
-    pub struct TitleEndsWith;
-    impl ::cynic::schema::Field for TitleEndsWith {
+    pub struct title_ends_with;
+    impl ::cynic::schema::Field for title_ends_with {
         type Type = Option<super::String>;
         const NAME: &'static str = "title_ends_with";
     }
-    impl ::cynic::schema::HasInputField<TitleEndsWith, Option<super::String>> for super::JobWhereInput {}
-    pub struct TitleNotEndsWith;
-    impl ::cynic::schema::Field for TitleNotEndsWith {
+    impl ::cynic::schema::HasInputField<title_ends_with, Option<super::String>>
+        for super::JobWhereInput
+    {
+    }
+    pub struct title_not_ends_with;
+    impl ::cynic::schema::Field for title_not_ends_with {
         type Type = Option<super::String>;
         const NAME: &'static str = "title_not_ends_with";
     }
-    impl ::cynic::schema::HasInputField<TitleNotEndsWith, Option<super::String>>
+    impl ::cynic::schema::HasInputField<title_not_ends_with, Option<super::String>>
         for super::JobWhereInput
     {
     }
-    pub struct Slug;
-    impl ::cynic::schema::Field for Slug {
+    pub struct slug;
+    impl ::cynic::schema::Field for slug {
         type Type = Option<super::String>;
         const NAME: &'static str = "slug";
     }
-    impl ::cynic::schema::HasInputField<Slug, Option<super::String>> for super::JobWhereInput {}
-    pub struct SlugNot;
-    impl ::cynic::schema::Field for SlugNot {
+    impl ::cynic::schema::HasInputField<slug, Option<super::String>> for super::JobWhereInput {}
+    pub struct slug_not;
+    impl ::cynic::schema::Field for slug_not {
         type Type = Option<super::String>;
         const NAME: &'static str = "slug_not";
     }
-    impl ::cynic::schema::HasInputField<SlugNot, Option<super::String>> for super::JobWhereInput {}
-    pub struct SlugIn;
-    impl ::cynic::schema::Field for SlugIn {
+    impl ::cynic::schema::HasInputField<slug_not, Option<super::String>> for super::JobWhereInput {}
+    pub struct slug_in;
+    impl ::cynic::schema::Field for slug_in {
         type Type = Option<Vec<super::String>>;
         const NAME: &'static str = "slug_in";
     }
-    impl ::cynic::schema::HasInputField<SlugIn, Option<Vec<super::String>>> for super::JobWhereInput {}
-    pub struct SlugNotIn;
-    impl ::cynic::schema::Field for SlugNotIn {
+    impl ::cynic::schema::HasInputField<slug_in, Option<Vec<super::String>>> for super::JobWhereInput {}
+    pub struct slug_not_in;
+    impl ::cynic::schema::Field for slug_not_in {
         type Type = Option<Vec<super::String>>;
         const NAME: &'static str = "slug_not_in";
     }
-    impl ::cynic::schema::HasInputField<SlugNotIn, Option<Vec<super::String>>>
+    impl ::cynic::schema::HasInputField<slug_not_in, Option<Vec<super::String>>>
         for super::JobWhereInput
     {
     }
-    pub struct SlugLt;
-    impl ::cynic::schema::Field for SlugLt {
+    pub struct slug_lt;
+    impl ::cynic::schema::Field for slug_lt {
         type Type = Option<super::String>;
         const NAME: &'static str = "slug_lt";
     }
-    impl ::cynic::schema::HasInputField<SlugLt, Option<super::String>> for super::JobWhereInput {}
-    pub struct SlugLte;
-    impl ::cynic::schema::Field for SlugLte {
+    impl ::cynic::schema::HasInputField<slug_lt, Option<super::String>> for super::JobWhereInput {}
+    pub struct slug_lte;
+    impl ::cynic::schema::Field for slug_lte {
         type Type = Option<super::String>;
         const NAME: &'static str = "slug_lte";
     }
-    impl ::cynic::schema::HasInputField<SlugLte, Option<super::String>> for super::JobWhereInput {}
-    pub struct SlugGt;
-    impl ::cynic::schema::Field for SlugGt {
+    impl ::cynic::schema::HasInputField<slug_lte, Option<super::String>> for super::JobWhereInput {}
+    pub struct slug_gt;
+    impl ::cynic::schema::Field for slug_gt {
         type Type = Option<super::String>;
         const NAME: &'static str = "slug_gt";
     }
-    impl ::cynic::schema::HasInputField<SlugGt, Option<super::String>> for super::JobWhereInput {}
-    pub struct SlugGte;
-    impl ::cynic::schema::Field for SlugGte {
+    impl ::cynic::schema::HasInputField<slug_gt, Option<super::String>> for super::JobWhereInput {}
+    pub struct slug_gte;
+    impl ::cynic::schema::Field for slug_gte {
         type Type = Option<super::String>;
         const NAME: &'static str = "slug_gte";
     }
-    impl ::cynic::schema::HasInputField<SlugGte, Option<super::String>> for super::JobWhereInput {}
-    pub struct SlugContains;
-    impl ::cynic::schema::Field for SlugContains {
+    impl ::cynic::schema::HasInputField<slug_gte, Option<super::String>> for super::JobWhereInput {}
+    pub struct slug_contains;
+    impl ::cynic::schema::Field for slug_contains {
         type Type = Option<super::String>;
         const NAME: &'static str = "slug_contains";
     }
-    impl ::cynic::schema::HasInputField<SlugContains, Option<super::String>> for super::JobWhereInput {}
-    pub struct SlugNotContains;
-    impl ::cynic::schema::Field for SlugNotContains {
+    impl ::cynic::schema::HasInputField<slug_contains, Option<super::String>> for super::JobWhereInput {}
+    pub struct slug_not_contains;
+    impl ::cynic::schema::Field for slug_not_contains {
         type Type = Option<super::String>;
         const NAME: &'static str = "slug_not_contains";
     }
-    impl ::cynic::schema::HasInputField<SlugNotContains, Option<super::String>>
+    impl ::cynic::schema::HasInputField<slug_not_contains, Option<super::String>>
         for super::JobWhereInput
     {
     }
-    pub struct SlugStartsWith;
-    impl ::cynic::schema::Field for SlugStartsWith {
+    pub struct slug_starts_with;
+    impl ::cynic::schema::Field for slug_starts_with {
         type Type = Option<super::String>;
         const NAME: &'static str = "slug_starts_with";
     }
-    impl ::cynic::schema::HasInputField<SlugStartsWith, Option<super::String>>
+    impl ::cynic::schema::HasInputField<slug_starts_with, Option<super::String>>
         for super::JobWhereInput
     {
     }
-    pub struct SlugNotStartsWith;
-    impl ::cynic::schema::Field for SlugNotStartsWith {
+    pub struct slug_not_starts_with;
+    impl ::cynic::schema::Field for slug_not_starts_with {
         type Type = Option<super::String>;
         const NAME: &'static str = "slug_not_starts_with";
     }
-    impl ::cynic::schema::HasInputField<SlugNotStartsWith, Option<super::String>>
+    impl ::cynic::schema::HasInputField<slug_not_starts_with, Option<super::String>>
         for super::JobWhereInput
     {
     }
-    pub struct SlugEndsWith;
-    impl ::cynic::schema::Field for SlugEndsWith {
+    pub struct slug_ends_with;
+    impl ::cynic::schema::Field for slug_ends_with {
         type Type = Option<super::String>;
         const NAME: &'static str = "slug_ends_with";
     }
-    impl ::cynic::schema::HasInputField<SlugEndsWith, Option<super::String>> for super::JobWhereInput {}
-    pub struct SlugNotEndsWith;
-    impl ::cynic::schema::Field for SlugNotEndsWith {
+    impl ::cynic::schema::HasInputField<slug_ends_with, Option<super::String>>
+        for super::JobWhereInput
+    {
+    }
+    pub struct slug_not_ends_with;
+    impl ::cynic::schema::Field for slug_not_ends_with {
         type Type = Option<super::String>;
         const NAME: &'static str = "slug_not_ends_with";
     }
-    impl ::cynic::schema::HasInputField<SlugNotEndsWith, Option<super::String>>
+    impl ::cynic::schema::HasInputField<slug_not_ends_with, Option<super::String>>
         for super::JobWhereInput
     {
     }
-    pub struct Commitment;
-    impl ::cynic::schema::Field for Commitment {
+    pub struct commitment;
+    impl ::cynic::schema::Field for commitment {
         type Type = Option<super::CommitmentWhereInput>;
         const NAME: &'static str = "commitment";
     }
-    impl ::cynic::schema::HasInputField<Commitment, Option<super::CommitmentWhereInput>>
+    impl ::cynic::schema::HasInputField<commitment, Option<super::CommitmentWhereInput>>
         for super::JobWhereInput
     {
     }
-    pub struct CitiesEvery;
-    impl ::cynic::schema::Field for CitiesEvery {
+    pub struct cities_every;
+    impl ::cynic::schema::Field for cities_every {
         type Type = Option<super::CityWhereInput>;
         const NAME: &'static str = "cities_every";
     }
-    impl ::cynic::schema::HasInputField<CitiesEvery, Option<super::CityWhereInput>>
+    impl ::cynic::schema::HasInputField<cities_every, Option<super::CityWhereInput>>
         for super::JobWhereInput
     {
     }
-    pub struct CitiesSome;
-    impl ::cynic::schema::Field for CitiesSome {
+    pub struct cities_some;
+    impl ::cynic::schema::Field for cities_some {
         type Type = Option<super::CityWhereInput>;
         const NAME: &'static str = "cities_some";
     }
-    impl ::cynic::schema::HasInputField<CitiesSome, Option<super::CityWhereInput>>
+    impl ::cynic::schema::HasInputField<cities_some, Option<super::CityWhereInput>>
         for super::JobWhereInput
     {
     }
-    pub struct CitiesNone;
-    impl ::cynic::schema::Field for CitiesNone {
+    pub struct cities_none;
+    impl ::cynic::schema::Field for cities_none {
         type Type = Option<super::CityWhereInput>;
         const NAME: &'static str = "cities_none";
     }
-    impl ::cynic::schema::HasInputField<CitiesNone, Option<super::CityWhereInput>>
+    impl ::cynic::schema::HasInputField<cities_none, Option<super::CityWhereInput>>
         for super::JobWhereInput
     {
     }
-    pub struct CountriesEvery;
-    impl ::cynic::schema::Field for CountriesEvery {
+    pub struct countries_every;
+    impl ::cynic::schema::Field for countries_every {
         type Type = Option<super::CountryWhereInput>;
         const NAME: &'static str = "countries_every";
     }
-    impl ::cynic::schema::HasInputField<CountriesEvery, Option<super::CountryWhereInput>>
+    impl ::cynic::schema::HasInputField<countries_every, Option<super::CountryWhereInput>>
         for super::JobWhereInput
     {
     }
-    pub struct CountriesSome;
-    impl ::cynic::schema::Field for CountriesSome {
+    pub struct countries_some;
+    impl ::cynic::schema::Field for countries_some {
         type Type = Option<super::CountryWhereInput>;
         const NAME: &'static str = "countries_some";
     }
-    impl ::cynic::schema::HasInputField<CountriesSome, Option<super::CountryWhereInput>>
+    impl ::cynic::schema::HasInputField<countries_some, Option<super::CountryWhereInput>>
         for super::JobWhereInput
     {
     }
-    pub struct CountriesNone;
-    impl ::cynic::schema::Field for CountriesNone {
+    pub struct countries_none;
+    impl ::cynic::schema::Field for countries_none {
         type Type = Option<super::CountryWhereInput>;
         const NAME: &'static str = "countries_none";
     }
-    impl ::cynic::schema::HasInputField<CountriesNone, Option<super::CountryWhereInput>>
+    impl ::cynic::schema::HasInputField<countries_none, Option<super::CountryWhereInput>>
         for super::JobWhereInput
     {
     }
-    pub struct RemotesEvery;
-    impl ::cynic::schema::Field for RemotesEvery {
+    pub struct remotes_every;
+    impl ::cynic::schema::Field for remotes_every {
         type Type = Option<super::RemoteWhereInput>;
         const NAME: &'static str = "remotes_every";
     }
-    impl ::cynic::schema::HasInputField<RemotesEvery, Option<super::RemoteWhereInput>>
+    impl ::cynic::schema::HasInputField<remotes_every, Option<super::RemoteWhereInput>>
         for super::JobWhereInput
     {
     }
-    pub struct RemotesSome;
-    impl ::cynic::schema::Field for RemotesSome {
+    pub struct remotes_some;
+    impl ::cynic::schema::Field for remotes_some {
         type Type = Option<super::RemoteWhereInput>;
         const NAME: &'static str = "remotes_some";
     }
-    impl ::cynic::schema::HasInputField<RemotesSome, Option<super::RemoteWhereInput>>
+    impl ::cynic::schema::HasInputField<remotes_some, Option<super::RemoteWhereInput>>
         for super::JobWhereInput
     {
     }
-    pub struct RemotesNone;
-    impl ::cynic::schema::Field for RemotesNone {
+    pub struct remotes_none;
+    impl ::cynic::schema::Field for remotes_none {
         type Type = Option<super::RemoteWhereInput>;
         const NAME: &'static str = "remotes_none";
     }
-    impl ::cynic::schema::HasInputField<RemotesNone, Option<super::RemoteWhereInput>>
+    impl ::cynic::schema::HasInputField<remotes_none, Option<super::RemoteWhereInput>>
         for super::JobWhereInput
     {
     }
-    pub struct Description;
-    impl ::cynic::schema::Field for Description {
+    pub struct description;
+    impl ::cynic::schema::Field for description {
         type Type = Option<super::String>;
         const NAME: &'static str = "description";
     }
-    impl ::cynic::schema::HasInputField<Description, Option<super::String>> for super::JobWhereInput {}
-    pub struct DescriptionNot;
-    impl ::cynic::schema::Field for DescriptionNot {
+    impl ::cynic::schema::HasInputField<description, Option<super::String>> for super::JobWhereInput {}
+    pub struct description_not;
+    impl ::cynic::schema::Field for description_not {
         type Type = Option<super::String>;
         const NAME: &'static str = "description_not";
     }
-    impl ::cynic::schema::HasInputField<DescriptionNot, Option<super::String>>
+    impl ::cynic::schema::HasInputField<description_not, Option<super::String>>
         for super::JobWhereInput
     {
     }
-    pub struct DescriptionIn;
-    impl ::cynic::schema::Field for DescriptionIn {
+    pub struct description_in;
+    impl ::cynic::schema::Field for description_in {
         type Type = Option<Vec<super::String>>;
         const NAME: &'static str = "description_in";
     }
-    impl ::cynic::schema::HasInputField<DescriptionIn, Option<Vec<super::String>>>
+    impl ::cynic::schema::HasInputField<description_in, Option<Vec<super::String>>>
         for super::JobWhereInput
     {
     }
-    pub struct DescriptionNotIn;
-    impl ::cynic::schema::Field for DescriptionNotIn {
+    pub struct description_not_in;
+    impl ::cynic::schema::Field for description_not_in {
         type Type = Option<Vec<super::String>>;
         const NAME: &'static str = "description_not_in";
     }
-    impl ::cynic::schema::HasInputField<DescriptionNotIn, Option<Vec<super::String>>>
+    impl ::cynic::schema::HasInputField<description_not_in, Option<Vec<super::String>>>
         for super::JobWhereInput
     {
     }
-    pub struct DescriptionLt;
-    impl ::cynic::schema::Field for DescriptionLt {
+    pub struct description_lt;
+    impl ::cynic::schema::Field for description_lt {
         type Type = Option<super::String>;
         const NAME: &'static str = "description_lt";
     }
-    impl ::cynic::schema::HasInputField<DescriptionLt, Option<super::String>> for super::JobWhereInput {}
-    pub struct DescriptionLte;
-    impl ::cynic::schema::Field for DescriptionLte {
+    impl ::cynic::schema::HasInputField<description_lt, Option<super::String>>
+        for super::JobWhereInput
+    {
+    }
+    pub struct description_lte;
+    impl ::cynic::schema::Field for description_lte {
         type Type = Option<super::String>;
         const NAME: &'static str = "description_lte";
     }
-    impl ::cynic::schema::HasInputField<DescriptionLte, Option<super::String>>
+    impl ::cynic::schema::HasInputField<description_lte, Option<super::String>>
         for super::JobWhereInput
     {
     }
-    pub struct DescriptionGt;
-    impl ::cynic::schema::Field for DescriptionGt {
+    pub struct description_gt;
+    impl ::cynic::schema::Field for description_gt {
         type Type = Option<super::String>;
         const NAME: &'static str = "description_gt";
     }
-    impl ::cynic::schema::HasInputField<DescriptionGt, Option<super::String>> for super::JobWhereInput {}
-    pub struct DescriptionGte;
-    impl ::cynic::schema::Field for DescriptionGte {
+    impl ::cynic::schema::HasInputField<description_gt, Option<super::String>>
+        for super::JobWhereInput
+    {
+    }
+    pub struct description_gte;
+    impl ::cynic::schema::Field for description_gte {
         type Type = Option<super::String>;
         const NAME: &'static str = "description_gte";
     }
-    impl ::cynic::schema::HasInputField<DescriptionGte, Option<super::String>>
+    impl ::cynic::schema::HasInputField<description_gte, Option<super::String>>
         for super::JobWhereInput
     {
     }
-    pub struct DescriptionContains;
-    impl ::cynic::schema::Field for DescriptionContains {
+    pub struct description_contains;
+    impl ::cynic::schema::Field for description_contains {
         type Type = Option<super::String>;
         const NAME: &'static str = "description_contains";
     }
-    impl ::cynic::schema::HasInputField<DescriptionContains, Option<super::String>>
+    impl ::cynic::schema::HasInputField<description_contains, Option<super::String>>
         for super::JobWhereInput
     {
     }
-    pub struct DescriptionNotContains;
-    impl ::cynic::schema::Field for DescriptionNotContains {
+    pub struct description_not_contains;
+    impl ::cynic::schema::Field for description_not_contains {
         type Type = Option<super::String>;
         const NAME: &'static str = "description_not_contains";
     }
-    impl ::cynic::schema::HasInputField<DescriptionNotContains, Option<super::String>>
+    impl ::cynic::schema::HasInputField<description_not_contains, Option<super::String>>
         for super::JobWhereInput
     {
     }
-    pub struct DescriptionStartsWith;
-    impl ::cynic::schema::Field for DescriptionStartsWith {
+    pub struct description_starts_with;
+    impl ::cynic::schema::Field for description_starts_with {
         type Type = Option<super::String>;
         const NAME: &'static str = "description_starts_with";
     }
-    impl ::cynic::schema::HasInputField<DescriptionStartsWith, Option<super::String>>
+    impl ::cynic::schema::HasInputField<description_starts_with, Option<super::String>>
         for super::JobWhereInput
     {
     }
-    pub struct DescriptionNotStartsWith;
-    impl ::cynic::schema::Field for DescriptionNotStartsWith {
+    pub struct description_not_starts_with;
+    impl ::cynic::schema::Field for description_not_starts_with {
         type Type = Option<super::String>;
         const NAME: &'static str = "description_not_starts_with";
     }
-    impl ::cynic::schema::HasInputField<DescriptionNotStartsWith, Option<super::String>>
+    impl ::cynic::schema::HasInputField<description_not_starts_with, Option<super::String>>
         for super::JobWhereInput
     {
     }
-    pub struct DescriptionEndsWith;
-    impl ::cynic::schema::Field for DescriptionEndsWith {
+    pub struct description_ends_with;
+    impl ::cynic::schema::Field for description_ends_with {
         type Type = Option<super::String>;
         const NAME: &'static str = "description_ends_with";
     }
-    impl ::cynic::schema::HasInputField<DescriptionEndsWith, Option<super::String>>
+    impl ::cynic::schema::HasInputField<description_ends_with, Option<super::String>>
         for super::JobWhereInput
     {
     }
-    pub struct DescriptionNotEndsWith;
-    impl ::cynic::schema::Field for DescriptionNotEndsWith {
+    pub struct description_not_ends_with;
+    impl ::cynic::schema::Field for description_not_ends_with {
         type Type = Option<super::String>;
         const NAME: &'static str = "description_not_ends_with";
     }
-    impl ::cynic::schema::HasInputField<DescriptionNotEndsWith, Option<super::String>>
+    impl ::cynic::schema::HasInputField<description_not_ends_with, Option<super::String>>
         for super::JobWhereInput
     {
     }
-    pub struct ApplyUrl;
-    impl ::cynic::schema::Field for ApplyUrl {
+    pub struct applyUrl;
+    impl ::cynic::schema::Field for applyUrl {
         type Type = Option<super::String>;
         const NAME: &'static str = "applyUrl";
     }
-    impl ::cynic::schema::HasInputField<ApplyUrl, Option<super::String>> for super::JobWhereInput {}
-    pub struct ApplyUrlNot;
-    impl ::cynic::schema::Field for ApplyUrlNot {
+    impl ::cynic::schema::HasInputField<applyUrl, Option<super::String>> for super::JobWhereInput {}
+    pub struct applyUrl_not;
+    impl ::cynic::schema::Field for applyUrl_not {
         type Type = Option<super::String>;
         const NAME: &'static str = "applyUrl_not";
     }
-    impl ::cynic::schema::HasInputField<ApplyUrlNot, Option<super::String>> for super::JobWhereInput {}
-    pub struct ApplyUrlIn;
-    impl ::cynic::schema::Field for ApplyUrlIn {
+    impl ::cynic::schema::HasInputField<applyUrl_not, Option<super::String>> for super::JobWhereInput {}
+    pub struct applyUrl_in;
+    impl ::cynic::schema::Field for applyUrl_in {
         type Type = Option<Vec<super::String>>;
         const NAME: &'static str = "applyUrl_in";
     }
-    impl ::cynic::schema::HasInputField<ApplyUrlIn, Option<Vec<super::String>>>
+    impl ::cynic::schema::HasInputField<applyUrl_in, Option<Vec<super::String>>>
         for super::JobWhereInput
     {
     }
-    pub struct ApplyUrlNotIn;
-    impl ::cynic::schema::Field for ApplyUrlNotIn {
+    pub struct applyUrl_not_in;
+    impl ::cynic::schema::Field for applyUrl_not_in {
         type Type = Option<Vec<super::String>>;
         const NAME: &'static str = "applyUrl_not_in";
     }
-    impl ::cynic::schema::HasInputField<ApplyUrlNotIn, Option<Vec<super::String>>>
+    impl ::cynic::schema::HasInputField<applyUrl_not_in, Option<Vec<super::String>>>
         for super::JobWhereInput
     {
     }
-    pub struct ApplyUrlLt;
-    impl ::cynic::schema::Field for ApplyUrlLt {
+    pub struct applyUrl_lt;
+    impl ::cynic::schema::Field for applyUrl_lt {
         type Type = Option<super::String>;
         const NAME: &'static str = "applyUrl_lt";
     }
-    impl ::cynic::schema::HasInputField<ApplyUrlLt, Option<super::String>> for super::JobWhereInput {}
-    pub struct ApplyUrlLte;
-    impl ::cynic::schema::Field for ApplyUrlLte {
+    impl ::cynic::schema::HasInputField<applyUrl_lt, Option<super::String>> for super::JobWhereInput {}
+    pub struct applyUrl_lte;
+    impl ::cynic::schema::Field for applyUrl_lte {
         type Type = Option<super::String>;
         const NAME: &'static str = "applyUrl_lte";
     }
-    impl ::cynic::schema::HasInputField<ApplyUrlLte, Option<super::String>> for super::JobWhereInput {}
-    pub struct ApplyUrlGt;
-    impl ::cynic::schema::Field for ApplyUrlGt {
+    impl ::cynic::schema::HasInputField<applyUrl_lte, Option<super::String>> for super::JobWhereInput {}
+    pub struct applyUrl_gt;
+    impl ::cynic::schema::Field for applyUrl_gt {
         type Type = Option<super::String>;
         const NAME: &'static str = "applyUrl_gt";
     }
-    impl ::cynic::schema::HasInputField<ApplyUrlGt, Option<super::String>> for super::JobWhereInput {}
-    pub struct ApplyUrlGte;
-    impl ::cynic::schema::Field for ApplyUrlGte {
+    impl ::cynic::schema::HasInputField<applyUrl_gt, Option<super::String>> for super::JobWhereInput {}
+    pub struct applyUrl_gte;
+    impl ::cynic::schema::Field for applyUrl_gte {
         type Type = Option<super::String>;
         const NAME: &'static str = "applyUrl_gte";
     }
-    impl ::cynic::schema::HasInputField<ApplyUrlGte, Option<super::String>> for super::JobWhereInput {}
-    pub struct ApplyUrlContains;
-    impl ::cynic::schema::Field for ApplyUrlContains {
+    impl ::cynic::schema::HasInputField<applyUrl_gte, Option<super::String>> for super::JobWhereInput {}
+    pub struct applyUrl_contains;
+    impl ::cynic::schema::Field for applyUrl_contains {
         type Type = Option<super::String>;
         const NAME: &'static str = "applyUrl_contains";
     }
-    impl ::cynic::schema::HasInputField<ApplyUrlContains, Option<super::String>>
+    impl ::cynic::schema::HasInputField<applyUrl_contains, Option<super::String>>
         for super::JobWhereInput
     {
     }
-    pub struct ApplyUrlNotContains;
-    impl ::cynic::schema::Field for ApplyUrlNotContains {
+    pub struct applyUrl_not_contains;
+    impl ::cynic::schema::Field for applyUrl_not_contains {
         type Type = Option<super::String>;
         const NAME: &'static str = "applyUrl_not_contains";
     }
-    impl ::cynic::schema::HasInputField<ApplyUrlNotContains, Option<super::String>>
+    impl ::cynic::schema::HasInputField<applyUrl_not_contains, Option<super::String>>
         for super::JobWhereInput
     {
     }
-    pub struct ApplyUrlStartsWith;
-    impl ::cynic::schema::Field for ApplyUrlStartsWith {
+    pub struct applyUrl_starts_with;
+    impl ::cynic::schema::Field for applyUrl_starts_with {
         type Type = Option<super::String>;
         const NAME: &'static str = "applyUrl_starts_with";
     }
-    impl ::cynic::schema::HasInputField<ApplyUrlStartsWith, Option<super::String>>
+    impl ::cynic::schema::HasInputField<applyUrl_starts_with, Option<super::String>>
         for super::JobWhereInput
     {
     }
-    pub struct ApplyUrlNotStartsWith;
-    impl ::cynic::schema::Field for ApplyUrlNotStartsWith {
+    pub struct applyUrl_not_starts_with;
+    impl ::cynic::schema::Field for applyUrl_not_starts_with {
         type Type = Option<super::String>;
         const NAME: &'static str = "applyUrl_not_starts_with";
     }
-    impl ::cynic::schema::HasInputField<ApplyUrlNotStartsWith, Option<super::String>>
+    impl ::cynic::schema::HasInputField<applyUrl_not_starts_with, Option<super::String>>
         for super::JobWhereInput
     {
     }
-    pub struct ApplyUrlEndsWith;
-    impl ::cynic::schema::Field for ApplyUrlEndsWith {
+    pub struct applyUrl_ends_with;
+    impl ::cynic::schema::Field for applyUrl_ends_with {
         type Type = Option<super::String>;
         const NAME: &'static str = "applyUrl_ends_with";
     }
-    impl ::cynic::schema::HasInputField<ApplyUrlEndsWith, Option<super::String>>
+    impl ::cynic::schema::HasInputField<applyUrl_ends_with, Option<super::String>>
         for super::JobWhereInput
     {
     }
-    pub struct ApplyUrlNotEndsWith;
-    impl ::cynic::schema::Field for ApplyUrlNotEndsWith {
+    pub struct applyUrl_not_ends_with;
+    impl ::cynic::schema::Field for applyUrl_not_ends_with {
         type Type = Option<super::String>;
         const NAME: &'static str = "applyUrl_not_ends_with";
     }
-    impl ::cynic::schema::HasInputField<ApplyUrlNotEndsWith, Option<super::String>>
+    impl ::cynic::schema::HasInputField<applyUrl_not_ends_with, Option<super::String>>
         for super::JobWhereInput
     {
     }
-    pub struct Company;
-    impl ::cynic::schema::Field for Company {
+    pub struct company;
+    impl ::cynic::schema::Field for company {
         type Type = Option<super::CompanyWhereInput>;
         const NAME: &'static str = "company";
     }
-    impl ::cynic::schema::HasInputField<Company, Option<super::CompanyWhereInput>>
+    impl ::cynic::schema::HasInputField<company, Option<super::CompanyWhereInput>>
         for super::JobWhereInput
     {
     }
-    pub struct TagsEvery;
-    impl ::cynic::schema::Field for TagsEvery {
+    pub struct tags_every;
+    impl ::cynic::schema::Field for tags_every {
         type Type = Option<super::TagWhereInput>;
         const NAME: &'static str = "tags_every";
     }
-    impl ::cynic::schema::HasInputField<TagsEvery, Option<super::TagWhereInput>>
+    impl ::cynic::schema::HasInputField<tags_every, Option<super::TagWhereInput>>
         for super::JobWhereInput
     {
     }
-    pub struct TagsSome;
-    impl ::cynic::schema::Field for TagsSome {
+    pub struct tags_some;
+    impl ::cynic::schema::Field for tags_some {
         type Type = Option<super::TagWhereInput>;
         const NAME: &'static str = "tags_some";
     }
-    impl ::cynic::schema::HasInputField<TagsSome, Option<super::TagWhereInput>>
+    impl ::cynic::schema::HasInputField<tags_some, Option<super::TagWhereInput>>
         for super::JobWhereInput
     {
     }
-    pub struct TagsNone;
-    impl ::cynic::schema::Field for TagsNone {
+    pub struct tags_none;
+    impl ::cynic::schema::Field for tags_none {
         type Type = Option<super::TagWhereInput>;
         const NAME: &'static str = "tags_none";
     }
-    impl ::cynic::schema::HasInputField<TagsNone, Option<super::TagWhereInput>>
+    impl ::cynic::schema::HasInputField<tags_none, Option<super::TagWhereInput>>
         for super::JobWhereInput
     {
     }
-    pub struct IsPublished;
-    impl ::cynic::schema::Field for IsPublished {
+    pub struct isPublished;
+    impl ::cynic::schema::Field for isPublished {
         type Type = Option<super::Boolean>;
         const NAME: &'static str = "isPublished";
     }
-    impl ::cynic::schema::HasInputField<IsPublished, Option<super::Boolean>> for super::JobWhereInput {}
-    pub struct IsPublishedNot;
-    impl ::cynic::schema::Field for IsPublishedNot {
+    impl ::cynic::schema::HasInputField<isPublished, Option<super::Boolean>> for super::JobWhereInput {}
+    pub struct isPublished_not;
+    impl ::cynic::schema::Field for isPublished_not {
         type Type = Option<super::Boolean>;
         const NAME: &'static str = "isPublished_not";
     }
-    impl ::cynic::schema::HasInputField<IsPublishedNot, Option<super::Boolean>>
+    impl ::cynic::schema::HasInputField<isPublished_not, Option<super::Boolean>>
         for super::JobWhereInput
     {
     }
-    pub struct IsFeatured;
-    impl ::cynic::schema::Field for IsFeatured {
+    pub struct isFeatured;
+    impl ::cynic::schema::Field for isFeatured {
         type Type = Option<super::Boolean>;
         const NAME: &'static str = "isFeatured";
     }
-    impl ::cynic::schema::HasInputField<IsFeatured, Option<super::Boolean>> for super::JobWhereInput {}
-    pub struct IsFeaturedNot;
-    impl ::cynic::schema::Field for IsFeaturedNot {
+    impl ::cynic::schema::HasInputField<isFeatured, Option<super::Boolean>> for super::JobWhereInput {}
+    pub struct isFeatured_not;
+    impl ::cynic::schema::Field for isFeatured_not {
         type Type = Option<super::Boolean>;
         const NAME: &'static str = "isFeatured_not";
     }
-    impl ::cynic::schema::HasInputField<IsFeaturedNot, Option<super::Boolean>>
+    impl ::cynic::schema::HasInputField<isFeatured_not, Option<super::Boolean>>
         for super::JobWhereInput
     {
     }
-    pub struct LocationNames;
-    impl ::cynic::schema::Field for LocationNames {
+    pub struct locationNames;
+    impl ::cynic::schema::Field for locationNames {
         type Type = Option<super::String>;
         const NAME: &'static str = "locationNames";
     }
-    impl ::cynic::schema::HasInputField<LocationNames, Option<super::String>> for super::JobWhereInput {}
-    pub struct LocationNamesNot;
-    impl ::cynic::schema::Field for LocationNamesNot {
+    impl ::cynic::schema::HasInputField<locationNames, Option<super::String>> for super::JobWhereInput {}
+    pub struct locationNames_not;
+    impl ::cynic::schema::Field for locationNames_not {
         type Type = Option<super::String>;
         const NAME: &'static str = "locationNames_not";
     }
-    impl ::cynic::schema::HasInputField<LocationNamesNot, Option<super::String>>
+    impl ::cynic::schema::HasInputField<locationNames_not, Option<super::String>>
         for super::JobWhereInput
     {
     }
-    pub struct LocationNamesIn;
-    impl ::cynic::schema::Field for LocationNamesIn {
+    pub struct locationNames_in;
+    impl ::cynic::schema::Field for locationNames_in {
         type Type = Option<Vec<super::String>>;
         const NAME: &'static str = "locationNames_in";
     }
-    impl ::cynic::schema::HasInputField<LocationNamesIn, Option<Vec<super::String>>>
+    impl ::cynic::schema::HasInputField<locationNames_in, Option<Vec<super::String>>>
         for super::JobWhereInput
     {
     }
-    pub struct LocationNamesNotIn;
-    impl ::cynic::schema::Field for LocationNamesNotIn {
+    pub struct locationNames_not_in;
+    impl ::cynic::schema::Field for locationNames_not_in {
         type Type = Option<Vec<super::String>>;
         const NAME: &'static str = "locationNames_not_in";
     }
-    impl ::cynic::schema::HasInputField<LocationNamesNotIn, Option<Vec<super::String>>>
+    impl ::cynic::schema::HasInputField<locationNames_not_in, Option<Vec<super::String>>>
         for super::JobWhereInput
     {
     }
-    pub struct LocationNamesLt;
-    impl ::cynic::schema::Field for LocationNamesLt {
+    pub struct locationNames_lt;
+    impl ::cynic::schema::Field for locationNames_lt {
         type Type = Option<super::String>;
         const NAME: &'static str = "locationNames_lt";
     }
-    impl ::cynic::schema::HasInputField<LocationNamesLt, Option<super::String>>
+    impl ::cynic::schema::HasInputField<locationNames_lt, Option<super::String>>
         for super::JobWhereInput
     {
     }
-    pub struct LocationNamesLte;
-    impl ::cynic::schema::Field for LocationNamesLte {
+    pub struct locationNames_lte;
+    impl ::cynic::schema::Field for locationNames_lte {
         type Type = Option<super::String>;
         const NAME: &'static str = "locationNames_lte";
     }
-    impl ::cynic::schema::HasInputField<LocationNamesLte, Option<super::String>>
+    impl ::cynic::schema::HasInputField<locationNames_lte, Option<super::String>>
         for super::JobWhereInput
     {
     }
-    pub struct LocationNamesGt;
-    impl ::cynic::schema::Field for LocationNamesGt {
+    pub struct locationNames_gt;
+    impl ::cynic::schema::Field for locationNames_gt {
         type Type = Option<super::String>;
         const NAME: &'static str = "locationNames_gt";
     }
-    impl ::cynic::schema::HasInputField<LocationNamesGt, Option<super::String>>
+    impl ::cynic::schema::HasInputField<locationNames_gt, Option<super::String>>
         for super::JobWhereInput
     {
     }
-    pub struct LocationNamesGte;
-    impl ::cynic::schema::Field for LocationNamesGte {
+    pub struct locationNames_gte;
+    impl ::cynic::schema::Field for locationNames_gte {
         type Type = Option<super::String>;
         const NAME: &'static str = "locationNames_gte";
     }
-    impl ::cynic::schema::HasInputField<LocationNamesGte, Option<super::String>>
+    impl ::cynic::schema::HasInputField<locationNames_gte, Option<super::String>>
         for super::JobWhereInput
     {
     }
-    pub struct LocationNamesContains;
-    impl ::cynic::schema::Field for LocationNamesContains {
+    pub struct locationNames_contains;
+    impl ::cynic::schema::Field for locationNames_contains {
         type Type = Option<super::String>;
         const NAME: &'static str = "locationNames_contains";
     }
-    impl ::cynic::schema::HasInputField<LocationNamesContains, Option<super::String>>
+    impl ::cynic::schema::HasInputField<locationNames_contains, Option<super::String>>
         for super::JobWhereInput
     {
     }
-    pub struct LocationNamesNotContains;
-    impl ::cynic::schema::Field for LocationNamesNotContains {
+    pub struct locationNames_not_contains;
+    impl ::cynic::schema::Field for locationNames_not_contains {
         type Type = Option<super::String>;
         const NAME: &'static str = "locationNames_not_contains";
     }
-    impl ::cynic::schema::HasInputField<LocationNamesNotContains, Option<super::String>>
+    impl ::cynic::schema::HasInputField<locationNames_not_contains, Option<super::String>>
         for super::JobWhereInput
     {
     }
-    pub struct LocationNamesStartsWith;
-    impl ::cynic::schema::Field for LocationNamesStartsWith {
+    pub struct locationNames_starts_with;
+    impl ::cynic::schema::Field for locationNames_starts_with {
         type Type = Option<super::String>;
         const NAME: &'static str = "locationNames_starts_with";
     }
-    impl ::cynic::schema::HasInputField<LocationNamesStartsWith, Option<super::String>>
+    impl ::cynic::schema::HasInputField<locationNames_starts_with, Option<super::String>>
         for super::JobWhereInput
     {
     }
-    pub struct LocationNamesNotStartsWith;
-    impl ::cynic::schema::Field for LocationNamesNotStartsWith {
+    pub struct locationNames_not_starts_with;
+    impl ::cynic::schema::Field for locationNames_not_starts_with {
         type Type = Option<super::String>;
         const NAME: &'static str = "locationNames_not_starts_with";
     }
-    impl ::cynic::schema::HasInputField<LocationNamesNotStartsWith, Option<super::String>>
+    impl ::cynic::schema::HasInputField<locationNames_not_starts_with, Option<super::String>>
         for super::JobWhereInput
     {
     }
-    pub struct LocationNamesEndsWith;
-    impl ::cynic::schema::Field for LocationNamesEndsWith {
+    pub struct locationNames_ends_with;
+    impl ::cynic::schema::Field for locationNames_ends_with {
         type Type = Option<super::String>;
         const NAME: &'static str = "locationNames_ends_with";
     }
-    impl ::cynic::schema::HasInputField<LocationNamesEndsWith, Option<super::String>>
+    impl ::cynic::schema::HasInputField<locationNames_ends_with, Option<super::String>>
         for super::JobWhereInput
     {
     }
-    pub struct LocationNamesNotEndsWith;
-    impl ::cynic::schema::Field for LocationNamesNotEndsWith {
+    pub struct locationNames_not_ends_with;
+    impl ::cynic::schema::Field for locationNames_not_ends_with {
         type Type = Option<super::String>;
         const NAME: &'static str = "locationNames_not_ends_with";
     }
-    impl ::cynic::schema::HasInputField<LocationNamesNotEndsWith, Option<super::String>>
+    impl ::cynic::schema::HasInputField<locationNames_not_ends_with, Option<super::String>>
         for super::JobWhereInput
     {
     }
-    pub struct UserEmail;
-    impl ::cynic::schema::Field for UserEmail {
+    pub struct userEmail;
+    impl ::cynic::schema::Field for userEmail {
         type Type = Option<super::String>;
         const NAME: &'static str = "userEmail";
     }
-    impl ::cynic::schema::HasInputField<UserEmail, Option<super::String>> for super::JobWhereInput {}
-    pub struct UserEmailNot;
-    impl ::cynic::schema::Field for UserEmailNot {
+    impl ::cynic::schema::HasInputField<userEmail, Option<super::String>> for super::JobWhereInput {}
+    pub struct userEmail_not;
+    impl ::cynic::schema::Field for userEmail_not {
         type Type = Option<super::String>;
         const NAME: &'static str = "userEmail_not";
     }
-    impl ::cynic::schema::HasInputField<UserEmailNot, Option<super::String>> for super::JobWhereInput {}
-    pub struct UserEmailIn;
-    impl ::cynic::schema::Field for UserEmailIn {
+    impl ::cynic::schema::HasInputField<userEmail_not, Option<super::String>> for super::JobWhereInput {}
+    pub struct userEmail_in;
+    impl ::cynic::schema::Field for userEmail_in {
         type Type = Option<Vec<super::String>>;
         const NAME: &'static str = "userEmail_in";
     }
-    impl ::cynic::schema::HasInputField<UserEmailIn, Option<Vec<super::String>>>
+    impl ::cynic::schema::HasInputField<userEmail_in, Option<Vec<super::String>>>
         for super::JobWhereInput
     {
     }
-    pub struct UserEmailNotIn;
-    impl ::cynic::schema::Field for UserEmailNotIn {
+    pub struct userEmail_not_in;
+    impl ::cynic::schema::Field for userEmail_not_in {
         type Type = Option<Vec<super::String>>;
         const NAME: &'static str = "userEmail_not_in";
     }
-    impl ::cynic::schema::HasInputField<UserEmailNotIn, Option<Vec<super::String>>>
+    impl ::cynic::schema::HasInputField<userEmail_not_in, Option<Vec<super::String>>>
         for super::JobWhereInput
     {
     }
-    pub struct UserEmailLt;
-    impl ::cynic::schema::Field for UserEmailLt {
+    pub struct userEmail_lt;
+    impl ::cynic::schema::Field for userEmail_lt {
         type Type = Option<super::String>;
         const NAME: &'static str = "userEmail_lt";
     }
-    impl ::cynic::schema::HasInputField<UserEmailLt, Option<super::String>> for super::JobWhereInput {}
-    pub struct UserEmailLte;
-    impl ::cynic::schema::Field for UserEmailLte {
+    impl ::cynic::schema::HasInputField<userEmail_lt, Option<super::String>> for super::JobWhereInput {}
+    pub struct userEmail_lte;
+    impl ::cynic::schema::Field for userEmail_lte {
         type Type = Option<super::String>;
         const NAME: &'static str = "userEmail_lte";
     }
-    impl ::cynic::schema::HasInputField<UserEmailLte, Option<super::String>> for super::JobWhereInput {}
-    pub struct UserEmailGt;
-    impl ::cynic::schema::Field for UserEmailGt {
+    impl ::cynic::schema::HasInputField<userEmail_lte, Option<super::String>> for super::JobWhereInput {}
+    pub struct userEmail_gt;
+    impl ::cynic::schema::Field for userEmail_gt {
         type Type = Option<super::String>;
         const NAME: &'static str = "userEmail_gt";
     }
-    impl ::cynic::schema::HasInputField<UserEmailGt, Option<super::String>> for super::JobWhereInput {}
-    pub struct UserEmailGte;
-    impl ::cynic::schema::Field for UserEmailGte {
+    impl ::cynic::schema::HasInputField<userEmail_gt, Option<super::String>> for super::JobWhereInput {}
+    pub struct userEmail_gte;
+    impl ::cynic::schema::Field for userEmail_gte {
         type Type = Option<super::String>;
         const NAME: &'static str = "userEmail_gte";
     }
-    impl ::cynic::schema::HasInputField<UserEmailGte, Option<super::String>> for super::JobWhereInput {}
-    pub struct UserEmailContains;
-    impl ::cynic::schema::Field for UserEmailContains {
+    impl ::cynic::schema::HasInputField<userEmail_gte, Option<super::String>> for super::JobWhereInput {}
+    pub struct userEmail_contains;
+    impl ::cynic::schema::Field for userEmail_contains {
         type Type = Option<super::String>;
         const NAME: &'static str = "userEmail_contains";
     }
-    impl ::cynic::schema::HasInputField<UserEmailContains, Option<super::String>>
+    impl ::cynic::schema::HasInputField<userEmail_contains, Option<super::String>>
         for super::JobWhereInput
     {
     }
-    pub struct UserEmailNotContains;
-    impl ::cynic::schema::Field for UserEmailNotContains {
+    pub struct userEmail_not_contains;
+    impl ::cynic::schema::Field for userEmail_not_contains {
         type Type = Option<super::String>;
         const NAME: &'static str = "userEmail_not_contains";
     }
-    impl ::cynic::schema::HasInputField<UserEmailNotContains, Option<super::String>>
+    impl ::cynic::schema::HasInputField<userEmail_not_contains, Option<super::String>>
         for super::JobWhereInput
     {
     }
-    pub struct UserEmailStartsWith;
-    impl ::cynic::schema::Field for UserEmailStartsWith {
+    pub struct userEmail_starts_with;
+    impl ::cynic::schema::Field for userEmail_starts_with {
         type Type = Option<super::String>;
         const NAME: &'static str = "userEmail_starts_with";
     }
-    impl ::cynic::schema::HasInputField<UserEmailStartsWith, Option<super::String>>
+    impl ::cynic::schema::HasInputField<userEmail_starts_with, Option<super::String>>
         for super::JobWhereInput
     {
     }
-    pub struct UserEmailNotStartsWith;
-    impl ::cynic::schema::Field for UserEmailNotStartsWith {
+    pub struct userEmail_not_starts_with;
+    impl ::cynic::schema::Field for userEmail_not_starts_with {
         type Type = Option<super::String>;
         const NAME: &'static str = "userEmail_not_starts_with";
     }
-    impl ::cynic::schema::HasInputField<UserEmailNotStartsWith, Option<super::String>>
+    impl ::cynic::schema::HasInputField<userEmail_not_starts_with, Option<super::String>>
         for super::JobWhereInput
     {
     }
-    pub struct UserEmailEndsWith;
-    impl ::cynic::schema::Field for UserEmailEndsWith {
+    pub struct userEmail_ends_with;
+    impl ::cynic::schema::Field for userEmail_ends_with {
         type Type = Option<super::String>;
         const NAME: &'static str = "userEmail_ends_with";
     }
-    impl ::cynic::schema::HasInputField<UserEmailEndsWith, Option<super::String>>
+    impl ::cynic::schema::HasInputField<userEmail_ends_with, Option<super::String>>
         for super::JobWhereInput
     {
     }
-    pub struct UserEmailNotEndsWith;
-    impl ::cynic::schema::Field for UserEmailNotEndsWith {
+    pub struct userEmail_not_ends_with;
+    impl ::cynic::schema::Field for userEmail_not_ends_with {
         type Type = Option<super::String>;
         const NAME: &'static str = "userEmail_not_ends_with";
     }
-    impl ::cynic::schema::HasInputField<UserEmailNotEndsWith, Option<super::String>>
+    impl ::cynic::schema::HasInputField<userEmail_not_ends_with, Option<super::String>>
         for super::JobWhereInput
     {
     }
-    pub struct PostedAt;
-    impl ::cynic::schema::Field for PostedAt {
+    pub struct postedAt;
+    impl ::cynic::schema::Field for postedAt {
         type Type = Option<super::DateTime>;
         const NAME: &'static str = "postedAt";
     }
-    impl ::cynic::schema::HasInputField<PostedAt, Option<super::DateTime>> for super::JobWhereInput {}
-    pub struct PostedAtNot;
-    impl ::cynic::schema::Field for PostedAtNot {
+    impl ::cynic::schema::HasInputField<postedAt, Option<super::DateTime>> for super::JobWhereInput {}
+    pub struct postedAt_not;
+    impl ::cynic::schema::Field for postedAt_not {
         type Type = Option<super::DateTime>;
         const NAME: &'static str = "postedAt_not";
     }
-    impl ::cynic::schema::HasInputField<PostedAtNot, Option<super::DateTime>> for super::JobWhereInput {}
-    pub struct PostedAtIn;
-    impl ::cynic::schema::Field for PostedAtIn {
+    impl ::cynic::schema::HasInputField<postedAt_not, Option<super::DateTime>>
+        for super::JobWhereInput
+    {
+    }
+    pub struct postedAt_in;
+    impl ::cynic::schema::Field for postedAt_in {
         type Type = Option<Vec<super::DateTime>>;
         const NAME: &'static str = "postedAt_in";
     }
-    impl ::cynic::schema::HasInputField<PostedAtIn, Option<Vec<super::DateTime>>>
+    impl ::cynic::schema::HasInputField<postedAt_in, Option<Vec<super::DateTime>>>
         for super::JobWhereInput
     {
     }
-    pub struct PostedAtNotIn;
-    impl ::cynic::schema::Field for PostedAtNotIn {
+    pub struct postedAt_not_in;
+    impl ::cynic::schema::Field for postedAt_not_in {
         type Type = Option<Vec<super::DateTime>>;
         const NAME: &'static str = "postedAt_not_in";
     }
-    impl ::cynic::schema::HasInputField<PostedAtNotIn, Option<Vec<super::DateTime>>>
+    impl ::cynic::schema::HasInputField<postedAt_not_in, Option<Vec<super::DateTime>>>
         for super::JobWhereInput
     {
     }
-    pub struct PostedAtLt;
-    impl ::cynic::schema::Field for PostedAtLt {
+    pub struct postedAt_lt;
+    impl ::cynic::schema::Field for postedAt_lt {
         type Type = Option<super::DateTime>;
         const NAME: &'static str = "postedAt_lt";
     }
-    impl ::cynic::schema::HasInputField<PostedAtLt, Option<super::DateTime>> for super::JobWhereInput {}
-    pub struct PostedAtLte;
-    impl ::cynic::schema::Field for PostedAtLte {
+    impl ::cynic::schema::HasInputField<postedAt_lt, Option<super::DateTime>> for super::JobWhereInput {}
+    pub struct postedAt_lte;
+    impl ::cynic::schema::Field for postedAt_lte {
         type Type = Option<super::DateTime>;
         const NAME: &'static str = "postedAt_lte";
     }
-    impl ::cynic::schema::HasInputField<PostedAtLte, Option<super::DateTime>> for super::JobWhereInput {}
-    pub struct PostedAtGt;
-    impl ::cynic::schema::Field for PostedAtGt {
+    impl ::cynic::schema::HasInputField<postedAt_lte, Option<super::DateTime>>
+        for super::JobWhereInput
+    {
+    }
+    pub struct postedAt_gt;
+    impl ::cynic::schema::Field for postedAt_gt {
         type Type = Option<super::DateTime>;
         const NAME: &'static str = "postedAt_gt";
     }
-    impl ::cynic::schema::HasInputField<PostedAtGt, Option<super::DateTime>> for super::JobWhereInput {}
-    pub struct PostedAtGte;
-    impl ::cynic::schema::Field for PostedAtGte {
+    impl ::cynic::schema::HasInputField<postedAt_gt, Option<super::DateTime>> for super::JobWhereInput {}
+    pub struct postedAt_gte;
+    impl ::cynic::schema::Field for postedAt_gte {
         type Type = Option<super::DateTime>;
         const NAME: &'static str = "postedAt_gte";
     }
-    impl ::cynic::schema::HasInputField<PostedAtGte, Option<super::DateTime>> for super::JobWhereInput {}
-    pub struct CreatedAt;
-    impl ::cynic::schema::Field for CreatedAt {
+    impl ::cynic::schema::HasInputField<postedAt_gte, Option<super::DateTime>>
+        for super::JobWhereInput
+    {
+    }
+    pub struct createdAt;
+    impl ::cynic::schema::Field for createdAt {
         type Type = Option<super::DateTime>;
         const NAME: &'static str = "createdAt";
     }
-    impl ::cynic::schema::HasInputField<CreatedAt, Option<super::DateTime>> for super::JobWhereInput {}
-    pub struct CreatedAtNot;
-    impl ::cynic::schema::Field for CreatedAtNot {
+    impl ::cynic::schema::HasInputField<createdAt, Option<super::DateTime>> for super::JobWhereInput {}
+    pub struct createdAt_not;
+    impl ::cynic::schema::Field for createdAt_not {
         type Type = Option<super::DateTime>;
         const NAME: &'static str = "createdAt_not";
     }
-    impl ::cynic::schema::HasInputField<CreatedAtNot, Option<super::DateTime>>
+    impl ::cynic::schema::HasInputField<createdAt_not, Option<super::DateTime>>
         for super::JobWhereInput
     {
     }
-    pub struct CreatedAtIn;
-    impl ::cynic::schema::Field for CreatedAtIn {
+    pub struct createdAt_in;
+    impl ::cynic::schema::Field for createdAt_in {
         type Type = Option<Vec<super::DateTime>>;
         const NAME: &'static str = "createdAt_in";
     }
-    impl ::cynic::schema::HasInputField<CreatedAtIn, Option<Vec<super::DateTime>>>
+    impl ::cynic::schema::HasInputField<createdAt_in, Option<Vec<super::DateTime>>>
         for super::JobWhereInput
     {
     }
-    pub struct CreatedAtNotIn;
-    impl ::cynic::schema::Field for CreatedAtNotIn {
+    pub struct createdAt_not_in;
+    impl ::cynic::schema::Field for createdAt_not_in {
         type Type = Option<Vec<super::DateTime>>;
         const NAME: &'static str = "createdAt_not_in";
     }
-    impl ::cynic::schema::HasInputField<CreatedAtNotIn, Option<Vec<super::DateTime>>>
+    impl ::cynic::schema::HasInputField<createdAt_not_in, Option<Vec<super::DateTime>>>
         for super::JobWhereInput
     {
     }
-    pub struct CreatedAtLt;
-    impl ::cynic::schema::Field for CreatedAtLt {
+    pub struct createdAt_lt;
+    impl ::cynic::schema::Field for createdAt_lt {
         type Type = Option<super::DateTime>;
         const NAME: &'static str = "createdAt_lt";
     }
-    impl ::cynic::schema::HasInputField<CreatedAtLt, Option<super::DateTime>> for super::JobWhereInput {}
-    pub struct CreatedAtLte;
-    impl ::cynic::schema::Field for CreatedAtLte {
+    impl ::cynic::schema::HasInputField<createdAt_lt, Option<super::DateTime>>
+        for super::JobWhereInput
+    {
+    }
+    pub struct createdAt_lte;
+    impl ::cynic::schema::Field for createdAt_lte {
         type Type = Option<super::DateTime>;
         const NAME: &'static str = "createdAt_lte";
     }
-    impl ::cynic::schema::HasInputField<CreatedAtLte, Option<super::DateTime>>
+    impl ::cynic::schema::HasInputField<createdAt_lte, Option<super::DateTime>>
         for super::JobWhereInput
     {
     }
-    pub struct CreatedAtGt;
-    impl ::cynic::schema::Field for CreatedAtGt {
+    pub struct createdAt_gt;
+    impl ::cynic::schema::Field for createdAt_gt {
         type Type = Option<super::DateTime>;
         const NAME: &'static str = "createdAt_gt";
     }
-    impl ::cynic::schema::HasInputField<CreatedAtGt, Option<super::DateTime>> for super::JobWhereInput {}
-    pub struct CreatedAtGte;
-    impl ::cynic::schema::Field for CreatedAtGte {
+    impl ::cynic::schema::HasInputField<createdAt_gt, Option<super::DateTime>>
+        for super::JobWhereInput
+    {
+    }
+    pub struct createdAt_gte;
+    impl ::cynic::schema::Field for createdAt_gte {
         type Type = Option<super::DateTime>;
         const NAME: &'static str = "createdAt_gte";
     }
-    impl ::cynic::schema::HasInputField<CreatedAtGte, Option<super::DateTime>>
+    impl ::cynic::schema::HasInputField<createdAt_gte, Option<super::DateTime>>
         for super::JobWhereInput
     {
     }
-    pub struct UpdatedAt;
-    impl ::cynic::schema::Field for UpdatedAt {
+    pub struct updatedAt;
+    impl ::cynic::schema::Field for updatedAt {
         type Type = Option<super::DateTime>;
         const NAME: &'static str = "updatedAt";
     }
-    impl ::cynic::schema::HasInputField<UpdatedAt, Option<super::DateTime>> for super::JobWhereInput {}
-    pub struct UpdatedAtNot;
-    impl ::cynic::schema::Field for UpdatedAtNot {
+    impl ::cynic::schema::HasInputField<updatedAt, Option<super::DateTime>> for super::JobWhereInput {}
+    pub struct updatedAt_not;
+    impl ::cynic::schema::Field for updatedAt_not {
         type Type = Option<super::DateTime>;
         const NAME: &'static str = "updatedAt_not";
     }
-    impl ::cynic::schema::HasInputField<UpdatedAtNot, Option<super::DateTime>>
+    impl ::cynic::schema::HasInputField<updatedAt_not, Option<super::DateTime>>
         for super::JobWhereInput
     {
     }
-    pub struct UpdatedAtIn;
-    impl ::cynic::schema::Field for UpdatedAtIn {
+    pub struct updatedAt_in;
+    impl ::cynic::schema::Field for updatedAt_in {
         type Type = Option<Vec<super::DateTime>>;
         const NAME: &'static str = "updatedAt_in";
     }
-    impl ::cynic::schema::HasInputField<UpdatedAtIn, Option<Vec<super::DateTime>>>
+    impl ::cynic::schema::HasInputField<updatedAt_in, Option<Vec<super::DateTime>>>
         for super::JobWhereInput
     {
     }
-    pub struct UpdatedAtNotIn;
-    impl ::cynic::schema::Field for UpdatedAtNotIn {
+    pub struct updatedAt_not_in;
+    impl ::cynic::schema::Field for updatedAt_not_in {
         type Type = Option<Vec<super::DateTime>>;
         const NAME: &'static str = "updatedAt_not_in";
     }
-    impl ::cynic::schema::HasInputField<UpdatedAtNotIn, Option<Vec<super::DateTime>>>
+    impl ::cynic::schema::HasInputField<updatedAt_not_in, Option<Vec<super::DateTime>>>
         for super::JobWhereInput
     {
     }
-    pub struct UpdatedAtLt;
-    impl ::cynic::schema::Field for UpdatedAtLt {
+    pub struct updatedAt_lt;
+    impl ::cynic::schema::Field for updatedAt_lt {
         type Type = Option<super::DateTime>;
         const NAME: &'static str = "updatedAt_lt";
     }
-    impl ::cynic::schema::HasInputField<UpdatedAtLt, Option<super::DateTime>> for super::JobWhereInput {}
-    pub struct UpdatedAtLte;
-    impl ::cynic::schema::Field for UpdatedAtLte {
+    impl ::cynic::schema::HasInputField<updatedAt_lt, Option<super::DateTime>>
+        for super::JobWhereInput
+    {
+    }
+    pub struct updatedAt_lte;
+    impl ::cynic::schema::Field for updatedAt_lte {
         type Type = Option<super::DateTime>;
         const NAME: &'static str = "updatedAt_lte";
     }
-    impl ::cynic::schema::HasInputField<UpdatedAtLte, Option<super::DateTime>>
+    impl ::cynic::schema::HasInputField<updatedAt_lte, Option<super::DateTime>>
         for super::JobWhereInput
     {
     }
-    pub struct UpdatedAtGt;
-    impl ::cynic::schema::Field for UpdatedAtGt {
+    pub struct updatedAt_gt;
+    impl ::cynic::schema::Field for updatedAt_gt {
         type Type = Option<super::DateTime>;
         const NAME: &'static str = "updatedAt_gt";
     }
-    impl ::cynic::schema::HasInputField<UpdatedAtGt, Option<super::DateTime>> for super::JobWhereInput {}
-    pub struct UpdatedAtGte;
-    impl ::cynic::schema::Field for UpdatedAtGte {
+    impl ::cynic::schema::HasInputField<updatedAt_gt, Option<super::DateTime>>
+        for super::JobWhereInput
+    {
+    }
+    pub struct updatedAt_gte;
+    impl ::cynic::schema::Field for updatedAt_gte {
         type Type = Option<super::DateTime>;
         const NAME: &'static str = "updatedAt_gte";
     }
-    impl ::cynic::schema::HasInputField<UpdatedAtGte, Option<super::DateTime>>
+    impl ::cynic::schema::HasInputField<updatedAt_gte, Option<super::DateTime>>
         for super::JobWhereInput
     {
     }
-    pub struct And;
-    impl ::cynic::schema::Field for And {
+    pub struct AND;
+    impl ::cynic::schema::Field for AND {
         type Type = Option<Vec<super::JobWhereInput>>;
         const NAME: &'static str = "AND";
     }
-    impl ::cynic::schema::HasInputField<And, Option<Vec<super::JobWhereInput>>>
+    impl ::cynic::schema::HasInputField<AND, Option<Vec<super::JobWhereInput>>>
         for super::JobWhereInput
     {
     }
-    pub struct Or;
-    impl ::cynic::schema::Field for Or {
+    pub struct OR;
+    impl ::cynic::schema::Field for OR {
         type Type = Option<Vec<super::JobWhereInput>>;
         const NAME: &'static str = "OR";
     }
-    impl ::cynic::schema::HasInputField<Or, Option<Vec<super::JobWhereInput>>>
+    impl ::cynic::schema::HasInputField<OR, Option<Vec<super::JobWhereInput>>>
         for super::JobWhereInput
     {
     }
-    pub struct Not;
-    impl ::cynic::schema::Field for Not {
+    pub struct NOT;
+    impl ::cynic::schema::Field for NOT {
         type Type = Option<Vec<super::JobWhereInput>>;
         const NAME: &'static str = "NOT";
     }
-    impl ::cynic::schema::HasInputField<Not, Option<Vec<super::JobWhereInput>>>
+    impl ::cynic::schema::HasInputField<NOT, Option<Vec<super::JobWhereInput>>>
         for super::JobWhereInput
     {
     }
@@ -4654,142 +4768,142 @@ pub mod job_where_input_fields {
 pub struct JobsInput;
 impl ::cynic::schema::InputObjectMarker for JobsInput {}
 pub mod jobs_input_fields {
-    pub struct Type;
-    impl ::cynic::schema::Field for Type {
+    pub struct r#type;
+    impl ::cynic::schema::Field for r#type {
         type Type = Option<super::String>;
         const NAME: &'static str = "type";
     }
-    impl ::cynic::schema::HasInputField<Type, Option<super::String>> for super::JobsInput {}
-    pub struct Slug;
-    impl ::cynic::schema::Field for Slug {
+    impl ::cynic::schema::HasInputField<r#type, Option<super::String>> for super::JobsInput {}
+    pub struct slug;
+    impl ::cynic::schema::Field for slug {
         type Type = Option<super::String>;
         const NAME: &'static str = "slug";
     }
-    impl ::cynic::schema::HasInputField<Slug, Option<super::String>> for super::JobsInput {}
+    impl ::cynic::schema::HasInputField<slug, Option<super::String>> for super::JobsInput {}
 }
 pub struct Location;
 pub mod location_fields {
-    pub struct Id;
-    impl ::cynic::schema::Field for Id {
-        type Type = super::Id;
+    pub struct id;
+    impl ::cynic::schema::Field for id {
+        type Type = super::ID;
         const NAME: &'static str = "id";
     }
-    impl ::cynic::schema::HasField<Id> for super::Location {
-        type Type = super::Id;
+    impl ::cynic::schema::HasField<id> for super::Location {
+        type Type = super::ID;
     }
-    pub struct Slug;
-    impl ::cynic::schema::Field for Slug {
+    pub struct slug;
+    impl ::cynic::schema::Field for slug {
         type Type = super::String;
         const NAME: &'static str = "slug";
     }
-    impl ::cynic::schema::HasField<Slug> for super::Location {
+    impl ::cynic::schema::HasField<slug> for super::Location {
         type Type = super::String;
     }
-    pub struct Name;
-    impl ::cynic::schema::Field for Name {
+    pub struct name;
+    impl ::cynic::schema::Field for name {
         type Type = super::String;
         const NAME: &'static str = "name";
     }
-    impl ::cynic::schema::HasField<Name> for super::Location {
+    impl ::cynic::schema::HasField<name> for super::Location {
         type Type = super::String;
     }
-    pub struct Type;
-    impl ::cynic::schema::Field for Type {
+    pub struct r#type;
+    impl ::cynic::schema::Field for r#type {
         type Type = super::String;
         const NAME: &'static str = "type";
     }
-    impl ::cynic::schema::HasField<Type> for super::Location {
+    impl ::cynic::schema::HasField<r#type> for super::Location {
         type Type = super::String;
     }
 }
 pub struct LocationInput;
 impl ::cynic::schema::InputObjectMarker for LocationInput {}
 pub mod location_input_fields {
-    pub struct Slug;
-    impl ::cynic::schema::Field for Slug {
+    pub struct slug;
+    impl ::cynic::schema::Field for slug {
         type Type = super::String;
         const NAME: &'static str = "slug";
     }
-    impl ::cynic::schema::HasInputField<Slug, super::String> for super::LocationInput {}
+    impl ::cynic::schema::HasInputField<slug, super::String> for super::LocationInput {}
 }
 pub struct LocationsInput;
 impl ::cynic::schema::InputObjectMarker for LocationsInput {}
 pub mod locations_input_fields {
-    pub struct Value;
-    impl ::cynic::schema::Field for Value {
+    pub struct value;
+    impl ::cynic::schema::Field for value {
         type Type = super::String;
         const NAME: &'static str = "value";
     }
-    impl ::cynic::schema::HasInputField<Value, super::String> for super::LocationsInput {}
+    impl ::cynic::schema::HasInputField<value, super::String> for super::LocationsInput {}
 }
 pub struct Mutation;
 pub mod mutation_fields {
-    pub struct Subscribe;
-    impl ::cynic::schema::Field for Subscribe {
+    pub struct subscribe;
+    impl ::cynic::schema::Field for subscribe {
         type Type = super::User;
         const NAME: &'static str = "subscribe";
     }
-    impl ::cynic::schema::HasField<Subscribe> for super::Mutation {
+    impl ::cynic::schema::HasField<subscribe> for super::Mutation {
         type Type = super::User;
     }
     pub mod subscribe_arguments {
-        pub struct Input;
-        impl ::cynic::schema::HasArgument<Input> for super::Subscribe {
+        pub struct input;
+        impl ::cynic::schema::HasArgument<input> for super::subscribe {
             type ArgumentType = super::super::SubscribeInput;
             const NAME: &'static str = "input";
         }
     }
-    pub struct PostJob;
-    impl ::cynic::schema::Field for PostJob {
+    pub struct postJob;
+    impl ::cynic::schema::Field for postJob {
         type Type = super::Job;
         const NAME: &'static str = "postJob";
     }
-    impl ::cynic::schema::HasField<PostJob> for super::Mutation {
+    impl ::cynic::schema::HasField<postJob> for super::Mutation {
         type Type = super::Job;
     }
     pub mod post_job_arguments {
-        pub struct Input;
-        impl ::cynic::schema::HasArgument<Input> for super::PostJob {
+        pub struct input;
+        impl ::cynic::schema::HasArgument<input> for super::postJob {
             type ArgumentType = super::super::PostJobInput;
             const NAME: &'static str = "input";
         }
     }
-    pub struct UpdateJob;
-    impl ::cynic::schema::Field for UpdateJob {
+    pub struct updateJob;
+    impl ::cynic::schema::Field for updateJob {
         type Type = super::Job;
         const NAME: &'static str = "updateJob";
     }
-    impl ::cynic::schema::HasField<UpdateJob> for super::Mutation {
+    impl ::cynic::schema::HasField<updateJob> for super::Mutation {
         type Type = super::Job;
     }
     pub mod update_job_arguments {
-        pub struct Input;
-        impl ::cynic::schema::HasArgument<Input> for super::UpdateJob {
+        pub struct input;
+        impl ::cynic::schema::HasArgument<input> for super::updateJob {
             type ArgumentType = super::super::UpdateJobInput;
             const NAME: &'static str = "input";
         }
-        pub struct AdminSecret;
-        impl ::cynic::schema::HasArgument<AdminSecret> for super::UpdateJob {
+        pub struct adminSecret;
+        impl ::cynic::schema::HasArgument<adminSecret> for super::updateJob {
             type ArgumentType = super::super::String;
             const NAME: &'static str = "adminSecret";
         }
     }
-    pub struct UpdateCompany;
-    impl ::cynic::schema::Field for UpdateCompany {
+    pub struct updateCompany;
+    impl ::cynic::schema::Field for updateCompany {
         type Type = super::Company;
         const NAME: &'static str = "updateCompany";
     }
-    impl ::cynic::schema::HasField<UpdateCompany> for super::Mutation {
+    impl ::cynic::schema::HasField<updateCompany> for super::Mutation {
         type Type = super::Company;
     }
     pub mod update_company_arguments {
-        pub struct Input;
-        impl ::cynic::schema::HasArgument<Input> for super::UpdateCompany {
+        pub struct input;
+        impl ::cynic::schema::HasArgument<input> for super::updateCompany {
             type ArgumentType = super::super::UpdateCompanyInput;
             const NAME: &'static str = "input";
         }
-        pub struct AdminSecret;
-        impl ::cynic::schema::HasArgument<AdminSecret> for super::UpdateCompany {
+        pub struct adminSecret;
+        impl ::cynic::schema::HasArgument<adminSecret> for super::updateCompany {
             type ArgumentType = super::super::String;
             const NAME: &'static str = "adminSecret";
         }
@@ -4798,275 +4912,275 @@ pub mod mutation_fields {
 pub struct PostJobInput;
 impl ::cynic::schema::InputObjectMarker for PostJobInput {}
 pub mod post_job_input_fields {
-    pub struct Title;
-    impl ::cynic::schema::Field for Title {
+    pub struct title;
+    impl ::cynic::schema::Field for title {
         type Type = super::String;
         const NAME: &'static str = "title";
     }
-    impl ::cynic::schema::HasInputField<Title, super::String> for super::PostJobInput {}
-    pub struct CommitmentId;
-    impl ::cynic::schema::Field for CommitmentId {
-        type Type = super::Id;
+    impl ::cynic::schema::HasInputField<title, super::String> for super::PostJobInput {}
+    pub struct commitmentId;
+    impl ::cynic::schema::Field for commitmentId {
+        type Type = super::ID;
         const NAME: &'static str = "commitmentId";
     }
-    impl ::cynic::schema::HasInputField<CommitmentId, super::Id> for super::PostJobInput {}
-    pub struct CompanyName;
-    impl ::cynic::schema::Field for CompanyName {
+    impl ::cynic::schema::HasInputField<commitmentId, super::ID> for super::PostJobInput {}
+    pub struct companyName;
+    impl ::cynic::schema::Field for companyName {
         type Type = super::String;
         const NAME: &'static str = "companyName";
     }
-    impl ::cynic::schema::HasInputField<CompanyName, super::String> for super::PostJobInput {}
-    pub struct LocationNames;
-    impl ::cynic::schema::Field for LocationNames {
+    impl ::cynic::schema::HasInputField<companyName, super::String> for super::PostJobInput {}
+    pub struct locationNames;
+    impl ::cynic::schema::Field for locationNames {
         type Type = super::String;
         const NAME: &'static str = "locationNames";
     }
-    impl ::cynic::schema::HasInputField<LocationNames, super::String> for super::PostJobInput {}
-    pub struct UserEmail;
-    impl ::cynic::schema::Field for UserEmail {
+    impl ::cynic::schema::HasInputField<locationNames, super::String> for super::PostJobInput {}
+    pub struct userEmail;
+    impl ::cynic::schema::Field for userEmail {
         type Type = super::String;
         const NAME: &'static str = "userEmail";
     }
-    impl ::cynic::schema::HasInputField<UserEmail, super::String> for super::PostJobInput {}
-    pub struct Description;
-    impl ::cynic::schema::Field for Description {
+    impl ::cynic::schema::HasInputField<userEmail, super::String> for super::PostJobInput {}
+    pub struct description;
+    impl ::cynic::schema::Field for description {
         type Type = super::String;
         const NAME: &'static str = "description";
     }
-    impl ::cynic::schema::HasInputField<Description, super::String> for super::PostJobInput {}
-    pub struct ApplyUrl;
-    impl ::cynic::schema::Field for ApplyUrl {
+    impl ::cynic::schema::HasInputField<description, super::String> for super::PostJobInput {}
+    pub struct applyUrl;
+    impl ::cynic::schema::Field for applyUrl {
         type Type = super::String;
         const NAME: &'static str = "applyUrl";
     }
-    impl ::cynic::schema::HasInputField<ApplyUrl, super::String> for super::PostJobInput {}
+    impl ::cynic::schema::HasInputField<applyUrl, super::String> for super::PostJobInput {}
 }
 pub struct Query;
 pub mod query_fields {
-    pub struct Jobs;
-    impl ::cynic::schema::Field for Jobs {
+    pub struct jobs;
+    impl ::cynic::schema::Field for jobs {
         type Type = Vec<super::Job>;
         const NAME: &'static str = "jobs";
     }
-    impl ::cynic::schema::HasField<Jobs> for super::Query {
+    impl ::cynic::schema::HasField<jobs> for super::Query {
         type Type = Vec<super::Job>;
     }
     pub mod jobs_arguments {
-        pub struct Input;
-        impl ::cynic::schema::HasArgument<Input> for super::Jobs {
+        pub struct input;
+        impl ::cynic::schema::HasArgument<input> for super::jobs {
             type ArgumentType = Option<super::super::JobsInput>;
             const NAME: &'static str = "input";
         }
     }
-    pub struct Job;
-    impl ::cynic::schema::Field for Job {
+    pub struct job;
+    impl ::cynic::schema::Field for job {
         type Type = super::Job;
         const NAME: &'static str = "job";
     }
-    impl ::cynic::schema::HasField<Job> for super::Query {
+    impl ::cynic::schema::HasField<job> for super::Query {
         type Type = super::Job;
     }
     pub mod job_arguments {
-        pub struct Input;
-        impl ::cynic::schema::HasArgument<Input> for super::Job {
+        pub struct input;
+        impl ::cynic::schema::HasArgument<input> for super::job {
             type ArgumentType = super::super::JobInput;
             const NAME: &'static str = "input";
         }
     }
-    pub struct Locations;
-    impl ::cynic::schema::Field for Locations {
+    pub struct locations;
+    impl ::cynic::schema::Field for locations {
         type Type = Vec<super::Location>;
         const NAME: &'static str = "locations";
     }
-    impl ::cynic::schema::HasField<Locations> for super::Query {
+    impl ::cynic::schema::HasField<locations> for super::Query {
         type Type = Vec<super::Location>;
     }
     pub mod locations_arguments {
-        pub struct Input;
-        impl ::cynic::schema::HasArgument<Input> for super::Locations {
+        pub struct input;
+        impl ::cynic::schema::HasArgument<input> for super::locations {
             type ArgumentType = super::super::LocationsInput;
             const NAME: &'static str = "input";
         }
     }
-    pub struct City;
-    impl ::cynic::schema::Field for City {
+    pub struct city;
+    impl ::cynic::schema::Field for city {
         type Type = super::City;
         const NAME: &'static str = "city";
     }
-    impl ::cynic::schema::HasField<City> for super::Query {
+    impl ::cynic::schema::HasField<city> for super::Query {
         type Type = super::City;
     }
     pub mod city_arguments {
-        pub struct Input;
-        impl ::cynic::schema::HasArgument<Input> for super::City {
+        pub struct input;
+        impl ::cynic::schema::HasArgument<input> for super::city {
             type ArgumentType = super::super::LocationInput;
             const NAME: &'static str = "input";
         }
     }
-    pub struct Country;
-    impl ::cynic::schema::Field for Country {
+    pub struct country;
+    impl ::cynic::schema::Field for country {
         type Type = super::Country;
         const NAME: &'static str = "country";
     }
-    impl ::cynic::schema::HasField<Country> for super::Query {
+    impl ::cynic::schema::HasField<country> for super::Query {
         type Type = super::Country;
     }
     pub mod country_arguments {
-        pub struct Input;
-        impl ::cynic::schema::HasArgument<Input> for super::Country {
+        pub struct input;
+        impl ::cynic::schema::HasArgument<input> for super::country {
             type ArgumentType = super::super::LocationInput;
             const NAME: &'static str = "input";
         }
     }
-    pub struct Remote;
-    impl ::cynic::schema::Field for Remote {
+    pub struct remote;
+    impl ::cynic::schema::Field for remote {
         type Type = super::Remote;
         const NAME: &'static str = "remote";
     }
-    impl ::cynic::schema::HasField<Remote> for super::Query {
+    impl ::cynic::schema::HasField<remote> for super::Query {
         type Type = super::Remote;
     }
     pub mod remote_arguments {
-        pub struct Input;
-        impl ::cynic::schema::HasArgument<Input> for super::Remote {
+        pub struct input;
+        impl ::cynic::schema::HasArgument<input> for super::remote {
             type ArgumentType = super::super::LocationInput;
             const NAME: &'static str = "input";
         }
     }
-    pub struct Commitments;
-    impl ::cynic::schema::Field for Commitments {
+    pub struct commitments;
+    impl ::cynic::schema::Field for commitments {
         type Type = Vec<super::Commitment>;
         const NAME: &'static str = "commitments";
     }
-    impl ::cynic::schema::HasField<Commitments> for super::Query {
+    impl ::cynic::schema::HasField<commitments> for super::Query {
         type Type = Vec<super::Commitment>;
     }
-    pub struct Cities;
-    impl ::cynic::schema::Field for Cities {
+    pub struct cities;
+    impl ::cynic::schema::Field for cities {
         type Type = Vec<super::City>;
         const NAME: &'static str = "cities";
     }
-    impl ::cynic::schema::HasField<Cities> for super::Query {
+    impl ::cynic::schema::HasField<cities> for super::Query {
         type Type = Vec<super::City>;
     }
-    pub struct Countries;
-    impl ::cynic::schema::Field for Countries {
+    pub struct countries;
+    impl ::cynic::schema::Field for countries {
         type Type = Vec<super::Country>;
         const NAME: &'static str = "countries";
     }
-    impl ::cynic::schema::HasField<Countries> for super::Query {
+    impl ::cynic::schema::HasField<countries> for super::Query {
         type Type = Vec<super::Country>;
     }
-    pub struct Remotes;
-    impl ::cynic::schema::Field for Remotes {
+    pub struct remotes;
+    impl ::cynic::schema::Field for remotes {
         type Type = Vec<super::Remote>;
         const NAME: &'static str = "remotes";
     }
-    impl ::cynic::schema::HasField<Remotes> for super::Query {
+    impl ::cynic::schema::HasField<remotes> for super::Query {
         type Type = Vec<super::Remote>;
     }
-    pub struct Companies;
-    impl ::cynic::schema::Field for Companies {
+    pub struct companies;
+    impl ::cynic::schema::Field for companies {
         type Type = Vec<super::Company>;
         const NAME: &'static str = "companies";
     }
-    impl ::cynic::schema::HasField<Companies> for super::Query {
+    impl ::cynic::schema::HasField<companies> for super::Query {
         type Type = Vec<super::Company>;
     }
 }
 pub struct Remote;
 pub mod remote_fields {
-    pub struct Id;
-    impl ::cynic::schema::Field for Id {
-        type Type = super::Id;
+    pub struct id;
+    impl ::cynic::schema::Field for id {
+        type Type = super::ID;
         const NAME: &'static str = "id";
     }
-    impl ::cynic::schema::HasField<Id> for super::Remote {
-        type Type = super::Id;
+    impl ::cynic::schema::HasField<id> for super::Remote {
+        type Type = super::ID;
     }
-    pub struct Name;
-    impl ::cynic::schema::Field for Name {
+    pub struct name;
+    impl ::cynic::schema::Field for name {
         type Type = super::String;
         const NAME: &'static str = "name";
     }
-    impl ::cynic::schema::HasField<Name> for super::Remote {
+    impl ::cynic::schema::HasField<name> for super::Remote {
         type Type = super::String;
     }
-    pub struct Slug;
-    impl ::cynic::schema::Field for Slug {
+    pub struct slug;
+    impl ::cynic::schema::Field for slug {
         type Type = super::String;
         const NAME: &'static str = "slug";
     }
-    impl ::cynic::schema::HasField<Slug> for super::Remote {
+    impl ::cynic::schema::HasField<slug> for super::Remote {
         type Type = super::String;
     }
-    pub struct Type;
-    impl ::cynic::schema::Field for Type {
+    pub struct r#type;
+    impl ::cynic::schema::Field for r#type {
         type Type = super::String;
         const NAME: &'static str = "type";
     }
-    impl ::cynic::schema::HasField<Type> for super::Remote {
+    impl ::cynic::schema::HasField<r#type> for super::Remote {
         type Type = super::String;
     }
-    pub struct Jobs;
-    impl ::cynic::schema::Field for Jobs {
+    pub struct jobs;
+    impl ::cynic::schema::Field for jobs {
         type Type = Option<Vec<super::Job>>;
         const NAME: &'static str = "jobs";
     }
-    impl ::cynic::schema::HasField<Jobs> for super::Remote {
+    impl ::cynic::schema::HasField<jobs> for super::Remote {
         type Type = Option<Vec<super::Job>>;
     }
     pub mod jobs_arguments {
-        pub struct Where;
-        impl ::cynic::schema::HasArgument<Where> for super::Jobs {
+        pub struct r#where;
+        impl ::cynic::schema::HasArgument<r#where> for super::jobs {
             type ArgumentType = Option<super::super::JobWhereInput>;
             const NAME: &'static str = "where";
         }
-        pub struct OrderBy;
-        impl ::cynic::schema::HasArgument<OrderBy> for super::Jobs {
+        pub struct orderBy;
+        impl ::cynic::schema::HasArgument<orderBy> for super::jobs {
             type ArgumentType = Option<super::super::JobOrderByInput>;
             const NAME: &'static str = "orderBy";
         }
-        pub struct Skip;
-        impl ::cynic::schema::HasArgument<Skip> for super::Jobs {
+        pub struct skip;
+        impl ::cynic::schema::HasArgument<skip> for super::jobs {
             type ArgumentType = Option<super::super::Int>;
             const NAME: &'static str = "skip";
         }
-        pub struct After;
-        impl ::cynic::schema::HasArgument<After> for super::Jobs {
+        pub struct after;
+        impl ::cynic::schema::HasArgument<after> for super::jobs {
             type ArgumentType = Option<super::super::String>;
             const NAME: &'static str = "after";
         }
-        pub struct Before;
-        impl ::cynic::schema::HasArgument<Before> for super::Jobs {
+        pub struct before;
+        impl ::cynic::schema::HasArgument<before> for super::jobs {
             type ArgumentType = Option<super::super::String>;
             const NAME: &'static str = "before";
         }
-        pub struct First;
-        impl ::cynic::schema::HasArgument<First> for super::Jobs {
+        pub struct first;
+        impl ::cynic::schema::HasArgument<first> for super::jobs {
             type ArgumentType = Option<super::super::Int>;
             const NAME: &'static str = "first";
         }
-        pub struct Last;
-        impl ::cynic::schema::HasArgument<Last> for super::Jobs {
+        pub struct last;
+        impl ::cynic::schema::HasArgument<last> for super::jobs {
             type ArgumentType = Option<super::super::Int>;
             const NAME: &'static str = "last";
         }
     }
-    pub struct CreatedAt;
-    impl ::cynic::schema::Field for CreatedAt {
+    pub struct createdAt;
+    impl ::cynic::schema::Field for createdAt {
         type Type = super::DateTime;
         const NAME: &'static str = "createdAt";
     }
-    impl ::cynic::schema::HasField<CreatedAt> for super::Remote {
+    impl ::cynic::schema::HasField<createdAt> for super::Remote {
         type Type = super::DateTime;
     }
-    pub struct UpdatedAt;
-    impl ::cynic::schema::Field for UpdatedAt {
+    pub struct updatedAt;
+    impl ::cynic::schema::Field for updatedAt {
         type Type = super::DateTime;
         const NAME: &'static str = "updatedAt";
     }
-    impl ::cynic::schema::HasField<UpdatedAt> for super::Remote {
+    impl ::cynic::schema::HasField<updatedAt> for super::Remote {
         type Type = super::DateTime;
     }
 }
@@ -5074,612 +5188,618 @@ pub struct RemoteOrderByInput {}
 pub struct RemoteWhereInput;
 impl ::cynic::schema::InputObjectMarker for RemoteWhereInput {}
 pub mod remote_where_input_fields {
-    pub struct Id;
-    impl ::cynic::schema::Field for Id {
-        type Type = Option<super::Id>;
+    pub struct id;
+    impl ::cynic::schema::Field for id {
+        type Type = Option<super::ID>;
         const NAME: &'static str = "id";
     }
-    impl ::cynic::schema::HasInputField<Id, Option<super::Id>> for super::RemoteWhereInput {}
-    pub struct IdNot;
-    impl ::cynic::schema::Field for IdNot {
-        type Type = Option<super::Id>;
+    impl ::cynic::schema::HasInputField<id, Option<super::ID>> for super::RemoteWhereInput {}
+    pub struct id_not;
+    impl ::cynic::schema::Field for id_not {
+        type Type = Option<super::ID>;
         const NAME: &'static str = "id_not";
     }
-    impl ::cynic::schema::HasInputField<IdNot, Option<super::Id>> for super::RemoteWhereInput {}
-    pub struct IdIn;
-    impl ::cynic::schema::Field for IdIn {
-        type Type = Option<Vec<super::Id>>;
+    impl ::cynic::schema::HasInputField<id_not, Option<super::ID>> for super::RemoteWhereInput {}
+    pub struct id_in;
+    impl ::cynic::schema::Field for id_in {
+        type Type = Option<Vec<super::ID>>;
         const NAME: &'static str = "id_in";
     }
-    impl ::cynic::schema::HasInputField<IdIn, Option<Vec<super::Id>>> for super::RemoteWhereInput {}
-    pub struct IdNotIn;
-    impl ::cynic::schema::Field for IdNotIn {
-        type Type = Option<Vec<super::Id>>;
+    impl ::cynic::schema::HasInputField<id_in, Option<Vec<super::ID>>> for super::RemoteWhereInput {}
+    pub struct id_not_in;
+    impl ::cynic::schema::Field for id_not_in {
+        type Type = Option<Vec<super::ID>>;
         const NAME: &'static str = "id_not_in";
     }
-    impl ::cynic::schema::HasInputField<IdNotIn, Option<Vec<super::Id>>> for super::RemoteWhereInput {}
-    pub struct IdLt;
-    impl ::cynic::schema::Field for IdLt {
-        type Type = Option<super::Id>;
+    impl ::cynic::schema::HasInputField<id_not_in, Option<Vec<super::ID>>> for super::RemoteWhereInput {}
+    pub struct id_lt;
+    impl ::cynic::schema::Field for id_lt {
+        type Type = Option<super::ID>;
         const NAME: &'static str = "id_lt";
     }
-    impl ::cynic::schema::HasInputField<IdLt, Option<super::Id>> for super::RemoteWhereInput {}
-    pub struct IdLte;
-    impl ::cynic::schema::Field for IdLte {
-        type Type = Option<super::Id>;
+    impl ::cynic::schema::HasInputField<id_lt, Option<super::ID>> for super::RemoteWhereInput {}
+    pub struct id_lte;
+    impl ::cynic::schema::Field for id_lte {
+        type Type = Option<super::ID>;
         const NAME: &'static str = "id_lte";
     }
-    impl ::cynic::schema::HasInputField<IdLte, Option<super::Id>> for super::RemoteWhereInput {}
-    pub struct IdGt;
-    impl ::cynic::schema::Field for IdGt {
-        type Type = Option<super::Id>;
+    impl ::cynic::schema::HasInputField<id_lte, Option<super::ID>> for super::RemoteWhereInput {}
+    pub struct id_gt;
+    impl ::cynic::schema::Field for id_gt {
+        type Type = Option<super::ID>;
         const NAME: &'static str = "id_gt";
     }
-    impl ::cynic::schema::HasInputField<IdGt, Option<super::Id>> for super::RemoteWhereInput {}
-    pub struct IdGte;
-    impl ::cynic::schema::Field for IdGte {
-        type Type = Option<super::Id>;
+    impl ::cynic::schema::HasInputField<id_gt, Option<super::ID>> for super::RemoteWhereInput {}
+    pub struct id_gte;
+    impl ::cynic::schema::Field for id_gte {
+        type Type = Option<super::ID>;
         const NAME: &'static str = "id_gte";
     }
-    impl ::cynic::schema::HasInputField<IdGte, Option<super::Id>> for super::RemoteWhereInput {}
-    pub struct IdContains;
-    impl ::cynic::schema::Field for IdContains {
-        type Type = Option<super::Id>;
+    impl ::cynic::schema::HasInputField<id_gte, Option<super::ID>> for super::RemoteWhereInput {}
+    pub struct id_contains;
+    impl ::cynic::schema::Field for id_contains {
+        type Type = Option<super::ID>;
         const NAME: &'static str = "id_contains";
     }
-    impl ::cynic::schema::HasInputField<IdContains, Option<super::Id>> for super::RemoteWhereInput {}
-    pub struct IdNotContains;
-    impl ::cynic::schema::Field for IdNotContains {
-        type Type = Option<super::Id>;
+    impl ::cynic::schema::HasInputField<id_contains, Option<super::ID>> for super::RemoteWhereInput {}
+    pub struct id_not_contains;
+    impl ::cynic::schema::Field for id_not_contains {
+        type Type = Option<super::ID>;
         const NAME: &'static str = "id_not_contains";
     }
-    impl ::cynic::schema::HasInputField<IdNotContains, Option<super::Id>> for super::RemoteWhereInput {}
-    pub struct IdStartsWith;
-    impl ::cynic::schema::Field for IdStartsWith {
-        type Type = Option<super::Id>;
-        const NAME: &'static str = "id_starts_with";
-    }
-    impl ::cynic::schema::HasInputField<IdStartsWith, Option<super::Id>> for super::RemoteWhereInput {}
-    pub struct IdNotStartsWith;
-    impl ::cynic::schema::Field for IdNotStartsWith {
-        type Type = Option<super::Id>;
-        const NAME: &'static str = "id_not_starts_with";
-    }
-    impl ::cynic::schema::HasInputField<IdNotStartsWith, Option<super::Id>>
+    impl ::cynic::schema::HasInputField<id_not_contains, Option<super::ID>>
         for super::RemoteWhereInput
     {
     }
-    pub struct IdEndsWith;
-    impl ::cynic::schema::Field for IdEndsWith {
-        type Type = Option<super::Id>;
+    pub struct id_starts_with;
+    impl ::cynic::schema::Field for id_starts_with {
+        type Type = Option<super::ID>;
+        const NAME: &'static str = "id_starts_with";
+    }
+    impl ::cynic::schema::HasInputField<id_starts_with, Option<super::ID>> for super::RemoteWhereInput {}
+    pub struct id_not_starts_with;
+    impl ::cynic::schema::Field for id_not_starts_with {
+        type Type = Option<super::ID>;
+        const NAME: &'static str = "id_not_starts_with";
+    }
+    impl ::cynic::schema::HasInputField<id_not_starts_with, Option<super::ID>>
+        for super::RemoteWhereInput
+    {
+    }
+    pub struct id_ends_with;
+    impl ::cynic::schema::Field for id_ends_with {
+        type Type = Option<super::ID>;
         const NAME: &'static str = "id_ends_with";
     }
-    impl ::cynic::schema::HasInputField<IdEndsWith, Option<super::Id>> for super::RemoteWhereInput {}
-    pub struct IdNotEndsWith;
-    impl ::cynic::schema::Field for IdNotEndsWith {
-        type Type = Option<super::Id>;
+    impl ::cynic::schema::HasInputField<id_ends_with, Option<super::ID>> for super::RemoteWhereInput {}
+    pub struct id_not_ends_with;
+    impl ::cynic::schema::Field for id_not_ends_with {
+        type Type = Option<super::ID>;
         const NAME: &'static str = "id_not_ends_with";
     }
-    impl ::cynic::schema::HasInputField<IdNotEndsWith, Option<super::Id>> for super::RemoteWhereInput {}
-    pub struct Name;
-    impl ::cynic::schema::Field for Name {
+    impl ::cynic::schema::HasInputField<id_not_ends_with, Option<super::ID>>
+        for super::RemoteWhereInput
+    {
+    }
+    pub struct name;
+    impl ::cynic::schema::Field for name {
         type Type = Option<super::String>;
         const NAME: &'static str = "name";
     }
-    impl ::cynic::schema::HasInputField<Name, Option<super::String>> for super::RemoteWhereInput {}
-    pub struct NameNot;
-    impl ::cynic::schema::Field for NameNot {
+    impl ::cynic::schema::HasInputField<name, Option<super::String>> for super::RemoteWhereInput {}
+    pub struct name_not;
+    impl ::cynic::schema::Field for name_not {
         type Type = Option<super::String>;
         const NAME: &'static str = "name_not";
     }
-    impl ::cynic::schema::HasInputField<NameNot, Option<super::String>> for super::RemoteWhereInput {}
-    pub struct NameIn;
-    impl ::cynic::schema::Field for NameIn {
+    impl ::cynic::schema::HasInputField<name_not, Option<super::String>> for super::RemoteWhereInput {}
+    pub struct name_in;
+    impl ::cynic::schema::Field for name_in {
         type Type = Option<Vec<super::String>>;
         const NAME: &'static str = "name_in";
     }
-    impl ::cynic::schema::HasInputField<NameIn, Option<Vec<super::String>>>
+    impl ::cynic::schema::HasInputField<name_in, Option<Vec<super::String>>>
         for super::RemoteWhereInput
     {
     }
-    pub struct NameNotIn;
-    impl ::cynic::schema::Field for NameNotIn {
+    pub struct name_not_in;
+    impl ::cynic::schema::Field for name_not_in {
         type Type = Option<Vec<super::String>>;
         const NAME: &'static str = "name_not_in";
     }
-    impl ::cynic::schema::HasInputField<NameNotIn, Option<Vec<super::String>>>
+    impl ::cynic::schema::HasInputField<name_not_in, Option<Vec<super::String>>>
         for super::RemoteWhereInput
     {
     }
-    pub struct NameLt;
-    impl ::cynic::schema::Field for NameLt {
+    pub struct name_lt;
+    impl ::cynic::schema::Field for name_lt {
         type Type = Option<super::String>;
         const NAME: &'static str = "name_lt";
     }
-    impl ::cynic::schema::HasInputField<NameLt, Option<super::String>> for super::RemoteWhereInput {}
-    pub struct NameLte;
-    impl ::cynic::schema::Field for NameLte {
+    impl ::cynic::schema::HasInputField<name_lt, Option<super::String>> for super::RemoteWhereInput {}
+    pub struct name_lte;
+    impl ::cynic::schema::Field for name_lte {
         type Type = Option<super::String>;
         const NAME: &'static str = "name_lte";
     }
-    impl ::cynic::schema::HasInputField<NameLte, Option<super::String>> for super::RemoteWhereInput {}
-    pub struct NameGt;
-    impl ::cynic::schema::Field for NameGt {
+    impl ::cynic::schema::HasInputField<name_lte, Option<super::String>> for super::RemoteWhereInput {}
+    pub struct name_gt;
+    impl ::cynic::schema::Field for name_gt {
         type Type = Option<super::String>;
         const NAME: &'static str = "name_gt";
     }
-    impl ::cynic::schema::HasInputField<NameGt, Option<super::String>> for super::RemoteWhereInput {}
-    pub struct NameGte;
-    impl ::cynic::schema::Field for NameGte {
+    impl ::cynic::schema::HasInputField<name_gt, Option<super::String>> for super::RemoteWhereInput {}
+    pub struct name_gte;
+    impl ::cynic::schema::Field for name_gte {
         type Type = Option<super::String>;
         const NAME: &'static str = "name_gte";
     }
-    impl ::cynic::schema::HasInputField<NameGte, Option<super::String>> for super::RemoteWhereInput {}
-    pub struct NameContains;
-    impl ::cynic::schema::Field for NameContains {
+    impl ::cynic::schema::HasInputField<name_gte, Option<super::String>> for super::RemoteWhereInput {}
+    pub struct name_contains;
+    impl ::cynic::schema::Field for name_contains {
         type Type = Option<super::String>;
         const NAME: &'static str = "name_contains";
     }
-    impl ::cynic::schema::HasInputField<NameContains, Option<super::String>>
+    impl ::cynic::schema::HasInputField<name_contains, Option<super::String>>
         for super::RemoteWhereInput
     {
     }
-    pub struct NameNotContains;
-    impl ::cynic::schema::Field for NameNotContains {
+    pub struct name_not_contains;
+    impl ::cynic::schema::Field for name_not_contains {
         type Type = Option<super::String>;
         const NAME: &'static str = "name_not_contains";
     }
-    impl ::cynic::schema::HasInputField<NameNotContains, Option<super::String>>
+    impl ::cynic::schema::HasInputField<name_not_contains, Option<super::String>>
         for super::RemoteWhereInput
     {
     }
-    pub struct NameStartsWith;
-    impl ::cynic::schema::Field for NameStartsWith {
+    pub struct name_starts_with;
+    impl ::cynic::schema::Field for name_starts_with {
         type Type = Option<super::String>;
         const NAME: &'static str = "name_starts_with";
     }
-    impl ::cynic::schema::HasInputField<NameStartsWith, Option<super::String>>
+    impl ::cynic::schema::HasInputField<name_starts_with, Option<super::String>>
         for super::RemoteWhereInput
     {
     }
-    pub struct NameNotStartsWith;
-    impl ::cynic::schema::Field for NameNotStartsWith {
+    pub struct name_not_starts_with;
+    impl ::cynic::schema::Field for name_not_starts_with {
         type Type = Option<super::String>;
         const NAME: &'static str = "name_not_starts_with";
     }
-    impl ::cynic::schema::HasInputField<NameNotStartsWith, Option<super::String>>
+    impl ::cynic::schema::HasInputField<name_not_starts_with, Option<super::String>>
         for super::RemoteWhereInput
     {
     }
-    pub struct NameEndsWith;
-    impl ::cynic::schema::Field for NameEndsWith {
+    pub struct name_ends_with;
+    impl ::cynic::schema::Field for name_ends_with {
         type Type = Option<super::String>;
         const NAME: &'static str = "name_ends_with";
     }
-    impl ::cynic::schema::HasInputField<NameEndsWith, Option<super::String>>
+    impl ::cynic::schema::HasInputField<name_ends_with, Option<super::String>>
         for super::RemoteWhereInput
     {
     }
-    pub struct NameNotEndsWith;
-    impl ::cynic::schema::Field for NameNotEndsWith {
+    pub struct name_not_ends_with;
+    impl ::cynic::schema::Field for name_not_ends_with {
         type Type = Option<super::String>;
         const NAME: &'static str = "name_not_ends_with";
     }
-    impl ::cynic::schema::HasInputField<NameNotEndsWith, Option<super::String>>
+    impl ::cynic::schema::HasInputField<name_not_ends_with, Option<super::String>>
         for super::RemoteWhereInput
     {
     }
-    pub struct Slug;
-    impl ::cynic::schema::Field for Slug {
+    pub struct slug;
+    impl ::cynic::schema::Field for slug {
         type Type = Option<super::String>;
         const NAME: &'static str = "slug";
     }
-    impl ::cynic::schema::HasInputField<Slug, Option<super::String>> for super::RemoteWhereInput {}
-    pub struct SlugNot;
-    impl ::cynic::schema::Field for SlugNot {
+    impl ::cynic::schema::HasInputField<slug, Option<super::String>> for super::RemoteWhereInput {}
+    pub struct slug_not;
+    impl ::cynic::schema::Field for slug_not {
         type Type = Option<super::String>;
         const NAME: &'static str = "slug_not";
     }
-    impl ::cynic::schema::HasInputField<SlugNot, Option<super::String>> for super::RemoteWhereInput {}
-    pub struct SlugIn;
-    impl ::cynic::schema::Field for SlugIn {
+    impl ::cynic::schema::HasInputField<slug_not, Option<super::String>> for super::RemoteWhereInput {}
+    pub struct slug_in;
+    impl ::cynic::schema::Field for slug_in {
         type Type = Option<Vec<super::String>>;
         const NAME: &'static str = "slug_in";
     }
-    impl ::cynic::schema::HasInputField<SlugIn, Option<Vec<super::String>>>
+    impl ::cynic::schema::HasInputField<slug_in, Option<Vec<super::String>>>
         for super::RemoteWhereInput
     {
     }
-    pub struct SlugNotIn;
-    impl ::cynic::schema::Field for SlugNotIn {
+    pub struct slug_not_in;
+    impl ::cynic::schema::Field for slug_not_in {
         type Type = Option<Vec<super::String>>;
         const NAME: &'static str = "slug_not_in";
     }
-    impl ::cynic::schema::HasInputField<SlugNotIn, Option<Vec<super::String>>>
+    impl ::cynic::schema::HasInputField<slug_not_in, Option<Vec<super::String>>>
         for super::RemoteWhereInput
     {
     }
-    pub struct SlugLt;
-    impl ::cynic::schema::Field for SlugLt {
+    pub struct slug_lt;
+    impl ::cynic::schema::Field for slug_lt {
         type Type = Option<super::String>;
         const NAME: &'static str = "slug_lt";
     }
-    impl ::cynic::schema::HasInputField<SlugLt, Option<super::String>> for super::RemoteWhereInput {}
-    pub struct SlugLte;
-    impl ::cynic::schema::Field for SlugLte {
+    impl ::cynic::schema::HasInputField<slug_lt, Option<super::String>> for super::RemoteWhereInput {}
+    pub struct slug_lte;
+    impl ::cynic::schema::Field for slug_lte {
         type Type = Option<super::String>;
         const NAME: &'static str = "slug_lte";
     }
-    impl ::cynic::schema::HasInputField<SlugLte, Option<super::String>> for super::RemoteWhereInput {}
-    pub struct SlugGt;
-    impl ::cynic::schema::Field for SlugGt {
+    impl ::cynic::schema::HasInputField<slug_lte, Option<super::String>> for super::RemoteWhereInput {}
+    pub struct slug_gt;
+    impl ::cynic::schema::Field for slug_gt {
         type Type = Option<super::String>;
         const NAME: &'static str = "slug_gt";
     }
-    impl ::cynic::schema::HasInputField<SlugGt, Option<super::String>> for super::RemoteWhereInput {}
-    pub struct SlugGte;
-    impl ::cynic::schema::Field for SlugGte {
+    impl ::cynic::schema::HasInputField<slug_gt, Option<super::String>> for super::RemoteWhereInput {}
+    pub struct slug_gte;
+    impl ::cynic::schema::Field for slug_gte {
         type Type = Option<super::String>;
         const NAME: &'static str = "slug_gte";
     }
-    impl ::cynic::schema::HasInputField<SlugGte, Option<super::String>> for super::RemoteWhereInput {}
-    pub struct SlugContains;
-    impl ::cynic::schema::Field for SlugContains {
+    impl ::cynic::schema::HasInputField<slug_gte, Option<super::String>> for super::RemoteWhereInput {}
+    pub struct slug_contains;
+    impl ::cynic::schema::Field for slug_contains {
         type Type = Option<super::String>;
         const NAME: &'static str = "slug_contains";
     }
-    impl ::cynic::schema::HasInputField<SlugContains, Option<super::String>>
+    impl ::cynic::schema::HasInputField<slug_contains, Option<super::String>>
         for super::RemoteWhereInput
     {
     }
-    pub struct SlugNotContains;
-    impl ::cynic::schema::Field for SlugNotContains {
+    pub struct slug_not_contains;
+    impl ::cynic::schema::Field for slug_not_contains {
         type Type = Option<super::String>;
         const NAME: &'static str = "slug_not_contains";
     }
-    impl ::cynic::schema::HasInputField<SlugNotContains, Option<super::String>>
+    impl ::cynic::schema::HasInputField<slug_not_contains, Option<super::String>>
         for super::RemoteWhereInput
     {
     }
-    pub struct SlugStartsWith;
-    impl ::cynic::schema::Field for SlugStartsWith {
+    pub struct slug_starts_with;
+    impl ::cynic::schema::Field for slug_starts_with {
         type Type = Option<super::String>;
         const NAME: &'static str = "slug_starts_with";
     }
-    impl ::cynic::schema::HasInputField<SlugStartsWith, Option<super::String>>
+    impl ::cynic::schema::HasInputField<slug_starts_with, Option<super::String>>
         for super::RemoteWhereInput
     {
     }
-    pub struct SlugNotStartsWith;
-    impl ::cynic::schema::Field for SlugNotStartsWith {
+    pub struct slug_not_starts_with;
+    impl ::cynic::schema::Field for slug_not_starts_with {
         type Type = Option<super::String>;
         const NAME: &'static str = "slug_not_starts_with";
     }
-    impl ::cynic::schema::HasInputField<SlugNotStartsWith, Option<super::String>>
+    impl ::cynic::schema::HasInputField<slug_not_starts_with, Option<super::String>>
         for super::RemoteWhereInput
     {
     }
-    pub struct SlugEndsWith;
-    impl ::cynic::schema::Field for SlugEndsWith {
+    pub struct slug_ends_with;
+    impl ::cynic::schema::Field for slug_ends_with {
         type Type = Option<super::String>;
         const NAME: &'static str = "slug_ends_with";
     }
-    impl ::cynic::schema::HasInputField<SlugEndsWith, Option<super::String>>
+    impl ::cynic::schema::HasInputField<slug_ends_with, Option<super::String>>
         for super::RemoteWhereInput
     {
     }
-    pub struct SlugNotEndsWith;
-    impl ::cynic::schema::Field for SlugNotEndsWith {
+    pub struct slug_not_ends_with;
+    impl ::cynic::schema::Field for slug_not_ends_with {
         type Type = Option<super::String>;
         const NAME: &'static str = "slug_not_ends_with";
     }
-    impl ::cynic::schema::HasInputField<SlugNotEndsWith, Option<super::String>>
+    impl ::cynic::schema::HasInputField<slug_not_ends_with, Option<super::String>>
         for super::RemoteWhereInput
     {
     }
-    pub struct Type;
-    impl ::cynic::schema::Field for Type {
+    pub struct r#type;
+    impl ::cynic::schema::Field for r#type {
         type Type = Option<super::String>;
         const NAME: &'static str = "type";
     }
-    impl ::cynic::schema::HasInputField<Type, Option<super::String>> for super::RemoteWhereInput {}
-    pub struct TypeNot;
-    impl ::cynic::schema::Field for TypeNot {
+    impl ::cynic::schema::HasInputField<r#type, Option<super::String>> for super::RemoteWhereInput {}
+    pub struct type_not;
+    impl ::cynic::schema::Field for type_not {
         type Type = Option<super::String>;
         const NAME: &'static str = "type_not";
     }
-    impl ::cynic::schema::HasInputField<TypeNot, Option<super::String>> for super::RemoteWhereInput {}
-    pub struct TypeIn;
-    impl ::cynic::schema::Field for TypeIn {
+    impl ::cynic::schema::HasInputField<type_not, Option<super::String>> for super::RemoteWhereInput {}
+    pub struct type_in;
+    impl ::cynic::schema::Field for type_in {
         type Type = Option<Vec<super::String>>;
         const NAME: &'static str = "type_in";
     }
-    impl ::cynic::schema::HasInputField<TypeIn, Option<Vec<super::String>>>
+    impl ::cynic::schema::HasInputField<type_in, Option<Vec<super::String>>>
         for super::RemoteWhereInput
     {
     }
-    pub struct TypeNotIn;
-    impl ::cynic::schema::Field for TypeNotIn {
+    pub struct type_not_in;
+    impl ::cynic::schema::Field for type_not_in {
         type Type = Option<Vec<super::String>>;
         const NAME: &'static str = "type_not_in";
     }
-    impl ::cynic::schema::HasInputField<TypeNotIn, Option<Vec<super::String>>>
+    impl ::cynic::schema::HasInputField<type_not_in, Option<Vec<super::String>>>
         for super::RemoteWhereInput
     {
     }
-    pub struct TypeLt;
-    impl ::cynic::schema::Field for TypeLt {
+    pub struct type_lt;
+    impl ::cynic::schema::Field for type_lt {
         type Type = Option<super::String>;
         const NAME: &'static str = "type_lt";
     }
-    impl ::cynic::schema::HasInputField<TypeLt, Option<super::String>> for super::RemoteWhereInput {}
-    pub struct TypeLte;
-    impl ::cynic::schema::Field for TypeLte {
+    impl ::cynic::schema::HasInputField<type_lt, Option<super::String>> for super::RemoteWhereInput {}
+    pub struct type_lte;
+    impl ::cynic::schema::Field for type_lte {
         type Type = Option<super::String>;
         const NAME: &'static str = "type_lte";
     }
-    impl ::cynic::schema::HasInputField<TypeLte, Option<super::String>> for super::RemoteWhereInput {}
-    pub struct TypeGt;
-    impl ::cynic::schema::Field for TypeGt {
+    impl ::cynic::schema::HasInputField<type_lte, Option<super::String>> for super::RemoteWhereInput {}
+    pub struct type_gt;
+    impl ::cynic::schema::Field for type_gt {
         type Type = Option<super::String>;
         const NAME: &'static str = "type_gt";
     }
-    impl ::cynic::schema::HasInputField<TypeGt, Option<super::String>> for super::RemoteWhereInput {}
-    pub struct TypeGte;
-    impl ::cynic::schema::Field for TypeGte {
+    impl ::cynic::schema::HasInputField<type_gt, Option<super::String>> for super::RemoteWhereInput {}
+    pub struct type_gte;
+    impl ::cynic::schema::Field for type_gte {
         type Type = Option<super::String>;
         const NAME: &'static str = "type_gte";
     }
-    impl ::cynic::schema::HasInputField<TypeGte, Option<super::String>> for super::RemoteWhereInput {}
-    pub struct TypeContains;
-    impl ::cynic::schema::Field for TypeContains {
+    impl ::cynic::schema::HasInputField<type_gte, Option<super::String>> for super::RemoteWhereInput {}
+    pub struct type_contains;
+    impl ::cynic::schema::Field for type_contains {
         type Type = Option<super::String>;
         const NAME: &'static str = "type_contains";
     }
-    impl ::cynic::schema::HasInputField<TypeContains, Option<super::String>>
+    impl ::cynic::schema::HasInputField<type_contains, Option<super::String>>
         for super::RemoteWhereInput
     {
     }
-    pub struct TypeNotContains;
-    impl ::cynic::schema::Field for TypeNotContains {
+    pub struct type_not_contains;
+    impl ::cynic::schema::Field for type_not_contains {
         type Type = Option<super::String>;
         const NAME: &'static str = "type_not_contains";
     }
-    impl ::cynic::schema::HasInputField<TypeNotContains, Option<super::String>>
+    impl ::cynic::schema::HasInputField<type_not_contains, Option<super::String>>
         for super::RemoteWhereInput
     {
     }
-    pub struct TypeStartsWith;
-    impl ::cynic::schema::Field for TypeStartsWith {
+    pub struct type_starts_with;
+    impl ::cynic::schema::Field for type_starts_with {
         type Type = Option<super::String>;
         const NAME: &'static str = "type_starts_with";
     }
-    impl ::cynic::schema::HasInputField<TypeStartsWith, Option<super::String>>
+    impl ::cynic::schema::HasInputField<type_starts_with, Option<super::String>>
         for super::RemoteWhereInput
     {
     }
-    pub struct TypeNotStartsWith;
-    impl ::cynic::schema::Field for TypeNotStartsWith {
+    pub struct type_not_starts_with;
+    impl ::cynic::schema::Field for type_not_starts_with {
         type Type = Option<super::String>;
         const NAME: &'static str = "type_not_starts_with";
     }
-    impl ::cynic::schema::HasInputField<TypeNotStartsWith, Option<super::String>>
+    impl ::cynic::schema::HasInputField<type_not_starts_with, Option<super::String>>
         for super::RemoteWhereInput
     {
     }
-    pub struct TypeEndsWith;
-    impl ::cynic::schema::Field for TypeEndsWith {
+    pub struct type_ends_with;
+    impl ::cynic::schema::Field for type_ends_with {
         type Type = Option<super::String>;
         const NAME: &'static str = "type_ends_with";
     }
-    impl ::cynic::schema::HasInputField<TypeEndsWith, Option<super::String>>
+    impl ::cynic::schema::HasInputField<type_ends_with, Option<super::String>>
         for super::RemoteWhereInput
     {
     }
-    pub struct TypeNotEndsWith;
-    impl ::cynic::schema::Field for TypeNotEndsWith {
+    pub struct type_not_ends_with;
+    impl ::cynic::schema::Field for type_not_ends_with {
         type Type = Option<super::String>;
         const NAME: &'static str = "type_not_ends_with";
     }
-    impl ::cynic::schema::HasInputField<TypeNotEndsWith, Option<super::String>>
+    impl ::cynic::schema::HasInputField<type_not_ends_with, Option<super::String>>
         for super::RemoteWhereInput
     {
     }
-    pub struct JobsEvery;
-    impl ::cynic::schema::Field for JobsEvery {
+    pub struct jobs_every;
+    impl ::cynic::schema::Field for jobs_every {
         type Type = Option<super::JobWhereInput>;
         const NAME: &'static str = "jobs_every";
     }
-    impl ::cynic::schema::HasInputField<JobsEvery, Option<super::JobWhereInput>>
+    impl ::cynic::schema::HasInputField<jobs_every, Option<super::JobWhereInput>>
         for super::RemoteWhereInput
     {
     }
-    pub struct JobsSome;
-    impl ::cynic::schema::Field for JobsSome {
+    pub struct jobs_some;
+    impl ::cynic::schema::Field for jobs_some {
         type Type = Option<super::JobWhereInput>;
         const NAME: &'static str = "jobs_some";
     }
-    impl ::cynic::schema::HasInputField<JobsSome, Option<super::JobWhereInput>>
+    impl ::cynic::schema::HasInputField<jobs_some, Option<super::JobWhereInput>>
         for super::RemoteWhereInput
     {
     }
-    pub struct JobsNone;
-    impl ::cynic::schema::Field for JobsNone {
+    pub struct jobs_none;
+    impl ::cynic::schema::Field for jobs_none {
         type Type = Option<super::JobWhereInput>;
         const NAME: &'static str = "jobs_none";
     }
-    impl ::cynic::schema::HasInputField<JobsNone, Option<super::JobWhereInput>>
+    impl ::cynic::schema::HasInputField<jobs_none, Option<super::JobWhereInput>>
         for super::RemoteWhereInput
     {
     }
-    pub struct CreatedAt;
-    impl ::cynic::schema::Field for CreatedAt {
+    pub struct createdAt;
+    impl ::cynic::schema::Field for createdAt {
         type Type = Option<super::DateTime>;
         const NAME: &'static str = "createdAt";
     }
-    impl ::cynic::schema::HasInputField<CreatedAt, Option<super::DateTime>>
+    impl ::cynic::schema::HasInputField<createdAt, Option<super::DateTime>>
         for super::RemoteWhereInput
     {
     }
-    pub struct CreatedAtNot;
-    impl ::cynic::schema::Field for CreatedAtNot {
+    pub struct createdAt_not;
+    impl ::cynic::schema::Field for createdAt_not {
         type Type = Option<super::DateTime>;
         const NAME: &'static str = "createdAt_not";
     }
-    impl ::cynic::schema::HasInputField<CreatedAtNot, Option<super::DateTime>>
+    impl ::cynic::schema::HasInputField<createdAt_not, Option<super::DateTime>>
         for super::RemoteWhereInput
     {
     }
-    pub struct CreatedAtIn;
-    impl ::cynic::schema::Field for CreatedAtIn {
+    pub struct createdAt_in;
+    impl ::cynic::schema::Field for createdAt_in {
         type Type = Option<Vec<super::DateTime>>;
         const NAME: &'static str = "createdAt_in";
     }
-    impl ::cynic::schema::HasInputField<CreatedAtIn, Option<Vec<super::DateTime>>>
+    impl ::cynic::schema::HasInputField<createdAt_in, Option<Vec<super::DateTime>>>
         for super::RemoteWhereInput
     {
     }
-    pub struct CreatedAtNotIn;
-    impl ::cynic::schema::Field for CreatedAtNotIn {
+    pub struct createdAt_not_in;
+    impl ::cynic::schema::Field for createdAt_not_in {
         type Type = Option<Vec<super::DateTime>>;
         const NAME: &'static str = "createdAt_not_in";
     }
-    impl ::cynic::schema::HasInputField<CreatedAtNotIn, Option<Vec<super::DateTime>>>
+    impl ::cynic::schema::HasInputField<createdAt_not_in, Option<Vec<super::DateTime>>>
         for super::RemoteWhereInput
     {
     }
-    pub struct CreatedAtLt;
-    impl ::cynic::schema::Field for CreatedAtLt {
+    pub struct createdAt_lt;
+    impl ::cynic::schema::Field for createdAt_lt {
         type Type = Option<super::DateTime>;
         const NAME: &'static str = "createdAt_lt";
     }
-    impl ::cynic::schema::HasInputField<CreatedAtLt, Option<super::DateTime>>
+    impl ::cynic::schema::HasInputField<createdAt_lt, Option<super::DateTime>>
         for super::RemoteWhereInput
     {
     }
-    pub struct CreatedAtLte;
-    impl ::cynic::schema::Field for CreatedAtLte {
+    pub struct createdAt_lte;
+    impl ::cynic::schema::Field for createdAt_lte {
         type Type = Option<super::DateTime>;
         const NAME: &'static str = "createdAt_lte";
     }
-    impl ::cynic::schema::HasInputField<CreatedAtLte, Option<super::DateTime>>
+    impl ::cynic::schema::HasInputField<createdAt_lte, Option<super::DateTime>>
         for super::RemoteWhereInput
     {
     }
-    pub struct CreatedAtGt;
-    impl ::cynic::schema::Field for CreatedAtGt {
+    pub struct createdAt_gt;
+    impl ::cynic::schema::Field for createdAt_gt {
         type Type = Option<super::DateTime>;
         const NAME: &'static str = "createdAt_gt";
     }
-    impl ::cynic::schema::HasInputField<CreatedAtGt, Option<super::DateTime>>
+    impl ::cynic::schema::HasInputField<createdAt_gt, Option<super::DateTime>>
         for super::RemoteWhereInput
     {
     }
-    pub struct CreatedAtGte;
-    impl ::cynic::schema::Field for CreatedAtGte {
+    pub struct createdAt_gte;
+    impl ::cynic::schema::Field for createdAt_gte {
         type Type = Option<super::DateTime>;
         const NAME: &'static str = "createdAt_gte";
     }
-    impl ::cynic::schema::HasInputField<CreatedAtGte, Option<super::DateTime>>
+    impl ::cynic::schema::HasInputField<createdAt_gte, Option<super::DateTime>>
         for super::RemoteWhereInput
     {
     }
-    pub struct UpdatedAt;
-    impl ::cynic::schema::Field for UpdatedAt {
+    pub struct updatedAt;
+    impl ::cynic::schema::Field for updatedAt {
         type Type = Option<super::DateTime>;
         const NAME: &'static str = "updatedAt";
     }
-    impl ::cynic::schema::HasInputField<UpdatedAt, Option<super::DateTime>>
+    impl ::cynic::schema::HasInputField<updatedAt, Option<super::DateTime>>
         for super::RemoteWhereInput
     {
     }
-    pub struct UpdatedAtNot;
-    impl ::cynic::schema::Field for UpdatedAtNot {
+    pub struct updatedAt_not;
+    impl ::cynic::schema::Field for updatedAt_not {
         type Type = Option<super::DateTime>;
         const NAME: &'static str = "updatedAt_not";
     }
-    impl ::cynic::schema::HasInputField<UpdatedAtNot, Option<super::DateTime>>
+    impl ::cynic::schema::HasInputField<updatedAt_not, Option<super::DateTime>>
         for super::RemoteWhereInput
     {
     }
-    pub struct UpdatedAtIn;
-    impl ::cynic::schema::Field for UpdatedAtIn {
+    pub struct updatedAt_in;
+    impl ::cynic::schema::Field for updatedAt_in {
         type Type = Option<Vec<super::DateTime>>;
         const NAME: &'static str = "updatedAt_in";
     }
-    impl ::cynic::schema::HasInputField<UpdatedAtIn, Option<Vec<super::DateTime>>>
+    impl ::cynic::schema::HasInputField<updatedAt_in, Option<Vec<super::DateTime>>>
         for super::RemoteWhereInput
     {
     }
-    pub struct UpdatedAtNotIn;
-    impl ::cynic::schema::Field for UpdatedAtNotIn {
+    pub struct updatedAt_not_in;
+    impl ::cynic::schema::Field for updatedAt_not_in {
         type Type = Option<Vec<super::DateTime>>;
         const NAME: &'static str = "updatedAt_not_in";
     }
-    impl ::cynic::schema::HasInputField<UpdatedAtNotIn, Option<Vec<super::DateTime>>>
+    impl ::cynic::schema::HasInputField<updatedAt_not_in, Option<Vec<super::DateTime>>>
         for super::RemoteWhereInput
     {
     }
-    pub struct UpdatedAtLt;
-    impl ::cynic::schema::Field for UpdatedAtLt {
+    pub struct updatedAt_lt;
+    impl ::cynic::schema::Field for updatedAt_lt {
         type Type = Option<super::DateTime>;
         const NAME: &'static str = "updatedAt_lt";
     }
-    impl ::cynic::schema::HasInputField<UpdatedAtLt, Option<super::DateTime>>
+    impl ::cynic::schema::HasInputField<updatedAt_lt, Option<super::DateTime>>
         for super::RemoteWhereInput
     {
     }
-    pub struct UpdatedAtLte;
-    impl ::cynic::schema::Field for UpdatedAtLte {
+    pub struct updatedAt_lte;
+    impl ::cynic::schema::Field for updatedAt_lte {
         type Type = Option<super::DateTime>;
         const NAME: &'static str = "updatedAt_lte";
     }
-    impl ::cynic::schema::HasInputField<UpdatedAtLte, Option<super::DateTime>>
+    impl ::cynic::schema::HasInputField<updatedAt_lte, Option<super::DateTime>>
         for super::RemoteWhereInput
     {
     }
-    pub struct UpdatedAtGt;
-    impl ::cynic::schema::Field for UpdatedAtGt {
+    pub struct updatedAt_gt;
+    impl ::cynic::schema::Field for updatedAt_gt {
         type Type = Option<super::DateTime>;
         const NAME: &'static str = "updatedAt_gt";
     }
-    impl ::cynic::schema::HasInputField<UpdatedAtGt, Option<super::DateTime>>
+    impl ::cynic::schema::HasInputField<updatedAt_gt, Option<super::DateTime>>
         for super::RemoteWhereInput
     {
     }
-    pub struct UpdatedAtGte;
-    impl ::cynic::schema::Field for UpdatedAtGte {
+    pub struct updatedAt_gte;
+    impl ::cynic::schema::Field for updatedAt_gte {
         type Type = Option<super::DateTime>;
         const NAME: &'static str = "updatedAt_gte";
     }
-    impl ::cynic::schema::HasInputField<UpdatedAtGte, Option<super::DateTime>>
+    impl ::cynic::schema::HasInputField<updatedAt_gte, Option<super::DateTime>>
         for super::RemoteWhereInput
     {
     }
-    pub struct And;
-    impl ::cynic::schema::Field for And {
+    pub struct AND;
+    impl ::cynic::schema::Field for AND {
         type Type = Option<Vec<super::RemoteWhereInput>>;
         const NAME: &'static str = "AND";
     }
-    impl ::cynic::schema::HasInputField<And, Option<Vec<super::RemoteWhereInput>>>
+    impl ::cynic::schema::HasInputField<AND, Option<Vec<super::RemoteWhereInput>>>
         for super::RemoteWhereInput
     {
     }
-    pub struct Or;
-    impl ::cynic::schema::Field for Or {
+    pub struct OR;
+    impl ::cynic::schema::Field for OR {
         type Type = Option<Vec<super::RemoteWhereInput>>;
         const NAME: &'static str = "OR";
     }
-    impl ::cynic::schema::HasInputField<Or, Option<Vec<super::RemoteWhereInput>>>
+    impl ::cynic::schema::HasInputField<OR, Option<Vec<super::RemoteWhereInput>>>
         for super::RemoteWhereInput
     {
     }
-    pub struct Not;
-    impl ::cynic::schema::Field for Not {
+    pub struct NOT;
+    impl ::cynic::schema::Field for NOT {
         type Type = Option<Vec<super::RemoteWhereInput>>;
         const NAME: &'static str = "NOT";
     }
-    impl ::cynic::schema::HasInputField<Not, Option<Vec<super::RemoteWhereInput>>>
+    impl ::cynic::schema::HasInputField<NOT, Option<Vec<super::RemoteWhereInput>>>
         for super::RemoteWhereInput
     {
     }
@@ -5687,104 +5807,104 @@ pub mod remote_where_input_fields {
 pub struct SubscribeInput;
 impl ::cynic::schema::InputObjectMarker for SubscribeInput {}
 pub mod subscribe_input_fields {
-    pub struct Name;
-    impl ::cynic::schema::Field for Name {
+    pub struct name;
+    impl ::cynic::schema::Field for name {
         type Type = super::String;
         const NAME: &'static str = "name";
     }
-    impl ::cynic::schema::HasInputField<Name, super::String> for super::SubscribeInput {}
-    pub struct Email;
-    impl ::cynic::schema::Field for Email {
+    impl ::cynic::schema::HasInputField<name, super::String> for super::SubscribeInput {}
+    pub struct email;
+    impl ::cynic::schema::Field for email {
         type Type = super::String;
         const NAME: &'static str = "email";
     }
-    impl ::cynic::schema::HasInputField<Email, super::String> for super::SubscribeInput {}
+    impl ::cynic::schema::HasInputField<email, super::String> for super::SubscribeInput {}
 }
 pub struct Tag;
 pub mod tag_fields {
-    pub struct Id;
-    impl ::cynic::schema::Field for Id {
-        type Type = super::Id;
+    pub struct id;
+    impl ::cynic::schema::Field for id {
+        type Type = super::ID;
         const NAME: &'static str = "id";
     }
-    impl ::cynic::schema::HasField<Id> for super::Tag {
-        type Type = super::Id;
+    impl ::cynic::schema::HasField<id> for super::Tag {
+        type Type = super::ID;
     }
-    pub struct Name;
-    impl ::cynic::schema::Field for Name {
+    pub struct name;
+    impl ::cynic::schema::Field for name {
         type Type = super::String;
         const NAME: &'static str = "name";
     }
-    impl ::cynic::schema::HasField<Name> for super::Tag {
+    impl ::cynic::schema::HasField<name> for super::Tag {
         type Type = super::String;
     }
-    pub struct Slug;
-    impl ::cynic::schema::Field for Slug {
+    pub struct slug;
+    impl ::cynic::schema::Field for slug {
         type Type = super::String;
         const NAME: &'static str = "slug";
     }
-    impl ::cynic::schema::HasField<Slug> for super::Tag {
+    impl ::cynic::schema::HasField<slug> for super::Tag {
         type Type = super::String;
     }
-    pub struct Jobs;
-    impl ::cynic::schema::Field for Jobs {
+    pub struct jobs;
+    impl ::cynic::schema::Field for jobs {
         type Type = Option<Vec<super::Job>>;
         const NAME: &'static str = "jobs";
     }
-    impl ::cynic::schema::HasField<Jobs> for super::Tag {
+    impl ::cynic::schema::HasField<jobs> for super::Tag {
         type Type = Option<Vec<super::Job>>;
     }
     pub mod jobs_arguments {
-        pub struct Where;
-        impl ::cynic::schema::HasArgument<Where> for super::Jobs {
+        pub struct r#where;
+        impl ::cynic::schema::HasArgument<r#where> for super::jobs {
             type ArgumentType = Option<super::super::JobWhereInput>;
             const NAME: &'static str = "where";
         }
-        pub struct OrderBy;
-        impl ::cynic::schema::HasArgument<OrderBy> for super::Jobs {
+        pub struct orderBy;
+        impl ::cynic::schema::HasArgument<orderBy> for super::jobs {
             type ArgumentType = Option<super::super::JobOrderByInput>;
             const NAME: &'static str = "orderBy";
         }
-        pub struct Skip;
-        impl ::cynic::schema::HasArgument<Skip> for super::Jobs {
+        pub struct skip;
+        impl ::cynic::schema::HasArgument<skip> for super::jobs {
             type ArgumentType = Option<super::super::Int>;
             const NAME: &'static str = "skip";
         }
-        pub struct After;
-        impl ::cynic::schema::HasArgument<After> for super::Jobs {
+        pub struct after;
+        impl ::cynic::schema::HasArgument<after> for super::jobs {
             type ArgumentType = Option<super::super::String>;
             const NAME: &'static str = "after";
         }
-        pub struct Before;
-        impl ::cynic::schema::HasArgument<Before> for super::Jobs {
+        pub struct before;
+        impl ::cynic::schema::HasArgument<before> for super::jobs {
             type ArgumentType = Option<super::super::String>;
             const NAME: &'static str = "before";
         }
-        pub struct First;
-        impl ::cynic::schema::HasArgument<First> for super::Jobs {
+        pub struct first;
+        impl ::cynic::schema::HasArgument<first> for super::jobs {
             type ArgumentType = Option<super::super::Int>;
             const NAME: &'static str = "first";
         }
-        pub struct Last;
-        impl ::cynic::schema::HasArgument<Last> for super::Jobs {
+        pub struct last;
+        impl ::cynic::schema::HasArgument<last> for super::jobs {
             type ArgumentType = Option<super::super::Int>;
             const NAME: &'static str = "last";
         }
     }
-    pub struct CreatedAt;
-    impl ::cynic::schema::Field for CreatedAt {
+    pub struct createdAt;
+    impl ::cynic::schema::Field for createdAt {
         type Type = super::DateTime;
         const NAME: &'static str = "createdAt";
     }
-    impl ::cynic::schema::HasField<CreatedAt> for super::Tag {
+    impl ::cynic::schema::HasField<createdAt> for super::Tag {
         type Type = super::DateTime;
     }
-    pub struct UpdatedAt;
-    impl ::cynic::schema::Field for UpdatedAt {
+    pub struct updatedAt;
+    impl ::cynic::schema::Field for updatedAt {
         type Type = super::DateTime;
         const NAME: &'static str = "updatedAt";
     }
-    impl ::cynic::schema::HasField<UpdatedAt> for super::Tag {
+    impl ::cynic::schema::HasField<updatedAt> for super::Tag {
         type Type = super::DateTime;
     }
 }
@@ -5792,465 +5912,486 @@ pub struct TagOrderByInput {}
 pub struct TagWhereInput;
 impl ::cynic::schema::InputObjectMarker for TagWhereInput {}
 pub mod tag_where_input_fields {
-    pub struct Id;
-    impl ::cynic::schema::Field for Id {
-        type Type = Option<super::Id>;
+    pub struct id;
+    impl ::cynic::schema::Field for id {
+        type Type = Option<super::ID>;
         const NAME: &'static str = "id";
     }
-    impl ::cynic::schema::HasInputField<Id, Option<super::Id>> for super::TagWhereInput {}
-    pub struct IdNot;
-    impl ::cynic::schema::Field for IdNot {
-        type Type = Option<super::Id>;
+    impl ::cynic::schema::HasInputField<id, Option<super::ID>> for super::TagWhereInput {}
+    pub struct id_not;
+    impl ::cynic::schema::Field for id_not {
+        type Type = Option<super::ID>;
         const NAME: &'static str = "id_not";
     }
-    impl ::cynic::schema::HasInputField<IdNot, Option<super::Id>> for super::TagWhereInput {}
-    pub struct IdIn;
-    impl ::cynic::schema::Field for IdIn {
-        type Type = Option<Vec<super::Id>>;
+    impl ::cynic::schema::HasInputField<id_not, Option<super::ID>> for super::TagWhereInput {}
+    pub struct id_in;
+    impl ::cynic::schema::Field for id_in {
+        type Type = Option<Vec<super::ID>>;
         const NAME: &'static str = "id_in";
     }
-    impl ::cynic::schema::HasInputField<IdIn, Option<Vec<super::Id>>> for super::TagWhereInput {}
-    pub struct IdNotIn;
-    impl ::cynic::schema::Field for IdNotIn {
-        type Type = Option<Vec<super::Id>>;
+    impl ::cynic::schema::HasInputField<id_in, Option<Vec<super::ID>>> for super::TagWhereInput {}
+    pub struct id_not_in;
+    impl ::cynic::schema::Field for id_not_in {
+        type Type = Option<Vec<super::ID>>;
         const NAME: &'static str = "id_not_in";
     }
-    impl ::cynic::schema::HasInputField<IdNotIn, Option<Vec<super::Id>>> for super::TagWhereInput {}
-    pub struct IdLt;
-    impl ::cynic::schema::Field for IdLt {
-        type Type = Option<super::Id>;
+    impl ::cynic::schema::HasInputField<id_not_in, Option<Vec<super::ID>>> for super::TagWhereInput {}
+    pub struct id_lt;
+    impl ::cynic::schema::Field for id_lt {
+        type Type = Option<super::ID>;
         const NAME: &'static str = "id_lt";
     }
-    impl ::cynic::schema::HasInputField<IdLt, Option<super::Id>> for super::TagWhereInput {}
-    pub struct IdLte;
-    impl ::cynic::schema::Field for IdLte {
-        type Type = Option<super::Id>;
+    impl ::cynic::schema::HasInputField<id_lt, Option<super::ID>> for super::TagWhereInput {}
+    pub struct id_lte;
+    impl ::cynic::schema::Field for id_lte {
+        type Type = Option<super::ID>;
         const NAME: &'static str = "id_lte";
     }
-    impl ::cynic::schema::HasInputField<IdLte, Option<super::Id>> for super::TagWhereInput {}
-    pub struct IdGt;
-    impl ::cynic::schema::Field for IdGt {
-        type Type = Option<super::Id>;
+    impl ::cynic::schema::HasInputField<id_lte, Option<super::ID>> for super::TagWhereInput {}
+    pub struct id_gt;
+    impl ::cynic::schema::Field for id_gt {
+        type Type = Option<super::ID>;
         const NAME: &'static str = "id_gt";
     }
-    impl ::cynic::schema::HasInputField<IdGt, Option<super::Id>> for super::TagWhereInput {}
-    pub struct IdGte;
-    impl ::cynic::schema::Field for IdGte {
-        type Type = Option<super::Id>;
+    impl ::cynic::schema::HasInputField<id_gt, Option<super::ID>> for super::TagWhereInput {}
+    pub struct id_gte;
+    impl ::cynic::schema::Field for id_gte {
+        type Type = Option<super::ID>;
         const NAME: &'static str = "id_gte";
     }
-    impl ::cynic::schema::HasInputField<IdGte, Option<super::Id>> for super::TagWhereInput {}
-    pub struct IdContains;
-    impl ::cynic::schema::Field for IdContains {
-        type Type = Option<super::Id>;
+    impl ::cynic::schema::HasInputField<id_gte, Option<super::ID>> for super::TagWhereInput {}
+    pub struct id_contains;
+    impl ::cynic::schema::Field for id_contains {
+        type Type = Option<super::ID>;
         const NAME: &'static str = "id_contains";
     }
-    impl ::cynic::schema::HasInputField<IdContains, Option<super::Id>> for super::TagWhereInput {}
-    pub struct IdNotContains;
-    impl ::cynic::schema::Field for IdNotContains {
-        type Type = Option<super::Id>;
+    impl ::cynic::schema::HasInputField<id_contains, Option<super::ID>> for super::TagWhereInput {}
+    pub struct id_not_contains;
+    impl ::cynic::schema::Field for id_not_contains {
+        type Type = Option<super::ID>;
         const NAME: &'static str = "id_not_contains";
     }
-    impl ::cynic::schema::HasInputField<IdNotContains, Option<super::Id>> for super::TagWhereInput {}
-    pub struct IdStartsWith;
-    impl ::cynic::schema::Field for IdStartsWith {
-        type Type = Option<super::Id>;
+    impl ::cynic::schema::HasInputField<id_not_contains, Option<super::ID>> for super::TagWhereInput {}
+    pub struct id_starts_with;
+    impl ::cynic::schema::Field for id_starts_with {
+        type Type = Option<super::ID>;
         const NAME: &'static str = "id_starts_with";
     }
-    impl ::cynic::schema::HasInputField<IdStartsWith, Option<super::Id>> for super::TagWhereInput {}
-    pub struct IdNotStartsWith;
-    impl ::cynic::schema::Field for IdNotStartsWith {
-        type Type = Option<super::Id>;
+    impl ::cynic::schema::HasInputField<id_starts_with, Option<super::ID>> for super::TagWhereInput {}
+    pub struct id_not_starts_with;
+    impl ::cynic::schema::Field for id_not_starts_with {
+        type Type = Option<super::ID>;
         const NAME: &'static str = "id_not_starts_with";
     }
-    impl ::cynic::schema::HasInputField<IdNotStartsWith, Option<super::Id>> for super::TagWhereInput {}
-    pub struct IdEndsWith;
-    impl ::cynic::schema::Field for IdEndsWith {
-        type Type = Option<super::Id>;
+    impl ::cynic::schema::HasInputField<id_not_starts_with, Option<super::ID>>
+        for super::TagWhereInput
+    {
+    }
+    pub struct id_ends_with;
+    impl ::cynic::schema::Field for id_ends_with {
+        type Type = Option<super::ID>;
         const NAME: &'static str = "id_ends_with";
     }
-    impl ::cynic::schema::HasInputField<IdEndsWith, Option<super::Id>> for super::TagWhereInput {}
-    pub struct IdNotEndsWith;
-    impl ::cynic::schema::Field for IdNotEndsWith {
-        type Type = Option<super::Id>;
+    impl ::cynic::schema::HasInputField<id_ends_with, Option<super::ID>> for super::TagWhereInput {}
+    pub struct id_not_ends_with;
+    impl ::cynic::schema::Field for id_not_ends_with {
+        type Type = Option<super::ID>;
         const NAME: &'static str = "id_not_ends_with";
     }
-    impl ::cynic::schema::HasInputField<IdNotEndsWith, Option<super::Id>> for super::TagWhereInput {}
-    pub struct Name;
-    impl ::cynic::schema::Field for Name {
+    impl ::cynic::schema::HasInputField<id_not_ends_with, Option<super::ID>> for super::TagWhereInput {}
+    pub struct name;
+    impl ::cynic::schema::Field for name {
         type Type = Option<super::String>;
         const NAME: &'static str = "name";
     }
-    impl ::cynic::schema::HasInputField<Name, Option<super::String>> for super::TagWhereInput {}
-    pub struct NameNot;
-    impl ::cynic::schema::Field for NameNot {
+    impl ::cynic::schema::HasInputField<name, Option<super::String>> for super::TagWhereInput {}
+    pub struct name_not;
+    impl ::cynic::schema::Field for name_not {
         type Type = Option<super::String>;
         const NAME: &'static str = "name_not";
     }
-    impl ::cynic::schema::HasInputField<NameNot, Option<super::String>> for super::TagWhereInput {}
-    pub struct NameIn;
-    impl ::cynic::schema::Field for NameIn {
+    impl ::cynic::schema::HasInputField<name_not, Option<super::String>> for super::TagWhereInput {}
+    pub struct name_in;
+    impl ::cynic::schema::Field for name_in {
         type Type = Option<Vec<super::String>>;
         const NAME: &'static str = "name_in";
     }
-    impl ::cynic::schema::HasInputField<NameIn, Option<Vec<super::String>>> for super::TagWhereInput {}
-    pub struct NameNotIn;
-    impl ::cynic::schema::Field for NameNotIn {
+    impl ::cynic::schema::HasInputField<name_in, Option<Vec<super::String>>> for super::TagWhereInput {}
+    pub struct name_not_in;
+    impl ::cynic::schema::Field for name_not_in {
         type Type = Option<Vec<super::String>>;
         const NAME: &'static str = "name_not_in";
     }
-    impl ::cynic::schema::HasInputField<NameNotIn, Option<Vec<super::String>>>
+    impl ::cynic::schema::HasInputField<name_not_in, Option<Vec<super::String>>>
         for super::TagWhereInput
     {
     }
-    pub struct NameLt;
-    impl ::cynic::schema::Field for NameLt {
+    pub struct name_lt;
+    impl ::cynic::schema::Field for name_lt {
         type Type = Option<super::String>;
         const NAME: &'static str = "name_lt";
     }
-    impl ::cynic::schema::HasInputField<NameLt, Option<super::String>> for super::TagWhereInput {}
-    pub struct NameLte;
-    impl ::cynic::schema::Field for NameLte {
+    impl ::cynic::schema::HasInputField<name_lt, Option<super::String>> for super::TagWhereInput {}
+    pub struct name_lte;
+    impl ::cynic::schema::Field for name_lte {
         type Type = Option<super::String>;
         const NAME: &'static str = "name_lte";
     }
-    impl ::cynic::schema::HasInputField<NameLte, Option<super::String>> for super::TagWhereInput {}
-    pub struct NameGt;
-    impl ::cynic::schema::Field for NameGt {
+    impl ::cynic::schema::HasInputField<name_lte, Option<super::String>> for super::TagWhereInput {}
+    pub struct name_gt;
+    impl ::cynic::schema::Field for name_gt {
         type Type = Option<super::String>;
         const NAME: &'static str = "name_gt";
     }
-    impl ::cynic::schema::HasInputField<NameGt, Option<super::String>> for super::TagWhereInput {}
-    pub struct NameGte;
-    impl ::cynic::schema::Field for NameGte {
+    impl ::cynic::schema::HasInputField<name_gt, Option<super::String>> for super::TagWhereInput {}
+    pub struct name_gte;
+    impl ::cynic::schema::Field for name_gte {
         type Type = Option<super::String>;
         const NAME: &'static str = "name_gte";
     }
-    impl ::cynic::schema::HasInputField<NameGte, Option<super::String>> for super::TagWhereInput {}
-    pub struct NameContains;
-    impl ::cynic::schema::Field for NameContains {
+    impl ::cynic::schema::HasInputField<name_gte, Option<super::String>> for super::TagWhereInput {}
+    pub struct name_contains;
+    impl ::cynic::schema::Field for name_contains {
         type Type = Option<super::String>;
         const NAME: &'static str = "name_contains";
     }
-    impl ::cynic::schema::HasInputField<NameContains, Option<super::String>> for super::TagWhereInput {}
-    pub struct NameNotContains;
-    impl ::cynic::schema::Field for NameNotContains {
+    impl ::cynic::schema::HasInputField<name_contains, Option<super::String>> for super::TagWhereInput {}
+    pub struct name_not_contains;
+    impl ::cynic::schema::Field for name_not_contains {
         type Type = Option<super::String>;
         const NAME: &'static str = "name_not_contains";
     }
-    impl ::cynic::schema::HasInputField<NameNotContains, Option<super::String>>
+    impl ::cynic::schema::HasInputField<name_not_contains, Option<super::String>>
         for super::TagWhereInput
     {
     }
-    pub struct NameStartsWith;
-    impl ::cynic::schema::Field for NameStartsWith {
+    pub struct name_starts_with;
+    impl ::cynic::schema::Field for name_starts_with {
         type Type = Option<super::String>;
         const NAME: &'static str = "name_starts_with";
     }
-    impl ::cynic::schema::HasInputField<NameStartsWith, Option<super::String>>
+    impl ::cynic::schema::HasInputField<name_starts_with, Option<super::String>>
         for super::TagWhereInput
     {
     }
-    pub struct NameNotStartsWith;
-    impl ::cynic::schema::Field for NameNotStartsWith {
+    pub struct name_not_starts_with;
+    impl ::cynic::schema::Field for name_not_starts_with {
         type Type = Option<super::String>;
         const NAME: &'static str = "name_not_starts_with";
     }
-    impl ::cynic::schema::HasInputField<NameNotStartsWith, Option<super::String>>
+    impl ::cynic::schema::HasInputField<name_not_starts_with, Option<super::String>>
         for super::TagWhereInput
     {
     }
-    pub struct NameEndsWith;
-    impl ::cynic::schema::Field for NameEndsWith {
+    pub struct name_ends_with;
+    impl ::cynic::schema::Field for name_ends_with {
         type Type = Option<super::String>;
         const NAME: &'static str = "name_ends_with";
     }
-    impl ::cynic::schema::HasInputField<NameEndsWith, Option<super::String>> for super::TagWhereInput {}
-    pub struct NameNotEndsWith;
-    impl ::cynic::schema::Field for NameNotEndsWith {
+    impl ::cynic::schema::HasInputField<name_ends_with, Option<super::String>>
+        for super::TagWhereInput
+    {
+    }
+    pub struct name_not_ends_with;
+    impl ::cynic::schema::Field for name_not_ends_with {
         type Type = Option<super::String>;
         const NAME: &'static str = "name_not_ends_with";
     }
-    impl ::cynic::schema::HasInputField<NameNotEndsWith, Option<super::String>>
+    impl ::cynic::schema::HasInputField<name_not_ends_with, Option<super::String>>
         for super::TagWhereInput
     {
     }
-    pub struct Slug;
-    impl ::cynic::schema::Field for Slug {
+    pub struct slug;
+    impl ::cynic::schema::Field for slug {
         type Type = Option<super::String>;
         const NAME: &'static str = "slug";
     }
-    impl ::cynic::schema::HasInputField<Slug, Option<super::String>> for super::TagWhereInput {}
-    pub struct SlugNot;
-    impl ::cynic::schema::Field for SlugNot {
+    impl ::cynic::schema::HasInputField<slug, Option<super::String>> for super::TagWhereInput {}
+    pub struct slug_not;
+    impl ::cynic::schema::Field for slug_not {
         type Type = Option<super::String>;
         const NAME: &'static str = "slug_not";
     }
-    impl ::cynic::schema::HasInputField<SlugNot, Option<super::String>> for super::TagWhereInput {}
-    pub struct SlugIn;
-    impl ::cynic::schema::Field for SlugIn {
+    impl ::cynic::schema::HasInputField<slug_not, Option<super::String>> for super::TagWhereInput {}
+    pub struct slug_in;
+    impl ::cynic::schema::Field for slug_in {
         type Type = Option<Vec<super::String>>;
         const NAME: &'static str = "slug_in";
     }
-    impl ::cynic::schema::HasInputField<SlugIn, Option<Vec<super::String>>> for super::TagWhereInput {}
-    pub struct SlugNotIn;
-    impl ::cynic::schema::Field for SlugNotIn {
+    impl ::cynic::schema::HasInputField<slug_in, Option<Vec<super::String>>> for super::TagWhereInput {}
+    pub struct slug_not_in;
+    impl ::cynic::schema::Field for slug_not_in {
         type Type = Option<Vec<super::String>>;
         const NAME: &'static str = "slug_not_in";
     }
-    impl ::cynic::schema::HasInputField<SlugNotIn, Option<Vec<super::String>>>
+    impl ::cynic::schema::HasInputField<slug_not_in, Option<Vec<super::String>>>
         for super::TagWhereInput
     {
     }
-    pub struct SlugLt;
-    impl ::cynic::schema::Field for SlugLt {
+    pub struct slug_lt;
+    impl ::cynic::schema::Field for slug_lt {
         type Type = Option<super::String>;
         const NAME: &'static str = "slug_lt";
     }
-    impl ::cynic::schema::HasInputField<SlugLt, Option<super::String>> for super::TagWhereInput {}
-    pub struct SlugLte;
-    impl ::cynic::schema::Field for SlugLte {
+    impl ::cynic::schema::HasInputField<slug_lt, Option<super::String>> for super::TagWhereInput {}
+    pub struct slug_lte;
+    impl ::cynic::schema::Field for slug_lte {
         type Type = Option<super::String>;
         const NAME: &'static str = "slug_lte";
     }
-    impl ::cynic::schema::HasInputField<SlugLte, Option<super::String>> for super::TagWhereInput {}
-    pub struct SlugGt;
-    impl ::cynic::schema::Field for SlugGt {
+    impl ::cynic::schema::HasInputField<slug_lte, Option<super::String>> for super::TagWhereInput {}
+    pub struct slug_gt;
+    impl ::cynic::schema::Field for slug_gt {
         type Type = Option<super::String>;
         const NAME: &'static str = "slug_gt";
     }
-    impl ::cynic::schema::HasInputField<SlugGt, Option<super::String>> for super::TagWhereInput {}
-    pub struct SlugGte;
-    impl ::cynic::schema::Field for SlugGte {
+    impl ::cynic::schema::HasInputField<slug_gt, Option<super::String>> for super::TagWhereInput {}
+    pub struct slug_gte;
+    impl ::cynic::schema::Field for slug_gte {
         type Type = Option<super::String>;
         const NAME: &'static str = "slug_gte";
     }
-    impl ::cynic::schema::HasInputField<SlugGte, Option<super::String>> for super::TagWhereInput {}
-    pub struct SlugContains;
-    impl ::cynic::schema::Field for SlugContains {
+    impl ::cynic::schema::HasInputField<slug_gte, Option<super::String>> for super::TagWhereInput {}
+    pub struct slug_contains;
+    impl ::cynic::schema::Field for slug_contains {
         type Type = Option<super::String>;
         const NAME: &'static str = "slug_contains";
     }
-    impl ::cynic::schema::HasInputField<SlugContains, Option<super::String>> for super::TagWhereInput {}
-    pub struct SlugNotContains;
-    impl ::cynic::schema::Field for SlugNotContains {
+    impl ::cynic::schema::HasInputField<slug_contains, Option<super::String>> for super::TagWhereInput {}
+    pub struct slug_not_contains;
+    impl ::cynic::schema::Field for slug_not_contains {
         type Type = Option<super::String>;
         const NAME: &'static str = "slug_not_contains";
     }
-    impl ::cynic::schema::HasInputField<SlugNotContains, Option<super::String>>
+    impl ::cynic::schema::HasInputField<slug_not_contains, Option<super::String>>
         for super::TagWhereInput
     {
     }
-    pub struct SlugStartsWith;
-    impl ::cynic::schema::Field for SlugStartsWith {
+    pub struct slug_starts_with;
+    impl ::cynic::schema::Field for slug_starts_with {
         type Type = Option<super::String>;
         const NAME: &'static str = "slug_starts_with";
     }
-    impl ::cynic::schema::HasInputField<SlugStartsWith, Option<super::String>>
+    impl ::cynic::schema::HasInputField<slug_starts_with, Option<super::String>>
         for super::TagWhereInput
     {
     }
-    pub struct SlugNotStartsWith;
-    impl ::cynic::schema::Field for SlugNotStartsWith {
+    pub struct slug_not_starts_with;
+    impl ::cynic::schema::Field for slug_not_starts_with {
         type Type = Option<super::String>;
         const NAME: &'static str = "slug_not_starts_with";
     }
-    impl ::cynic::schema::HasInputField<SlugNotStartsWith, Option<super::String>>
+    impl ::cynic::schema::HasInputField<slug_not_starts_with, Option<super::String>>
         for super::TagWhereInput
     {
     }
-    pub struct SlugEndsWith;
-    impl ::cynic::schema::Field for SlugEndsWith {
+    pub struct slug_ends_with;
+    impl ::cynic::schema::Field for slug_ends_with {
         type Type = Option<super::String>;
         const NAME: &'static str = "slug_ends_with";
     }
-    impl ::cynic::schema::HasInputField<SlugEndsWith, Option<super::String>> for super::TagWhereInput {}
-    pub struct SlugNotEndsWith;
-    impl ::cynic::schema::Field for SlugNotEndsWith {
+    impl ::cynic::schema::HasInputField<slug_ends_with, Option<super::String>>
+        for super::TagWhereInput
+    {
+    }
+    pub struct slug_not_ends_with;
+    impl ::cynic::schema::Field for slug_not_ends_with {
         type Type = Option<super::String>;
         const NAME: &'static str = "slug_not_ends_with";
     }
-    impl ::cynic::schema::HasInputField<SlugNotEndsWith, Option<super::String>>
+    impl ::cynic::schema::HasInputField<slug_not_ends_with, Option<super::String>>
         for super::TagWhereInput
     {
     }
-    pub struct JobsEvery;
-    impl ::cynic::schema::Field for JobsEvery {
+    pub struct jobs_every;
+    impl ::cynic::schema::Field for jobs_every {
         type Type = Option<super::JobWhereInput>;
         const NAME: &'static str = "jobs_every";
     }
-    impl ::cynic::schema::HasInputField<JobsEvery, Option<super::JobWhereInput>>
+    impl ::cynic::schema::HasInputField<jobs_every, Option<super::JobWhereInput>>
         for super::TagWhereInput
     {
     }
-    pub struct JobsSome;
-    impl ::cynic::schema::Field for JobsSome {
+    pub struct jobs_some;
+    impl ::cynic::schema::Field for jobs_some {
         type Type = Option<super::JobWhereInput>;
         const NAME: &'static str = "jobs_some";
     }
-    impl ::cynic::schema::HasInputField<JobsSome, Option<super::JobWhereInput>>
+    impl ::cynic::schema::HasInputField<jobs_some, Option<super::JobWhereInput>>
         for super::TagWhereInput
     {
     }
-    pub struct JobsNone;
-    impl ::cynic::schema::Field for JobsNone {
+    pub struct jobs_none;
+    impl ::cynic::schema::Field for jobs_none {
         type Type = Option<super::JobWhereInput>;
         const NAME: &'static str = "jobs_none";
     }
-    impl ::cynic::schema::HasInputField<JobsNone, Option<super::JobWhereInput>>
+    impl ::cynic::schema::HasInputField<jobs_none, Option<super::JobWhereInput>>
         for super::TagWhereInput
     {
     }
-    pub struct CreatedAt;
-    impl ::cynic::schema::Field for CreatedAt {
+    pub struct createdAt;
+    impl ::cynic::schema::Field for createdAt {
         type Type = Option<super::DateTime>;
         const NAME: &'static str = "createdAt";
     }
-    impl ::cynic::schema::HasInputField<CreatedAt, Option<super::DateTime>> for super::TagWhereInput {}
-    pub struct CreatedAtNot;
-    impl ::cynic::schema::Field for CreatedAtNot {
+    impl ::cynic::schema::HasInputField<createdAt, Option<super::DateTime>> for super::TagWhereInput {}
+    pub struct createdAt_not;
+    impl ::cynic::schema::Field for createdAt_not {
         type Type = Option<super::DateTime>;
         const NAME: &'static str = "createdAt_not";
     }
-    impl ::cynic::schema::HasInputField<CreatedAtNot, Option<super::DateTime>>
+    impl ::cynic::schema::HasInputField<createdAt_not, Option<super::DateTime>>
         for super::TagWhereInput
     {
     }
-    pub struct CreatedAtIn;
-    impl ::cynic::schema::Field for CreatedAtIn {
+    pub struct createdAt_in;
+    impl ::cynic::schema::Field for createdAt_in {
         type Type = Option<Vec<super::DateTime>>;
         const NAME: &'static str = "createdAt_in";
     }
-    impl ::cynic::schema::HasInputField<CreatedAtIn, Option<Vec<super::DateTime>>>
+    impl ::cynic::schema::HasInputField<createdAt_in, Option<Vec<super::DateTime>>>
         for super::TagWhereInput
     {
     }
-    pub struct CreatedAtNotIn;
-    impl ::cynic::schema::Field for CreatedAtNotIn {
+    pub struct createdAt_not_in;
+    impl ::cynic::schema::Field for createdAt_not_in {
         type Type = Option<Vec<super::DateTime>>;
         const NAME: &'static str = "createdAt_not_in";
     }
-    impl ::cynic::schema::HasInputField<CreatedAtNotIn, Option<Vec<super::DateTime>>>
+    impl ::cynic::schema::HasInputField<createdAt_not_in, Option<Vec<super::DateTime>>>
         for super::TagWhereInput
     {
     }
-    pub struct CreatedAtLt;
-    impl ::cynic::schema::Field for CreatedAtLt {
+    pub struct createdAt_lt;
+    impl ::cynic::schema::Field for createdAt_lt {
         type Type = Option<super::DateTime>;
         const NAME: &'static str = "createdAt_lt";
     }
-    impl ::cynic::schema::HasInputField<CreatedAtLt, Option<super::DateTime>> for super::TagWhereInput {}
-    pub struct CreatedAtLte;
-    impl ::cynic::schema::Field for CreatedAtLte {
+    impl ::cynic::schema::HasInputField<createdAt_lt, Option<super::DateTime>>
+        for super::TagWhereInput
+    {
+    }
+    pub struct createdAt_lte;
+    impl ::cynic::schema::Field for createdAt_lte {
         type Type = Option<super::DateTime>;
         const NAME: &'static str = "createdAt_lte";
     }
-    impl ::cynic::schema::HasInputField<CreatedAtLte, Option<super::DateTime>>
+    impl ::cynic::schema::HasInputField<createdAt_lte, Option<super::DateTime>>
         for super::TagWhereInput
     {
     }
-    pub struct CreatedAtGt;
-    impl ::cynic::schema::Field for CreatedAtGt {
+    pub struct createdAt_gt;
+    impl ::cynic::schema::Field for createdAt_gt {
         type Type = Option<super::DateTime>;
         const NAME: &'static str = "createdAt_gt";
     }
-    impl ::cynic::schema::HasInputField<CreatedAtGt, Option<super::DateTime>> for super::TagWhereInput {}
-    pub struct CreatedAtGte;
-    impl ::cynic::schema::Field for CreatedAtGte {
+    impl ::cynic::schema::HasInputField<createdAt_gt, Option<super::DateTime>>
+        for super::TagWhereInput
+    {
+    }
+    pub struct createdAt_gte;
+    impl ::cynic::schema::Field for createdAt_gte {
         type Type = Option<super::DateTime>;
         const NAME: &'static str = "createdAt_gte";
     }
-    impl ::cynic::schema::HasInputField<CreatedAtGte, Option<super::DateTime>>
+    impl ::cynic::schema::HasInputField<createdAt_gte, Option<super::DateTime>>
         for super::TagWhereInput
     {
     }
-    pub struct UpdatedAt;
-    impl ::cynic::schema::Field for UpdatedAt {
+    pub struct updatedAt;
+    impl ::cynic::schema::Field for updatedAt {
         type Type = Option<super::DateTime>;
         const NAME: &'static str = "updatedAt";
     }
-    impl ::cynic::schema::HasInputField<UpdatedAt, Option<super::DateTime>> for super::TagWhereInput {}
-    pub struct UpdatedAtNot;
-    impl ::cynic::schema::Field for UpdatedAtNot {
+    impl ::cynic::schema::HasInputField<updatedAt, Option<super::DateTime>> for super::TagWhereInput {}
+    pub struct updatedAt_not;
+    impl ::cynic::schema::Field for updatedAt_not {
         type Type = Option<super::DateTime>;
         const NAME: &'static str = "updatedAt_not";
     }
-    impl ::cynic::schema::HasInputField<UpdatedAtNot, Option<super::DateTime>>
+    impl ::cynic::schema::HasInputField<updatedAt_not, Option<super::DateTime>>
         for super::TagWhereInput
     {
     }
-    pub struct UpdatedAtIn;
-    impl ::cynic::schema::Field for UpdatedAtIn {
+    pub struct updatedAt_in;
+    impl ::cynic::schema::Field for updatedAt_in {
         type Type = Option<Vec<super::DateTime>>;
         const NAME: &'static str = "updatedAt_in";
     }
-    impl ::cynic::schema::HasInputField<UpdatedAtIn, Option<Vec<super::DateTime>>>
+    impl ::cynic::schema::HasInputField<updatedAt_in, Option<Vec<super::DateTime>>>
         for super::TagWhereInput
     {
     }
-    pub struct UpdatedAtNotIn;
-    impl ::cynic::schema::Field for UpdatedAtNotIn {
+    pub struct updatedAt_not_in;
+    impl ::cynic::schema::Field for updatedAt_not_in {
         type Type = Option<Vec<super::DateTime>>;
         const NAME: &'static str = "updatedAt_not_in";
     }
-    impl ::cynic::schema::HasInputField<UpdatedAtNotIn, Option<Vec<super::DateTime>>>
+    impl ::cynic::schema::HasInputField<updatedAt_not_in, Option<Vec<super::DateTime>>>
         for super::TagWhereInput
     {
     }
-    pub struct UpdatedAtLt;
-    impl ::cynic::schema::Field for UpdatedAtLt {
+    pub struct updatedAt_lt;
+    impl ::cynic::schema::Field for updatedAt_lt {
         type Type = Option<super::DateTime>;
         const NAME: &'static str = "updatedAt_lt";
     }
-    impl ::cynic::schema::HasInputField<UpdatedAtLt, Option<super::DateTime>> for super::TagWhereInput {}
-    pub struct UpdatedAtLte;
-    impl ::cynic::schema::Field for UpdatedAtLte {
+    impl ::cynic::schema::HasInputField<updatedAt_lt, Option<super::DateTime>>
+        for super::TagWhereInput
+    {
+    }
+    pub struct updatedAt_lte;
+    impl ::cynic::schema::Field for updatedAt_lte {
         type Type = Option<super::DateTime>;
         const NAME: &'static str = "updatedAt_lte";
     }
-    impl ::cynic::schema::HasInputField<UpdatedAtLte, Option<super::DateTime>>
+    impl ::cynic::schema::HasInputField<updatedAt_lte, Option<super::DateTime>>
         for super::TagWhereInput
     {
     }
-    pub struct UpdatedAtGt;
-    impl ::cynic::schema::Field for UpdatedAtGt {
+    pub struct updatedAt_gt;
+    impl ::cynic::schema::Field for updatedAt_gt {
         type Type = Option<super::DateTime>;
         const NAME: &'static str = "updatedAt_gt";
     }
-    impl ::cynic::schema::HasInputField<UpdatedAtGt, Option<super::DateTime>> for super::TagWhereInput {}
-    pub struct UpdatedAtGte;
-    impl ::cynic::schema::Field for UpdatedAtGte {
+    impl ::cynic::schema::HasInputField<updatedAt_gt, Option<super::DateTime>>
+        for super::TagWhereInput
+    {
+    }
+    pub struct updatedAt_gte;
+    impl ::cynic::schema::Field for updatedAt_gte {
         type Type = Option<super::DateTime>;
         const NAME: &'static str = "updatedAt_gte";
     }
-    impl ::cynic::schema::HasInputField<UpdatedAtGte, Option<super::DateTime>>
+    impl ::cynic::schema::HasInputField<updatedAt_gte, Option<super::DateTime>>
         for super::TagWhereInput
     {
     }
-    pub struct And;
-    impl ::cynic::schema::Field for And {
+    pub struct AND;
+    impl ::cynic::schema::Field for AND {
         type Type = Option<Vec<super::TagWhereInput>>;
         const NAME: &'static str = "AND";
     }
-    impl ::cynic::schema::HasInputField<And, Option<Vec<super::TagWhereInput>>>
+    impl ::cynic::schema::HasInputField<AND, Option<Vec<super::TagWhereInput>>>
         for super::TagWhereInput
     {
     }
-    pub struct Or;
-    impl ::cynic::schema::Field for Or {
+    pub struct OR;
+    impl ::cynic::schema::Field for OR {
         type Type = Option<Vec<super::TagWhereInput>>;
         const NAME: &'static str = "OR";
     }
-    impl ::cynic::schema::HasInputField<Or, Option<Vec<super::TagWhereInput>>>
+    impl ::cynic::schema::HasInputField<OR, Option<Vec<super::TagWhereInput>>>
         for super::TagWhereInput
     {
     }
-    pub struct Not;
-    impl ::cynic::schema::Field for Not {
+    pub struct NOT;
+    impl ::cynic::schema::Field for NOT {
         type Type = Option<Vec<super::TagWhereInput>>;
         const NAME: &'static str = "NOT";
     }
-    impl ::cynic::schema::HasInputField<Not, Option<Vec<super::TagWhereInput>>>
+    impl ::cynic::schema::HasInputField<NOT, Option<Vec<super::TagWhereInput>>>
         for super::TagWhereInput
     {
     }
@@ -6258,83 +6399,83 @@ pub mod tag_where_input_fields {
 pub struct UpdateCompanyInput;
 impl ::cynic::schema::InputObjectMarker for UpdateCompanyInput {}
 pub mod update_company_input_fields {
-    pub struct Id;
-    impl ::cynic::schema::Field for Id {
-        type Type = super::Id;
+    pub struct id;
+    impl ::cynic::schema::Field for id {
+        type Type = super::ID;
         const NAME: &'static str = "id";
     }
-    impl ::cynic::schema::HasInputField<Id, super::Id> for super::UpdateCompanyInput {}
-    pub struct LogoUrl;
-    impl ::cynic::schema::Field for LogoUrl {
+    impl ::cynic::schema::HasInputField<id, super::ID> for super::UpdateCompanyInput {}
+    pub struct logoUrl;
+    impl ::cynic::schema::Field for logoUrl {
         type Type = super::String;
         const NAME: &'static str = "logoUrl";
     }
-    impl ::cynic::schema::HasInputField<LogoUrl, super::String> for super::UpdateCompanyInput {}
+    impl ::cynic::schema::HasInputField<logoUrl, super::String> for super::UpdateCompanyInput {}
 }
 pub struct UpdateJobInput;
 impl ::cynic::schema::InputObjectMarker for UpdateJobInput {}
 pub mod update_job_input_fields {
-    pub struct Id;
-    impl ::cynic::schema::Field for Id {
-        type Type = super::Id;
+    pub struct id;
+    impl ::cynic::schema::Field for id {
+        type Type = super::ID;
         const NAME: &'static str = "id";
     }
-    impl ::cynic::schema::HasInputField<Id, super::Id> for super::UpdateJobInput {}
-    pub struct Description;
-    impl ::cynic::schema::Field for Description {
+    impl ::cynic::schema::HasInputField<id, super::ID> for super::UpdateJobInput {}
+    pub struct description;
+    impl ::cynic::schema::Field for description {
         type Type = super::String;
         const NAME: &'static str = "description";
     }
-    impl ::cynic::schema::HasInputField<Description, super::String> for super::UpdateJobInput {}
+    impl ::cynic::schema::HasInputField<description, super::String> for super::UpdateJobInput {}
 }
 pub struct User;
 pub mod user_fields {
-    pub struct Id;
-    impl ::cynic::schema::Field for Id {
-        type Type = super::Id;
+    pub struct id;
+    impl ::cynic::schema::Field for id {
+        type Type = super::ID;
         const NAME: &'static str = "id";
     }
-    impl ::cynic::schema::HasField<Id> for super::User {
-        type Type = super::Id;
+    impl ::cynic::schema::HasField<id> for super::User {
+        type Type = super::ID;
     }
-    pub struct Name;
-    impl ::cynic::schema::Field for Name {
+    pub struct name;
+    impl ::cynic::schema::Field for name {
         type Type = Option<super::String>;
         const NAME: &'static str = "name";
     }
-    impl ::cynic::schema::HasField<Name> for super::User {
+    impl ::cynic::schema::HasField<name> for super::User {
         type Type = Option<super::String>;
     }
-    pub struct Email;
-    impl ::cynic::schema::Field for Email {
+    pub struct email;
+    impl ::cynic::schema::Field for email {
         type Type = super::String;
         const NAME: &'static str = "email";
     }
-    impl ::cynic::schema::HasField<Email> for super::User {
+    impl ::cynic::schema::HasField<email> for super::User {
         type Type = super::String;
     }
-    pub struct Subscribe;
-    impl ::cynic::schema::Field for Subscribe {
+    pub struct subscribe;
+    impl ::cynic::schema::Field for subscribe {
         type Type = super::Boolean;
         const NAME: &'static str = "subscribe";
     }
-    impl ::cynic::schema::HasField<Subscribe> for super::User {
+    impl ::cynic::schema::HasField<subscribe> for super::User {
         type Type = super::Boolean;
     }
-    pub struct CreatedAt;
-    impl ::cynic::schema::Field for CreatedAt {
+    pub struct createdAt;
+    impl ::cynic::schema::Field for createdAt {
         type Type = super::DateTime;
         const NAME: &'static str = "createdAt";
     }
-    impl ::cynic::schema::HasField<CreatedAt> for super::User {
+    impl ::cynic::schema::HasField<createdAt> for super::User {
         type Type = super::DateTime;
     }
-    pub struct UpdatedAt;
-    impl ::cynic::schema::Field for UpdatedAt {
+    pub struct updatedAt;
+    impl ::cynic::schema::Field for updatedAt {
         type Type = super::DateTime;
         const NAME: &'static str = "updatedAt";
     }
-    impl ::cynic::schema::HasField<UpdatedAt> for super::User {
+    impl ::cynic::schema::HasField<updatedAt> for super::User {
         type Type = super::DateTime;
     }
 }
@@ -6375,7 +6516,7 @@ pub type Boolean = bool;
 pub type String = std::string::String;
 pub type Float = f64;
 pub type Int = i32;
-pub type Id = ::cynic::Id;
+pub type ID = ::cynic::Id;
 pub mod variable {
     use cynic::variables::VariableType;
     #[doc = r" Used to determine the type of a given variable that"]

--- a/cynic-codegen/tests/snapshots/use_schema__schema_file_2.snap
+++ b/cynic-codegen/tests/snapshots/use_schema__schema_file_2.snap
@@ -9,92 +9,92 @@ impl ::cynic::schema::MutationRoot for MutationRoot {}
 impl ::cynic::schema::SubscriptionRoot for SubscriptionRoot {}
 pub struct Book;
 pub mod book_fields {
-    pub struct Id;
-    impl ::cynic::schema::Field for Id {
+    pub struct id;
+    impl ::cynic::schema::Field for id {
         type Type = super::String;
         const NAME: &'static str = "id";
     }
-    impl ::cynic::schema::HasField<Id> for super::Book {
+    impl ::cynic::schema::HasField<id> for super::Book {
         type Type = super::String;
     }
-    pub struct Name;
-    impl ::cynic::schema::Field for Name {
+    pub struct name;
+    impl ::cynic::schema::Field for name {
         type Type = super::String;
         const NAME: &'static str = "name";
     }
-    impl ::cynic::schema::HasField<Name> for super::Book {
+    impl ::cynic::schema::HasField<name> for super::Book {
         type Type = super::String;
     }
-    pub struct Author;
-    impl ::cynic::schema::Field for Author {
+    pub struct author;
+    impl ::cynic::schema::Field for author {
         type Type = super::String;
         const NAME: &'static str = "author";
     }
-    impl ::cynic::schema::HasField<Author> for super::Book {
+    impl ::cynic::schema::HasField<author> for super::Book {
         type Type = super::String;
     }
 }
 pub struct BookChanged;
 pub mod book_changed_fields {
-    pub struct MutationType;
-    impl ::cynic::schema::Field for MutationType {
+    pub struct mutationType;
+    impl ::cynic::schema::Field for mutationType {
         type Type = super::MutationType;
         const NAME: &'static str = "mutationType";
     }
-    impl ::cynic::schema::HasField<MutationType> for super::BookChanged {
+    impl ::cynic::schema::HasField<mutationType> for super::BookChanged {
         type Type = super::MutationType;
     }
-    pub struct Id;
-    impl ::cynic::schema::Field for Id {
-        type Type = super::Id;
+    pub struct id;
+    impl ::cynic::schema::Field for id {
+        type Type = super::ID;
         const NAME: &'static str = "id";
     }
-    impl ::cynic::schema::HasField<Id> for super::BookChanged {
-        type Type = super::Id;
+    impl ::cynic::schema::HasField<id> for super::BookChanged {
+        type Type = super::ID;
     }
-    pub struct Book;
-    impl ::cynic::schema::Field for Book {
+    pub struct book;
+    impl ::cynic::schema::Field for book {
         type Type = Option<super::Book>;
         const NAME: &'static str = "book";
     }
-    impl ::cynic::schema::HasField<Book> for super::BookChanged {
+    impl ::cynic::schema::HasField<book> for super::BookChanged {
         type Type = Option<super::Book>;
     }
 }
 pub struct MutationRoot;
 pub mod mutation_root_fields {
-    pub struct CreateBook;
-    impl ::cynic::schema::Field for CreateBook {
-        type Type = super::Id;
+    pub struct createBook;
+    impl ::cynic::schema::Field for createBook {
+        type Type = super::ID;
         const NAME: &'static str = "createBook";
     }
-    impl ::cynic::schema::HasField<CreateBook> for super::MutationRoot {
-        type Type = super::Id;
+    impl ::cynic::schema::HasField<createBook> for super::MutationRoot {
+        type Type = super::ID;
     }
     pub mod create_book_arguments {
-        pub struct Name;
-        impl ::cynic::schema::HasArgument<Name> for super::CreateBook {
+        pub struct name;
+        impl ::cynic::schema::HasArgument<name> for super::createBook {
             type ArgumentType = super::super::String;
             const NAME: &'static str = "name";
         }
-        pub struct Author;
-        impl ::cynic::schema::HasArgument<Author> for super::CreateBook {
+        pub struct author;
+        impl ::cynic::schema::HasArgument<author> for super::createBook {
             type ArgumentType = super::super::String;
             const NAME: &'static str = "author";
         }
     }
-    pub struct DeleteBook;
-    impl ::cynic::schema::Field for DeleteBook {
+    pub struct deleteBook;
+    impl ::cynic::schema::Field for deleteBook {
         type Type = super::Boolean;
         const NAME: &'static str = "deleteBook";
     }
-    impl ::cynic::schema::HasField<DeleteBook> for super::MutationRoot {
+    impl ::cynic::schema::HasField<deleteBook> for super::MutationRoot {
         type Type = super::Boolean;
     }
     pub mod delete_book_arguments {
-        pub struct Id;
-        impl ::cynic::schema::HasArgument<Id> for super::DeleteBook {
-            type ArgumentType = super::super::Id;
+        pub struct id;
+        impl ::cynic::schema::HasArgument<id> for super::deleteBook {
+            type ArgumentType = super::super::ID;
             const NAME: &'static str = "id";
         }
     }
@@ -102,43 +102,43 @@ pub mod mutation_root_fields {
 pub struct MutationType {}
 pub struct QueryRoot;
 pub mod query_root_fields {
-    pub struct Books;
-    impl ::cynic::schema::Field for Books {
+    pub struct books;
+    impl ::cynic::schema::Field for books {
         type Type = Vec<super::Book>;
         const NAME: &'static str = "books";
     }
-    impl ::cynic::schema::HasField<Books> for super::QueryRoot {
+    impl ::cynic::schema::HasField<books> for super::QueryRoot {
         type Type = Vec<super::Book>;
     }
 }
 pub struct SubscriptionRoot;
 pub mod subscription_root_fields {
-    pub struct Interval;
-    impl ::cynic::schema::Field for Interval {
+    pub struct interval;
+    impl ::cynic::schema::Field for interval {
         type Type = super::Int;
         const NAME: &'static str = "interval";
     }
-    impl ::cynic::schema::HasField<Interval> for super::SubscriptionRoot {
+    impl ::cynic::schema::HasField<interval> for super::SubscriptionRoot {
         type Type = super::Int;
     }
     pub mod interval_arguments {
-        pub struct N;
-        impl ::cynic::schema::HasArgument<N> for super::Interval {
+        pub struct n;
+        impl ::cynic::schema::HasArgument<n> for super::interval {
             type ArgumentType = super::super::Int;
             const NAME: &'static str = "n";
         }
     }
-    pub struct Books;
-    impl ::cynic::schema::Field for Books {
+    pub struct books;
+    impl ::cynic::schema::Field for books {
         type Type = super::BookChanged;
         const NAME: &'static str = "books";
     }
-    impl ::cynic::schema::HasField<Books> for super::SubscriptionRoot {
+    impl ::cynic::schema::HasField<books> for super::SubscriptionRoot {
         type Type = super::BookChanged;
     }
     pub mod books_arguments {
-        pub struct MutationType;
-        impl ::cynic::schema::HasArgument<MutationType> for super::Books {
+        pub struct mutationType;
+        impl ::cynic::schema::HasArgument<mutationType> for super::books {
             type ArgumentType = Option<super::super::MutationType>;
             const NAME: &'static str = "mutationType";
         }
@@ -163,7 +163,7 @@ pub type Boolean = bool;
 pub type String = std::string::String;
 pub type Float = f64;
 pub type Int = i32;
-pub type Id = ::cynic::Id;
+pub type ID = ::cynic::Id;
 pub mod variable {
     use cynic::variables::VariableType;
     #[doc = r" Used to determine the type of a given variable that"]

--- a/cynic-codegen/tests/snapshots/use_schema__schema_file_3.snap
+++ b/cynic-codegen/tests/snapshots/use_schema__schema_file_3.snap
@@ -7,2667 +7,2667 @@ expression: "format_code(format!(\"{}\", tokens))"
 impl ::cynic::schema::QueryRoot for Root {}
 pub struct Film;
 pub mod film_fields {
-    pub struct Title;
-    impl ::cynic::schema::Field for Title {
+    pub struct title;
+    impl ::cynic::schema::Field for title {
         type Type = Option<super::String>;
         const NAME: &'static str = "title";
     }
-    impl ::cynic::schema::HasField<Title> for super::Film {
+    impl ::cynic::schema::HasField<title> for super::Film {
         type Type = Option<super::String>;
     }
-    pub struct EpisodeId;
-    impl ::cynic::schema::Field for EpisodeId {
+    pub struct episodeID;
+    impl ::cynic::schema::Field for episodeID {
         type Type = Option<super::Int>;
         const NAME: &'static str = "episodeID";
     }
-    impl ::cynic::schema::HasField<EpisodeId> for super::Film {
+    impl ::cynic::schema::HasField<episodeID> for super::Film {
         type Type = Option<super::Int>;
     }
-    pub struct OpeningCrawl;
-    impl ::cynic::schema::Field for OpeningCrawl {
+    pub struct openingCrawl;
+    impl ::cynic::schema::Field for openingCrawl {
         type Type = Option<super::String>;
         const NAME: &'static str = "openingCrawl";
     }
-    impl ::cynic::schema::HasField<OpeningCrawl> for super::Film {
+    impl ::cynic::schema::HasField<openingCrawl> for super::Film {
         type Type = Option<super::String>;
     }
-    pub struct Director;
-    impl ::cynic::schema::Field for Director {
+    pub struct director;
+    impl ::cynic::schema::Field for director {
         type Type = Option<super::String>;
         const NAME: &'static str = "director";
     }
-    impl ::cynic::schema::HasField<Director> for super::Film {
+    impl ::cynic::schema::HasField<director> for super::Film {
         type Type = Option<super::String>;
     }
-    pub struct Producers;
-    impl ::cynic::schema::Field for Producers {
+    pub struct producers;
+    impl ::cynic::schema::Field for producers {
         type Type = Option<Vec<Option<super::String>>>;
         const NAME: &'static str = "producers";
     }
-    impl ::cynic::schema::HasField<Producers> for super::Film {
+    impl ::cynic::schema::HasField<producers> for super::Film {
         type Type = Option<Vec<Option<super::String>>>;
     }
-    pub struct ReleaseDate;
-    impl ::cynic::schema::Field for ReleaseDate {
+    pub struct releaseDate;
+    impl ::cynic::schema::Field for releaseDate {
         type Type = Option<super::String>;
         const NAME: &'static str = "releaseDate";
     }
-    impl ::cynic::schema::HasField<ReleaseDate> for super::Film {
+    impl ::cynic::schema::HasField<releaseDate> for super::Film {
         type Type = Option<super::String>;
     }
-    pub struct SpeciesConnection;
-    impl ::cynic::schema::Field for SpeciesConnection {
+    pub struct speciesConnection;
+    impl ::cynic::schema::Field for speciesConnection {
         type Type = Option<super::FilmSpeciesConnection>;
         const NAME: &'static str = "speciesConnection";
     }
-    impl ::cynic::schema::HasField<SpeciesConnection> for super::Film {
+    impl ::cynic::schema::HasField<speciesConnection> for super::Film {
         type Type = Option<super::FilmSpeciesConnection>;
     }
     pub mod species_connection_arguments {
-        pub struct After;
-        impl ::cynic::schema::HasArgument<After> for super::SpeciesConnection {
+        pub struct after;
+        impl ::cynic::schema::HasArgument<after> for super::speciesConnection {
             type ArgumentType = Option<super::super::String>;
             const NAME: &'static str = "after";
         }
-        pub struct First;
-        impl ::cynic::schema::HasArgument<First> for super::SpeciesConnection {
+        pub struct first;
+        impl ::cynic::schema::HasArgument<first> for super::speciesConnection {
             type ArgumentType = Option<super::super::Int>;
             const NAME: &'static str = "first";
         }
-        pub struct Before;
-        impl ::cynic::schema::HasArgument<Before> for super::SpeciesConnection {
+        pub struct before;
+        impl ::cynic::schema::HasArgument<before> for super::speciesConnection {
             type ArgumentType = Option<super::super::String>;
             const NAME: &'static str = "before";
         }
-        pub struct Last;
-        impl ::cynic::schema::HasArgument<Last> for super::SpeciesConnection {
+        pub struct last;
+        impl ::cynic::schema::HasArgument<last> for super::speciesConnection {
             type ArgumentType = Option<super::super::Int>;
             const NAME: &'static str = "last";
         }
     }
-    pub struct StarshipConnection;
-    impl ::cynic::schema::Field for StarshipConnection {
+    pub struct starshipConnection;
+    impl ::cynic::schema::Field for starshipConnection {
         type Type = Option<super::FilmStarshipsConnection>;
         const NAME: &'static str = "starshipConnection";
     }
-    impl ::cynic::schema::HasField<StarshipConnection> for super::Film {
+    impl ::cynic::schema::HasField<starshipConnection> for super::Film {
         type Type = Option<super::FilmStarshipsConnection>;
     }
     pub mod starship_connection_arguments {
-        pub struct After;
-        impl ::cynic::schema::HasArgument<After> for super::StarshipConnection {
+        pub struct after;
+        impl ::cynic::schema::HasArgument<after> for super::starshipConnection {
             type ArgumentType = Option<super::super::String>;
             const NAME: &'static str = "after";
         }
-        pub struct First;
-        impl ::cynic::schema::HasArgument<First> for super::StarshipConnection {
+        pub struct first;
+        impl ::cynic::schema::HasArgument<first> for super::starshipConnection {
             type ArgumentType = Option<super::super::Int>;
             const NAME: &'static str = "first";
         }
-        pub struct Before;
-        impl ::cynic::schema::HasArgument<Before> for super::StarshipConnection {
+        pub struct before;
+        impl ::cynic::schema::HasArgument<before> for super::starshipConnection {
             type ArgumentType = Option<super::super::String>;
             const NAME: &'static str = "before";
         }
-        pub struct Last;
-        impl ::cynic::schema::HasArgument<Last> for super::StarshipConnection {
+        pub struct last;
+        impl ::cynic::schema::HasArgument<last> for super::starshipConnection {
             type ArgumentType = Option<super::super::Int>;
             const NAME: &'static str = "last";
         }
     }
-    pub struct VehicleConnection;
-    impl ::cynic::schema::Field for VehicleConnection {
+    pub struct vehicleConnection;
+    impl ::cynic::schema::Field for vehicleConnection {
         type Type = Option<super::FilmVehiclesConnection>;
         const NAME: &'static str = "vehicleConnection";
     }
-    impl ::cynic::schema::HasField<VehicleConnection> for super::Film {
+    impl ::cynic::schema::HasField<vehicleConnection> for super::Film {
         type Type = Option<super::FilmVehiclesConnection>;
     }
     pub mod vehicle_connection_arguments {
-        pub struct After;
-        impl ::cynic::schema::HasArgument<After> for super::VehicleConnection {
+        pub struct after;
+        impl ::cynic::schema::HasArgument<after> for super::vehicleConnection {
             type ArgumentType = Option<super::super::String>;
             const NAME: &'static str = "after";
         }
-        pub struct First;
-        impl ::cynic::schema::HasArgument<First> for super::VehicleConnection {
+        pub struct first;
+        impl ::cynic::schema::HasArgument<first> for super::vehicleConnection {
             type ArgumentType = Option<super::super::Int>;
             const NAME: &'static str = "first";
         }
-        pub struct Before;
-        impl ::cynic::schema::HasArgument<Before> for super::VehicleConnection {
+        pub struct before;
+        impl ::cynic::schema::HasArgument<before> for super::vehicleConnection {
             type ArgumentType = Option<super::super::String>;
             const NAME: &'static str = "before";
         }
-        pub struct Last;
-        impl ::cynic::schema::HasArgument<Last> for super::VehicleConnection {
+        pub struct last;
+        impl ::cynic::schema::HasArgument<last> for super::vehicleConnection {
             type ArgumentType = Option<super::super::Int>;
             const NAME: &'static str = "last";
         }
     }
-    pub struct CharacterConnection;
-    impl ::cynic::schema::Field for CharacterConnection {
+    pub struct characterConnection;
+    impl ::cynic::schema::Field for characterConnection {
         type Type = Option<super::FilmCharactersConnection>;
         const NAME: &'static str = "characterConnection";
     }
-    impl ::cynic::schema::HasField<CharacterConnection> for super::Film {
+    impl ::cynic::schema::HasField<characterConnection> for super::Film {
         type Type = Option<super::FilmCharactersConnection>;
     }
     pub mod character_connection_arguments {
-        pub struct After;
-        impl ::cynic::schema::HasArgument<After> for super::CharacterConnection {
+        pub struct after;
+        impl ::cynic::schema::HasArgument<after> for super::characterConnection {
             type ArgumentType = Option<super::super::String>;
             const NAME: &'static str = "after";
         }
-        pub struct First;
-        impl ::cynic::schema::HasArgument<First> for super::CharacterConnection {
+        pub struct first;
+        impl ::cynic::schema::HasArgument<first> for super::characterConnection {
             type ArgumentType = Option<super::super::Int>;
             const NAME: &'static str = "first";
         }
-        pub struct Before;
-        impl ::cynic::schema::HasArgument<Before> for super::CharacterConnection {
+        pub struct before;
+        impl ::cynic::schema::HasArgument<before> for super::characterConnection {
             type ArgumentType = Option<super::super::String>;
             const NAME: &'static str = "before";
         }
-        pub struct Last;
-        impl ::cynic::schema::HasArgument<Last> for super::CharacterConnection {
+        pub struct last;
+        impl ::cynic::schema::HasArgument<last> for super::characterConnection {
             type ArgumentType = Option<super::super::Int>;
             const NAME: &'static str = "last";
         }
     }
-    pub struct PlanetConnection;
-    impl ::cynic::schema::Field for PlanetConnection {
+    pub struct planetConnection;
+    impl ::cynic::schema::Field for planetConnection {
         type Type = Option<super::FilmPlanetsConnection>;
         const NAME: &'static str = "planetConnection";
     }
-    impl ::cynic::schema::HasField<PlanetConnection> for super::Film {
+    impl ::cynic::schema::HasField<planetConnection> for super::Film {
         type Type = Option<super::FilmPlanetsConnection>;
     }
     pub mod planet_connection_arguments {
-        pub struct After;
-        impl ::cynic::schema::HasArgument<After> for super::PlanetConnection {
+        pub struct after;
+        impl ::cynic::schema::HasArgument<after> for super::planetConnection {
             type ArgumentType = Option<super::super::String>;
             const NAME: &'static str = "after";
         }
-        pub struct First;
-        impl ::cynic::schema::HasArgument<First> for super::PlanetConnection {
+        pub struct first;
+        impl ::cynic::schema::HasArgument<first> for super::planetConnection {
             type ArgumentType = Option<super::super::Int>;
             const NAME: &'static str = "first";
         }
-        pub struct Before;
-        impl ::cynic::schema::HasArgument<Before> for super::PlanetConnection {
+        pub struct before;
+        impl ::cynic::schema::HasArgument<before> for super::planetConnection {
             type ArgumentType = Option<super::super::String>;
             const NAME: &'static str = "before";
         }
-        pub struct Last;
-        impl ::cynic::schema::HasArgument<Last> for super::PlanetConnection {
+        pub struct last;
+        impl ::cynic::schema::HasArgument<last> for super::planetConnection {
             type ArgumentType = Option<super::super::Int>;
             const NAME: &'static str = "last";
         }
     }
-    pub struct Created;
-    impl ::cynic::schema::Field for Created {
+    pub struct created;
+    impl ::cynic::schema::Field for created {
         type Type = Option<super::String>;
         const NAME: &'static str = "created";
     }
-    impl ::cynic::schema::HasField<Created> for super::Film {
+    impl ::cynic::schema::HasField<created> for super::Film {
         type Type = Option<super::String>;
     }
-    pub struct Edited;
-    impl ::cynic::schema::Field for Edited {
+    pub struct edited;
+    impl ::cynic::schema::Field for edited {
         type Type = Option<super::String>;
         const NAME: &'static str = "edited";
     }
-    impl ::cynic::schema::HasField<Edited> for super::Film {
+    impl ::cynic::schema::HasField<edited> for super::Film {
         type Type = Option<super::String>;
     }
-    pub struct Id;
-    impl ::cynic::schema::Field for Id {
-        type Type = super::Id;
+    pub struct id;
+    impl ::cynic::schema::Field for id {
+        type Type = super::ID;
         const NAME: &'static str = "id";
     }
-    impl ::cynic::schema::HasField<Id> for super::Film {
-        type Type = super::Id;
+    impl ::cynic::schema::HasField<id> for super::Film {
+        type Type = super::ID;
     }
 }
 pub struct FilmCharactersConnection;
 pub mod film_characters_connection_fields {
-    pub struct PageInfo;
-    impl ::cynic::schema::Field for PageInfo {
+    pub struct pageInfo;
+    impl ::cynic::schema::Field for pageInfo {
         type Type = super::PageInfo;
         const NAME: &'static str = "pageInfo";
     }
-    impl ::cynic::schema::HasField<PageInfo> for super::FilmCharactersConnection {
+    impl ::cynic::schema::HasField<pageInfo> for super::FilmCharactersConnection {
         type Type = super::PageInfo;
     }
-    pub struct Edges;
-    impl ::cynic::schema::Field for Edges {
+    pub struct edges;
+    impl ::cynic::schema::Field for edges {
         type Type = Option<Vec<Option<super::FilmCharactersEdge>>>;
         const NAME: &'static str = "edges";
     }
-    impl ::cynic::schema::HasField<Edges> for super::FilmCharactersConnection {
+    impl ::cynic::schema::HasField<edges> for super::FilmCharactersConnection {
         type Type = Option<Vec<Option<super::FilmCharactersEdge>>>;
     }
-    pub struct TotalCount;
-    impl ::cynic::schema::Field for TotalCount {
+    pub struct totalCount;
+    impl ::cynic::schema::Field for totalCount {
         type Type = Option<super::Int>;
         const NAME: &'static str = "totalCount";
     }
-    impl ::cynic::schema::HasField<TotalCount> for super::FilmCharactersConnection {
+    impl ::cynic::schema::HasField<totalCount> for super::FilmCharactersConnection {
         type Type = Option<super::Int>;
     }
-    pub struct Characters;
-    impl ::cynic::schema::Field for Characters {
+    pub struct characters;
+    impl ::cynic::schema::Field for characters {
         type Type = Option<Vec<Option<super::Person>>>;
         const NAME: &'static str = "characters";
     }
-    impl ::cynic::schema::HasField<Characters> for super::FilmCharactersConnection {
+    impl ::cynic::schema::HasField<characters> for super::FilmCharactersConnection {
         type Type = Option<Vec<Option<super::Person>>>;
     }
 }
 pub struct FilmCharactersEdge;
 pub mod film_characters_edge_fields {
-    pub struct Node;
-    impl ::cynic::schema::Field for Node {
+    pub struct node;
+    impl ::cynic::schema::Field for node {
         type Type = Option<super::Person>;
         const NAME: &'static str = "node";
     }
-    impl ::cynic::schema::HasField<Node> for super::FilmCharactersEdge {
+    impl ::cynic::schema::HasField<node> for super::FilmCharactersEdge {
         type Type = Option<super::Person>;
     }
-    pub struct Cursor;
-    impl ::cynic::schema::Field for Cursor {
+    pub struct cursor;
+    impl ::cynic::schema::Field for cursor {
         type Type = super::String;
         const NAME: &'static str = "cursor";
     }
-    impl ::cynic::schema::HasField<Cursor> for super::FilmCharactersEdge {
+    impl ::cynic::schema::HasField<cursor> for super::FilmCharactersEdge {
         type Type = super::String;
     }
 }
 pub struct FilmPlanetsConnection;
 pub mod film_planets_connection_fields {
-    pub struct PageInfo;
-    impl ::cynic::schema::Field for PageInfo {
+    pub struct pageInfo;
+    impl ::cynic::schema::Field for pageInfo {
         type Type = super::PageInfo;
         const NAME: &'static str = "pageInfo";
     }
-    impl ::cynic::schema::HasField<PageInfo> for super::FilmPlanetsConnection {
+    impl ::cynic::schema::HasField<pageInfo> for super::FilmPlanetsConnection {
         type Type = super::PageInfo;
     }
-    pub struct Edges;
-    impl ::cynic::schema::Field for Edges {
+    pub struct edges;
+    impl ::cynic::schema::Field for edges {
         type Type = Option<Vec<Option<super::FilmPlanetsEdge>>>;
         const NAME: &'static str = "edges";
     }
-    impl ::cynic::schema::HasField<Edges> for super::FilmPlanetsConnection {
+    impl ::cynic::schema::HasField<edges> for super::FilmPlanetsConnection {
         type Type = Option<Vec<Option<super::FilmPlanetsEdge>>>;
     }
-    pub struct TotalCount;
-    impl ::cynic::schema::Field for TotalCount {
+    pub struct totalCount;
+    impl ::cynic::schema::Field for totalCount {
         type Type = Option<super::Int>;
         const NAME: &'static str = "totalCount";
     }
-    impl ::cynic::schema::HasField<TotalCount> for super::FilmPlanetsConnection {
+    impl ::cynic::schema::HasField<totalCount> for super::FilmPlanetsConnection {
         type Type = Option<super::Int>;
     }
-    pub struct Planets;
-    impl ::cynic::schema::Field for Planets {
+    pub struct planets;
+    impl ::cynic::schema::Field for planets {
         type Type = Option<Vec<Option<super::Planet>>>;
         const NAME: &'static str = "planets";
     }
-    impl ::cynic::schema::HasField<Planets> for super::FilmPlanetsConnection {
+    impl ::cynic::schema::HasField<planets> for super::FilmPlanetsConnection {
         type Type = Option<Vec<Option<super::Planet>>>;
     }
 }
 pub struct FilmPlanetsEdge;
 pub mod film_planets_edge_fields {
-    pub struct Node;
-    impl ::cynic::schema::Field for Node {
+    pub struct node;
+    impl ::cynic::schema::Field for node {
         type Type = Option<super::Planet>;
         const NAME: &'static str = "node";
     }
-    impl ::cynic::schema::HasField<Node> for super::FilmPlanetsEdge {
+    impl ::cynic::schema::HasField<node> for super::FilmPlanetsEdge {
         type Type = Option<super::Planet>;
     }
-    pub struct Cursor;
-    impl ::cynic::schema::Field for Cursor {
+    pub struct cursor;
+    impl ::cynic::schema::Field for cursor {
         type Type = super::String;
         const NAME: &'static str = "cursor";
     }
-    impl ::cynic::schema::HasField<Cursor> for super::FilmPlanetsEdge {
+    impl ::cynic::schema::HasField<cursor> for super::FilmPlanetsEdge {
         type Type = super::String;
     }
 }
 pub struct FilmSpeciesConnection;
 pub mod film_species_connection_fields {
-    pub struct PageInfo;
-    impl ::cynic::schema::Field for PageInfo {
+    pub struct pageInfo;
+    impl ::cynic::schema::Field for pageInfo {
         type Type = super::PageInfo;
         const NAME: &'static str = "pageInfo";
     }
-    impl ::cynic::schema::HasField<PageInfo> for super::FilmSpeciesConnection {
+    impl ::cynic::schema::HasField<pageInfo> for super::FilmSpeciesConnection {
         type Type = super::PageInfo;
     }
-    pub struct Edges;
-    impl ::cynic::schema::Field for Edges {
+    pub struct edges;
+    impl ::cynic::schema::Field for edges {
         type Type = Option<Vec<Option<super::FilmSpeciesEdge>>>;
         const NAME: &'static str = "edges";
     }
-    impl ::cynic::schema::HasField<Edges> for super::FilmSpeciesConnection {
+    impl ::cynic::schema::HasField<edges> for super::FilmSpeciesConnection {
         type Type = Option<Vec<Option<super::FilmSpeciesEdge>>>;
     }
-    pub struct TotalCount;
-    impl ::cynic::schema::Field for TotalCount {
+    pub struct totalCount;
+    impl ::cynic::schema::Field for totalCount {
         type Type = Option<super::Int>;
         const NAME: &'static str = "totalCount";
     }
-    impl ::cynic::schema::HasField<TotalCount> for super::FilmSpeciesConnection {
+    impl ::cynic::schema::HasField<totalCount> for super::FilmSpeciesConnection {
         type Type = Option<super::Int>;
     }
-    pub struct Species;
-    impl ::cynic::schema::Field for Species {
+    pub struct species;
+    impl ::cynic::schema::Field for species {
         type Type = Option<Vec<Option<super::Species>>>;
         const NAME: &'static str = "species";
     }
-    impl ::cynic::schema::HasField<Species> for super::FilmSpeciesConnection {
+    impl ::cynic::schema::HasField<species> for super::FilmSpeciesConnection {
         type Type = Option<Vec<Option<super::Species>>>;
     }
 }
 pub struct FilmSpeciesEdge;
 pub mod film_species_edge_fields {
-    pub struct Node;
-    impl ::cynic::schema::Field for Node {
+    pub struct node;
+    impl ::cynic::schema::Field for node {
         type Type = Option<super::Species>;
         const NAME: &'static str = "node";
     }
-    impl ::cynic::schema::HasField<Node> for super::FilmSpeciesEdge {
+    impl ::cynic::schema::HasField<node> for super::FilmSpeciesEdge {
         type Type = Option<super::Species>;
     }
-    pub struct Cursor;
-    impl ::cynic::schema::Field for Cursor {
+    pub struct cursor;
+    impl ::cynic::schema::Field for cursor {
         type Type = super::String;
         const NAME: &'static str = "cursor";
     }
-    impl ::cynic::schema::HasField<Cursor> for super::FilmSpeciesEdge {
+    impl ::cynic::schema::HasField<cursor> for super::FilmSpeciesEdge {
         type Type = super::String;
     }
 }
 pub struct FilmStarshipsConnection;
 pub mod film_starships_connection_fields {
-    pub struct PageInfo;
-    impl ::cynic::schema::Field for PageInfo {
+    pub struct pageInfo;
+    impl ::cynic::schema::Field for pageInfo {
         type Type = super::PageInfo;
         const NAME: &'static str = "pageInfo";
     }
-    impl ::cynic::schema::HasField<PageInfo> for super::FilmStarshipsConnection {
+    impl ::cynic::schema::HasField<pageInfo> for super::FilmStarshipsConnection {
         type Type = super::PageInfo;
     }
-    pub struct Edges;
-    impl ::cynic::schema::Field for Edges {
+    pub struct edges;
+    impl ::cynic::schema::Field for edges {
         type Type = Option<Vec<Option<super::FilmStarshipsEdge>>>;
         const NAME: &'static str = "edges";
     }
-    impl ::cynic::schema::HasField<Edges> for super::FilmStarshipsConnection {
+    impl ::cynic::schema::HasField<edges> for super::FilmStarshipsConnection {
         type Type = Option<Vec<Option<super::FilmStarshipsEdge>>>;
     }
-    pub struct TotalCount;
-    impl ::cynic::schema::Field for TotalCount {
+    pub struct totalCount;
+    impl ::cynic::schema::Field for totalCount {
         type Type = Option<super::Int>;
         const NAME: &'static str = "totalCount";
     }
-    impl ::cynic::schema::HasField<TotalCount> for super::FilmStarshipsConnection {
+    impl ::cynic::schema::HasField<totalCount> for super::FilmStarshipsConnection {
         type Type = Option<super::Int>;
     }
-    pub struct Starships;
-    impl ::cynic::schema::Field for Starships {
+    pub struct starships;
+    impl ::cynic::schema::Field for starships {
         type Type = Option<Vec<Option<super::Starship>>>;
         const NAME: &'static str = "starships";
     }
-    impl ::cynic::schema::HasField<Starships> for super::FilmStarshipsConnection {
+    impl ::cynic::schema::HasField<starships> for super::FilmStarshipsConnection {
         type Type = Option<Vec<Option<super::Starship>>>;
     }
 }
 pub struct FilmStarshipsEdge;
 pub mod film_starships_edge_fields {
-    pub struct Node;
-    impl ::cynic::schema::Field for Node {
+    pub struct node;
+    impl ::cynic::schema::Field for node {
         type Type = Option<super::Starship>;
         const NAME: &'static str = "node";
     }
-    impl ::cynic::schema::HasField<Node> for super::FilmStarshipsEdge {
+    impl ::cynic::schema::HasField<node> for super::FilmStarshipsEdge {
         type Type = Option<super::Starship>;
     }
-    pub struct Cursor;
-    impl ::cynic::schema::Field for Cursor {
+    pub struct cursor;
+    impl ::cynic::schema::Field for cursor {
         type Type = super::String;
         const NAME: &'static str = "cursor";
     }
-    impl ::cynic::schema::HasField<Cursor> for super::FilmStarshipsEdge {
+    impl ::cynic::schema::HasField<cursor> for super::FilmStarshipsEdge {
         type Type = super::String;
     }
 }
 pub struct FilmVehiclesConnection;
 pub mod film_vehicles_connection_fields {
-    pub struct PageInfo;
-    impl ::cynic::schema::Field for PageInfo {
+    pub struct pageInfo;
+    impl ::cynic::schema::Field for pageInfo {
         type Type = super::PageInfo;
         const NAME: &'static str = "pageInfo";
     }
-    impl ::cynic::schema::HasField<PageInfo> for super::FilmVehiclesConnection {
+    impl ::cynic::schema::HasField<pageInfo> for super::FilmVehiclesConnection {
         type Type = super::PageInfo;
     }
-    pub struct Edges;
-    impl ::cynic::schema::Field for Edges {
+    pub struct edges;
+    impl ::cynic::schema::Field for edges {
         type Type = Option<Vec<Option<super::FilmVehiclesEdge>>>;
         const NAME: &'static str = "edges";
     }
-    impl ::cynic::schema::HasField<Edges> for super::FilmVehiclesConnection {
+    impl ::cynic::schema::HasField<edges> for super::FilmVehiclesConnection {
         type Type = Option<Vec<Option<super::FilmVehiclesEdge>>>;
     }
-    pub struct TotalCount;
-    impl ::cynic::schema::Field for TotalCount {
+    pub struct totalCount;
+    impl ::cynic::schema::Field for totalCount {
         type Type = Option<super::Int>;
         const NAME: &'static str = "totalCount";
     }
-    impl ::cynic::schema::HasField<TotalCount> for super::FilmVehiclesConnection {
+    impl ::cynic::schema::HasField<totalCount> for super::FilmVehiclesConnection {
         type Type = Option<super::Int>;
     }
-    pub struct Vehicles;
-    impl ::cynic::schema::Field for Vehicles {
+    pub struct vehicles;
+    impl ::cynic::schema::Field for vehicles {
         type Type = Option<Vec<Option<super::Vehicle>>>;
         const NAME: &'static str = "vehicles";
     }
-    impl ::cynic::schema::HasField<Vehicles> for super::FilmVehiclesConnection {
+    impl ::cynic::schema::HasField<vehicles> for super::FilmVehiclesConnection {
         type Type = Option<Vec<Option<super::Vehicle>>>;
     }
 }
 pub struct FilmVehiclesEdge;
 pub mod film_vehicles_edge_fields {
-    pub struct Node;
-    impl ::cynic::schema::Field for Node {
+    pub struct node;
+    impl ::cynic::schema::Field for node {
         type Type = Option<super::Vehicle>;
         const NAME: &'static str = "node";
     }
-    impl ::cynic::schema::HasField<Node> for super::FilmVehiclesEdge {
+    impl ::cynic::schema::HasField<node> for super::FilmVehiclesEdge {
         type Type = Option<super::Vehicle>;
     }
-    pub struct Cursor;
-    impl ::cynic::schema::Field for Cursor {
+    pub struct cursor;
+    impl ::cynic::schema::Field for cursor {
         type Type = super::String;
         const NAME: &'static str = "cursor";
     }
-    impl ::cynic::schema::HasField<Cursor> for super::FilmVehiclesEdge {
+    impl ::cynic::schema::HasField<cursor> for super::FilmVehiclesEdge {
         type Type = super::String;
     }
 }
 pub struct FilmsConnection;
 pub mod films_connection_fields {
-    pub struct PageInfo;
-    impl ::cynic::schema::Field for PageInfo {
+    pub struct pageInfo;
+    impl ::cynic::schema::Field for pageInfo {
         type Type = super::PageInfo;
         const NAME: &'static str = "pageInfo";
     }
-    impl ::cynic::schema::HasField<PageInfo> for super::FilmsConnection {
+    impl ::cynic::schema::HasField<pageInfo> for super::FilmsConnection {
         type Type = super::PageInfo;
     }
-    pub struct Edges;
-    impl ::cynic::schema::Field for Edges {
+    pub struct edges;
+    impl ::cynic::schema::Field for edges {
         type Type = Option<Vec<Option<super::FilmsEdge>>>;
         const NAME: &'static str = "edges";
     }
-    impl ::cynic::schema::HasField<Edges> for super::FilmsConnection {
+    impl ::cynic::schema::HasField<edges> for super::FilmsConnection {
         type Type = Option<Vec<Option<super::FilmsEdge>>>;
     }
-    pub struct TotalCount;
-    impl ::cynic::schema::Field for TotalCount {
+    pub struct totalCount;
+    impl ::cynic::schema::Field for totalCount {
         type Type = Option<super::Int>;
         const NAME: &'static str = "totalCount";
     }
-    impl ::cynic::schema::HasField<TotalCount> for super::FilmsConnection {
+    impl ::cynic::schema::HasField<totalCount> for super::FilmsConnection {
         type Type = Option<super::Int>;
     }
-    pub struct Films;
-    impl ::cynic::schema::Field for Films {
+    pub struct films;
+    impl ::cynic::schema::Field for films {
         type Type = Option<Vec<Option<super::Film>>>;
         const NAME: &'static str = "films";
     }
-    impl ::cynic::schema::HasField<Films> for super::FilmsConnection {
+    impl ::cynic::schema::HasField<films> for super::FilmsConnection {
         type Type = Option<Vec<Option<super::Film>>>;
     }
 }
 pub struct FilmsEdge;
 pub mod films_edge_fields {
-    pub struct Node;
-    impl ::cynic::schema::Field for Node {
+    pub struct node;
+    impl ::cynic::schema::Field for node {
         type Type = Option<super::Film>;
         const NAME: &'static str = "node";
     }
-    impl ::cynic::schema::HasField<Node> for super::FilmsEdge {
+    impl ::cynic::schema::HasField<node> for super::FilmsEdge {
         type Type = Option<super::Film>;
     }
-    pub struct Cursor;
-    impl ::cynic::schema::Field for Cursor {
+    pub struct cursor;
+    impl ::cynic::schema::Field for cursor {
         type Type = super::String;
         const NAME: &'static str = "cursor";
     }
-    impl ::cynic::schema::HasField<Cursor> for super::FilmsEdge {
+    impl ::cynic::schema::HasField<cursor> for super::FilmsEdge {
         type Type = super::String;
     }
 }
 pub struct Node;
 pub mod node_fields {
-    pub struct Id;
-    impl ::cynic::schema::Field for Id {
-        type Type = super::Id;
+    pub struct id;
+    impl ::cynic::schema::Field for id {
+        type Type = super::ID;
         const NAME: &'static str = "id";
     }
-    impl ::cynic::schema::HasField<Id> for super::Node {
-        type Type = super::Id;
+    impl ::cynic::schema::HasField<id> for super::Node {
+        type Type = super::ID;
     }
 }
 pub struct PageInfo;
 pub mod page_info_fields {
-    pub struct HasNextPage;
-    impl ::cynic::schema::Field for HasNextPage {
+    pub struct hasNextPage;
+    impl ::cynic::schema::Field for hasNextPage {
         type Type = super::Boolean;
         const NAME: &'static str = "hasNextPage";
     }
-    impl ::cynic::schema::HasField<HasNextPage> for super::PageInfo {
+    impl ::cynic::schema::HasField<hasNextPage> for super::PageInfo {
         type Type = super::Boolean;
     }
-    pub struct HasPreviousPage;
-    impl ::cynic::schema::Field for HasPreviousPage {
+    pub struct hasPreviousPage;
+    impl ::cynic::schema::Field for hasPreviousPage {
         type Type = super::Boolean;
         const NAME: &'static str = "hasPreviousPage";
     }
-    impl ::cynic::schema::HasField<HasPreviousPage> for super::PageInfo {
+    impl ::cynic::schema::HasField<hasPreviousPage> for super::PageInfo {
         type Type = super::Boolean;
     }
-    pub struct StartCursor;
-    impl ::cynic::schema::Field for StartCursor {
+    pub struct startCursor;
+    impl ::cynic::schema::Field for startCursor {
         type Type = Option<super::String>;
         const NAME: &'static str = "startCursor";
     }
-    impl ::cynic::schema::HasField<StartCursor> for super::PageInfo {
+    impl ::cynic::schema::HasField<startCursor> for super::PageInfo {
         type Type = Option<super::String>;
     }
-    pub struct EndCursor;
-    impl ::cynic::schema::Field for EndCursor {
+    pub struct endCursor;
+    impl ::cynic::schema::Field for endCursor {
         type Type = Option<super::String>;
         const NAME: &'static str = "endCursor";
     }
-    impl ::cynic::schema::HasField<EndCursor> for super::PageInfo {
+    impl ::cynic::schema::HasField<endCursor> for super::PageInfo {
         type Type = Option<super::String>;
     }
 }
 pub struct PeopleConnection;
 pub mod people_connection_fields {
-    pub struct PageInfo;
-    impl ::cynic::schema::Field for PageInfo {
+    pub struct pageInfo;
+    impl ::cynic::schema::Field for pageInfo {
         type Type = super::PageInfo;
         const NAME: &'static str = "pageInfo";
     }
-    impl ::cynic::schema::HasField<PageInfo> for super::PeopleConnection {
+    impl ::cynic::schema::HasField<pageInfo> for super::PeopleConnection {
         type Type = super::PageInfo;
     }
-    pub struct Edges;
-    impl ::cynic::schema::Field for Edges {
+    pub struct edges;
+    impl ::cynic::schema::Field for edges {
         type Type = Option<Vec<Option<super::PeopleEdge>>>;
         const NAME: &'static str = "edges";
     }
-    impl ::cynic::schema::HasField<Edges> for super::PeopleConnection {
+    impl ::cynic::schema::HasField<edges> for super::PeopleConnection {
         type Type = Option<Vec<Option<super::PeopleEdge>>>;
     }
-    pub struct TotalCount;
-    impl ::cynic::schema::Field for TotalCount {
+    pub struct totalCount;
+    impl ::cynic::schema::Field for totalCount {
         type Type = Option<super::Int>;
         const NAME: &'static str = "totalCount";
     }
-    impl ::cynic::schema::HasField<TotalCount> for super::PeopleConnection {
+    impl ::cynic::schema::HasField<totalCount> for super::PeopleConnection {
         type Type = Option<super::Int>;
     }
-    pub struct People;
-    impl ::cynic::schema::Field for People {
+    pub struct people;
+    impl ::cynic::schema::Field for people {
         type Type = Option<Vec<Option<super::Person>>>;
         const NAME: &'static str = "people";
     }
-    impl ::cynic::schema::HasField<People> for super::PeopleConnection {
+    impl ::cynic::schema::HasField<people> for super::PeopleConnection {
         type Type = Option<Vec<Option<super::Person>>>;
     }
 }
 pub struct PeopleEdge;
 pub mod people_edge_fields {
-    pub struct Node;
-    impl ::cynic::schema::Field for Node {
+    pub struct node;
+    impl ::cynic::schema::Field for node {
         type Type = Option<super::Person>;
         const NAME: &'static str = "node";
     }
-    impl ::cynic::schema::HasField<Node> for super::PeopleEdge {
+    impl ::cynic::schema::HasField<node> for super::PeopleEdge {
         type Type = Option<super::Person>;
     }
-    pub struct Cursor;
-    impl ::cynic::schema::Field for Cursor {
+    pub struct cursor;
+    impl ::cynic::schema::Field for cursor {
         type Type = super::String;
         const NAME: &'static str = "cursor";
     }
-    impl ::cynic::schema::HasField<Cursor> for super::PeopleEdge {
+    impl ::cynic::schema::HasField<cursor> for super::PeopleEdge {
         type Type = super::String;
     }
 }
 pub struct Person;
 pub mod person_fields {
-    pub struct Name;
-    impl ::cynic::schema::Field for Name {
+    pub struct name;
+    impl ::cynic::schema::Field for name {
         type Type = Option<super::String>;
         const NAME: &'static str = "name";
     }
-    impl ::cynic::schema::HasField<Name> for super::Person {
+    impl ::cynic::schema::HasField<name> for super::Person {
         type Type = Option<super::String>;
     }
-    pub struct BirthYear;
-    impl ::cynic::schema::Field for BirthYear {
+    pub struct birthYear;
+    impl ::cynic::schema::Field for birthYear {
         type Type = Option<super::String>;
         const NAME: &'static str = "birthYear";
     }
-    impl ::cynic::schema::HasField<BirthYear> for super::Person {
+    impl ::cynic::schema::HasField<birthYear> for super::Person {
         type Type = Option<super::String>;
     }
-    pub struct EyeColor;
-    impl ::cynic::schema::Field for EyeColor {
+    pub struct eyeColor;
+    impl ::cynic::schema::Field for eyeColor {
         type Type = Option<super::String>;
         const NAME: &'static str = "eyeColor";
     }
-    impl ::cynic::schema::HasField<EyeColor> for super::Person {
+    impl ::cynic::schema::HasField<eyeColor> for super::Person {
         type Type = Option<super::String>;
     }
-    pub struct Gender;
-    impl ::cynic::schema::Field for Gender {
+    pub struct gender;
+    impl ::cynic::schema::Field for gender {
         type Type = Option<super::String>;
         const NAME: &'static str = "gender";
     }
-    impl ::cynic::schema::HasField<Gender> for super::Person {
+    impl ::cynic::schema::HasField<gender> for super::Person {
         type Type = Option<super::String>;
     }
-    pub struct HairColor;
-    impl ::cynic::schema::Field for HairColor {
+    pub struct hairColor;
+    impl ::cynic::schema::Field for hairColor {
         type Type = Option<super::String>;
         const NAME: &'static str = "hairColor";
     }
-    impl ::cynic::schema::HasField<HairColor> for super::Person {
+    impl ::cynic::schema::HasField<hairColor> for super::Person {
         type Type = Option<super::String>;
     }
-    pub struct Height;
-    impl ::cynic::schema::Field for Height {
+    pub struct height;
+    impl ::cynic::schema::Field for height {
         type Type = Option<super::Int>;
         const NAME: &'static str = "height";
     }
-    impl ::cynic::schema::HasField<Height> for super::Person {
+    impl ::cynic::schema::HasField<height> for super::Person {
         type Type = Option<super::Int>;
     }
-    pub struct Mass;
-    impl ::cynic::schema::Field for Mass {
+    pub struct mass;
+    impl ::cynic::schema::Field for mass {
         type Type = Option<super::Float>;
         const NAME: &'static str = "mass";
     }
-    impl ::cynic::schema::HasField<Mass> for super::Person {
+    impl ::cynic::schema::HasField<mass> for super::Person {
         type Type = Option<super::Float>;
     }
-    pub struct SkinColor;
-    impl ::cynic::schema::Field for SkinColor {
+    pub struct skinColor;
+    impl ::cynic::schema::Field for skinColor {
         type Type = Option<super::String>;
         const NAME: &'static str = "skinColor";
     }
-    impl ::cynic::schema::HasField<SkinColor> for super::Person {
+    impl ::cynic::schema::HasField<skinColor> for super::Person {
         type Type = Option<super::String>;
     }
-    pub struct Homeworld;
-    impl ::cynic::schema::Field for Homeworld {
+    pub struct homeworld;
+    impl ::cynic::schema::Field for homeworld {
         type Type = Option<super::Planet>;
         const NAME: &'static str = "homeworld";
     }
-    impl ::cynic::schema::HasField<Homeworld> for super::Person {
+    impl ::cynic::schema::HasField<homeworld> for super::Person {
         type Type = Option<super::Planet>;
     }
-    pub struct FilmConnection;
-    impl ::cynic::schema::Field for FilmConnection {
+    pub struct filmConnection;
+    impl ::cynic::schema::Field for filmConnection {
         type Type = Option<super::PersonFilmsConnection>;
         const NAME: &'static str = "filmConnection";
     }
-    impl ::cynic::schema::HasField<FilmConnection> for super::Person {
+    impl ::cynic::schema::HasField<filmConnection> for super::Person {
         type Type = Option<super::PersonFilmsConnection>;
     }
     pub mod film_connection_arguments {
-        pub struct After;
-        impl ::cynic::schema::HasArgument<After> for super::FilmConnection {
+        pub struct after;
+        impl ::cynic::schema::HasArgument<after> for super::filmConnection {
             type ArgumentType = Option<super::super::String>;
             const NAME: &'static str = "after";
         }
-        pub struct First;
-        impl ::cynic::schema::HasArgument<First> for super::FilmConnection {
+        pub struct first;
+        impl ::cynic::schema::HasArgument<first> for super::filmConnection {
             type ArgumentType = Option<super::super::Int>;
             const NAME: &'static str = "first";
         }
-        pub struct Before;
-        impl ::cynic::schema::HasArgument<Before> for super::FilmConnection {
+        pub struct before;
+        impl ::cynic::schema::HasArgument<before> for super::filmConnection {
             type ArgumentType = Option<super::super::String>;
             const NAME: &'static str = "before";
         }
-        pub struct Last;
-        impl ::cynic::schema::HasArgument<Last> for super::FilmConnection {
+        pub struct last;
+        impl ::cynic::schema::HasArgument<last> for super::filmConnection {
             type ArgumentType = Option<super::super::Int>;
             const NAME: &'static str = "last";
         }
     }
-    pub struct Species;
-    impl ::cynic::schema::Field for Species {
+    pub struct species;
+    impl ::cynic::schema::Field for species {
         type Type = Option<super::Species>;
         const NAME: &'static str = "species";
     }
-    impl ::cynic::schema::HasField<Species> for super::Person {
+    impl ::cynic::schema::HasField<species> for super::Person {
         type Type = Option<super::Species>;
     }
-    pub struct StarshipConnection;
-    impl ::cynic::schema::Field for StarshipConnection {
+    pub struct starshipConnection;
+    impl ::cynic::schema::Field for starshipConnection {
         type Type = Option<super::PersonStarshipsConnection>;
         const NAME: &'static str = "starshipConnection";
     }
-    impl ::cynic::schema::HasField<StarshipConnection> for super::Person {
+    impl ::cynic::schema::HasField<starshipConnection> for super::Person {
         type Type = Option<super::PersonStarshipsConnection>;
     }
     pub mod starship_connection_arguments {
-        pub struct After;
-        impl ::cynic::schema::HasArgument<After> for super::StarshipConnection {
+        pub struct after;
+        impl ::cynic::schema::HasArgument<after> for super::starshipConnection {
             type ArgumentType = Option<super::super::String>;
             const NAME: &'static str = "after";
         }
-        pub struct First;
-        impl ::cynic::schema::HasArgument<First> for super::StarshipConnection {
+        pub struct first;
+        impl ::cynic::schema::HasArgument<first> for super::starshipConnection {
             type ArgumentType = Option<super::super::Int>;
             const NAME: &'static str = "first";
         }
-        pub struct Before;
-        impl ::cynic::schema::HasArgument<Before> for super::StarshipConnection {
+        pub struct before;
+        impl ::cynic::schema::HasArgument<before> for super::starshipConnection {
             type ArgumentType = Option<super::super::String>;
             const NAME: &'static str = "before";
         }
-        pub struct Last;
-        impl ::cynic::schema::HasArgument<Last> for super::StarshipConnection {
+        pub struct last;
+        impl ::cynic::schema::HasArgument<last> for super::starshipConnection {
             type ArgumentType = Option<super::super::Int>;
             const NAME: &'static str = "last";
         }
     }
-    pub struct VehicleConnection;
-    impl ::cynic::schema::Field for VehicleConnection {
+    pub struct vehicleConnection;
+    impl ::cynic::schema::Field for vehicleConnection {
         type Type = Option<super::PersonVehiclesConnection>;
         const NAME: &'static str = "vehicleConnection";
     }
-    impl ::cynic::schema::HasField<VehicleConnection> for super::Person {
+    impl ::cynic::schema::HasField<vehicleConnection> for super::Person {
         type Type = Option<super::PersonVehiclesConnection>;
     }
     pub mod vehicle_connection_arguments {
-        pub struct After;
-        impl ::cynic::schema::HasArgument<After> for super::VehicleConnection {
+        pub struct after;
+        impl ::cynic::schema::HasArgument<after> for super::vehicleConnection {
             type ArgumentType = Option<super::super::String>;
             const NAME: &'static str = "after";
         }
-        pub struct First;
-        impl ::cynic::schema::HasArgument<First> for super::VehicleConnection {
+        pub struct first;
+        impl ::cynic::schema::HasArgument<first> for super::vehicleConnection {
             type ArgumentType = Option<super::super::Int>;
             const NAME: &'static str = "first";
         }
-        pub struct Before;
-        impl ::cynic::schema::HasArgument<Before> for super::VehicleConnection {
+        pub struct before;
+        impl ::cynic::schema::HasArgument<before> for super::vehicleConnection {
             type ArgumentType = Option<super::super::String>;
             const NAME: &'static str = "before";
         }
-        pub struct Last;
-        impl ::cynic::schema::HasArgument<Last> for super::VehicleConnection {
+        pub struct last;
+        impl ::cynic::schema::HasArgument<last> for super::vehicleConnection {
             type ArgumentType = Option<super::super::Int>;
             const NAME: &'static str = "last";
         }
     }
-    pub struct Created;
-    impl ::cynic::schema::Field for Created {
+    pub struct created;
+    impl ::cynic::schema::Field for created {
         type Type = Option<super::String>;
         const NAME: &'static str = "created";
     }
-    impl ::cynic::schema::HasField<Created> for super::Person {
+    impl ::cynic::schema::HasField<created> for super::Person {
         type Type = Option<super::String>;
     }
-    pub struct Edited;
-    impl ::cynic::schema::Field for Edited {
+    pub struct edited;
+    impl ::cynic::schema::Field for edited {
         type Type = Option<super::String>;
         const NAME: &'static str = "edited";
     }
-    impl ::cynic::schema::HasField<Edited> for super::Person {
+    impl ::cynic::schema::HasField<edited> for super::Person {
         type Type = Option<super::String>;
     }
-    pub struct Id;
-    impl ::cynic::schema::Field for Id {
-        type Type = super::Id;
+    pub struct id;
+    impl ::cynic::schema::Field for id {
+        type Type = super::ID;
         const NAME: &'static str = "id";
     }
-    impl ::cynic::schema::HasField<Id> for super::Person {
-        type Type = super::Id;
+    impl ::cynic::schema::HasField<id> for super::Person {
+        type Type = super::ID;
     }
 }
 pub struct PersonFilmsConnection;
 pub mod person_films_connection_fields {
-    pub struct PageInfo;
-    impl ::cynic::schema::Field for PageInfo {
+    pub struct pageInfo;
+    impl ::cynic::schema::Field for pageInfo {
         type Type = super::PageInfo;
         const NAME: &'static str = "pageInfo";
     }
-    impl ::cynic::schema::HasField<PageInfo> for super::PersonFilmsConnection {
+    impl ::cynic::schema::HasField<pageInfo> for super::PersonFilmsConnection {
         type Type = super::PageInfo;
     }
-    pub struct Edges;
-    impl ::cynic::schema::Field for Edges {
+    pub struct edges;
+    impl ::cynic::schema::Field for edges {
         type Type = Option<Vec<Option<super::PersonFilmsEdge>>>;
         const NAME: &'static str = "edges";
     }
-    impl ::cynic::schema::HasField<Edges> for super::PersonFilmsConnection {
+    impl ::cynic::schema::HasField<edges> for super::PersonFilmsConnection {
         type Type = Option<Vec<Option<super::PersonFilmsEdge>>>;
     }
-    pub struct TotalCount;
-    impl ::cynic::schema::Field for TotalCount {
+    pub struct totalCount;
+    impl ::cynic::schema::Field for totalCount {
         type Type = Option<super::Int>;
         const NAME: &'static str = "totalCount";
     }
-    impl ::cynic::schema::HasField<TotalCount> for super::PersonFilmsConnection {
+    impl ::cynic::schema::HasField<totalCount> for super::PersonFilmsConnection {
         type Type = Option<super::Int>;
     }
-    pub struct Films;
-    impl ::cynic::schema::Field for Films {
+    pub struct films;
+    impl ::cynic::schema::Field for films {
         type Type = Option<Vec<Option<super::Film>>>;
         const NAME: &'static str = "films";
     }
-    impl ::cynic::schema::HasField<Films> for super::PersonFilmsConnection {
+    impl ::cynic::schema::HasField<films> for super::PersonFilmsConnection {
         type Type = Option<Vec<Option<super::Film>>>;
     }
 }
 pub struct PersonFilmsEdge;
 pub mod person_films_edge_fields {
-    pub struct Node;
-    impl ::cynic::schema::Field for Node {
+    pub struct node;
+    impl ::cynic::schema::Field for node {
         type Type = Option<super::Film>;
         const NAME: &'static str = "node";
     }
-    impl ::cynic::schema::HasField<Node> for super::PersonFilmsEdge {
+    impl ::cynic::schema::HasField<node> for super::PersonFilmsEdge {
         type Type = Option<super::Film>;
     }
-    pub struct Cursor;
-    impl ::cynic::schema::Field for Cursor {
+    pub struct cursor;
+    impl ::cynic::schema::Field for cursor {
         type Type = super::String;
         const NAME: &'static str = "cursor";
     }
-    impl ::cynic::schema::HasField<Cursor> for super::PersonFilmsEdge {
+    impl ::cynic::schema::HasField<cursor> for super::PersonFilmsEdge {
         type Type = super::String;
     }
 }
 pub struct PersonStarshipsConnection;
 pub mod person_starships_connection_fields {
-    pub struct PageInfo;
-    impl ::cynic::schema::Field for PageInfo {
+    pub struct pageInfo;
+    impl ::cynic::schema::Field for pageInfo {
         type Type = super::PageInfo;
         const NAME: &'static str = "pageInfo";
     }
-    impl ::cynic::schema::HasField<PageInfo> for super::PersonStarshipsConnection {
+    impl ::cynic::schema::HasField<pageInfo> for super::PersonStarshipsConnection {
         type Type = super::PageInfo;
     }
-    pub struct Edges;
-    impl ::cynic::schema::Field for Edges {
+    pub struct edges;
+    impl ::cynic::schema::Field for edges {
         type Type = Option<Vec<Option<super::PersonStarshipsEdge>>>;
         const NAME: &'static str = "edges";
     }
-    impl ::cynic::schema::HasField<Edges> for super::PersonStarshipsConnection {
+    impl ::cynic::schema::HasField<edges> for super::PersonStarshipsConnection {
         type Type = Option<Vec<Option<super::PersonStarshipsEdge>>>;
     }
-    pub struct TotalCount;
-    impl ::cynic::schema::Field for TotalCount {
+    pub struct totalCount;
+    impl ::cynic::schema::Field for totalCount {
         type Type = Option<super::Int>;
         const NAME: &'static str = "totalCount";
     }
-    impl ::cynic::schema::HasField<TotalCount> for super::PersonStarshipsConnection {
+    impl ::cynic::schema::HasField<totalCount> for super::PersonStarshipsConnection {
         type Type = Option<super::Int>;
     }
-    pub struct Starships;
-    impl ::cynic::schema::Field for Starships {
+    pub struct starships;
+    impl ::cynic::schema::Field for starships {
         type Type = Option<Vec<Option<super::Starship>>>;
         const NAME: &'static str = "starships";
     }
-    impl ::cynic::schema::HasField<Starships> for super::PersonStarshipsConnection {
+    impl ::cynic::schema::HasField<starships> for super::PersonStarshipsConnection {
         type Type = Option<Vec<Option<super::Starship>>>;
     }
 }
 pub struct PersonStarshipsEdge;
 pub mod person_starships_edge_fields {
-    pub struct Node;
-    impl ::cynic::schema::Field for Node {
+    pub struct node;
+    impl ::cynic::schema::Field for node {
         type Type = Option<super::Starship>;
         const NAME: &'static str = "node";
     }
-    impl ::cynic::schema::HasField<Node> for super::PersonStarshipsEdge {
+    impl ::cynic::schema::HasField<node> for super::PersonStarshipsEdge {
         type Type = Option<super::Starship>;
     }
-    pub struct Cursor;
-    impl ::cynic::schema::Field for Cursor {
+    pub struct cursor;
+    impl ::cynic::schema::Field for cursor {
         type Type = super::String;
         const NAME: &'static str = "cursor";
     }
-    impl ::cynic::schema::HasField<Cursor> for super::PersonStarshipsEdge {
+    impl ::cynic::schema::HasField<cursor> for super::PersonStarshipsEdge {
         type Type = super::String;
     }
 }
 pub struct PersonVehiclesConnection;
 pub mod person_vehicles_connection_fields {
-    pub struct PageInfo;
-    impl ::cynic::schema::Field for PageInfo {
+    pub struct pageInfo;
+    impl ::cynic::schema::Field for pageInfo {
         type Type = super::PageInfo;
         const NAME: &'static str = "pageInfo";
     }
-    impl ::cynic::schema::HasField<PageInfo> for super::PersonVehiclesConnection {
+    impl ::cynic::schema::HasField<pageInfo> for super::PersonVehiclesConnection {
         type Type = super::PageInfo;
     }
-    pub struct Edges;
-    impl ::cynic::schema::Field for Edges {
+    pub struct edges;
+    impl ::cynic::schema::Field for edges {
         type Type = Option<Vec<Option<super::PersonVehiclesEdge>>>;
         const NAME: &'static str = "edges";
     }
-    impl ::cynic::schema::HasField<Edges> for super::PersonVehiclesConnection {
+    impl ::cynic::schema::HasField<edges> for super::PersonVehiclesConnection {
         type Type = Option<Vec<Option<super::PersonVehiclesEdge>>>;
     }
-    pub struct TotalCount;
-    impl ::cynic::schema::Field for TotalCount {
+    pub struct totalCount;
+    impl ::cynic::schema::Field for totalCount {
         type Type = Option<super::Int>;
         const NAME: &'static str = "totalCount";
     }
-    impl ::cynic::schema::HasField<TotalCount> for super::PersonVehiclesConnection {
+    impl ::cynic::schema::HasField<totalCount> for super::PersonVehiclesConnection {
         type Type = Option<super::Int>;
     }
-    pub struct Vehicles;
-    impl ::cynic::schema::Field for Vehicles {
+    pub struct vehicles;
+    impl ::cynic::schema::Field for vehicles {
         type Type = Option<Vec<Option<super::Vehicle>>>;
         const NAME: &'static str = "vehicles";
     }
-    impl ::cynic::schema::HasField<Vehicles> for super::PersonVehiclesConnection {
+    impl ::cynic::schema::HasField<vehicles> for super::PersonVehiclesConnection {
         type Type = Option<Vec<Option<super::Vehicle>>>;
     }
 }
 pub struct PersonVehiclesEdge;
 pub mod person_vehicles_edge_fields {
-    pub struct Node;
-    impl ::cynic::schema::Field for Node {
+    pub struct node;
+    impl ::cynic::schema::Field for node {
         type Type = Option<super::Vehicle>;
         const NAME: &'static str = "node";
     }
-    impl ::cynic::schema::HasField<Node> for super::PersonVehiclesEdge {
+    impl ::cynic::schema::HasField<node> for super::PersonVehiclesEdge {
         type Type = Option<super::Vehicle>;
     }
-    pub struct Cursor;
-    impl ::cynic::schema::Field for Cursor {
+    pub struct cursor;
+    impl ::cynic::schema::Field for cursor {
         type Type = super::String;
         const NAME: &'static str = "cursor";
     }
-    impl ::cynic::schema::HasField<Cursor> for super::PersonVehiclesEdge {
+    impl ::cynic::schema::HasField<cursor> for super::PersonVehiclesEdge {
         type Type = super::String;
     }
 }
 pub struct Planet;
 pub mod planet_fields {
-    pub struct Name;
-    impl ::cynic::schema::Field for Name {
+    pub struct name;
+    impl ::cynic::schema::Field for name {
         type Type = Option<super::String>;
         const NAME: &'static str = "name";
     }
-    impl ::cynic::schema::HasField<Name> for super::Planet {
+    impl ::cynic::schema::HasField<name> for super::Planet {
         type Type = Option<super::String>;
     }
-    pub struct Diameter;
-    impl ::cynic::schema::Field for Diameter {
+    pub struct diameter;
+    impl ::cynic::schema::Field for diameter {
         type Type = Option<super::Int>;
         const NAME: &'static str = "diameter";
     }
-    impl ::cynic::schema::HasField<Diameter> for super::Planet {
+    impl ::cynic::schema::HasField<diameter> for super::Planet {
         type Type = Option<super::Int>;
     }
-    pub struct RotationPeriod;
-    impl ::cynic::schema::Field for RotationPeriod {
+    pub struct rotationPeriod;
+    impl ::cynic::schema::Field for rotationPeriod {
         type Type = Option<super::Int>;
         const NAME: &'static str = "rotationPeriod";
     }
-    impl ::cynic::schema::HasField<RotationPeriod> for super::Planet {
+    impl ::cynic::schema::HasField<rotationPeriod> for super::Planet {
         type Type = Option<super::Int>;
     }
-    pub struct OrbitalPeriod;
-    impl ::cynic::schema::Field for OrbitalPeriod {
+    pub struct orbitalPeriod;
+    impl ::cynic::schema::Field for orbitalPeriod {
         type Type = Option<super::Int>;
         const NAME: &'static str = "orbitalPeriod";
     }
-    impl ::cynic::schema::HasField<OrbitalPeriod> for super::Planet {
+    impl ::cynic::schema::HasField<orbitalPeriod> for super::Planet {
         type Type = Option<super::Int>;
     }
-    pub struct Gravity;
-    impl ::cynic::schema::Field for Gravity {
+    pub struct gravity;
+    impl ::cynic::schema::Field for gravity {
         type Type = Option<super::String>;
         const NAME: &'static str = "gravity";
     }
-    impl ::cynic::schema::HasField<Gravity> for super::Planet {
+    impl ::cynic::schema::HasField<gravity> for super::Planet {
         type Type = Option<super::String>;
     }
-    pub struct Population;
-    impl ::cynic::schema::Field for Population {
+    pub struct population;
+    impl ::cynic::schema::Field for population {
         type Type = Option<super::Float>;
         const NAME: &'static str = "population";
     }
-    impl ::cynic::schema::HasField<Population> for super::Planet {
+    impl ::cynic::schema::HasField<population> for super::Planet {
         type Type = Option<super::Float>;
     }
-    pub struct Climates;
-    impl ::cynic::schema::Field for Climates {
+    pub struct climates;
+    impl ::cynic::schema::Field for climates {
         type Type = Option<Vec<Option<super::String>>>;
         const NAME: &'static str = "climates";
     }
-    impl ::cynic::schema::HasField<Climates> for super::Planet {
+    impl ::cynic::schema::HasField<climates> for super::Planet {
         type Type = Option<Vec<Option<super::String>>>;
     }
-    pub struct Terrains;
-    impl ::cynic::schema::Field for Terrains {
+    pub struct terrains;
+    impl ::cynic::schema::Field for terrains {
         type Type = Option<Vec<Option<super::String>>>;
         const NAME: &'static str = "terrains";
     }
-    impl ::cynic::schema::HasField<Terrains> for super::Planet {
+    impl ::cynic::schema::HasField<terrains> for super::Planet {
         type Type = Option<Vec<Option<super::String>>>;
     }
-    pub struct SurfaceWater;
-    impl ::cynic::schema::Field for SurfaceWater {
+    pub struct surfaceWater;
+    impl ::cynic::schema::Field for surfaceWater {
         type Type = Option<super::Float>;
         const NAME: &'static str = "surfaceWater";
     }
-    impl ::cynic::schema::HasField<SurfaceWater> for super::Planet {
+    impl ::cynic::schema::HasField<surfaceWater> for super::Planet {
         type Type = Option<super::Float>;
     }
-    pub struct ResidentConnection;
-    impl ::cynic::schema::Field for ResidentConnection {
+    pub struct residentConnection;
+    impl ::cynic::schema::Field for residentConnection {
         type Type = Option<super::PlanetResidentsConnection>;
         const NAME: &'static str = "residentConnection";
     }
-    impl ::cynic::schema::HasField<ResidentConnection> for super::Planet {
+    impl ::cynic::schema::HasField<residentConnection> for super::Planet {
         type Type = Option<super::PlanetResidentsConnection>;
     }
     pub mod resident_connection_arguments {
-        pub struct After;
-        impl ::cynic::schema::HasArgument<After> for super::ResidentConnection {
+        pub struct after;
+        impl ::cynic::schema::HasArgument<after> for super::residentConnection {
             type ArgumentType = Option<super::super::String>;
             const NAME: &'static str = "after";
         }
-        pub struct First;
-        impl ::cynic::schema::HasArgument<First> for super::ResidentConnection {
+        pub struct first;
+        impl ::cynic::schema::HasArgument<first> for super::residentConnection {
             type ArgumentType = Option<super::super::Int>;
             const NAME: &'static str = "first";
         }
-        pub struct Before;
-        impl ::cynic::schema::HasArgument<Before> for super::ResidentConnection {
+        pub struct before;
+        impl ::cynic::schema::HasArgument<before> for super::residentConnection {
             type ArgumentType = Option<super::super::String>;
             const NAME: &'static str = "before";
         }
-        pub struct Last;
-        impl ::cynic::schema::HasArgument<Last> for super::ResidentConnection {
+        pub struct last;
+        impl ::cynic::schema::HasArgument<last> for super::residentConnection {
             type ArgumentType = Option<super::super::Int>;
             const NAME: &'static str = "last";
         }
     }
-    pub struct FilmConnection;
-    impl ::cynic::schema::Field for FilmConnection {
+    pub struct filmConnection;
+    impl ::cynic::schema::Field for filmConnection {
         type Type = Option<super::PlanetFilmsConnection>;
         const NAME: &'static str = "filmConnection";
     }
-    impl ::cynic::schema::HasField<FilmConnection> for super::Planet {
+    impl ::cynic::schema::HasField<filmConnection> for super::Planet {
         type Type = Option<super::PlanetFilmsConnection>;
     }
     pub mod film_connection_arguments {
-        pub struct After;
-        impl ::cynic::schema::HasArgument<After> for super::FilmConnection {
+        pub struct after;
+        impl ::cynic::schema::HasArgument<after> for super::filmConnection {
             type ArgumentType = Option<super::super::String>;
             const NAME: &'static str = "after";
         }
-        pub struct First;
-        impl ::cynic::schema::HasArgument<First> for super::FilmConnection {
+        pub struct first;
+        impl ::cynic::schema::HasArgument<first> for super::filmConnection {
             type ArgumentType = Option<super::super::Int>;
             const NAME: &'static str = "first";
         }
-        pub struct Before;
-        impl ::cynic::schema::HasArgument<Before> for super::FilmConnection {
+        pub struct before;
+        impl ::cynic::schema::HasArgument<before> for super::filmConnection {
             type ArgumentType = Option<super::super::String>;
             const NAME: &'static str = "before";
         }
-        pub struct Last;
-        impl ::cynic::schema::HasArgument<Last> for super::FilmConnection {
+        pub struct last;
+        impl ::cynic::schema::HasArgument<last> for super::filmConnection {
             type ArgumentType = Option<super::super::Int>;
             const NAME: &'static str = "last";
         }
     }
-    pub struct Created;
-    impl ::cynic::schema::Field for Created {
+    pub struct created;
+    impl ::cynic::schema::Field for created {
         type Type = Option<super::String>;
         const NAME: &'static str = "created";
     }
-    impl ::cynic::schema::HasField<Created> for super::Planet {
+    impl ::cynic::schema::HasField<created> for super::Planet {
         type Type = Option<super::String>;
     }
-    pub struct Edited;
-    impl ::cynic::schema::Field for Edited {
+    pub struct edited;
+    impl ::cynic::schema::Field for edited {
         type Type = Option<super::String>;
         const NAME: &'static str = "edited";
     }
-    impl ::cynic::schema::HasField<Edited> for super::Planet {
+    impl ::cynic::schema::HasField<edited> for super::Planet {
         type Type = Option<super::String>;
     }
-    pub struct Id;
-    impl ::cynic::schema::Field for Id {
-        type Type = super::Id;
+    pub struct id;
+    impl ::cynic::schema::Field for id {
+        type Type = super::ID;
         const NAME: &'static str = "id";
     }
-    impl ::cynic::schema::HasField<Id> for super::Planet {
-        type Type = super::Id;
+    impl ::cynic::schema::HasField<id> for super::Planet {
+        type Type = super::ID;
     }
 }
 pub struct PlanetFilmsConnection;
 pub mod planet_films_connection_fields {
-    pub struct PageInfo;
-    impl ::cynic::schema::Field for PageInfo {
+    pub struct pageInfo;
+    impl ::cynic::schema::Field for pageInfo {
         type Type = super::PageInfo;
         const NAME: &'static str = "pageInfo";
     }
-    impl ::cynic::schema::HasField<PageInfo> for super::PlanetFilmsConnection {
+    impl ::cynic::schema::HasField<pageInfo> for super::PlanetFilmsConnection {
         type Type = super::PageInfo;
     }
-    pub struct Edges;
-    impl ::cynic::schema::Field for Edges {
+    pub struct edges;
+    impl ::cynic::schema::Field for edges {
         type Type = Option<Vec<Option<super::PlanetFilmsEdge>>>;
         const NAME: &'static str = "edges";
     }
-    impl ::cynic::schema::HasField<Edges> for super::PlanetFilmsConnection {
+    impl ::cynic::schema::HasField<edges> for super::PlanetFilmsConnection {
         type Type = Option<Vec<Option<super::PlanetFilmsEdge>>>;
     }
-    pub struct TotalCount;
-    impl ::cynic::schema::Field for TotalCount {
+    pub struct totalCount;
+    impl ::cynic::schema::Field for totalCount {
         type Type = Option<super::Int>;
         const NAME: &'static str = "totalCount";
     }
-    impl ::cynic::schema::HasField<TotalCount> for super::PlanetFilmsConnection {
+    impl ::cynic::schema::HasField<totalCount> for super::PlanetFilmsConnection {
         type Type = Option<super::Int>;
     }
-    pub struct Films;
-    impl ::cynic::schema::Field for Films {
+    pub struct films;
+    impl ::cynic::schema::Field for films {
         type Type = Option<Vec<Option<super::Film>>>;
         const NAME: &'static str = "films";
     }
-    impl ::cynic::schema::HasField<Films> for super::PlanetFilmsConnection {
+    impl ::cynic::schema::HasField<films> for super::PlanetFilmsConnection {
         type Type = Option<Vec<Option<super::Film>>>;
     }
 }
 pub struct PlanetFilmsEdge;
 pub mod planet_films_edge_fields {
-    pub struct Node;
-    impl ::cynic::schema::Field for Node {
+    pub struct node;
+    impl ::cynic::schema::Field for node {
         type Type = Option<super::Film>;
         const NAME: &'static str = "node";
     }
-    impl ::cynic::schema::HasField<Node> for super::PlanetFilmsEdge {
+    impl ::cynic::schema::HasField<node> for super::PlanetFilmsEdge {
         type Type = Option<super::Film>;
     }
-    pub struct Cursor;
-    impl ::cynic::schema::Field for Cursor {
+    pub struct cursor;
+    impl ::cynic::schema::Field for cursor {
         type Type = super::String;
         const NAME: &'static str = "cursor";
     }
-    impl ::cynic::schema::HasField<Cursor> for super::PlanetFilmsEdge {
+    impl ::cynic::schema::HasField<cursor> for super::PlanetFilmsEdge {
         type Type = super::String;
     }
 }
 pub struct PlanetResidentsConnection;
 pub mod planet_residents_connection_fields {
-    pub struct PageInfo;
-    impl ::cynic::schema::Field for PageInfo {
+    pub struct pageInfo;
+    impl ::cynic::schema::Field for pageInfo {
         type Type = super::PageInfo;
         const NAME: &'static str = "pageInfo";
     }
-    impl ::cynic::schema::HasField<PageInfo> for super::PlanetResidentsConnection {
+    impl ::cynic::schema::HasField<pageInfo> for super::PlanetResidentsConnection {
         type Type = super::PageInfo;
     }
-    pub struct Edges;
-    impl ::cynic::schema::Field for Edges {
+    pub struct edges;
+    impl ::cynic::schema::Field for edges {
         type Type = Option<Vec<Option<super::PlanetResidentsEdge>>>;
         const NAME: &'static str = "edges";
     }
-    impl ::cynic::schema::HasField<Edges> for super::PlanetResidentsConnection {
+    impl ::cynic::schema::HasField<edges> for super::PlanetResidentsConnection {
         type Type = Option<Vec<Option<super::PlanetResidentsEdge>>>;
     }
-    pub struct TotalCount;
-    impl ::cynic::schema::Field for TotalCount {
+    pub struct totalCount;
+    impl ::cynic::schema::Field for totalCount {
         type Type = Option<super::Int>;
         const NAME: &'static str = "totalCount";
     }
-    impl ::cynic::schema::HasField<TotalCount> for super::PlanetResidentsConnection {
+    impl ::cynic::schema::HasField<totalCount> for super::PlanetResidentsConnection {
         type Type = Option<super::Int>;
     }
-    pub struct Residents;
-    impl ::cynic::schema::Field for Residents {
+    pub struct residents;
+    impl ::cynic::schema::Field for residents {
         type Type = Option<Vec<Option<super::Person>>>;
         const NAME: &'static str = "residents";
     }
-    impl ::cynic::schema::HasField<Residents> for super::PlanetResidentsConnection {
+    impl ::cynic::schema::HasField<residents> for super::PlanetResidentsConnection {
         type Type = Option<Vec<Option<super::Person>>>;
     }
 }
 pub struct PlanetResidentsEdge;
 pub mod planet_residents_edge_fields {
-    pub struct Node;
-    impl ::cynic::schema::Field for Node {
+    pub struct node;
+    impl ::cynic::schema::Field for node {
         type Type = Option<super::Person>;
         const NAME: &'static str = "node";
     }
-    impl ::cynic::schema::HasField<Node> for super::PlanetResidentsEdge {
+    impl ::cynic::schema::HasField<node> for super::PlanetResidentsEdge {
         type Type = Option<super::Person>;
     }
-    pub struct Cursor;
-    impl ::cynic::schema::Field for Cursor {
+    pub struct cursor;
+    impl ::cynic::schema::Field for cursor {
         type Type = super::String;
         const NAME: &'static str = "cursor";
     }
-    impl ::cynic::schema::HasField<Cursor> for super::PlanetResidentsEdge {
+    impl ::cynic::schema::HasField<cursor> for super::PlanetResidentsEdge {
         type Type = super::String;
     }
 }
 pub struct PlanetsConnection;
 pub mod planets_connection_fields {
-    pub struct PageInfo;
-    impl ::cynic::schema::Field for PageInfo {
+    pub struct pageInfo;
+    impl ::cynic::schema::Field for pageInfo {
         type Type = super::PageInfo;
         const NAME: &'static str = "pageInfo";
     }
-    impl ::cynic::schema::HasField<PageInfo> for super::PlanetsConnection {
+    impl ::cynic::schema::HasField<pageInfo> for super::PlanetsConnection {
         type Type = super::PageInfo;
     }
-    pub struct Edges;
-    impl ::cynic::schema::Field for Edges {
+    pub struct edges;
+    impl ::cynic::schema::Field for edges {
         type Type = Option<Vec<Option<super::PlanetsEdge>>>;
         const NAME: &'static str = "edges";
     }
-    impl ::cynic::schema::HasField<Edges> for super::PlanetsConnection {
+    impl ::cynic::schema::HasField<edges> for super::PlanetsConnection {
         type Type = Option<Vec<Option<super::PlanetsEdge>>>;
     }
-    pub struct TotalCount;
-    impl ::cynic::schema::Field for TotalCount {
+    pub struct totalCount;
+    impl ::cynic::schema::Field for totalCount {
         type Type = Option<super::Int>;
         const NAME: &'static str = "totalCount";
     }
-    impl ::cynic::schema::HasField<TotalCount> for super::PlanetsConnection {
+    impl ::cynic::schema::HasField<totalCount> for super::PlanetsConnection {
         type Type = Option<super::Int>;
     }
-    pub struct Planets;
-    impl ::cynic::schema::Field for Planets {
+    pub struct planets;
+    impl ::cynic::schema::Field for planets {
         type Type = Option<Vec<Option<super::Planet>>>;
         const NAME: &'static str = "planets";
     }
-    impl ::cynic::schema::HasField<Planets> for super::PlanetsConnection {
+    impl ::cynic::schema::HasField<planets> for super::PlanetsConnection {
         type Type = Option<Vec<Option<super::Planet>>>;
     }
 }
 pub struct PlanetsEdge;
 pub mod planets_edge_fields {
-    pub struct Node;
-    impl ::cynic::schema::Field for Node {
+    pub struct node;
+    impl ::cynic::schema::Field for node {
         type Type = Option<super::Planet>;
         const NAME: &'static str = "node";
     }
-    impl ::cynic::schema::HasField<Node> for super::PlanetsEdge {
+    impl ::cynic::schema::HasField<node> for super::PlanetsEdge {
         type Type = Option<super::Planet>;
     }
-    pub struct Cursor;
-    impl ::cynic::schema::Field for Cursor {
+    pub struct cursor;
+    impl ::cynic::schema::Field for cursor {
         type Type = super::String;
         const NAME: &'static str = "cursor";
     }
-    impl ::cynic::schema::HasField<Cursor> for super::PlanetsEdge {
+    impl ::cynic::schema::HasField<cursor> for super::PlanetsEdge {
         type Type = super::String;
     }
 }
 pub struct Root;
 pub mod root_fields {
-    pub struct AllFilms;
-    impl ::cynic::schema::Field for AllFilms {
+    pub struct allFilms;
+    impl ::cynic::schema::Field for allFilms {
         type Type = Option<super::FilmsConnection>;
         const NAME: &'static str = "allFilms";
     }
-    impl ::cynic::schema::HasField<AllFilms> for super::Root {
+    impl ::cynic::schema::HasField<allFilms> for super::Root {
         type Type = Option<super::FilmsConnection>;
     }
     pub mod all_films_arguments {
-        pub struct After;
-        impl ::cynic::schema::HasArgument<After> for super::AllFilms {
+        pub struct after;
+        impl ::cynic::schema::HasArgument<after> for super::allFilms {
             type ArgumentType = Option<super::super::String>;
             const NAME: &'static str = "after";
         }
-        pub struct First;
-        impl ::cynic::schema::HasArgument<First> for super::AllFilms {
+        pub struct first;
+        impl ::cynic::schema::HasArgument<first> for super::allFilms {
             type ArgumentType = Option<super::super::Int>;
             const NAME: &'static str = "first";
         }
-        pub struct Before;
-        impl ::cynic::schema::HasArgument<Before> for super::AllFilms {
+        pub struct before;
+        impl ::cynic::schema::HasArgument<before> for super::allFilms {
             type ArgumentType = Option<super::super::String>;
             const NAME: &'static str = "before";
         }
-        pub struct Last;
-        impl ::cynic::schema::HasArgument<Last> for super::AllFilms {
+        pub struct last;
+        impl ::cynic::schema::HasArgument<last> for super::allFilms {
             type ArgumentType = Option<super::super::Int>;
             const NAME: &'static str = "last";
         }
     }
-    pub struct Film;
-    impl ::cynic::schema::Field for Film {
+    pub struct film;
+    impl ::cynic::schema::Field for film {
         type Type = Option<super::Film>;
         const NAME: &'static str = "film";
     }
-    impl ::cynic::schema::HasField<Film> for super::Root {
+    impl ::cynic::schema::HasField<film> for super::Root {
         type Type = Option<super::Film>;
     }
     pub mod film_arguments {
-        pub struct Id;
-        impl ::cynic::schema::HasArgument<Id> for super::Film {
-            type ArgumentType = Option<super::super::Id>;
+        pub struct id;
+        impl ::cynic::schema::HasArgument<id> for super::film {
+            type ArgumentType = Option<super::super::ID>;
             const NAME: &'static str = "id";
         }
-        pub struct FilmId;
-        impl ::cynic::schema::HasArgument<FilmId> for super::Film {
-            type ArgumentType = Option<super::super::Id>;
+        pub struct filmID;
+        impl ::cynic::schema::HasArgument<filmID> for super::film {
+            type ArgumentType = Option<super::super::ID>;
             const NAME: &'static str = "filmID";
         }
     }
-    pub struct AllPeople;
-    impl ::cynic::schema::Field for AllPeople {
+    pub struct allPeople;
+    impl ::cynic::schema::Field for allPeople {
         type Type = Option<super::PeopleConnection>;
         const NAME: &'static str = "allPeople";
     }
-    impl ::cynic::schema::HasField<AllPeople> for super::Root {
+    impl ::cynic::schema::HasField<allPeople> for super::Root {
         type Type = Option<super::PeopleConnection>;
     }
     pub mod all_people_arguments {
-        pub struct After;
-        impl ::cynic::schema::HasArgument<After> for super::AllPeople {
+        pub struct after;
+        impl ::cynic::schema::HasArgument<after> for super::allPeople {
             type ArgumentType = Option<super::super::String>;
             const NAME: &'static str = "after";
         }
-        pub struct First;
-        impl ::cynic::schema::HasArgument<First> for super::AllPeople {
+        pub struct first;
+        impl ::cynic::schema::HasArgument<first> for super::allPeople {
             type ArgumentType = Option<super::super::Int>;
             const NAME: &'static str = "first";
         }
-        pub struct Before;
-        impl ::cynic::schema::HasArgument<Before> for super::AllPeople {
+        pub struct before;
+        impl ::cynic::schema::HasArgument<before> for super::allPeople {
             type ArgumentType = Option<super::super::String>;
             const NAME: &'static str = "before";
         }
-        pub struct Last;
-        impl ::cynic::schema::HasArgument<Last> for super::AllPeople {
+        pub struct last;
+        impl ::cynic::schema::HasArgument<last> for super::allPeople {
             type ArgumentType = Option<super::super::Int>;
             const NAME: &'static str = "last";
         }
     }
-    pub struct Person;
-    impl ::cynic::schema::Field for Person {
+    pub struct person;
+    impl ::cynic::schema::Field for person {
         type Type = Option<super::Person>;
         const NAME: &'static str = "person";
     }
-    impl ::cynic::schema::HasField<Person> for super::Root {
+    impl ::cynic::schema::HasField<person> for super::Root {
         type Type = Option<super::Person>;
     }
     pub mod person_arguments {
-        pub struct Id;
-        impl ::cynic::schema::HasArgument<Id> for super::Person {
-            type ArgumentType = Option<super::super::Id>;
+        pub struct id;
+        impl ::cynic::schema::HasArgument<id> for super::person {
+            type ArgumentType = Option<super::super::ID>;
             const NAME: &'static str = "id";
         }
-        pub struct PersonId;
-        impl ::cynic::schema::HasArgument<PersonId> for super::Person {
-            type ArgumentType = Option<super::super::Id>;
+        pub struct personID;
+        impl ::cynic::schema::HasArgument<personID> for super::person {
+            type ArgumentType = Option<super::super::ID>;
             const NAME: &'static str = "personID";
         }
     }
-    pub struct AllPlanets;
-    impl ::cynic::schema::Field for AllPlanets {
+    pub struct allPlanets;
+    impl ::cynic::schema::Field for allPlanets {
         type Type = Option<super::PlanetsConnection>;
         const NAME: &'static str = "allPlanets";
     }
-    impl ::cynic::schema::HasField<AllPlanets> for super::Root {
+    impl ::cynic::schema::HasField<allPlanets> for super::Root {
         type Type = Option<super::PlanetsConnection>;
     }
     pub mod all_planets_arguments {
-        pub struct After;
-        impl ::cynic::schema::HasArgument<After> for super::AllPlanets {
+        pub struct after;
+        impl ::cynic::schema::HasArgument<after> for super::allPlanets {
             type ArgumentType = Option<super::super::String>;
             const NAME: &'static str = "after";
         }
-        pub struct First;
-        impl ::cynic::schema::HasArgument<First> for super::AllPlanets {
+        pub struct first;
+        impl ::cynic::schema::HasArgument<first> for super::allPlanets {
             type ArgumentType = Option<super::super::Int>;
             const NAME: &'static str = "first";
         }
-        pub struct Before;
-        impl ::cynic::schema::HasArgument<Before> for super::AllPlanets {
+        pub struct before;
+        impl ::cynic::schema::HasArgument<before> for super::allPlanets {
             type ArgumentType = Option<super::super::String>;
             const NAME: &'static str = "before";
         }
-        pub struct Last;
-        impl ::cynic::schema::HasArgument<Last> for super::AllPlanets {
+        pub struct last;
+        impl ::cynic::schema::HasArgument<last> for super::allPlanets {
             type ArgumentType = Option<super::super::Int>;
             const NAME: &'static str = "last";
         }
     }
-    pub struct Planet;
-    impl ::cynic::schema::Field for Planet {
+    pub struct planet;
+    impl ::cynic::schema::Field for planet {
         type Type = Option<super::Planet>;
         const NAME: &'static str = "planet";
     }
-    impl ::cynic::schema::HasField<Planet> for super::Root {
+    impl ::cynic::schema::HasField<planet> for super::Root {
         type Type = Option<super::Planet>;
     }
     pub mod planet_arguments {
-        pub struct Id;
-        impl ::cynic::schema::HasArgument<Id> for super::Planet {
-            type ArgumentType = Option<super::super::Id>;
+        pub struct id;
+        impl ::cynic::schema::HasArgument<id> for super::planet {
+            type ArgumentType = Option<super::super::ID>;
             const NAME: &'static str = "id";
         }
-        pub struct PlanetId;
-        impl ::cynic::schema::HasArgument<PlanetId> for super::Planet {
-            type ArgumentType = Option<super::super::Id>;
+        pub struct planetID;
+        impl ::cynic::schema::HasArgument<planetID> for super::planet {
+            type ArgumentType = Option<super::super::ID>;
             const NAME: &'static str = "planetID";
         }
     }
-    pub struct AllSpecies;
-    impl ::cynic::schema::Field for AllSpecies {
+    pub struct allSpecies;
+    impl ::cynic::schema::Field for allSpecies {
         type Type = Option<super::SpeciesConnection>;
         const NAME: &'static str = "allSpecies";
     }
-    impl ::cynic::schema::HasField<AllSpecies> for super::Root {
+    impl ::cynic::schema::HasField<allSpecies> for super::Root {
         type Type = Option<super::SpeciesConnection>;
     }
     pub mod all_species_arguments {
-        pub struct After;
-        impl ::cynic::schema::HasArgument<After> for super::AllSpecies {
+        pub struct after;
+        impl ::cynic::schema::HasArgument<after> for super::allSpecies {
             type ArgumentType = Option<super::super::String>;
             const NAME: &'static str = "after";
         }
-        pub struct First;
-        impl ::cynic::schema::HasArgument<First> for super::AllSpecies {
+        pub struct first;
+        impl ::cynic::schema::HasArgument<first> for super::allSpecies {
             type ArgumentType = Option<super::super::Int>;
             const NAME: &'static str = "first";
         }
-        pub struct Before;
-        impl ::cynic::schema::HasArgument<Before> for super::AllSpecies {
+        pub struct before;
+        impl ::cynic::schema::HasArgument<before> for super::allSpecies {
             type ArgumentType = Option<super::super::String>;
             const NAME: &'static str = "before";
         }
-        pub struct Last;
-        impl ::cynic::schema::HasArgument<Last> for super::AllSpecies {
+        pub struct last;
+        impl ::cynic::schema::HasArgument<last> for super::allSpecies {
             type ArgumentType = Option<super::super::Int>;
             const NAME: &'static str = "last";
         }
     }
-    pub struct Species;
-    impl ::cynic::schema::Field for Species {
+    pub struct species;
+    impl ::cynic::schema::Field for species {
         type Type = Option<super::Species>;
         const NAME: &'static str = "species";
     }
-    impl ::cynic::schema::HasField<Species> for super::Root {
+    impl ::cynic::schema::HasField<species> for super::Root {
         type Type = Option<super::Species>;
     }
     pub mod species_arguments {
-        pub struct Id;
-        impl ::cynic::schema::HasArgument<Id> for super::Species {
-            type ArgumentType = Option<super::super::Id>;
+        pub struct id;
+        impl ::cynic::schema::HasArgument<id> for super::species {
+            type ArgumentType = Option<super::super::ID>;
             const NAME: &'static str = "id";
         }
-        pub struct SpeciesId;
-        impl ::cynic::schema::HasArgument<SpeciesId> for super::Species {
-            type ArgumentType = Option<super::super::Id>;
+        pub struct speciesID;
+        impl ::cynic::schema::HasArgument<speciesID> for super::species {
+            type ArgumentType = Option<super::super::ID>;
             const NAME: &'static str = "speciesID";
         }
     }
-    pub struct AllStarships;
-    impl ::cynic::schema::Field for AllStarships {
+    pub struct allStarships;
+    impl ::cynic::schema::Field for allStarships {
         type Type = Option<super::StarshipsConnection>;
         const NAME: &'static str = "allStarships";
     }
-    impl ::cynic::schema::HasField<AllStarships> for super::Root {
+    impl ::cynic::schema::HasField<allStarships> for super::Root {
         type Type = Option<super::StarshipsConnection>;
     }
     pub mod all_starships_arguments {
-        pub struct After;
-        impl ::cynic::schema::HasArgument<After> for super::AllStarships {
+        pub struct after;
+        impl ::cynic::schema::HasArgument<after> for super::allStarships {
             type ArgumentType = Option<super::super::String>;
             const NAME: &'static str = "after";
         }
-        pub struct First;
-        impl ::cynic::schema::HasArgument<First> for super::AllStarships {
+        pub struct first;
+        impl ::cynic::schema::HasArgument<first> for super::allStarships {
             type ArgumentType = Option<super::super::Int>;
             const NAME: &'static str = "first";
         }
-        pub struct Before;
-        impl ::cynic::schema::HasArgument<Before> for super::AllStarships {
+        pub struct before;
+        impl ::cynic::schema::HasArgument<before> for super::allStarships {
             type ArgumentType = Option<super::super::String>;
             const NAME: &'static str = "before";
         }
-        pub struct Last;
-        impl ::cynic::schema::HasArgument<Last> for super::AllStarships {
+        pub struct last;
+        impl ::cynic::schema::HasArgument<last> for super::allStarships {
             type ArgumentType = Option<super::super::Int>;
             const NAME: &'static str = "last";
         }
     }
-    pub struct Starship;
-    impl ::cynic::schema::Field for Starship {
+    pub struct starship;
+    impl ::cynic::schema::Field for starship {
         type Type = Option<super::Starship>;
         const NAME: &'static str = "starship";
     }
-    impl ::cynic::schema::HasField<Starship> for super::Root {
+    impl ::cynic::schema::HasField<starship> for super::Root {
         type Type = Option<super::Starship>;
     }
     pub mod starship_arguments {
-        pub struct Id;
-        impl ::cynic::schema::HasArgument<Id> for super::Starship {
-            type ArgumentType = Option<super::super::Id>;
+        pub struct id;
+        impl ::cynic::schema::HasArgument<id> for super::starship {
+            type ArgumentType = Option<super::super::ID>;
             const NAME: &'static str = "id";
         }
-        pub struct StarshipId;
-        impl ::cynic::schema::HasArgument<StarshipId> for super::Starship {
-            type ArgumentType = Option<super::super::Id>;
+        pub struct starshipID;
+        impl ::cynic::schema::HasArgument<starshipID> for super::starship {
+            type ArgumentType = Option<super::super::ID>;
             const NAME: &'static str = "starshipID";
         }
     }
-    pub struct AllVehicles;
-    impl ::cynic::schema::Field for AllVehicles {
+    pub struct allVehicles;
+    impl ::cynic::schema::Field for allVehicles {
         type Type = Option<super::VehiclesConnection>;
         const NAME: &'static str = "allVehicles";
     }
-    impl ::cynic::schema::HasField<AllVehicles> for super::Root {
+    impl ::cynic::schema::HasField<allVehicles> for super::Root {
         type Type = Option<super::VehiclesConnection>;
     }
     pub mod all_vehicles_arguments {
-        pub struct After;
-        impl ::cynic::schema::HasArgument<After> for super::AllVehicles {
+        pub struct after;
+        impl ::cynic::schema::HasArgument<after> for super::allVehicles {
             type ArgumentType = Option<super::super::String>;
             const NAME: &'static str = "after";
         }
-        pub struct First;
-        impl ::cynic::schema::HasArgument<First> for super::AllVehicles {
+        pub struct first;
+        impl ::cynic::schema::HasArgument<first> for super::allVehicles {
             type ArgumentType = Option<super::super::Int>;
             const NAME: &'static str = "first";
         }
-        pub struct Before;
-        impl ::cynic::schema::HasArgument<Before> for super::AllVehicles {
+        pub struct before;
+        impl ::cynic::schema::HasArgument<before> for super::allVehicles {
             type ArgumentType = Option<super::super::String>;
             const NAME: &'static str = "before";
         }
-        pub struct Last;
-        impl ::cynic::schema::HasArgument<Last> for super::AllVehicles {
+        pub struct last;
+        impl ::cynic::schema::HasArgument<last> for super::allVehicles {
             type ArgumentType = Option<super::super::Int>;
             const NAME: &'static str = "last";
         }
     }
-    pub struct Vehicle;
-    impl ::cynic::schema::Field for Vehicle {
+    pub struct vehicle;
+    impl ::cynic::schema::Field for vehicle {
         type Type = Option<super::Vehicle>;
         const NAME: &'static str = "vehicle";
     }
-    impl ::cynic::schema::HasField<Vehicle> for super::Root {
+    impl ::cynic::schema::HasField<vehicle> for super::Root {
         type Type = Option<super::Vehicle>;
     }
     pub mod vehicle_arguments {
-        pub struct Id;
-        impl ::cynic::schema::HasArgument<Id> for super::Vehicle {
-            type ArgumentType = Option<super::super::Id>;
+        pub struct id;
+        impl ::cynic::schema::HasArgument<id> for super::vehicle {
+            type ArgumentType = Option<super::super::ID>;
             const NAME: &'static str = "id";
         }
-        pub struct VehicleId;
-        impl ::cynic::schema::HasArgument<VehicleId> for super::Vehicle {
-            type ArgumentType = Option<super::super::Id>;
+        pub struct vehicleID;
+        impl ::cynic::schema::HasArgument<vehicleID> for super::vehicle {
+            type ArgumentType = Option<super::super::ID>;
             const NAME: &'static str = "vehicleID";
         }
     }
-    pub struct Node;
-    impl ::cynic::schema::Field for Node {
+    pub struct node;
+    impl ::cynic::schema::Field for node {
         type Type = Option<super::Node>;
         const NAME: &'static str = "node";
     }
-    impl ::cynic::schema::HasField<Node> for super::Root {
+    impl ::cynic::schema::HasField<node> for super::Root {
         type Type = Option<super::Node>;
     }
     pub mod node_arguments {
-        pub struct Id;
-        impl ::cynic::schema::HasArgument<Id> for super::Node {
-            type ArgumentType = super::super::Id;
+        pub struct id;
+        impl ::cynic::schema::HasArgument<id> for super::node {
+            type ArgumentType = super::super::ID;
             const NAME: &'static str = "id";
         }
     }
 }
 pub struct Species;
 pub mod species_fields {
-    pub struct Name;
-    impl ::cynic::schema::Field for Name {
+    pub struct name;
+    impl ::cynic::schema::Field for name {
         type Type = Option<super::String>;
         const NAME: &'static str = "name";
     }
-    impl ::cynic::schema::HasField<Name> for super::Species {
+    impl ::cynic::schema::HasField<name> for super::Species {
         type Type = Option<super::String>;
     }
-    pub struct Classification;
-    impl ::cynic::schema::Field for Classification {
+    pub struct classification;
+    impl ::cynic::schema::Field for classification {
         type Type = Option<super::String>;
         const NAME: &'static str = "classification";
     }
-    impl ::cynic::schema::HasField<Classification> for super::Species {
+    impl ::cynic::schema::HasField<classification> for super::Species {
         type Type = Option<super::String>;
     }
-    pub struct Designation;
-    impl ::cynic::schema::Field for Designation {
+    pub struct designation;
+    impl ::cynic::schema::Field for designation {
         type Type = Option<super::String>;
         const NAME: &'static str = "designation";
     }
-    impl ::cynic::schema::HasField<Designation> for super::Species {
+    impl ::cynic::schema::HasField<designation> for super::Species {
         type Type = Option<super::String>;
     }
-    pub struct AverageHeight;
-    impl ::cynic::schema::Field for AverageHeight {
+    pub struct averageHeight;
+    impl ::cynic::schema::Field for averageHeight {
         type Type = Option<super::Float>;
         const NAME: &'static str = "averageHeight";
     }
-    impl ::cynic::schema::HasField<AverageHeight> for super::Species {
+    impl ::cynic::schema::HasField<averageHeight> for super::Species {
         type Type = Option<super::Float>;
     }
-    pub struct AverageLifespan;
-    impl ::cynic::schema::Field for AverageLifespan {
+    pub struct averageLifespan;
+    impl ::cynic::schema::Field for averageLifespan {
         type Type = Option<super::Int>;
         const NAME: &'static str = "averageLifespan";
     }
-    impl ::cynic::schema::HasField<AverageLifespan> for super::Species {
+    impl ::cynic::schema::HasField<averageLifespan> for super::Species {
         type Type = Option<super::Int>;
     }
-    pub struct EyeColors;
-    impl ::cynic::schema::Field for EyeColors {
+    pub struct eyeColors;
+    impl ::cynic::schema::Field for eyeColors {
         type Type = Option<Vec<Option<super::String>>>;
         const NAME: &'static str = "eyeColors";
     }
-    impl ::cynic::schema::HasField<EyeColors> for super::Species {
+    impl ::cynic::schema::HasField<eyeColors> for super::Species {
         type Type = Option<Vec<Option<super::String>>>;
     }
-    pub struct HairColors;
-    impl ::cynic::schema::Field for HairColors {
+    pub struct hairColors;
+    impl ::cynic::schema::Field for hairColors {
         type Type = Option<Vec<Option<super::String>>>;
         const NAME: &'static str = "hairColors";
     }
-    impl ::cynic::schema::HasField<HairColors> for super::Species {
+    impl ::cynic::schema::HasField<hairColors> for super::Species {
         type Type = Option<Vec<Option<super::String>>>;
     }
-    pub struct SkinColors;
-    impl ::cynic::schema::Field for SkinColors {
+    pub struct skinColors;
+    impl ::cynic::schema::Field for skinColors {
         type Type = Option<Vec<Option<super::String>>>;
         const NAME: &'static str = "skinColors";
     }
-    impl ::cynic::schema::HasField<SkinColors> for super::Species {
+    impl ::cynic::schema::HasField<skinColors> for super::Species {
         type Type = Option<Vec<Option<super::String>>>;
     }
-    pub struct Language;
-    impl ::cynic::schema::Field for Language {
+    pub struct language;
+    impl ::cynic::schema::Field for language {
         type Type = Option<super::String>;
         const NAME: &'static str = "language";
     }
-    impl ::cynic::schema::HasField<Language> for super::Species {
+    impl ::cynic::schema::HasField<language> for super::Species {
         type Type = Option<super::String>;
     }
-    pub struct Homeworld;
-    impl ::cynic::schema::Field for Homeworld {
+    pub struct homeworld;
+    impl ::cynic::schema::Field for homeworld {
         type Type = Option<super::Planet>;
         const NAME: &'static str = "homeworld";
     }
-    impl ::cynic::schema::HasField<Homeworld> for super::Species {
+    impl ::cynic::schema::HasField<homeworld> for super::Species {
         type Type = Option<super::Planet>;
     }
-    pub struct PersonConnection;
-    impl ::cynic::schema::Field for PersonConnection {
+    pub struct personConnection;
+    impl ::cynic::schema::Field for personConnection {
         type Type = Option<super::SpeciesPeopleConnection>;
         const NAME: &'static str = "personConnection";
     }
-    impl ::cynic::schema::HasField<PersonConnection> for super::Species {
+    impl ::cynic::schema::HasField<personConnection> for super::Species {
         type Type = Option<super::SpeciesPeopleConnection>;
     }
     pub mod person_connection_arguments {
-        pub struct After;
-        impl ::cynic::schema::HasArgument<After> for super::PersonConnection {
+        pub struct after;
+        impl ::cynic::schema::HasArgument<after> for super::personConnection {
             type ArgumentType = Option<super::super::String>;
             const NAME: &'static str = "after";
         }
-        pub struct First;
-        impl ::cynic::schema::HasArgument<First> for super::PersonConnection {
+        pub struct first;
+        impl ::cynic::schema::HasArgument<first> for super::personConnection {
             type ArgumentType = Option<super::super::Int>;
             const NAME: &'static str = "first";
         }
-        pub struct Before;
-        impl ::cynic::schema::HasArgument<Before> for super::PersonConnection {
+        pub struct before;
+        impl ::cynic::schema::HasArgument<before> for super::personConnection {
             type ArgumentType = Option<super::super::String>;
             const NAME: &'static str = "before";
         }
-        pub struct Last;
-        impl ::cynic::schema::HasArgument<Last> for super::PersonConnection {
+        pub struct last;
+        impl ::cynic::schema::HasArgument<last> for super::personConnection {
             type ArgumentType = Option<super::super::Int>;
             const NAME: &'static str = "last";
         }
     }
-    pub struct FilmConnection;
-    impl ::cynic::schema::Field for FilmConnection {
+    pub struct filmConnection;
+    impl ::cynic::schema::Field for filmConnection {
         type Type = Option<super::SpeciesFilmsConnection>;
         const NAME: &'static str = "filmConnection";
     }
-    impl ::cynic::schema::HasField<FilmConnection> for super::Species {
+    impl ::cynic::schema::HasField<filmConnection> for super::Species {
         type Type = Option<super::SpeciesFilmsConnection>;
     }
     pub mod film_connection_arguments {
-        pub struct After;
-        impl ::cynic::schema::HasArgument<After> for super::FilmConnection {
+        pub struct after;
+        impl ::cynic::schema::HasArgument<after> for super::filmConnection {
             type ArgumentType = Option<super::super::String>;
             const NAME: &'static str = "after";
         }
-        pub struct First;
-        impl ::cynic::schema::HasArgument<First> for super::FilmConnection {
+        pub struct first;
+        impl ::cynic::schema::HasArgument<first> for super::filmConnection {
             type ArgumentType = Option<super::super::Int>;
             const NAME: &'static str = "first";
         }
-        pub struct Before;
-        impl ::cynic::schema::HasArgument<Before> for super::FilmConnection {
+        pub struct before;
+        impl ::cynic::schema::HasArgument<before> for super::filmConnection {
             type ArgumentType = Option<super::super::String>;
             const NAME: &'static str = "before";
         }
-        pub struct Last;
-        impl ::cynic::schema::HasArgument<Last> for super::FilmConnection {
+        pub struct last;
+        impl ::cynic::schema::HasArgument<last> for super::filmConnection {
             type ArgumentType = Option<super::super::Int>;
             const NAME: &'static str = "last";
         }
     }
-    pub struct Created;
-    impl ::cynic::schema::Field for Created {
+    pub struct created;
+    impl ::cynic::schema::Field for created {
         type Type = Option<super::String>;
         const NAME: &'static str = "created";
     }
-    impl ::cynic::schema::HasField<Created> for super::Species {
+    impl ::cynic::schema::HasField<created> for super::Species {
         type Type = Option<super::String>;
     }
-    pub struct Edited;
-    impl ::cynic::schema::Field for Edited {
+    pub struct edited;
+    impl ::cynic::schema::Field for edited {
         type Type = Option<super::String>;
         const NAME: &'static str = "edited";
     }
-    impl ::cynic::schema::HasField<Edited> for super::Species {
+    impl ::cynic::schema::HasField<edited> for super::Species {
         type Type = Option<super::String>;
     }
-    pub struct Id;
-    impl ::cynic::schema::Field for Id {
-        type Type = super::Id;
+    pub struct id;
+    impl ::cynic::schema::Field for id {
+        type Type = super::ID;
         const NAME: &'static str = "id";
     }
-    impl ::cynic::schema::HasField<Id> for super::Species {
-        type Type = super::Id;
+    impl ::cynic::schema::HasField<id> for super::Species {
+        type Type = super::ID;
     }
 }
 pub struct SpeciesConnection;
 pub mod species_connection_fields {
-    pub struct PageInfo;
-    impl ::cynic::schema::Field for PageInfo {
+    pub struct pageInfo;
+    impl ::cynic::schema::Field for pageInfo {
         type Type = super::PageInfo;
         const NAME: &'static str = "pageInfo";
     }
-    impl ::cynic::schema::HasField<PageInfo> for super::SpeciesConnection {
+    impl ::cynic::schema::HasField<pageInfo> for super::SpeciesConnection {
         type Type = super::PageInfo;
     }
-    pub struct Edges;
-    impl ::cynic::schema::Field for Edges {
+    pub struct edges;
+    impl ::cynic::schema::Field for edges {
         type Type = Option<Vec<Option<super::SpeciesEdge>>>;
         const NAME: &'static str = "edges";
     }
-    impl ::cynic::schema::HasField<Edges> for super::SpeciesConnection {
+    impl ::cynic::schema::HasField<edges> for super::SpeciesConnection {
         type Type = Option<Vec<Option<super::SpeciesEdge>>>;
     }
-    pub struct TotalCount;
-    impl ::cynic::schema::Field for TotalCount {
+    pub struct totalCount;
+    impl ::cynic::schema::Field for totalCount {
         type Type = Option<super::Int>;
         const NAME: &'static str = "totalCount";
     }
-    impl ::cynic::schema::HasField<TotalCount> for super::SpeciesConnection {
+    impl ::cynic::schema::HasField<totalCount> for super::SpeciesConnection {
         type Type = Option<super::Int>;
     }
-    pub struct Species;
-    impl ::cynic::schema::Field for Species {
+    pub struct species;
+    impl ::cynic::schema::Field for species {
         type Type = Option<Vec<Option<super::Species>>>;
         const NAME: &'static str = "species";
     }
-    impl ::cynic::schema::HasField<Species> for super::SpeciesConnection {
+    impl ::cynic::schema::HasField<species> for super::SpeciesConnection {
         type Type = Option<Vec<Option<super::Species>>>;
     }
 }
 pub struct SpeciesEdge;
 pub mod species_edge_fields {
-    pub struct Node;
-    impl ::cynic::schema::Field for Node {
+    pub struct node;
+    impl ::cynic::schema::Field for node {
         type Type = Option<super::Species>;
         const NAME: &'static str = "node";
     }
-    impl ::cynic::schema::HasField<Node> for super::SpeciesEdge {
+    impl ::cynic::schema::HasField<node> for super::SpeciesEdge {
         type Type = Option<super::Species>;
     }
-    pub struct Cursor;
-    impl ::cynic::schema::Field for Cursor {
+    pub struct cursor;
+    impl ::cynic::schema::Field for cursor {
         type Type = super::String;
         const NAME: &'static str = "cursor";
     }
-    impl ::cynic::schema::HasField<Cursor> for super::SpeciesEdge {
+    impl ::cynic::schema::HasField<cursor> for super::SpeciesEdge {
         type Type = super::String;
     }
 }
 pub struct SpeciesFilmsConnection;
 pub mod species_films_connection_fields {
-    pub struct PageInfo;
-    impl ::cynic::schema::Field for PageInfo {
+    pub struct pageInfo;
+    impl ::cynic::schema::Field for pageInfo {
         type Type = super::PageInfo;
         const NAME: &'static str = "pageInfo";
     }
-    impl ::cynic::schema::HasField<PageInfo> for super::SpeciesFilmsConnection {
+    impl ::cynic::schema::HasField<pageInfo> for super::SpeciesFilmsConnection {
         type Type = super::PageInfo;
     }
-    pub struct Edges;
-    impl ::cynic::schema::Field for Edges {
+    pub struct edges;
+    impl ::cynic::schema::Field for edges {
         type Type = Option<Vec<Option<super::SpeciesFilmsEdge>>>;
         const NAME: &'static str = "edges";
     }
-    impl ::cynic::schema::HasField<Edges> for super::SpeciesFilmsConnection {
+    impl ::cynic::schema::HasField<edges> for super::SpeciesFilmsConnection {
         type Type = Option<Vec<Option<super::SpeciesFilmsEdge>>>;
     }
-    pub struct TotalCount;
-    impl ::cynic::schema::Field for TotalCount {
+    pub struct totalCount;
+    impl ::cynic::schema::Field for totalCount {
         type Type = Option<super::Int>;
         const NAME: &'static str = "totalCount";
     }
-    impl ::cynic::schema::HasField<TotalCount> for super::SpeciesFilmsConnection {
+    impl ::cynic::schema::HasField<totalCount> for super::SpeciesFilmsConnection {
         type Type = Option<super::Int>;
     }
-    pub struct Films;
-    impl ::cynic::schema::Field for Films {
+    pub struct films;
+    impl ::cynic::schema::Field for films {
         type Type = Option<Vec<Option<super::Film>>>;
         const NAME: &'static str = "films";
     }
-    impl ::cynic::schema::HasField<Films> for super::SpeciesFilmsConnection {
+    impl ::cynic::schema::HasField<films> for super::SpeciesFilmsConnection {
         type Type = Option<Vec<Option<super::Film>>>;
     }
 }
 pub struct SpeciesFilmsEdge;
 pub mod species_films_edge_fields {
-    pub struct Node;
-    impl ::cynic::schema::Field for Node {
+    pub struct node;
+    impl ::cynic::schema::Field for node {
         type Type = Option<super::Film>;
         const NAME: &'static str = "node";
     }
-    impl ::cynic::schema::HasField<Node> for super::SpeciesFilmsEdge {
+    impl ::cynic::schema::HasField<node> for super::SpeciesFilmsEdge {
         type Type = Option<super::Film>;
     }
-    pub struct Cursor;
-    impl ::cynic::schema::Field for Cursor {
+    pub struct cursor;
+    impl ::cynic::schema::Field for cursor {
         type Type = super::String;
         const NAME: &'static str = "cursor";
     }
-    impl ::cynic::schema::HasField<Cursor> for super::SpeciesFilmsEdge {
+    impl ::cynic::schema::HasField<cursor> for super::SpeciesFilmsEdge {
         type Type = super::String;
     }
 }
 pub struct SpeciesPeopleConnection;
 pub mod species_people_connection_fields {
-    pub struct PageInfo;
-    impl ::cynic::schema::Field for PageInfo {
+    pub struct pageInfo;
+    impl ::cynic::schema::Field for pageInfo {
         type Type = super::PageInfo;
         const NAME: &'static str = "pageInfo";
     }
-    impl ::cynic::schema::HasField<PageInfo> for super::SpeciesPeopleConnection {
+    impl ::cynic::schema::HasField<pageInfo> for super::SpeciesPeopleConnection {
         type Type = super::PageInfo;
     }
-    pub struct Edges;
-    impl ::cynic::schema::Field for Edges {
+    pub struct edges;
+    impl ::cynic::schema::Field for edges {
         type Type = Option<Vec<Option<super::SpeciesPeopleEdge>>>;
         const NAME: &'static str = "edges";
     }
-    impl ::cynic::schema::HasField<Edges> for super::SpeciesPeopleConnection {
+    impl ::cynic::schema::HasField<edges> for super::SpeciesPeopleConnection {
         type Type = Option<Vec<Option<super::SpeciesPeopleEdge>>>;
     }
-    pub struct TotalCount;
-    impl ::cynic::schema::Field for TotalCount {
+    pub struct totalCount;
+    impl ::cynic::schema::Field for totalCount {
         type Type = Option<super::Int>;
         const NAME: &'static str = "totalCount";
     }
-    impl ::cynic::schema::HasField<TotalCount> for super::SpeciesPeopleConnection {
+    impl ::cynic::schema::HasField<totalCount> for super::SpeciesPeopleConnection {
         type Type = Option<super::Int>;
     }
-    pub struct People;
-    impl ::cynic::schema::Field for People {
+    pub struct people;
+    impl ::cynic::schema::Field for people {
         type Type = Option<Vec<Option<super::Person>>>;
         const NAME: &'static str = "people";
     }
-    impl ::cynic::schema::HasField<People> for super::SpeciesPeopleConnection {
+    impl ::cynic::schema::HasField<people> for super::SpeciesPeopleConnection {
         type Type = Option<Vec<Option<super::Person>>>;
     }
 }
 pub struct SpeciesPeopleEdge;
 pub mod species_people_edge_fields {
-    pub struct Node;
-    impl ::cynic::schema::Field for Node {
+    pub struct node;
+    impl ::cynic::schema::Field for node {
         type Type = Option<super::Person>;
         const NAME: &'static str = "node";
     }
-    impl ::cynic::schema::HasField<Node> for super::SpeciesPeopleEdge {
+    impl ::cynic::schema::HasField<node> for super::SpeciesPeopleEdge {
         type Type = Option<super::Person>;
     }
-    pub struct Cursor;
-    impl ::cynic::schema::Field for Cursor {
+    pub struct cursor;
+    impl ::cynic::schema::Field for cursor {
         type Type = super::String;
         const NAME: &'static str = "cursor";
     }
-    impl ::cynic::schema::HasField<Cursor> for super::SpeciesPeopleEdge {
+    impl ::cynic::schema::HasField<cursor> for super::SpeciesPeopleEdge {
         type Type = super::String;
     }
 }
 pub struct Starship;
 pub mod starship_fields {
-    pub struct Name;
-    impl ::cynic::schema::Field for Name {
+    pub struct name;
+    impl ::cynic::schema::Field for name {
         type Type = Option<super::String>;
         const NAME: &'static str = "name";
     }
-    impl ::cynic::schema::HasField<Name> for super::Starship {
+    impl ::cynic::schema::HasField<name> for super::Starship {
         type Type = Option<super::String>;
     }
-    pub struct Model;
-    impl ::cynic::schema::Field for Model {
+    pub struct model;
+    impl ::cynic::schema::Field for model {
         type Type = Option<super::String>;
         const NAME: &'static str = "model";
     }
-    impl ::cynic::schema::HasField<Model> for super::Starship {
+    impl ::cynic::schema::HasField<model> for super::Starship {
         type Type = Option<super::String>;
     }
-    pub struct StarshipClass;
-    impl ::cynic::schema::Field for StarshipClass {
+    pub struct starshipClass;
+    impl ::cynic::schema::Field for starshipClass {
         type Type = Option<super::String>;
         const NAME: &'static str = "starshipClass";
     }
-    impl ::cynic::schema::HasField<StarshipClass> for super::Starship {
+    impl ::cynic::schema::HasField<starshipClass> for super::Starship {
         type Type = Option<super::String>;
     }
-    pub struct Manufacturers;
-    impl ::cynic::schema::Field for Manufacturers {
+    pub struct manufacturers;
+    impl ::cynic::schema::Field for manufacturers {
         type Type = Option<Vec<Option<super::String>>>;
         const NAME: &'static str = "manufacturers";
     }
-    impl ::cynic::schema::HasField<Manufacturers> for super::Starship {
+    impl ::cynic::schema::HasField<manufacturers> for super::Starship {
         type Type = Option<Vec<Option<super::String>>>;
     }
-    pub struct CostInCredits;
-    impl ::cynic::schema::Field for CostInCredits {
+    pub struct costInCredits;
+    impl ::cynic::schema::Field for costInCredits {
         type Type = Option<super::Float>;
         const NAME: &'static str = "costInCredits";
     }
-    impl ::cynic::schema::HasField<CostInCredits> for super::Starship {
+    impl ::cynic::schema::HasField<costInCredits> for super::Starship {
         type Type = Option<super::Float>;
     }
-    pub struct Length;
-    impl ::cynic::schema::Field for Length {
+    pub struct length;
+    impl ::cynic::schema::Field for length {
         type Type = Option<super::Float>;
         const NAME: &'static str = "length";
     }
-    impl ::cynic::schema::HasField<Length> for super::Starship {
+    impl ::cynic::schema::HasField<length> for super::Starship {
         type Type = Option<super::Float>;
     }
-    pub struct Crew;
-    impl ::cynic::schema::Field for Crew {
+    pub struct crew;
+    impl ::cynic::schema::Field for crew {
         type Type = Option<super::String>;
         const NAME: &'static str = "crew";
     }
-    impl ::cynic::schema::HasField<Crew> for super::Starship {
+    impl ::cynic::schema::HasField<crew> for super::Starship {
         type Type = Option<super::String>;
     }
-    pub struct Passengers;
-    impl ::cynic::schema::Field for Passengers {
+    pub struct passengers;
+    impl ::cynic::schema::Field for passengers {
         type Type = Option<super::String>;
         const NAME: &'static str = "passengers";
     }
-    impl ::cynic::schema::HasField<Passengers> for super::Starship {
+    impl ::cynic::schema::HasField<passengers> for super::Starship {
         type Type = Option<super::String>;
     }
-    pub struct MaxAtmospheringSpeed;
-    impl ::cynic::schema::Field for MaxAtmospheringSpeed {
+    pub struct maxAtmospheringSpeed;
+    impl ::cynic::schema::Field for maxAtmospheringSpeed {
         type Type = Option<super::Int>;
         const NAME: &'static str = "maxAtmospheringSpeed";
     }
-    impl ::cynic::schema::HasField<MaxAtmospheringSpeed> for super::Starship {
+    impl ::cynic::schema::HasField<maxAtmospheringSpeed> for super::Starship {
         type Type = Option<super::Int>;
     }
-    pub struct HyperdriveRating;
-    impl ::cynic::schema::Field for HyperdriveRating {
+    pub struct hyperdriveRating;
+    impl ::cynic::schema::Field for hyperdriveRating {
         type Type = Option<super::Float>;
         const NAME: &'static str = "hyperdriveRating";
     }
-    impl ::cynic::schema::HasField<HyperdriveRating> for super::Starship {
+    impl ::cynic::schema::HasField<hyperdriveRating> for super::Starship {
         type Type = Option<super::Float>;
     }
-    pub struct Mglt;
-    impl ::cynic::schema::Field for Mglt {
+    pub struct MGLT;
+    impl ::cynic::schema::Field for MGLT {
         type Type = Option<super::Int>;
         const NAME: &'static str = "MGLT";
     }
-    impl ::cynic::schema::HasField<Mglt> for super::Starship {
+    impl ::cynic::schema::HasField<MGLT> for super::Starship {
         type Type = Option<super::Int>;
     }
-    pub struct CargoCapacity;
-    impl ::cynic::schema::Field for CargoCapacity {
+    pub struct cargoCapacity;
+    impl ::cynic::schema::Field for cargoCapacity {
         type Type = Option<super::Float>;
         const NAME: &'static str = "cargoCapacity";
     }
-    impl ::cynic::schema::HasField<CargoCapacity> for super::Starship {
+    impl ::cynic::schema::HasField<cargoCapacity> for super::Starship {
         type Type = Option<super::Float>;
     }
-    pub struct Consumables;
-    impl ::cynic::schema::Field for Consumables {
+    pub struct consumables;
+    impl ::cynic::schema::Field for consumables {
         type Type = Option<super::String>;
         const NAME: &'static str = "consumables";
     }
-    impl ::cynic::schema::HasField<Consumables> for super::Starship {
+    impl ::cynic::schema::HasField<consumables> for super::Starship {
         type Type = Option<super::String>;
     }
-    pub struct PilotConnection;
-    impl ::cynic::schema::Field for PilotConnection {
+    pub struct pilotConnection;
+    impl ::cynic::schema::Field for pilotConnection {
         type Type = Option<super::StarshipPilotsConnection>;
         const NAME: &'static str = "pilotConnection";
     }
-    impl ::cynic::schema::HasField<PilotConnection> for super::Starship {
+    impl ::cynic::schema::HasField<pilotConnection> for super::Starship {
         type Type = Option<super::StarshipPilotsConnection>;
     }
     pub mod pilot_connection_arguments {
-        pub struct After;
-        impl ::cynic::schema::HasArgument<After> for super::PilotConnection {
+        pub struct after;
+        impl ::cynic::schema::HasArgument<after> for super::pilotConnection {
             type ArgumentType = Option<super::super::String>;
             const NAME: &'static str = "after";
         }
-        pub struct First;
-        impl ::cynic::schema::HasArgument<First> for super::PilotConnection {
+        pub struct first;
+        impl ::cynic::schema::HasArgument<first> for super::pilotConnection {
             type ArgumentType = Option<super::super::Int>;
             const NAME: &'static str = "first";
         }
-        pub struct Before;
-        impl ::cynic::schema::HasArgument<Before> for super::PilotConnection {
+        pub struct before;
+        impl ::cynic::schema::HasArgument<before> for super::pilotConnection {
             type ArgumentType = Option<super::super::String>;
             const NAME: &'static str = "before";
         }
-        pub struct Last;
-        impl ::cynic::schema::HasArgument<Last> for super::PilotConnection {
+        pub struct last;
+        impl ::cynic::schema::HasArgument<last> for super::pilotConnection {
             type ArgumentType = Option<super::super::Int>;
             const NAME: &'static str = "last";
         }
     }
-    pub struct FilmConnection;
-    impl ::cynic::schema::Field for FilmConnection {
+    pub struct filmConnection;
+    impl ::cynic::schema::Field for filmConnection {
         type Type = Option<super::StarshipFilmsConnection>;
         const NAME: &'static str = "filmConnection";
     }
-    impl ::cynic::schema::HasField<FilmConnection> for super::Starship {
+    impl ::cynic::schema::HasField<filmConnection> for super::Starship {
         type Type = Option<super::StarshipFilmsConnection>;
     }
     pub mod film_connection_arguments {
-        pub struct After;
-        impl ::cynic::schema::HasArgument<After> for super::FilmConnection {
+        pub struct after;
+        impl ::cynic::schema::HasArgument<after> for super::filmConnection {
             type ArgumentType = Option<super::super::String>;
             const NAME: &'static str = "after";
         }
-        pub struct First;
-        impl ::cynic::schema::HasArgument<First> for super::FilmConnection {
+        pub struct first;
+        impl ::cynic::schema::HasArgument<first> for super::filmConnection {
             type ArgumentType = Option<super::super::Int>;
             const NAME: &'static str = "first";
         }
-        pub struct Before;
-        impl ::cynic::schema::HasArgument<Before> for super::FilmConnection {
+        pub struct before;
+        impl ::cynic::schema::HasArgument<before> for super::filmConnection {
             type ArgumentType = Option<super::super::String>;
             const NAME: &'static str = "before";
         }
-        pub struct Last;
-        impl ::cynic::schema::HasArgument<Last> for super::FilmConnection {
+        pub struct last;
+        impl ::cynic::schema::HasArgument<last> for super::filmConnection {
             type ArgumentType = Option<super::super::Int>;
             const NAME: &'static str = "last";
         }
     }
-    pub struct Created;
-    impl ::cynic::schema::Field for Created {
+    pub struct created;
+    impl ::cynic::schema::Field for created {
         type Type = Option<super::String>;
         const NAME: &'static str = "created";
     }
-    impl ::cynic::schema::HasField<Created> for super::Starship {
+    impl ::cynic::schema::HasField<created> for super::Starship {
         type Type = Option<super::String>;
     }
-    pub struct Edited;
-    impl ::cynic::schema::Field for Edited {
+    pub struct edited;
+    impl ::cynic::schema::Field for edited {
         type Type = Option<super::String>;
         const NAME: &'static str = "edited";
     }
-    impl ::cynic::schema::HasField<Edited> for super::Starship {
+    impl ::cynic::schema::HasField<edited> for super::Starship {
         type Type = Option<super::String>;
     }
-    pub struct Id;
-    impl ::cynic::schema::Field for Id {
-        type Type = super::Id;
+    pub struct id;
+    impl ::cynic::schema::Field for id {
+        type Type = super::ID;
         const NAME: &'static str = "id";
     }
-    impl ::cynic::schema::HasField<Id> for super::Starship {
-        type Type = super::Id;
+    impl ::cynic::schema::HasField<id> for super::Starship {
+        type Type = super::ID;
     }
 }
 pub struct StarshipFilmsConnection;
 pub mod starship_films_connection_fields {
-    pub struct PageInfo;
-    impl ::cynic::schema::Field for PageInfo {
+    pub struct pageInfo;
+    impl ::cynic::schema::Field for pageInfo {
         type Type = super::PageInfo;
         const NAME: &'static str = "pageInfo";
     }
-    impl ::cynic::schema::HasField<PageInfo> for super::StarshipFilmsConnection {
+    impl ::cynic::schema::HasField<pageInfo> for super::StarshipFilmsConnection {
         type Type = super::PageInfo;
     }
-    pub struct Edges;
-    impl ::cynic::schema::Field for Edges {
+    pub struct edges;
+    impl ::cynic::schema::Field for edges {
         type Type = Option<Vec<Option<super::StarshipFilmsEdge>>>;
         const NAME: &'static str = "edges";
     }
-    impl ::cynic::schema::HasField<Edges> for super::StarshipFilmsConnection {
+    impl ::cynic::schema::HasField<edges> for super::StarshipFilmsConnection {
         type Type = Option<Vec<Option<super::StarshipFilmsEdge>>>;
     }
-    pub struct TotalCount;
-    impl ::cynic::schema::Field for TotalCount {
+    pub struct totalCount;
+    impl ::cynic::schema::Field for totalCount {
         type Type = Option<super::Int>;
         const NAME: &'static str = "totalCount";
     }
-    impl ::cynic::schema::HasField<TotalCount> for super::StarshipFilmsConnection {
+    impl ::cynic::schema::HasField<totalCount> for super::StarshipFilmsConnection {
         type Type = Option<super::Int>;
     }
-    pub struct Films;
-    impl ::cynic::schema::Field for Films {
+    pub struct films;
+    impl ::cynic::schema::Field for films {
         type Type = Option<Vec<Option<super::Film>>>;
         const NAME: &'static str = "films";
     }
-    impl ::cynic::schema::HasField<Films> for super::StarshipFilmsConnection {
+    impl ::cynic::schema::HasField<films> for super::StarshipFilmsConnection {
         type Type = Option<Vec<Option<super::Film>>>;
     }
 }
 pub struct StarshipFilmsEdge;
 pub mod starship_films_edge_fields {
-    pub struct Node;
-    impl ::cynic::schema::Field for Node {
+    pub struct node;
+    impl ::cynic::schema::Field for node {
         type Type = Option<super::Film>;
         const NAME: &'static str = "node";
     }
-    impl ::cynic::schema::HasField<Node> for super::StarshipFilmsEdge {
+    impl ::cynic::schema::HasField<node> for super::StarshipFilmsEdge {
         type Type = Option<super::Film>;
     }
-    pub struct Cursor;
-    impl ::cynic::schema::Field for Cursor {
+    pub struct cursor;
+    impl ::cynic::schema::Field for cursor {
         type Type = super::String;
         const NAME: &'static str = "cursor";
     }
-    impl ::cynic::schema::HasField<Cursor> for super::StarshipFilmsEdge {
+    impl ::cynic::schema::HasField<cursor> for super::StarshipFilmsEdge {
         type Type = super::String;
     }
 }
 pub struct StarshipPilotsConnection;
 pub mod starship_pilots_connection_fields {
-    pub struct PageInfo;
-    impl ::cynic::schema::Field for PageInfo {
+    pub struct pageInfo;
+    impl ::cynic::schema::Field for pageInfo {
         type Type = super::PageInfo;
         const NAME: &'static str = "pageInfo";
     }
-    impl ::cynic::schema::HasField<PageInfo> for super::StarshipPilotsConnection {
+    impl ::cynic::schema::HasField<pageInfo> for super::StarshipPilotsConnection {
         type Type = super::PageInfo;
     }
-    pub struct Edges;
-    impl ::cynic::schema::Field for Edges {
+    pub struct edges;
+    impl ::cynic::schema::Field for edges {
         type Type = Option<Vec<Option<super::StarshipPilotsEdge>>>;
         const NAME: &'static str = "edges";
     }
-    impl ::cynic::schema::HasField<Edges> for super::StarshipPilotsConnection {
+    impl ::cynic::schema::HasField<edges> for super::StarshipPilotsConnection {
         type Type = Option<Vec<Option<super::StarshipPilotsEdge>>>;
     }
-    pub struct TotalCount;
-    impl ::cynic::schema::Field for TotalCount {
+    pub struct totalCount;
+    impl ::cynic::schema::Field for totalCount {
         type Type = Option<super::Int>;
         const NAME: &'static str = "totalCount";
     }
-    impl ::cynic::schema::HasField<TotalCount> for super::StarshipPilotsConnection {
+    impl ::cynic::schema::HasField<totalCount> for super::StarshipPilotsConnection {
         type Type = Option<super::Int>;
     }
-    pub struct Pilots;
-    impl ::cynic::schema::Field for Pilots {
+    pub struct pilots;
+    impl ::cynic::schema::Field for pilots {
         type Type = Option<Vec<Option<super::Person>>>;
         const NAME: &'static str = "pilots";
     }
-    impl ::cynic::schema::HasField<Pilots> for super::StarshipPilotsConnection {
+    impl ::cynic::schema::HasField<pilots> for super::StarshipPilotsConnection {
         type Type = Option<Vec<Option<super::Person>>>;
     }
 }
 pub struct StarshipPilotsEdge;
 pub mod starship_pilots_edge_fields {
-    pub struct Node;
-    impl ::cynic::schema::Field for Node {
+    pub struct node;
+    impl ::cynic::schema::Field for node {
         type Type = Option<super::Person>;
         const NAME: &'static str = "node";
     }
-    impl ::cynic::schema::HasField<Node> for super::StarshipPilotsEdge {
+    impl ::cynic::schema::HasField<node> for super::StarshipPilotsEdge {
         type Type = Option<super::Person>;
     }
-    pub struct Cursor;
-    impl ::cynic::schema::Field for Cursor {
+    pub struct cursor;
+    impl ::cynic::schema::Field for cursor {
         type Type = super::String;
         const NAME: &'static str = "cursor";
     }
-    impl ::cynic::schema::HasField<Cursor> for super::StarshipPilotsEdge {
+    impl ::cynic::schema::HasField<cursor> for super::StarshipPilotsEdge {
         type Type = super::String;
     }
 }
 pub struct StarshipsConnection;
 pub mod starships_connection_fields {
-    pub struct PageInfo;
-    impl ::cynic::schema::Field for PageInfo {
+    pub struct pageInfo;
+    impl ::cynic::schema::Field for pageInfo {
         type Type = super::PageInfo;
         const NAME: &'static str = "pageInfo";
     }
-    impl ::cynic::schema::HasField<PageInfo> for super::StarshipsConnection {
+    impl ::cynic::schema::HasField<pageInfo> for super::StarshipsConnection {
         type Type = super::PageInfo;
     }
-    pub struct Edges;
-    impl ::cynic::schema::Field for Edges {
+    pub struct edges;
+    impl ::cynic::schema::Field for edges {
         type Type = Option<Vec<Option<super::StarshipsEdge>>>;
         const NAME: &'static str = "edges";
     }
-    impl ::cynic::schema::HasField<Edges> for super::StarshipsConnection {
+    impl ::cynic::schema::HasField<edges> for super::StarshipsConnection {
         type Type = Option<Vec<Option<super::StarshipsEdge>>>;
     }
-    pub struct TotalCount;
-    impl ::cynic::schema::Field for TotalCount {
+    pub struct totalCount;
+    impl ::cynic::schema::Field for totalCount {
         type Type = Option<super::Int>;
         const NAME: &'static str = "totalCount";
     }
-    impl ::cynic::schema::HasField<TotalCount> for super::StarshipsConnection {
+    impl ::cynic::schema::HasField<totalCount> for super::StarshipsConnection {
         type Type = Option<super::Int>;
     }
-    pub struct Starships;
-    impl ::cynic::schema::Field for Starships {
+    pub struct starships;
+    impl ::cynic::schema::Field for starships {
         type Type = Option<Vec<Option<super::Starship>>>;
         const NAME: &'static str = "starships";
     }
-    impl ::cynic::schema::HasField<Starships> for super::StarshipsConnection {
+    impl ::cynic::schema::HasField<starships> for super::StarshipsConnection {
         type Type = Option<Vec<Option<super::Starship>>>;
     }
 }
 pub struct StarshipsEdge;
 pub mod starships_edge_fields {
-    pub struct Node;
-    impl ::cynic::schema::Field for Node {
+    pub struct node;
+    impl ::cynic::schema::Field for node {
         type Type = Option<super::Starship>;
         const NAME: &'static str = "node";
     }
-    impl ::cynic::schema::HasField<Node> for super::StarshipsEdge {
+    impl ::cynic::schema::HasField<node> for super::StarshipsEdge {
         type Type = Option<super::Starship>;
     }
-    pub struct Cursor;
-    impl ::cynic::schema::Field for Cursor {
+    pub struct cursor;
+    impl ::cynic::schema::Field for cursor {
         type Type = super::String;
         const NAME: &'static str = "cursor";
     }
-    impl ::cynic::schema::HasField<Cursor> for super::StarshipsEdge {
+    impl ::cynic::schema::HasField<cursor> for super::StarshipsEdge {
         type Type = super::String;
     }
 }
 pub struct Vehicle;
 pub mod vehicle_fields {
-    pub struct Name;
-    impl ::cynic::schema::Field for Name {
+    pub struct name;
+    impl ::cynic::schema::Field for name {
         type Type = Option<super::String>;
         const NAME: &'static str = "name";
     }
-    impl ::cynic::schema::HasField<Name> for super::Vehicle {
+    impl ::cynic::schema::HasField<name> for super::Vehicle {
         type Type = Option<super::String>;
     }
-    pub struct Model;
-    impl ::cynic::schema::Field for Model {
+    pub struct model;
+    impl ::cynic::schema::Field for model {
         type Type = Option<super::String>;
         const NAME: &'static str = "model";
     }
-    impl ::cynic::schema::HasField<Model> for super::Vehicle {
+    impl ::cynic::schema::HasField<model> for super::Vehicle {
         type Type = Option<super::String>;
     }
-    pub struct VehicleClass;
-    impl ::cynic::schema::Field for VehicleClass {
+    pub struct vehicleClass;
+    impl ::cynic::schema::Field for vehicleClass {
         type Type = Option<super::String>;
         const NAME: &'static str = "vehicleClass";
     }
-    impl ::cynic::schema::HasField<VehicleClass> for super::Vehicle {
+    impl ::cynic::schema::HasField<vehicleClass> for super::Vehicle {
         type Type = Option<super::String>;
     }
-    pub struct Manufacturers;
-    impl ::cynic::schema::Field for Manufacturers {
+    pub struct manufacturers;
+    impl ::cynic::schema::Field for manufacturers {
         type Type = Option<Vec<Option<super::String>>>;
         const NAME: &'static str = "manufacturers";
     }
-    impl ::cynic::schema::HasField<Manufacturers> for super::Vehicle {
+    impl ::cynic::schema::HasField<manufacturers> for super::Vehicle {
         type Type = Option<Vec<Option<super::String>>>;
     }
-    pub struct CostInCredits;
-    impl ::cynic::schema::Field for CostInCredits {
+    pub struct costInCredits;
+    impl ::cynic::schema::Field for costInCredits {
         type Type = Option<super::Float>;
         const NAME: &'static str = "costInCredits";
     }
-    impl ::cynic::schema::HasField<CostInCredits> for super::Vehicle {
+    impl ::cynic::schema::HasField<costInCredits> for super::Vehicle {
         type Type = Option<super::Float>;
     }
-    pub struct Length;
-    impl ::cynic::schema::Field for Length {
+    pub struct length;
+    impl ::cynic::schema::Field for length {
         type Type = Option<super::Float>;
         const NAME: &'static str = "length";
     }
-    impl ::cynic::schema::HasField<Length> for super::Vehicle {
+    impl ::cynic::schema::HasField<length> for super::Vehicle {
         type Type = Option<super::Float>;
     }
-    pub struct Crew;
-    impl ::cynic::schema::Field for Crew {
+    pub struct crew;
+    impl ::cynic::schema::Field for crew {
         type Type = Option<super::String>;
         const NAME: &'static str = "crew";
     }
-    impl ::cynic::schema::HasField<Crew> for super::Vehicle {
+    impl ::cynic::schema::HasField<crew> for super::Vehicle {
         type Type = Option<super::String>;
     }
-    pub struct Passengers;
-    impl ::cynic::schema::Field for Passengers {
+    pub struct passengers;
+    impl ::cynic::schema::Field for passengers {
         type Type = Option<super::String>;
         const NAME: &'static str = "passengers";
     }
-    impl ::cynic::schema::HasField<Passengers> for super::Vehicle {
+    impl ::cynic::schema::HasField<passengers> for super::Vehicle {
         type Type = Option<super::String>;
     }
-    pub struct MaxAtmospheringSpeed;
-    impl ::cynic::schema::Field for MaxAtmospheringSpeed {
+    pub struct maxAtmospheringSpeed;
+    impl ::cynic::schema::Field for maxAtmospheringSpeed {
         type Type = Option<super::Int>;
         const NAME: &'static str = "maxAtmospheringSpeed";
     }
-    impl ::cynic::schema::HasField<MaxAtmospheringSpeed> for super::Vehicle {
+    impl ::cynic::schema::HasField<maxAtmospheringSpeed> for super::Vehicle {
         type Type = Option<super::Int>;
     }
-    pub struct CargoCapacity;
-    impl ::cynic::schema::Field for CargoCapacity {
+    pub struct cargoCapacity;
+    impl ::cynic::schema::Field for cargoCapacity {
         type Type = Option<super::Float>;
         const NAME: &'static str = "cargoCapacity";
     }
-    impl ::cynic::schema::HasField<CargoCapacity> for super::Vehicle {
+    impl ::cynic::schema::HasField<cargoCapacity> for super::Vehicle {
         type Type = Option<super::Float>;
     }
-    pub struct Consumables;
-    impl ::cynic::schema::Field for Consumables {
+    pub struct consumables;
+    impl ::cynic::schema::Field for consumables {
         type Type = Option<super::String>;
         const NAME: &'static str = "consumables";
     }
-    impl ::cynic::schema::HasField<Consumables> for super::Vehicle {
+    impl ::cynic::schema::HasField<consumables> for super::Vehicle {
         type Type = Option<super::String>;
     }
-    pub struct PilotConnection;
-    impl ::cynic::schema::Field for PilotConnection {
+    pub struct pilotConnection;
+    impl ::cynic::schema::Field for pilotConnection {
         type Type = Option<super::VehiclePilotsConnection>;
         const NAME: &'static str = "pilotConnection";
     }
-    impl ::cynic::schema::HasField<PilotConnection> for super::Vehicle {
+    impl ::cynic::schema::HasField<pilotConnection> for super::Vehicle {
         type Type = Option<super::VehiclePilotsConnection>;
     }
     pub mod pilot_connection_arguments {
-        pub struct After;
-        impl ::cynic::schema::HasArgument<After> for super::PilotConnection {
+        pub struct after;
+        impl ::cynic::schema::HasArgument<after> for super::pilotConnection {
             type ArgumentType = Option<super::super::String>;
             const NAME: &'static str = "after";
         }
-        pub struct First;
-        impl ::cynic::schema::HasArgument<First> for super::PilotConnection {
+        pub struct first;
+        impl ::cynic::schema::HasArgument<first> for super::pilotConnection {
             type ArgumentType = Option<super::super::Int>;
             const NAME: &'static str = "first";
         }
-        pub struct Before;
-        impl ::cynic::schema::HasArgument<Before> for super::PilotConnection {
+        pub struct before;
+        impl ::cynic::schema::HasArgument<before> for super::pilotConnection {
             type ArgumentType = Option<super::super::String>;
             const NAME: &'static str = "before";
         }
-        pub struct Last;
-        impl ::cynic::schema::HasArgument<Last> for super::PilotConnection {
+        pub struct last;
+        impl ::cynic::schema::HasArgument<last> for super::pilotConnection {
             type ArgumentType = Option<super::super::Int>;
             const NAME: &'static str = "last";
         }
     }
-    pub struct FilmConnection;
-    impl ::cynic::schema::Field for FilmConnection {
+    pub struct filmConnection;
+    impl ::cynic::schema::Field for filmConnection {
         type Type = Option<super::VehicleFilmsConnection>;
         const NAME: &'static str = "filmConnection";
     }
-    impl ::cynic::schema::HasField<FilmConnection> for super::Vehicle {
+    impl ::cynic::schema::HasField<filmConnection> for super::Vehicle {
         type Type = Option<super::VehicleFilmsConnection>;
     }
     pub mod film_connection_arguments {
-        pub struct After;
-        impl ::cynic::schema::HasArgument<After> for super::FilmConnection {
+        pub struct after;
+        impl ::cynic::schema::HasArgument<after> for super::filmConnection {
             type ArgumentType = Option<super::super::String>;
             const NAME: &'static str = "after";
         }
-        pub struct First;
-        impl ::cynic::schema::HasArgument<First> for super::FilmConnection {
+        pub struct first;
+        impl ::cynic::schema::HasArgument<first> for super::filmConnection {
             type ArgumentType = Option<super::super::Int>;
             const NAME: &'static str = "first";
         }
-        pub struct Before;
-        impl ::cynic::schema::HasArgument<Before> for super::FilmConnection {
+        pub struct before;
+        impl ::cynic::schema::HasArgument<before> for super::filmConnection {
             type ArgumentType = Option<super::super::String>;
             const NAME: &'static str = "before";
         }
-        pub struct Last;
-        impl ::cynic::schema::HasArgument<Last> for super::FilmConnection {
+        pub struct last;
+        impl ::cynic::schema::HasArgument<last> for super::filmConnection {
             type ArgumentType = Option<super::super::Int>;
             const NAME: &'static str = "last";
         }
     }
-    pub struct Created;
-    impl ::cynic::schema::Field for Created {
+    pub struct created;
+    impl ::cynic::schema::Field for created {
         type Type = Option<super::String>;
         const NAME: &'static str = "created";
     }
-    impl ::cynic::schema::HasField<Created> for super::Vehicle {
+    impl ::cynic::schema::HasField<created> for super::Vehicle {
         type Type = Option<super::String>;
     }
-    pub struct Edited;
-    impl ::cynic::schema::Field for Edited {
+    pub struct edited;
+    impl ::cynic::schema::Field for edited {
         type Type = Option<super::String>;
         const NAME: &'static str = "edited";
     }
-    impl ::cynic::schema::HasField<Edited> for super::Vehicle {
+    impl ::cynic::schema::HasField<edited> for super::Vehicle {
         type Type = Option<super::String>;
     }
-    pub struct Id;
-    impl ::cynic::schema::Field for Id {
-        type Type = super::Id;
+    pub struct id;
+    impl ::cynic::schema::Field for id {
+        type Type = super::ID;
         const NAME: &'static str = "id";
     }
-    impl ::cynic::schema::HasField<Id> for super::Vehicle {
-        type Type = super::Id;
+    impl ::cynic::schema::HasField<id> for super::Vehicle {
+        type Type = super::ID;
     }
 }
 pub struct VehicleFilmsConnection;
 pub mod vehicle_films_connection_fields {
-    pub struct PageInfo;
-    impl ::cynic::schema::Field for PageInfo {
+    pub struct pageInfo;
+    impl ::cynic::schema::Field for pageInfo {
         type Type = super::PageInfo;
         const NAME: &'static str = "pageInfo";
     }
-    impl ::cynic::schema::HasField<PageInfo> for super::VehicleFilmsConnection {
+    impl ::cynic::schema::HasField<pageInfo> for super::VehicleFilmsConnection {
         type Type = super::PageInfo;
     }
-    pub struct Edges;
-    impl ::cynic::schema::Field for Edges {
+    pub struct edges;
+    impl ::cynic::schema::Field for edges {
         type Type = Option<Vec<Option<super::VehicleFilmsEdge>>>;
         const NAME: &'static str = "edges";
     }
-    impl ::cynic::schema::HasField<Edges> for super::VehicleFilmsConnection {
+    impl ::cynic::schema::HasField<edges> for super::VehicleFilmsConnection {
         type Type = Option<Vec<Option<super::VehicleFilmsEdge>>>;
     }
-    pub struct TotalCount;
-    impl ::cynic::schema::Field for TotalCount {
+    pub struct totalCount;
+    impl ::cynic::schema::Field for totalCount {
         type Type = Option<super::Int>;
         const NAME: &'static str = "totalCount";
     }
-    impl ::cynic::schema::HasField<TotalCount> for super::VehicleFilmsConnection {
+    impl ::cynic::schema::HasField<totalCount> for super::VehicleFilmsConnection {
         type Type = Option<super::Int>;
     }
-    pub struct Films;
-    impl ::cynic::schema::Field for Films {
+    pub struct films;
+    impl ::cynic::schema::Field for films {
         type Type = Option<Vec<Option<super::Film>>>;
         const NAME: &'static str = "films";
     }
-    impl ::cynic::schema::HasField<Films> for super::VehicleFilmsConnection {
+    impl ::cynic::schema::HasField<films> for super::VehicleFilmsConnection {
         type Type = Option<Vec<Option<super::Film>>>;
     }
 }
 pub struct VehicleFilmsEdge;
 pub mod vehicle_films_edge_fields {
-    pub struct Node;
-    impl ::cynic::schema::Field for Node {
+    pub struct node;
+    impl ::cynic::schema::Field for node {
         type Type = Option<super::Film>;
         const NAME: &'static str = "node";
     }
-    impl ::cynic::schema::HasField<Node> for super::VehicleFilmsEdge {
+    impl ::cynic::schema::HasField<node> for super::VehicleFilmsEdge {
         type Type = Option<super::Film>;
     }
-    pub struct Cursor;
-    impl ::cynic::schema::Field for Cursor {
+    pub struct cursor;
+    impl ::cynic::schema::Field for cursor {
         type Type = super::String;
         const NAME: &'static str = "cursor";
     }
-    impl ::cynic::schema::HasField<Cursor> for super::VehicleFilmsEdge {
+    impl ::cynic::schema::HasField<cursor> for super::VehicleFilmsEdge {
         type Type = super::String;
     }
 }
 pub struct VehiclePilotsConnection;
 pub mod vehicle_pilots_connection_fields {
-    pub struct PageInfo;
-    impl ::cynic::schema::Field for PageInfo {
+    pub struct pageInfo;
+    impl ::cynic::schema::Field for pageInfo {
         type Type = super::PageInfo;
         const NAME: &'static str = "pageInfo";
     }
-    impl ::cynic::schema::HasField<PageInfo> for super::VehiclePilotsConnection {
+    impl ::cynic::schema::HasField<pageInfo> for super::VehiclePilotsConnection {
         type Type = super::PageInfo;
     }
-    pub struct Edges;
-    impl ::cynic::schema::Field for Edges {
+    pub struct edges;
+    impl ::cynic::schema::Field for edges {
         type Type = Option<Vec<Option<super::VehiclePilotsEdge>>>;
         const NAME: &'static str = "edges";
     }
-    impl ::cynic::schema::HasField<Edges> for super::VehiclePilotsConnection {
+    impl ::cynic::schema::HasField<edges> for super::VehiclePilotsConnection {
         type Type = Option<Vec<Option<super::VehiclePilotsEdge>>>;
     }
-    pub struct TotalCount;
-    impl ::cynic::schema::Field for TotalCount {
+    pub struct totalCount;
+    impl ::cynic::schema::Field for totalCount {
         type Type = Option<super::Int>;
         const NAME: &'static str = "totalCount";
     }
-    impl ::cynic::schema::HasField<TotalCount> for super::VehiclePilotsConnection {
+    impl ::cynic::schema::HasField<totalCount> for super::VehiclePilotsConnection {
         type Type = Option<super::Int>;
     }
-    pub struct Pilots;
-    impl ::cynic::schema::Field for Pilots {
+    pub struct pilots;
+    impl ::cynic::schema::Field for pilots {
         type Type = Option<Vec<Option<super::Person>>>;
         const NAME: &'static str = "pilots";
     }
-    impl ::cynic::schema::HasField<Pilots> for super::VehiclePilotsConnection {
+    impl ::cynic::schema::HasField<pilots> for super::VehiclePilotsConnection {
         type Type = Option<Vec<Option<super::Person>>>;
     }
 }
 pub struct VehiclePilotsEdge;
 pub mod vehicle_pilots_edge_fields {
-    pub struct Node;
-    impl ::cynic::schema::Field for Node {
+    pub struct node;
+    impl ::cynic::schema::Field for node {
         type Type = Option<super::Person>;
         const NAME: &'static str = "node";
     }
-    impl ::cynic::schema::HasField<Node> for super::VehiclePilotsEdge {
+    impl ::cynic::schema::HasField<node> for super::VehiclePilotsEdge {
         type Type = Option<super::Person>;
     }
-    pub struct Cursor;
-    impl ::cynic::schema::Field for Cursor {
+    pub struct cursor;
+    impl ::cynic::schema::Field for cursor {
         type Type = super::String;
         const NAME: &'static str = "cursor";
     }
-    impl ::cynic::schema::HasField<Cursor> for super::VehiclePilotsEdge {
+    impl ::cynic::schema::HasField<cursor> for super::VehiclePilotsEdge {
         type Type = super::String;
     }
 }
 pub struct VehiclesConnection;
 pub mod vehicles_connection_fields {
-    pub struct PageInfo;
-    impl ::cynic::schema::Field for PageInfo {
+    pub struct pageInfo;
+    impl ::cynic::schema::Field for pageInfo {
         type Type = super::PageInfo;
         const NAME: &'static str = "pageInfo";
     }
-    impl ::cynic::schema::HasField<PageInfo> for super::VehiclesConnection {
+    impl ::cynic::schema::HasField<pageInfo> for super::VehiclesConnection {
         type Type = super::PageInfo;
     }
-    pub struct Edges;
-    impl ::cynic::schema::Field for Edges {
+    pub struct edges;
+    impl ::cynic::schema::Field for edges {
         type Type = Option<Vec<Option<super::VehiclesEdge>>>;
         const NAME: &'static str = "edges";
     }
-    impl ::cynic::schema::HasField<Edges> for super::VehiclesConnection {
+    impl ::cynic::schema::HasField<edges> for super::VehiclesConnection {
         type Type = Option<Vec<Option<super::VehiclesEdge>>>;
     }
-    pub struct TotalCount;
-    impl ::cynic::schema::Field for TotalCount {
+    pub struct totalCount;
+    impl ::cynic::schema::Field for totalCount {
         type Type = Option<super::Int>;
         const NAME: &'static str = "totalCount";
     }
-    impl ::cynic::schema::HasField<TotalCount> for super::VehiclesConnection {
+    impl ::cynic::schema::HasField<totalCount> for super::VehiclesConnection {
         type Type = Option<super::Int>;
     }
-    pub struct Vehicles;
-    impl ::cynic::schema::Field for Vehicles {
+    pub struct vehicles;
+    impl ::cynic::schema::Field for vehicles {
         type Type = Option<Vec<Option<super::Vehicle>>>;
         const NAME: &'static str = "vehicles";
     }
-    impl ::cynic::schema::HasField<Vehicles> for super::VehiclesConnection {
+    impl ::cynic::schema::HasField<vehicles> for super::VehiclesConnection {
         type Type = Option<Vec<Option<super::Vehicle>>>;
     }
 }
 pub struct VehiclesEdge;
 pub mod vehicles_edge_fields {
-    pub struct Node;
-    impl ::cynic::schema::Field for Node {
+    pub struct node;
+    impl ::cynic::schema::Field for node {
         type Type = Option<super::Vehicle>;
         const NAME: &'static str = "node";
     }
-    impl ::cynic::schema::HasField<Node> for super::VehiclesEdge {
+    impl ::cynic::schema::HasField<node> for super::VehiclesEdge {
         type Type = Option<super::Vehicle>;
     }
-    pub struct Cursor;
-    impl ::cynic::schema::Field for Cursor {
+    pub struct cursor;
+    impl ::cynic::schema::Field for cursor {
         type Type = super::String;
         const NAME: &'static str = "cursor";
     }
-    impl ::cynic::schema::HasField<Cursor> for super::VehiclesEdge {
+    impl ::cynic::schema::HasField<cursor> for super::VehiclesEdge {
         type Type = super::String;
     }
 }
@@ -2841,7 +2841,7 @@ pub type Boolean = bool;
 pub type String = std::string::String;
 pub type Float = f64;
 pub type Int = i32;
-pub type Id = ::cynic::Id;
+pub type ID = ::cynic::Id;
 pub mod variable {
     use cynic::variables::VariableType;
     #[doc = r" Used to determine the type of a given variable that"]

--- a/cynic-codegen/tests/snapshots/use_schema__schema_file_4.snap
+++ b/cynic-codegen/tests/snapshots/use_schema__schema_file_4.snap
@@ -7,20 +7,20 @@ expression: "format_code(format!(\"{}\", tokens))"
 impl ::cynic::schema::QueryRoot for Foo {}
 pub struct Bar;
 pub mod bar_fields {
-    pub struct Id;
-    impl ::cynic::schema::Field for Id {
-        type Type = super::Uuid;
+    pub struct id;
+    impl ::cynic::schema::Field for id {
+        type Type = super::UUID;
         const NAME: &'static str = "id";
     }
-    impl ::cynic::schema::HasField<Id> for super::Bar {
-        type Type = super::Uuid;
+    impl ::cynic::schema::HasField<id> for super::Bar {
+        type Type = super::UUID;
     }
-    pub struct Name;
-    impl ::cynic::schema::Field for Name {
+    pub struct name;
+    impl ::cynic::schema::Field for name {
         type Type = Option<super::String>;
         const NAME: &'static str = "name";
     }
-    impl ::cynic::schema::HasField<Name> for super::Bar {
+    impl ::cynic::schema::HasField<name> for super::Bar {
         type Type = Option<super::String>;
     }
 }
@@ -34,71 +34,71 @@ pub mod foo_fields {
     impl ::cynic::schema::HasField<_Underscore> for super::Foo {
         type Type = Option<super::Boolean>;
     }
-    pub struct Self_;
-    impl ::cynic::schema::Field for Self_ {
+    pub struct self_;
+    impl ::cynic::schema::Field for self_ {
         type Type = Option<super::Boolean>;
         const NAME: &'static str = "self";
     }
-    impl ::cynic::schema::HasField<Self_> for super::Foo {
+    impl ::cynic::schema::HasField<self_> for super::Foo {
         type Type = Option<super::Boolean>;
     }
-    pub struct Super;
-    impl ::cynic::schema::Field for Super {
+    pub struct super_;
+    impl ::cynic::schema::Field for super_ {
         type Type = Option<super::Boolean>;
         const NAME: &'static str = "super";
     }
-    impl ::cynic::schema::HasField<Super> for super::Foo {
+    impl ::cynic::schema::HasField<super_> for super::Foo {
         type Type = Option<super::Boolean>;
     }
-    pub struct Crate;
-    impl ::cynic::schema::Field for Crate {
+    pub struct crate_;
+    impl ::cynic::schema::Field for crate_ {
         type Type = Option<super::Boolean>;
         const NAME: &'static str = "crate";
     }
-    impl ::cynic::schema::HasField<Crate> for super::Foo {
+    impl ::cynic::schema::HasField<crate_> for super::Foo {
         type Type = Option<super::Boolean>;
     }
-    pub struct Async;
-    impl ::cynic::schema::Field for Async {
+    pub struct r#async;
+    impl ::cynic::schema::Field for r#async {
         type Type = Option<super::Boolean>;
         const NAME: &'static str = "async";
     }
-    impl ::cynic::schema::HasField<Async> for super::Foo {
+    impl ::cynic::schema::HasField<r#async> for super::Foo {
         type Type = Option<super::Boolean>;
     }
-    pub struct Bar;
-    impl ::cynic::schema::Field for Bar {
+    pub struct bar;
+    impl ::cynic::schema::Field for bar {
         type Type = Option<super::Bar>;
         const NAME: &'static str = "bar";
     }
-    impl ::cynic::schema::HasField<Bar> for super::Foo {
+    impl ::cynic::schema::HasField<bar> for super::Foo {
         type Type = Option<super::Bar>;
     }
     pub mod bar_arguments {
-        pub struct Id;
-        impl ::cynic::schema::HasArgument<Id> for super::Bar {
-            type ArgumentType = super::super::Uuid;
+        pub struct id;
+        impl ::cynic::schema::HasArgument<id> for super::bar {
+            type ArgumentType = super::super::UUID;
             const NAME: &'static str = "id";
         }
     }
-    pub struct FieldWithKeywordArg;
-    impl ::cynic::schema::Field for FieldWithKeywordArg {
+    pub struct fieldWithKeywordArg;
+    impl ::cynic::schema::Field for fieldWithKeywordArg {
         type Type = Vec<super::Int>;
         const NAME: &'static str = "fieldWithKeywordArg";
     }
-    impl ::cynic::schema::HasField<FieldWithKeywordArg> for super::Foo {
+    impl ::cynic::schema::HasField<fieldWithKeywordArg> for super::Foo {
         type Type = Vec<super::Int>;
     }
     pub mod field_with_keyword_arg_arguments {
-        pub struct Where;
-        impl ::cynic::schema::HasArgument<Where> for super::FieldWithKeywordArg {
+        pub struct r#where;
+        impl ::cynic::schema::HasArgument<r#where> for super::fieldWithKeywordArg {
             type ArgumentType = Option<super::super::Int>;
             const NAME: &'static str = "where";
         }
     }
 }
 pub struct States {}
-pub struct Uuid {}
+pub struct UUID {}
 impl ::cynic::schema::NamedType for Bar {
     const NAME: &'static str = "Bar";
 }
@@ -109,7 +109,7 @@ pub type Boolean = bool;
 pub type String = std::string::String;
 pub type Float = f64;
 pub type Int = i32;
-pub type Id = ::cynic::Id;
+pub type ID = ::cynic::Id;
 pub mod variable {
     use cynic::variables::VariableType;
     #[doc = r" Used to determine the type of a given variable that"]

--- a/cynic-codegen/tests/snapshots/use_schema__schema_file_5.snap
+++ b/cynic-codegen/tests/snapshots/use_schema__schema_file_5.snap
@@ -8,145 +8,145 @@ impl ::cynic::schema::QueryRoot for Query {}
 pub struct AnInputType;
 impl ::cynic::schema::InputObjectMarker for AnInputType {}
 pub mod an_input_type_fields {
-    pub struct FavouriteDessert;
-    impl ::cynic::schema::Field for FavouriteDessert {
+    pub struct favouriteDessert;
+    impl ::cynic::schema::Field for favouriteDessert {
         type Type = Option<super::Dessert>;
         const NAME: &'static str = "favouriteDessert";
     }
-    impl ::cynic::schema::HasInputField<FavouriteDessert, Option<super::Dessert>>
+    impl ::cynic::schema::HasInputField<favouriteDessert, Option<super::Dessert>>
         for super::AnInputType
     {
     }
 }
 pub struct Dessert {}
-pub struct Json {}
+pub struct JSON {}
 pub struct MyUnionType {}
 pub struct Nested;
 pub mod nested_fields {
-    pub struct AString;
-    impl ::cynic::schema::Field for AString {
+    pub struct aString;
+    impl ::cynic::schema::Field for aString {
         type Type = super::String;
         const NAME: &'static str = "aString";
     }
-    impl ::cynic::schema::HasField<AString> for super::Nested {
+    impl ::cynic::schema::HasField<aString> for super::Nested {
         type Type = super::String;
     }
-    pub struct OptString;
-    impl ::cynic::schema::Field for OptString {
+    pub struct optString;
+    impl ::cynic::schema::Field for optString {
         type Type = Option<super::String>;
         const NAME: &'static str = "optString";
     }
-    impl ::cynic::schema::HasField<OptString> for super::Nested {
+    impl ::cynic::schema::HasField<optString> for super::Nested {
         type Type = Option<super::String>;
     }
 }
 pub struct Query;
 pub mod query_fields {
-    pub struct TestStruct;
-    impl ::cynic::schema::Field for TestStruct {
+    pub struct testStruct;
+    impl ::cynic::schema::Field for testStruct {
         type Type = Option<super::TestStruct>;
         const NAME: &'static str = "testStruct";
     }
-    impl ::cynic::schema::HasField<TestStruct> for super::Query {
+    impl ::cynic::schema::HasField<testStruct> for super::Query {
         type Type = Option<super::TestStruct>;
     }
-    pub struct MyUnion;
-    impl ::cynic::schema::Field for MyUnion {
+    pub struct myUnion;
+    impl ::cynic::schema::Field for myUnion {
         type Type = Option<super::MyUnionType>;
         const NAME: &'static str = "myUnion";
     }
-    impl ::cynic::schema::HasField<MyUnion> for super::Query {
+    impl ::cynic::schema::HasField<myUnion> for super::Query {
         type Type = Option<super::MyUnionType>;
     }
 }
 pub struct TestStruct;
 pub mod test_struct_fields {
-    pub struct FieldOne;
-    impl ::cynic::schema::Field for FieldOne {
+    pub struct fieldOne;
+    impl ::cynic::schema::Field for fieldOne {
         type Type = super::String;
         const NAME: &'static str = "fieldOne";
     }
-    impl ::cynic::schema::HasField<FieldOne> for super::TestStruct {
+    impl ::cynic::schema::HasField<fieldOne> for super::TestStruct {
         type Type = super::String;
     }
     pub mod field_one_arguments {
-        pub struct X;
-        impl ::cynic::schema::HasArgument<X> for super::FieldOne {
+        pub struct x;
+        impl ::cynic::schema::HasArgument<x> for super::fieldOne {
             type ArgumentType = Option<super::super::Int>;
             const NAME: &'static str = "x";
         }
-        pub struct Y;
-        impl ::cynic::schema::HasArgument<Y> for super::FieldOne {
+        pub struct y;
+        impl ::cynic::schema::HasArgument<y> for super::fieldOne {
             type ArgumentType = Option<super::super::String>;
             const NAME: &'static str = "y";
         }
     }
-    pub struct TastyCakes;
-    impl ::cynic::schema::Field for TastyCakes {
+    pub struct tastyCakes;
+    impl ::cynic::schema::Field for tastyCakes {
         type Type = super::Dessert;
         const NAME: &'static str = "tastyCakes";
     }
-    impl ::cynic::schema::HasField<TastyCakes> for super::TestStruct {
+    impl ::cynic::schema::HasField<tastyCakes> for super::TestStruct {
         type Type = super::Dessert;
     }
     pub mod tasty_cakes_arguments {
-        pub struct First;
-        impl ::cynic::schema::HasArgument<First> for super::TastyCakes {
+        pub struct first;
+        impl ::cynic::schema::HasArgument<first> for super::tastyCakes {
             type ArgumentType = super::super::Dessert;
             const NAME: &'static str = "first";
         }
-        pub struct Second;
-        impl ::cynic::schema::HasArgument<Second> for super::TastyCakes {
+        pub struct second;
+        impl ::cynic::schema::HasArgument<second> for super::tastyCakes {
             type ArgumentType = Option<super::super::Dessert>;
             const NAME: &'static str = "second";
         }
     }
-    pub struct FieldWithInput;
-    impl ::cynic::schema::Field for FieldWithInput {
+    pub struct fieldWithInput;
+    impl ::cynic::schema::Field for fieldWithInput {
         type Type = super::Dessert;
         const NAME: &'static str = "fieldWithInput";
     }
-    impl ::cynic::schema::HasField<FieldWithInput> for super::TestStruct {
+    impl ::cynic::schema::HasField<fieldWithInput> for super::TestStruct {
         type Type = super::Dessert;
     }
     pub mod field_with_input_arguments {
-        pub struct Input;
-        impl ::cynic::schema::HasArgument<Input> for super::FieldWithInput {
+        pub struct input;
+        impl ::cynic::schema::HasArgument<input> for super::fieldWithInput {
             type ArgumentType = super::super::AnInputType;
             const NAME: &'static str = "input";
         }
     }
-    pub struct Nested;
-    impl ::cynic::schema::Field for Nested {
+    pub struct nested;
+    impl ::cynic::schema::Field for nested {
         type Type = super::Nested;
         const NAME: &'static str = "nested";
     }
-    impl ::cynic::schema::HasField<Nested> for super::TestStruct {
+    impl ::cynic::schema::HasField<nested> for super::TestStruct {
         type Type = super::Nested;
     }
-    pub struct OptNested;
-    impl ::cynic::schema::Field for OptNested {
+    pub struct optNested;
+    impl ::cynic::schema::Field for optNested {
         type Type = Option<super::Nested>;
         const NAME: &'static str = "optNested";
     }
-    impl ::cynic::schema::HasField<OptNested> for super::TestStruct {
+    impl ::cynic::schema::HasField<optNested> for super::TestStruct {
         type Type = Option<super::Nested>;
     }
-    pub struct Dessert;
-    impl ::cynic::schema::Field for Dessert {
+    pub struct dessert;
+    impl ::cynic::schema::Field for dessert {
         type Type = Option<super::Dessert>;
         const NAME: &'static str = "dessert";
     }
-    impl ::cynic::schema::HasField<Dessert> for super::TestStruct {
+    impl ::cynic::schema::HasField<dessert> for super::TestStruct {
         type Type = Option<super::Dessert>;
     }
-    pub struct Json;
-    impl ::cynic::schema::Field for Json {
-        type Type = Option<super::Json>;
+    pub struct json;
+    impl ::cynic::schema::Field for json {
+        type Type = Option<super::JSON>;
         const NAME: &'static str = "json";
     }
-    impl ::cynic::schema::HasField<Json> for super::TestStruct {
-        type Type = Option<super::Json>;
+    impl ::cynic::schema::HasField<json> for super::TestStruct {
+        type Type = Option<super::JSON>;
     }
 }
 impl ::cynic::schema::HasSubtype<Nested> for MyUnionType {}
@@ -167,7 +167,7 @@ pub type Boolean = bool;
 pub type String = std::string::String;
 pub type Float = f64;
 pub type Int = i32;
-pub type Id = ::cynic::Id;
+pub type ID = ::cynic::Id;
 pub mod variable {
     use cynic::variables::VariableType;
     #[doc = r" Used to determine the type of a given variable that"]

--- a/cynic-querygen-web/src/graphiql_page.rs
+++ b/cynic-querygen-web/src/graphiql_page.rs
@@ -119,8 +119,8 @@ fn gql_editor(schema_url: &str, schema: Option<&str>, generated_code: &str) -> N
             }),
             attrs! {
                 "schema-url" => schema_url
-                "schema" => schema.unwrap_or("").replace("\n", "&NL;")
-                "generated-code" => generated_code.replace("\n", "&NL;")
+                "schema" => schema.unwrap_or("").replace('\n', "&NL;")
+                "generated-code" => generated_code.replace('\n', "&NL;")
             },
             Tag::from("gql-editor"),
         ]

--- a/cynic-querygen/src/output/mod.rs
+++ b/cynic-querygen/src/output/mod.rs
@@ -31,7 +31,15 @@ pub struct Scalar<'schema>(pub &'schema str);
 
 impl std::fmt::Display for Scalar<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let graphql_name = self.0;
+        let rust_name = self.0.to_pascal_case();
+
         writeln!(f, "#[derive(cynic::Scalar, Debug, Clone)]")?;
-        writeln!(f, "pub struct {}(pub String);", self.0.to_pascal_case())
+
+        if graphql_name != rust_name {
+            writeln!(f, "#[cynic(graphql_type = \"{}\")]", graphql_name)?;
+        }
+
+        writeln!(f, "pub struct {}(pub String);", rust_name)
     }
 }

--- a/cynic-querygen/src/query_parsing/mod.rs
+++ b/cynic-querygen/src/query_parsing/mod.rs
@@ -139,8 +139,7 @@ fn make_inline_fragments<'text>(
         variable_struct_name: inline_fragments
             .inner_selections
             .iter()
-            .map(|selection| variable_struct_details.variables_name_for_selection(selection))
-            .flatten()
+            .filter_map(|selection| variable_struct_details.variables_name_for_selection(selection))
             .next(),
         name: namers.inline_fragments.name_subject(&inline_fragments),
     }

--- a/cynic-querygen/src/schema/type_index.rs
+++ b/cynic-querygen/src/schema/type_index.rs
@@ -18,13 +18,12 @@ impl<'schema> TypeIndex<'schema> {
         let types = schema
             .definitions
             .iter()
-            .map(|definition| match definition {
+            .filter_map(|definition| match definition {
                 Definition::TypeDefinition(type_def) => {
                     Some((name_for_type(type_def), type_def.clone()))
                 }
                 _ => None,
             })
-            .flatten()
             .collect::<HashMap<_, _>>();
 
         let mut rv = TypeIndex::default();

--- a/cynic-querygen/tests/snapshots/misc_tests__scalar_casing.snap
+++ b/cynic-querygen/tests/snapshots/misc_tests__scalar_casing.snap
@@ -1,7 +1,7 @@
 ---
 source: cynic-querygen/tests/misc-tests.rs
 assertion_line: 43
-expression: "document_to_fragment_structs(query, schema,\n                             &QueryGenOptions::default()).expect(\"QueryGen Failed\")"
+expression: "document_to_fragment_structs(query, schema,\n        &QueryGenOptions::default()).expect(\"QueryGen Failed\")"
 
 ---
 #[cynic::schema_for_derives(
@@ -30,6 +30,7 @@ mod queries {
     }
 
     #[derive(cynic::Scalar, Debug, Clone)]
+    #[cynic(graphql_type = "UUID")]
     pub struct Uuid(pub String);
 
 }

--- a/tests/ui-tests/tests/cases/inputobject-guess-validation.rs
+++ b/tests/ui-tests/tests/cases/inputobject-guess-validation.rs
@@ -4,7 +4,7 @@ fn main() {}
 
 #[cynic::schema_for_derives(file = r#"./../../../schemas/github.graphql"#, module = "schema")]
 mod queries {
-    use super::{schema, types::*};
+    use super::schema;
 
     #[derive(cynic::Enum, Clone, Copy, Debug)]
     pub enum IssueOrderField {
@@ -26,42 +26,6 @@ mod queries {
     }
 }
 
-#[cynic::schema_for_derives(file = r#"./../../../schemas/github.graphql"#, module = "schema")]
-mod types {
-    use super::schema;
-
-    #[derive(cynic::Scalar, Debug, Clone)]
-    pub struct Date(pub String);
-
-    #[derive(cynic::Scalar, Debug, Clone)]
-    pub struct DateTime(pub String);
-
-    #[derive(cynic::Scalar, Debug, Clone)]
-    pub struct GitObjectID(pub String);
-
-    #[derive(cynic::Scalar, Debug, Clone)]
-    pub struct GitRefname(pub String);
-
-    #[derive(cynic::Scalar, Debug, Clone)]
-    pub struct GitSSHRemote(pub String);
-
-    #[derive(cynic::Scalar, Debug, Clone)]
-    pub struct GitTimestamp(pub String);
-
-    #[derive(cynic::Scalar, Debug, Clone)]
-    pub struct Html(pub String);
-
-    #[derive(cynic::Scalar, Debug, Clone)]
-    pub struct PreciseDateTime(pub String);
-
-    #[derive(cynic::Scalar, Debug, Clone)]
-    pub struct Uri(pub String);
-
-    #[derive(cynic::Scalar, Debug, Clone)]
-    pub struct X509Certificate(pub String);
-}
-
 mod schema {
-    use super::types::*;
     cynic::use_schema!(r#"./../../../schemas/github.graphql"#);
 }

--- a/tests/ui-tests/tests/cases/wrong-enum-type.rs
+++ b/tests/ui-tests/tests/cases/wrong-enum-type.rs
@@ -4,12 +4,13 @@ fn main() {}
 
 #[cynic::schema_for_derives(file = r#"./../../../schemas/github.graphql"#, module = "schema")]
 mod queries {
-    use super::{schema, types::*};
+    use super::schema;
 
     #[derive(cynic::QueryFragment, Debug)]
     pub struct CheckSuite {
         // Note: this is the wrong underlying enum type
-        // Should be CheckStatusState
+        // This field is actually a CheckStatusState, so this should fail to
+        // compile
         pub status: CheckConclusionState,
         pub conclusion: Option<CheckConclusionState>,
     }
@@ -27,42 +28,6 @@ mod queries {
     }
 }
 
-#[cynic::schema_for_derives(file = r#"./../../../schemas/github.graphql"#, module = "schema")]
-mod types {
-    use super::schema;
-
-    #[derive(cynic::Scalar, Debug, Clone)]
-    pub struct Date(pub String);
-
-    #[derive(cynic::Scalar, Debug, Clone)]
-    pub struct DateTime(pub String);
-
-    #[derive(cynic::Scalar, Debug, Clone)]
-    pub struct GitObjectID(pub String);
-
-    #[derive(cynic::Scalar, Debug, Clone)]
-    pub struct GitRefname(pub String);
-
-    #[derive(cynic::Scalar, Debug, Clone)]
-    pub struct GitSSHRemote(pub String);
-
-    #[derive(cynic::Scalar, Debug, Clone)]
-    pub struct GitTimestamp(pub String);
-
-    #[derive(cynic::Scalar, Debug, Clone)]
-    pub struct Html(pub String);
-
-    #[derive(cynic::Scalar, Debug, Clone)]
-    pub struct PreciseDateTime(pub String);
-
-    #[derive(cynic::Scalar, Debug, Clone)]
-    pub struct Uri(pub String);
-
-    #[derive(cynic::Scalar, Debug, Clone)]
-    pub struct X509Certificate(pub String);
-}
-
 mod schema {
-    use super::types::*;
     cynic::use_schema!(r#"./../../../schemas/github.graphql"#);
 }

--- a/tests/ui-tests/tests/cases/wrong-enum-type.stderr
+++ b/tests/ui-tests/tests/cases/wrong-enum-type.stderr
@@ -1,7 +1,7 @@
 error[E0277]: the trait bound `schema::CheckConclusionState: IsFieldType<CheckStatusState>` is not satisfied
-  --> tests/cases/wrong-enum-type.rs:13:21
+  --> tests/cases/wrong-enum-type.rs:14:21
    |
-13 |         pub status: CheckConclusionState,
+14 |         pub status: CheckConclusionState,
    |                     ^^^^^^^^^^^^^^^^^^^^ the trait `IsFieldType<CheckStatusState>` is not implemented for `schema::CheckConclusionState`
    |
 note: required by a bound in `SelectionBuilder::<'a, SchemaType, Variables>::select_field`


### PR DESCRIPTION
#### Why are we making this change?

The `use_schema` macro generates marker types for everything in a schema.
Prior to this change it would re-case those types to match rust casing norms -
usually `PascalCase` for types and `camelCase` for functions/fields.  It's not
clear that this was worthwhile though - users don't usually have to interact
with the contents of the schema module, and re-casing like this opens up some
odd edge cases.

For example #477 -  where a federated schema contains two `UUID` types with
different casing.  While this is definitely a weird edge case (and probably
_not_ something you'd want to do ideally), cynic should really be able to
handle it.

#### What effects does this change have?

It updates the `use_schema` macro to not re-case everything in the schema.
Instead keeping the original graphql schema casing, which is both easier and
less likely to cause problems

Fixes #477