### PR TITLE
[Merged by Bors] - Remove deprecated query_module attribute.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,9 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
   `serde_json::Value` for extensions.  They now have generic parameters that you
   should provide if you care about error extensions.
 - The output of the `use_schema` macro is no longer re-cased.
+- The deprecated `query_module` attribute for the various derive/attribute
+  macros has been removed - if you're using it you should update to
+  `schema_module` which behaves the same.
 
 
 ### Deprecations

--- a/cynic-codegen/src/enum_derive/input.rs
+++ b/cynic-codegen/src/enum_derive/input.rs
@@ -11,9 +11,6 @@ pub struct EnumDeriveInput {
 
     pub schema_path: SpannedValue<String>,
 
-    // query_module is deprecated, remove eventually.
-    #[darling(default)]
-    query_module: Option<SpannedValue<String>>,
     #[darling(default, rename = "schema_module")]
     schema_module_: Option<syn::Path>,
 
@@ -28,9 +25,6 @@ impl EnumDeriveInput {
     pub fn schema_module(&self) -> syn::Path {
         if let Some(schema_module) = &self.schema_module_ {
             return schema_module.clone();
-        }
-        if let Some(query_module) = &self.query_module {
-            return syn::parse_str(query_module).unwrap();
         }
         syn::parse2(quote::quote! { schema }).unwrap()
     }

--- a/cynic-codegen/src/fragment_derive/input.rs
+++ b/cynic-codegen/src/fragment_derive/input.rs
@@ -14,10 +14,6 @@ pub struct FragmentDeriveInput {
 
     pub schema_path: SpannedValue<String>,
 
-    // query_module is deprecated, remove eventually.
-    #[darling(default)]
-    query_module: Option<SpannedValue<String>>,
-
     #[darling(default, rename = "schema_module")]
     schema_module_: Option<syn::Path>,
 
@@ -36,9 +32,6 @@ impl FragmentDeriveInput {
     pub fn schema_module(&self) -> syn::Path {
         if let Some(schema_module) = &self.schema_module_ {
             return schema_module.clone();
-        }
-        if let Some(query_module) = &self.query_module {
-            return syn::parse_str(query_module).unwrap();
         }
         syn::parse2(quote::quote! { schema }).unwrap()
     }
@@ -276,7 +269,6 @@ mod tests {
                 ],
             )),
             schema_path: "abcd".to_string().into(),
-            query_module: None,
             schema_module_: None,
             graphql_type: Some("abcd".to_string().into()),
             argument_struct: None,
@@ -356,7 +348,6 @@ mod tests {
                 ],
             )),
             schema_path: "abcd".to_string().into(),
-            query_module: None,
             schema_module_: Some(syn::parse2(quote::quote! { abcd }).unwrap()),
             graphql_type: Some("abcd".to_string().into()),
             argument_struct: None,
@@ -376,7 +367,6 @@ mod tests {
                 vec![],
             )),
             schema_path: "abcd".to_string().into(),
-            query_module: None,
             schema_module_: Some(syn::parse2(quote::quote! { abcd }).unwrap()),
             graphql_type: Some("abcd".to_string().into()),
             argument_struct: None,
@@ -430,7 +420,6 @@ mod tests {
                 ],
             )),
             schema_path: "abcd".to_string().into(),
-            query_module: None,
             schema_module_: Some(syn::parse2(quote::quote! { abcd }).unwrap()),
             graphql_type: None,
             argument_struct: None,

--- a/cynic-codegen/src/fragment_derive/tests.rs
+++ b/cynic-codegen/src/fragment_derive/tests.rs
@@ -58,7 +58,7 @@ use super::fragment_derive;
         #[derive(cynic::QueryFragment, Debug)]
         #[cynic(
             schema_path = "../schemas/starwars.schema.graphql",
-            query_module = "schema"
+            schema_module = "schema"
         )]
         struct Film {
             #[cynic(spread)]
@@ -69,7 +69,7 @@ use super::fragment_derive;
         #[derive(cynic::QueryFragment, Debug)]
         #[cynic(
             schema_path = "../schemas/starwars.schema.graphql",
-            query_module = "schema"
+            schema_module = "schema"
         )]
         struct Film {
             #[cynic(flatten)]

--- a/cynic-codegen/src/inline_fragments_derive/input.rs
+++ b/cynic-codegen/src/inline_fragments_derive/input.rs
@@ -12,9 +12,6 @@ pub struct InlineFragmentsDeriveInput {
 
     pub schema_path: SpannedValue<String>,
 
-    // query_module is deprecated, remove eventually.
-    #[darling(default)]
-    query_module: Option<SpannedValue<String>>,
     #[darling(default, rename = "schema_module")]
     schema_module_: Option<syn::Path>,
 
@@ -32,9 +29,6 @@ impl InlineFragmentsDeriveInput {
     pub fn schema_module(&self) -> syn::Path {
         if let Some(schema_module) = &self.schema_module_ {
             return schema_module.clone();
-        }
-        if let Some(query_module) = &self.query_module {
-            return syn::parse_str(query_module).unwrap();
         }
         syn::parse2(quote::quote! { schema }).unwrap()
     }

--- a/cynic-codegen/src/input_object_derive/input.rs
+++ b/cynic-codegen/src/input_object_derive/input.rs
@@ -12,9 +12,6 @@ pub struct InputObjectDeriveInput {
 
     pub schema_path: SpannedValue<String>,
 
-    // query_module is deprecated, remove eventually.
-    #[darling(default)]
-    query_module: Option<SpannedValue<String>>,
     #[darling(default, rename = "schema_module")]
     schema_module_: Option<syn::Path>,
 
@@ -45,9 +42,6 @@ impl InputObjectDeriveInput {
     pub fn schema_module(&self) -> syn::Path {
         if let Some(schema_module) = &self.schema_module_ {
             return schema_module.clone();
-        }
-        if let Some(query_module) = &self.query_module {
-            return syn::parse_str(query_module).unwrap();
         }
         syn::parse2(quote::quote! { schema }).unwrap()
     }

--- a/cynic/tests/aliases.rs
+++ b/cynic/tests/aliases.rs
@@ -17,10 +17,7 @@ struct FilmQueryWithExplicitAlias {
 }
 
 #[derive(cynic::QueryFragment, Debug, PartialEq)]
-#[cynic(
-    schema_path = "../schemas/starwars.schema.graphql",
-    query_module = "schema"
-)]
+#[cynic(schema_path = "../schemas/starwars.schema.graphql")]
 struct Film {
     title: Option<String>,
 }

--- a/cynic/tests/enum-arguments.rs
+++ b/cynic/tests/enum-arguments.rs
@@ -11,17 +11,13 @@ fn test_enum_argument_literal() {
     use cynic::QueryBuilder;
 
     #[derive(cynic::QueryFragment, Serialize)]
-    #[cynic(
-        graphql_type = "BlogPost",
-        schema_path = "tests/test-schema.graphql",
-        query_module = "schema"
-    )]
+    #[cynic(graphql_type = "BlogPost", schema_path = "tests/test-schema.graphql")]
     struct Post {
         has_metadata: Option<bool>,
     }
 
     #[derive(cynic::QueryFragment)]
-    #[cynic(schema_path = "tests/test-schema.graphql", query_module = "schema")]
+    #[cynic(schema_path = "tests/test-schema.graphql")]
     struct Query {
         #[allow(dead_code)]
         #[arguments(filters: { states: DRAFT })]
@@ -45,20 +41,20 @@ fn test_enum_argument() {
     use cynic::QueryBuilder;
 
     #[derive(cynic::Enum)]
-    #[cynic(schema_path = "tests/test-schema.graphql", query_module = "schema")]
+    #[cynic(schema_path = "tests/test-schema.graphql")]
     enum PostState {
         Posted,
         Draft,
     }
 
     #[derive(cynic::InputObject)]
-    #[cynic(schema_path = "tests/test-schema.graphql", query_module = "schema")]
+    #[cynic(schema_path = "tests/test-schema.graphql")]
     struct PostFilters {
         states: Option<Vec<PostState>>,
     }
 
     #[derive(cynic::QueryFragment)]
-    #[cynic(schema_path = "tests/test-schema.graphql", query_module = "schema")]
+    #[cynic(schema_path = "tests/test-schema.graphql")]
     struct Query {
         #[allow(dead_code)]
         #[arguments(filters = PostFilters { states: Some(vec![PostState::Posted]) })]
@@ -78,7 +74,7 @@ fn test_enum_argument() {
 }
 
 #[derive(cynic::QueryFragment, Serialize)]
-#[cynic(schema_path = "tests/test-schema.graphql", query_module = "schema")]
+#[cynic(schema_path = "tests/test-schema.graphql")]
 struct BlogPost {
     has_metadata: Option<bool>,
 }

--- a/cynic/tests/inline-fragments.rs
+++ b/cynic/tests/inline-fragments.rs
@@ -5,11 +5,7 @@ use serde_json::json;
 use cynic::{InlineFragments, QueryFragment};
 
 #[derive(QueryFragment, Serialize)]
-#[cynic(
-    graphql_type = "Query",
-    schema_path = "tests/test-schema.graphql",
-    query_module = "schema"
-)]
+#[cynic(graphql_type = "Query", schema_path = "tests/test-schema.graphql")]
 struct AllPostsQuery {
     all_data: Vec<PostOrAuthor>,
     #[arguments(id: "123")]
@@ -17,21 +13,13 @@ struct AllPostsQuery {
 }
 
 #[derive(QueryFragment, Serialize, PartialEq, Debug)]
-#[cynic(
-    graphql_type = "BlogPost",
-    schema_path = "tests/test-schema.graphql",
-    query_module = "schema"
-)]
+#[cynic(graphql_type = "BlogPost", schema_path = "tests/test-schema.graphql")]
 struct Post {
     id: Option<cynic::Id>,
 }
 
 #[derive(QueryFragment, Serialize, PartialEq, Debug)]
-#[cynic(
-    graphql_type = "Author",
-    schema_path = "tests/test-schema.graphql",
-    query_module = "schema"
-)]
+#[cynic(graphql_type = "Author", schema_path = "tests/test-schema.graphql")]
 struct Author {
     name: Option<String>,
 }

--- a/cynic/tests/input-object-tests.rs
+++ b/cynic/tests/input-object-tests.rs
@@ -36,8 +36,7 @@ fn test_input_object_skip_serializing() {
     #[derive(cynic::InputObject)]
     #[cynic(
         graphql_type = "BlogPostInput",
-        schema_path = "tests/test-schema.graphql",
-        query_module = "schema"
+        schema_path = "tests/test-schema.graphql"
     )]
     struct BlogPost {
         content: String,
@@ -66,8 +65,7 @@ fn test_input_object_stable_order() {
     #[derive(cynic::InputObject)]
     #[cynic(
         graphql_type = "BlogPostInput",
-        schema_path = "tests/test-schema.graphql",
-        query_module = "schema"
+        schema_path = "tests/test-schema.graphql"
     )]
     struct BlogPost {
         content: String,

--- a/cynic/tests/recursive-queries.rs
+++ b/cynic/tests/recursive-queries.rs
@@ -9,33 +9,25 @@ mod schema {
 mod recursive_lists {
     use super::*;
     #[derive(QueryFragment, Serialize)]
-    #[cynic(
-        graphql_type = "Query",
-        schema_path = "tests/test-schema.graphql",
-        query_module = "schema"
-    )]
+    #[cynic(graphql_type = "Query", schema_path = "tests/test-schema.graphql")]
     struct AllPostsQuery {
         all_posts: Vec<Post>,
     }
 
     #[derive(QueryFragment, Serialize)]
-    #[cynic(
-        graphql_type = "BlogPost",
-        schema_path = "tests/test-schema.graphql",
-        query_module = "schema"
-    )]
+    #[cynic(graphql_type = "BlogPost", schema_path = "tests/test-schema.graphql")]
     struct Post {
         comments: Vec<Comment>,
     }
 
     #[derive(QueryFragment, Serialize)]
-    #[cynic(schema_path = "tests/test-schema.graphql", query_module = "schema")]
+    #[cynic(schema_path = "tests/test-schema.graphql")]
     struct Comment {
         author: Author,
     }
 
     #[derive(QueryFragment, Serialize)]
-    #[cynic(schema_path = "tests/test-schema.graphql", query_module = "schema")]
+    #[cynic(schema_path = "tests/test-schema.graphql")]
     struct Author {
         #[cynic(recurse = "2")]
         posts: Option<Vec<Post>>,
@@ -74,17 +66,13 @@ mod optional_recursive_types {
     use super::*;
 
     #[derive(QueryFragment, Serialize)]
-    #[cynic(
-        graphql_type = "Query",
-        schema_path = "tests/test-schema.graphql",
-        query_module = "schema"
-    )]
+    #[cynic(graphql_type = "Query", schema_path = "tests/test-schema.graphql")]
     struct FriendsQuery {
         all_authors: Vec<Author>,
     }
 
     #[derive(QueryFragment, Serialize)]
-    #[cynic(schema_path = "tests/test-schema.graphql", query_module = "schema")]
+    #[cynic(schema_path = "tests/test-schema.graphql")]
     struct Author {
         #[cynic(recurse = "2")]
         friends: Option<Vec<Author>>,
@@ -149,17 +137,13 @@ mod required_recursive_types {
     use super::*;
 
     #[derive(QueryFragment, Serialize)]
-    #[cynic(
-        graphql_type = "Query",
-        schema_path = "tests/test-schema.graphql",
-        query_module = "schema"
-    )]
+    #[cynic(graphql_type = "Query", schema_path = "tests/test-schema.graphql")]
     struct FriendsQuery {
         all_authors: Vec<Author>,
     }
 
     #[derive(QueryFragment, Serialize)]
-    #[cynic(schema_path = "tests/test-schema.graphql", query_module = "schema")]
+    #[cynic(schema_path = "tests/test-schema.graphql")]
     struct Author {
         #[cynic(recurse = "2")]
         me: Option<Box<Author>>,

--- a/cynic/tests/renames.rs
+++ b/cynic/tests/renames.rs
@@ -3,22 +3,14 @@ use serde::Serialize;
 use serde_json::json;
 
 #[derive(QueryFragment, Serialize)]
-#[cynic(
-    graphql_type = "Query",
-    schema_path = "tests/test-schema.graphql",
-    query_module = "schema"
-)]
+#[cynic(graphql_type = "Query", schema_path = "tests/test-schema.graphql")]
 struct AllPostsQuery {
     all_posts: Vec<Post>,
     all_data: Vec<PostOrAuthor>,
 }
 
 #[derive(QueryFragment, Serialize)]
-#[cynic(
-    graphql_type = "BlogPost",
-    schema_path = "tests/test-schema.graphql",
-    query_module = "schema"
-)]
+#[cynic(graphql_type = "BlogPost", schema_path = "tests/test-schema.graphql")]
 struct Post {
     // TODO: UI tests of failure on renames
     #[cynic(rename = "hasMetadata")]
@@ -27,11 +19,7 @@ struct Post {
 }
 
 #[derive(QueryFragment, Serialize)]
-#[cynic(
-    graphql_type = "Author",
-    schema_path = "tests/test-schema.graphql",
-    query_module = "schema"
-)]
+#[cynic(graphql_type = "Author", schema_path = "tests/test-schema.graphql")]
 struct Author {
     name: Option<String>,
 }

--- a/cynic/tests/simple_schema_tests.rs
+++ b/cynic/tests/simple_schema_tests.rs
@@ -18,7 +18,7 @@ struct TestStruct {
 }
 
 #[derive(cynic::QueryFragment, PartialEq, Debug)]
-#[cynic(schema_path = "src/bin/simple.graphql", query_module = "schema")]
+#[cynic(schema_path = "src/bin/simple.graphql")]
 struct Nested {
     a_string: String,
     opt_string: Option<String>,

--- a/examples/examples/chrono-scalars.rs
+++ b/examples/examples/chrono-scalars.rs
@@ -9,10 +9,7 @@ type DateTime = chrono::DateTime<chrono::Utc>;
 cynic::impl_scalar!(DateTime, schema::DateTime);
 
 #[derive(cynic::QueryFragment, Debug)]
-#[cynic(
-    schema_path = "../schemas/graphql.jobs.graphql",
-    query_module = "schema"
-)]
+#[cynic(schema_path = "../schemas/graphql.jobs.graphql")]
 struct Job {
     created_at: DateTime,
 }

--- a/examples/examples/manual-reqwest.rs
+++ b/examples/examples/manual-reqwest.rs
@@ -6,10 +6,7 @@ mod schema {
 }
 
 #[derive(cynic::QueryFragment, Debug)]
-#[cynic(
-    schema_path = "../schemas/starwars.schema.graphql",
-    query_module = "schema"
-)]
+#[cynic(schema_path = "../schemas/starwars.schema.graphql")]
 struct Film {
     title: Option<String>,
     director: Option<String>,

--- a/examples/examples/querying-interfaces.rs
+++ b/examples/examples/querying-interfaces.rs
@@ -5,10 +5,7 @@ mod schema {
 }
 
 #[derive(cynic::InlineFragments, Debug)]
-#[cynic(
-    schema_path = "../schemas/starwars.schema.graphql",
-    query_module = "schema"
-)]
+#[cynic(schema_path = "../schemas/starwars.schema.graphql")]
 enum Node {
     Film(Film),
     Planet(Planet),
@@ -18,19 +15,13 @@ enum Node {
 }
 
 #[derive(cynic::QueryFragment, Debug)]
-#[cynic(
-    schema_path = "../schemas/starwars.schema.graphql",
-    query_module = "schema"
-)]
+#[cynic(schema_path = "../schemas/starwars.schema.graphql")]
 struct Film {
     title: Option<String>,
 }
 
 #[derive(cynic::QueryFragment, Debug)]
-#[cynic(
-    schema_path = "../schemas/starwars.schema.graphql",
-    query_module = "schema"
-)]
+#[cynic(schema_path = "../schemas/starwars.schema.graphql")]
 struct Planet {
     name: Option<String>,
 }

--- a/examples/examples/reqwest-async.rs
+++ b/examples/examples/reqwest-async.rs
@@ -8,10 +8,7 @@ mod schema {
 }
 
 #[derive(cynic::QueryFragment, Debug)]
-#[cynic(
-    schema_path = "../schemas/starwars.schema.graphql",
-    query_module = "schema"
-)]
+#[cynic(schema_path = "../schemas/starwars.schema.graphql")]
 struct Film {
     title: Option<String>,
     director: Option<String>,

--- a/examples/examples/spread.rs
+++ b/examples/examples/spread.rs
@@ -7,7 +7,6 @@ mod schema {
 #[derive(cynic::QueryFragment, Debug)]
 #[cynic(
     schema_path = "../schemas/starwars.schema.graphql",
-    query_module = "schema",
     graphql_type = "Film"
 )]
 struct FilmDetails {
@@ -16,10 +15,7 @@ struct FilmDetails {
 }
 
 #[derive(cynic::QueryFragment, Debug)]
-#[cynic(
-    schema_path = "../schemas/starwars.schema.graphql",
-    query_module = "schema"
-)]
+#[cynic(schema_path = "../schemas/starwars.schema.graphql")]
 struct Film {
     #[cynic(spread)]
     details: FilmDetails,

--- a/examples/examples/starwars.rs
+++ b/examples/examples/starwars.rs
@@ -5,10 +5,7 @@ mod schema {
 }
 
 #[derive(cynic::QueryFragment, Debug)]
-#[cynic(
-    schema_path = "../schemas/starwars.schema.graphql",
-    query_module = "schema"
-)]
+#[cynic(schema_path = "../schemas/starwars.schema.graphql")]
 struct Film {
     title: Option<String>,
     director: Option<String>,

--- a/examples/examples/surf-client.rs
+++ b/examples/examples/surf-client.rs
@@ -8,10 +8,7 @@ mod schema {
 }
 
 #[derive(cynic::QueryFragment, Debug)]
-#[cynic(
-    schema_path = "../schemas/starwars.schema.graphql",
-    query_module = "schema"
-)]
+#[cynic(schema_path = "../schemas/starwars.schema.graphql")]
 struct Film {
     title: Option<String>,
     director: Option<String>,

--- a/tests/ui-tests/tests/cases/inline-fragment-fallback-validation.rs
+++ b/tests/ui-tests/tests/cases/inline-fragment-fallback-validation.rs
@@ -17,10 +17,7 @@ enum MyFailingUnionType {
 }
 
 #[derive(cynic::QueryFragment)]
-#[cynic(
-    schema_path = "../../../cynic/src/bin/simple.graphql",
-    query_module = "schema"
-)]
+#[cynic(schema_path = "../../../cynic/src/bin/simple.graphql")]
 struct Nested {
     pub a_string: String,
     pub opt_string: Option<String>,


### PR DESCRIPTION
The initial versions of cynic had a query_module parameter to various
derives.  At some point I decided this was a silly term and renamed it
to schema_module.  I kept the old attribute around for backwards
compatability though.

Now that I'm getting ready for v2 I think it's time to retire the
deprecated query_module attribute.

Fixes #416