### PR TITLE
[Merged by Bors] - Tolerate backwards compatible schema changes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,10 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
   occurrences of a custom scalar in the output (#346)
 - Cynic should now support schemas which have 2 similarly named but differently
   cased scalars.
+- Cynic should no longer fail to compile in the face of various non-breaking
+  schema changes.
+- `#[cynic(flatten)]` no longer allows you to omit a list type on output fields.
+  Previously this would compile but probably fail to deserialize.
 
 ### Changes
 
@@ -80,6 +84,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 - `use_schema` output can now live in a separate crate from queries, which
   should help with large schema support. (The exception is `impl_scalar`
   invocations which must live in the same crate as the schema)
+- Cynic now allows fields to be `Arc` or `Rc`
 
 ## v1.0.0 - 2021-12-09
 

--- a/cynic-codegen/src/fragment_derive/input.rs
+++ b/cynic-codegen/src/fragment_derive/input.rs
@@ -195,7 +195,7 @@ impl FragmentDeriveField {
         } else if *self.spread {
             CheckMode::Spreading
         } else {
-            CheckMode::Normal
+            CheckMode::OutputTypes
         }
     }
 

--- a/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__input_6.snap
+++ b/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__input_6.snap
@@ -11,7 +11,7 @@ impl<'de> ::cynic::QueryFragment<'de> for Film {
     const TYPE: Option<&'static str> = Some("Film");
     fn query(mut builder: ::cynic::queries::SelectionBuilder<Self::SchemaType, Self::Variables>) {
         #![allow(unused_mut)]
-        let mut field_builder = builder . select_flattened_field :: < schema :: film_fields :: producers , < String as :: cynic :: schema :: IsScalar < < schema :: film_fields :: producers as :: cynic :: schema :: Field > :: Type >> :: SchemaType , < schema :: film_fields :: producers as :: cynic :: schema :: Field > :: Type , > () ;
+        let mut field_builder = builder . select_flattened_field :: < schema :: film_fields :: producers , < Vec < String > as :: cynic :: schema :: IsScalar < < schema :: film_fields :: producers as :: cynic :: schema :: Field > :: Type >> :: SchemaType , < schema :: film_fields :: producers as :: cynic :: schema :: Field > :: Type , > () ;
     }
 }
 #[automatically_derived]
@@ -49,7 +49,7 @@ impl<'de> ::cynic::serde::Deserialize<'de> for Film {
                                 ));
                             }
                             producers = Some(
-                                map.next_value::<::cynic::__private::Flattened<String>>()?
+                                map.next_value::<::cynic::__private::Flattened<Vec<String>>>()?
                                     .into_inner(),
                             );
                         }

--- a/cynic-codegen/src/fragment_derive/tests.rs
+++ b/cynic-codegen/src/fragment_derive/tests.rs
@@ -73,7 +73,7 @@ use super::fragment_derive;
         )]
         struct Film {
             #[cynic(flatten)]
-            producers: String,
+            producers: Vec<String>,
         }
     ),
     parse_quote!(

--- a/cynic-codegen/src/input_object_derive/field_serializer.rs
+++ b/cynic-codegen/src/input_object_derive/field_serializer.rs
@@ -33,7 +33,7 @@ impl<'a> FieldSerializer<'a> {
         if let Err(e) = check_types_are_compatible(
             &self.graphql_field.value_type,
             &self.rust_field.ty,
-            CheckMode::Normal,
+            CheckMode::InputTypes,
         ) {
             return Some(e);
         }
@@ -43,7 +43,7 @@ impl<'a> FieldSerializer<'a> {
         if self.rust_field.skip_serializing_if.is_some() && !nullable {
             return Some(syn::Error::new(
                 self.rust_field.skip_serializing_if.as_ref().unwrap().span(),
-                "You can't specify skip_serializing_if on a required field".to_string(),
+                "You can't specify skip_serializing_if on a non nullable field".to_string(),
             ));
         }
 


### PR DESCRIPTION
#### Why are we making this change?

GraphQLs type coercion rules allow for certain changes to be made to a
schema without being considered a breaking change.  Amongst other
things:

1. Required fields in input types can be made optional without breaking
   clients.
2. Optional fields in output types can be made required.
3. Input fields can be made into lists without breaking, as a single
   item coerces into a list with a single item.

Cynic did not support this very well though - the type checking was
fairly strict and mostly expected a 1:1 mapping between the schema and
the rust types provided.


#### What effects does this change have?

This PR updates the type checking to closer follow the graphql rules.

Fixes #239
