### PR TITLE
[Merged by Bors] - Properly pin rust, update trybuild

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,7 +21,8 @@ jobs:
       - uses: actions/checkout@v2
 
       - uses: dtolnay/rust-toolchain@1.60.0
-        components: rustfmt
+        with:
+          components: rustfmt
 
       - uses: Swatinem/rust-cache@v1
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,7 +22,6 @@ jobs:
 
       - uses: actions-rs/toolchain@v1
         with:
-          profile: minimal
           default: true
           toolchain: 1.60.0
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,6 +23,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
+          default: true
           toolchain: 1.60.0
 
       - uses: Swatinem/rust-cache@v1

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,10 +20,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: actions-rs/toolchain@v1
-        with:
-          default: true
-          toolchain: 1.60.0
+      - uses: dtolnay/rust-toolchain@1.60.0
+        components: rustfmt
 
       - uses: Swatinem/rust-cache@v1
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2482,13 +2482,14 @@ checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
 name = "trybuild"
-version = "1.0.56"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d60539445867cdd9680b2bfe2d0428f1814b7d5c9652f09d8d3eae9d19308db"
+checksum = "764b9e244b482a9b81bde596aa37aa6f1347bf8007adab25e59f901b32b4e0a0"
 dependencies = [
  "glob",
  "once_cell",
  "serde",
+ "serde_derive",
  "serde_json",
  "termcolor",
  "toml",

--- a/cynic/tests/enum-arguments.rs
+++ b/cynic/tests/enum-arguments.rs
@@ -1,7 +1,6 @@
 //! Tests of the generated serialization code for InputObjects
 
 use serde::Serialize;
-use serde_json::json;
 
 mod schema {
     cynic::use_schema!("tests/test-schema.graphql");
@@ -24,6 +23,7 @@ fn test_enum_argument_literal() {
     #[derive(cynic::QueryFragment)]
     #[cynic(schema_path = "tests/test-schema.graphql", query_module = "schema")]
     struct Query {
+        #[allow(dead_code)]
         #[arguments(filters: { states: DRAFT })]
         filtered_posts: Vec<BlogPost>,
     }
@@ -60,6 +60,7 @@ fn test_enum_argument() {
     #[derive(cynic::QueryFragment)]
     #[cynic(schema_path = "tests/test-schema.graphql", query_module = "schema")]
     struct Query {
+        #[allow(dead_code)]
         #[arguments(filters = PostFilters { states: Some(vec![PostState::Posted]) })]
         filtered_posts: Vec<BlogPost>,
     }


### PR DESCRIPTION
#### Why are we making this change?

The latest rust compiler has changed the format of some of our errors, causing the ui tests to fail.  This isn't the first time this has happened.

#### What effects does this change have?

- Pins rust to 1.60.0 so the error messages in ui-tests are stable
- Updates trybuild because it's on quite an old version
