### PR TITLE
[Merged by Bors] - Don't serialize enums as strings in GQL

### DIFF
--- a/cynic-codegen/src/enum_derive/mod.rs
+++ b/cynic-codegen/src/enum_derive/mod.rs
@@ -88,6 +88,15 @@ pub fn enum_derive_impl(
             .collect();
 
         let variants: Vec<_> = pairs.iter().map(|(variant, _)| &variant.ident).collect();
+        let variant_indexes: Vec<_> = pairs
+            .iter()
+            .enumerate()
+            .map(|(i, _)| {
+                proc_macro2::Literal::u32_suffixed(
+                    i.try_into().expect("an enum with less than 2^32 variants"),
+                )
+            })
+            .collect();
 
         let schema_module = input.schema_module();
         let ident = input.ident;
@@ -105,7 +114,7 @@ pub fn enum_derive_impl(
                     S: ::cynic::serde::Serializer {
                         match self {
                             #(
-                                #ident::#variants => serializer.serialize_str(#string_literals),
+                                #ident::#variants => serializer.serialize_unit_variant(#graphql_type_name, #variant_indexes, #string_literals),
                             )*
                         }
                     }

--- a/cynic-codegen/src/enum_derive/snapshots/cynic_codegen__enum_derive__tests__input_1.snap
+++ b/cynic-codegen/src/enum_derive/snapshots/cynic_codegen__enum_derive__tests__input_1.snap
@@ -1,6 +1,6 @@
 ---
 source: cynic-codegen/src/enum_derive/mod.rs
-assertion_line: 382
+assertion_line: 390
 expression: "format_code(format!(\"{}\", tokens))"
 
 ---
@@ -15,9 +15,9 @@ impl ::cynic::serde::Serialize for States {
         S: ::cynic::serde::Serializer,
     {
         match self {
-            States::Closed => serializer.serialize_str("CLOSED"),
-            States::Deleted => serializer.serialize_str("DELETED"),
-            States::Open => serializer.serialize_str("OPEN"),
+            States::Closed => serializer.serialize_unit_variant("States", 0u32, "CLOSED"),
+            States::Deleted => serializer.serialize_unit_variant("States", 1u32, "DELETED"),
+            States::Open => serializer.serialize_unit_variant("States", 2u32, "OPEN"),
         }
     }
 }

--- a/cynic-codegen/src/fragment_derive/arguments/analyse.rs
+++ b/cynic-codegen/src/fragment_derive/arguments/analyse.rs
@@ -196,15 +196,23 @@ fn analyse_value_type<'a>(
             (InputType::Scalar(_), ArgumentLiteral::Null(span)) => {
                 Err(syn::Error::new(span, "Expected a scalar here but found a null").into())
             }
+            (InputType::Scalar(_), ArgumentLiteral::Enum(i)) => Err(syn::Error::new(
+                i.span(),
+                "Expected a scalar here but found an unquoted string",
+            )
+            .into()),
             (InputType::Scalar(_), ArgumentLiteral::Literal(lit)) => {
                 Ok(ArgumentValue::Literal(lit))
             }
 
+            (InputType::Enum(en), ArgumentLiteral::Enum(i)) => Ok(ArgumentValue::Variant(
+                analysis.enum_variant(en, i.to_string(), i.span())?,
+            )),
             (InputType::Enum(en), ArgumentLiteral::Literal(Lit::Str(s))) => Ok(
                 ArgumentValue::Variant(analysis.enum_variant(en, s.value(), s.span())?),
             ),
             (InputType::Enum(_), lit) => {
-                Err(syn::Error::new(lit.span(), "Expected an enum variant here").into())
+                Err(syn::Error::new(lit.span(), "Expected an enum here").into())
             }
 
             (InputType::InputObject(def), ArgumentLiteral::Object(fields, span)) => {

--- a/cynic-codegen/src/fragment_derive/arguments/parsing.rs
+++ b/cynic-codegen/src/fragment_derive/arguments/parsing.rs
@@ -71,6 +71,7 @@ impl Parse for FieldArgument {
 #[derive(Debug, Clone)]
 pub enum ArgumentLiteral {
     Literal(syn::Lit),
+    Enum(proc_macro2::Ident),
     Object(Punctuated<FieldArgument, Token![,]>, Span),
     List(Punctuated<ArgumentLiteral, Token![,]>, Span),
     Variable(proc_macro2::Ident, Span),
@@ -81,6 +82,7 @@ impl ArgumentLiteral {
     pub(super) fn span(&self) -> Span {
         match self {
             ArgumentLiteral::Literal(lit) => lit.span(),
+            ArgumentLiteral::Enum(ident) => ident.span(),
             ArgumentLiteral::Object(_, span) => *span,
             ArgumentLiteral::List(_, span) => *span,
             ArgumentLiteral::Variable(_, span) => *span,
@@ -130,10 +132,7 @@ impl Parse for ArgumentLiteral {
                 return Ok(ArgumentLiteral::Null(ident.span()));
             }
 
-            Err(syn::Error::new(
-                ident.span(),
-                format!("Unknown token: {ident}"),
-            ))
+            return Ok(ArgumentLiteral::Enum(ident));
         } else {
             Err(lookahead.error())
         }

--- a/cynic/src/queries/ast.rs
+++ b/cynic/src/queries/ast.rs
@@ -71,6 +71,8 @@ pub enum InputLiteral {
     Variable(&'static str),
     /// A null
     Null,
+    /// One of the values of an enum
+    EnumValue(&'static str),
 }
 
 #[derive(Debug, Default)]
@@ -173,6 +175,9 @@ impl std::fmt::Display for InputLiteral {
             }
             InputLiteral::Null => {
                 write!(f, "null")
+            }
+            InputLiteral::EnumValue(name) => {
+                write!(f, "{name}")
             }
         }
     }

--- a/cynic/src/queries/input_literal_ser.rs
+++ b/cynic/src/queries/input_literal_ser.rs
@@ -125,7 +125,7 @@ impl<'a> ser::Serializer for InputLiteralSerializer {
         _variant_index: u32,
         variant: &'static str,
     ) -> Result<Self::Ok, Self::Error> {
-        Ok(InputLiteral::String(Cow::Borrowed(variant)))
+        Ok(InputLiteral::EnumValue(variant))
     }
 
     fn serialize_newtype_struct<T: ?Sized>(


### PR DESCRIPTION
#### Why are we making this change?

GraphQL enums are represented as strings in JSON, but when printed in GraphQL they should be unquoted literals. 

#### What effects does this change have?

Fixes the representation of enums in GraphQL, and any other serialization format that differentiates enums & strings.

Fixes #484 
