### PR TITLE
[Merged by Bors] - Fix querying for interface field in generator.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /target
 **/target
 **/*.rs.bk
+
+.DS_Store

--- a/cynic-querygen/src/lib.rs
+++ b/cynic-querygen/src/lib.rs
@@ -32,6 +32,9 @@ pub enum Error {
     #[error("expected type `{0}` to be an object")]
     ExpectedObject(String),
 
+    #[error("expected type `{0}` to be an object or an interface")]
+    ExpectedObjectOrInterface(String),
+
     #[error("expected type `{0}` to be an input object")]
     ExpectedInputObject(String),
 

--- a/cynic-querygen/src/schema/type_index.rs
+++ b/cynic-querygen/src/schema/type_index.rs
@@ -136,10 +136,14 @@ impl<'schema> TypeIndex<'schema> {
                     .get(inner_name)
                     .ok_or_else(|| Error::UnknownType(inner_name.to_string()))?;
 
-                if let TypeDefinition::Object(object) = inner_type {
-                    self.find_field_recursive(&object.fields, inner_name, rest)
-                } else {
-                    Err(Error::ExpectedObject(inner_name.to_string()))
+                match inner_type {
+                    TypeDefinition::Object(object) => {
+                        self.find_field_recursive(&object.fields, inner_name, rest)
+                    }
+                    TypeDefinition::Interface(iface) => {
+                        self.find_field_recursive(&iface.fields, inner_name, rest)
+                    }
+                    _ => Err(Error::ExpectedObjectOrInterface(inner_name.to_string())),
                 }
             }
         }

--- a/cynic-querygen/tests/github-tests.rs
+++ b/cynic-querygen/tests/github-tests.rs
@@ -28,3 +28,4 @@ test_query!(
     inline_fragment_with_arguments,
     "inline-fragment-with-arguments.graphql"
 );
+test_query!(field_on_interface, "field-on-interface.graphql");

--- a/cynic-querygen/tests/queries/github/field-on-interface.graphql
+++ b/cynic-querygen/tests/queries/github/field-on-interface.graphql
@@ -1,0 +1,13 @@
+query FieldOnInterface {
+  repository(owner: "obmarg", name: "cynic") {
+    issues(first: 1) {
+      edges {
+        node {
+          author {
+            login
+          }
+        }
+      }
+    }
+  }
+}

--- a/cynic-querygen/tests/snapshots/github_tests__field_on_interface.snap
+++ b/cynic-querygen/tests/snapshots/github_tests__field_on_interface.snap
@@ -1,0 +1,53 @@
+---
+source: cynic-querygen/tests/github-tests.rs
+assertion_line: 31
+expression: "document_to_fragment_structs(query, schema,\n        &QueryGenOptions::default()).expect(\"QueryGen Failed\")"
+
+---
+#[cynic::schema_for_derives(
+    file = r#"schema.graphql"#,
+    module = "schema",
+)]
+mod queries {
+    use super::schema;
+
+    #[derive(cynic::QueryFragment, Debug)]
+    #[cynic(graphql_type = "Query")]
+    pub struct FieldOnInterface {
+        #[arguments(owner: "obmarg", name: "cynic")]
+        pub repository: Option<Repository>,
+    }
+
+    #[derive(cynic::QueryFragment, Debug)]
+    pub struct Repository {
+        #[arguments(first: 1)]
+        pub issues: IssueConnection,
+    }
+
+    #[derive(cynic::QueryFragment, Debug)]
+    pub struct IssueConnection {
+        pub edges: Option<Vec<Option<IssueEdge>>>,
+    }
+
+    #[derive(cynic::QueryFragment, Debug)]
+    pub struct IssueEdge {
+        pub node: Option<Issue>,
+    }
+
+    #[derive(cynic::QueryFragment, Debug)]
+    pub struct Issue {
+        pub author: Option<Actor>,
+    }
+
+    #[derive(cynic::QueryFragment, Debug)]
+    pub struct Actor {
+        pub login: String,
+    }
+
+}
+
+mod schema {
+    cynic::use_schema!(r#"schema.graphql"#);
+}
+
+


### PR DESCRIPTION
The generator wasn't correctly handling fields of interface types when
they weren't inside a spread.  This fixes that oversight.

Fixes #515 
