### PR TITLE
[Merged by Bors] - Fix support of arguments & input fields with defaults.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,13 +48,12 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
   `Cargo.toml`.
 - `cynic` no longer re-exports `serde_json`
 - The `GraphQlError` & `GraphQlResponse` structs no longer contain a
-  `serde_json::Value` for extensions.  They now have generic parameters that you
+  `serde_json::Value` for extensions. They now have generic parameters that you
   should provide if you care about error extensions.
 - The output of the `use_schema` macro is no longer re-cased.
 - The deprecated `query_module` attribute for the various derive/attribute
   macros has been removed - if you're using it you should update to
   `schema_module` which behaves the same.
-
 
 ### Deprecations
 
@@ -72,6 +71,8 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
   schema changes.
 - `#[cynic(flatten)]` no longer allows you to omit a list type on output fields.
   Previously this would compile but probably fail to deserialize.
+- Non-nullable arguments & input object fields with defaults are no longer
+  considered required
 
 ### Changes
 

--- a/cynic-codegen/src/fragment_derive/arguments/analyse.rs
+++ b/cynic-codegen/src/fragment_derive/arguments/analyse.rs
@@ -276,7 +276,7 @@ fn validate(
 
     let required_args = arguments
         .iter()
-        .filter(|a| !matches!(a.value_type, TypeRef::Nullable(_)))
+        .filter(|v| v.is_required())
         .map(|a| a.name.as_str().to_string())
         .collect::<HashSet<_>>();
 

--- a/cynic-codegen/src/fragment_derive/arguments/snapshots/cynic_codegen__fragment_derive__arguments__tests__case_01_scalars.snap
+++ b/cynic-codegen/src/fragment_derive/arguments/snapshots/cynic_codegen__fragment_derive__arguments__tests__case_01_scalars.snap
@@ -1,7 +1,7 @@
 ---
-source: cynic-codegen/src/fragment_derive_2/arguments/tests.rs
-assertion_line: 30
-expression: "analyse(literals, field, Span::call_site()).map(|o| o.arguments)"
+source: cynic-codegen/src/fragment_derive/arguments/tests.rs
+assertion_line: 32
+expression: "analyse(literals, field, Some(&format_ident!(\"MyArguments\").into()),\n        Span::call_site()).map(|o| o.arguments)"
 
 ---
 Ok(
@@ -15,6 +15,7 @@ Ok(
                 value_type: NamedInputType(
                     "Int",
                 ),
+                has_default: false,
             },
             value: Literal(
                 Int(
@@ -33,6 +34,7 @@ Ok(
                 value_type: NamedInputType(
                     "Float",
                 ),
+                has_default: false,
             },
             value: Literal(
                 Int(
@@ -51,6 +53,7 @@ Ok(
                 value_type: NamedInputType(
                     "ID",
                 ),
+                has_default: false,
             },
             value: Literal(
                 Str(

--- a/cynic-codegen/src/fragment_derive/arguments/snapshots/cynic_codegen__fragment_derive__arguments__tests__case_02_missing_nullable_scalars.snap
+++ b/cynic-codegen/src/fragment_derive/arguments/snapshots/cynic_codegen__fragment_derive__arguments__tests__case_02_missing_nullable_scalars.snap
@@ -1,7 +1,7 @@
 ---
-source: cynic-codegen/src/fragment_derive_2/arguments/tests.rs
-assertion_line: 30
-expression: "analyse(literals, field, Span::call_site()).map(|o| o.arguments)"
+source: cynic-codegen/src/fragment_derive/arguments/tests.rs
+assertion_line: 32
+expression: "analyse(literals, field, Some(&format_ident!(\"MyArguments\").into()),\n        Span::call_site()).map(|o| o.arguments)"
 
 ---
 Ok(
@@ -17,6 +17,7 @@ Ok(
                         "Int",
                     ),
                 ),
+                has_default: false,
             },
             value: Some(
                 Literal(

--- a/cynic-codegen/src/fragment_derive/arguments/snapshots/cynic_codegen__fragment_derive__arguments__tests__case_04_a_list_of_strings.snap
+++ b/cynic-codegen/src/fragment_derive/arguments/snapshots/cynic_codegen__fragment_derive__arguments__tests__case_04_a_list_of_strings.snap
@@ -1,7 +1,7 @@
 ---
-source: cynic-codegen/src/fragment_derive_2/arguments/tests.rs
-assertion_line: 30
-expression: "analyse(literals, field, Span::call_site()).map(|o| o.arguments)"
+source: cynic-codegen/src/fragment_derive/arguments/tests.rs
+assertion_line: 32
+expression: "analyse(literals, field, Some(&format_ident!(\"MyArguments\").into()),\n        Span::call_site()).map(|o| o.arguments)"
 
 ---
 Ok(
@@ -15,6 +15,7 @@ Ok(
                 value_type: NamedInputType(
                     "BookFilters",
                 ),
+                has_default: false,
             },
             value: Object(
                 Object {
@@ -34,6 +35,7 @@ Ok(
                                         ),
                                     ),
                                 ),
+                                has_default: false,
                             },
                             InputValue {
                                 description: None,
@@ -45,6 +47,7 @@ Ok(
                                         "BookState",
                                     ),
                                 ),
+                                has_default: false,
                             },
                         ],
                     },
@@ -62,6 +65,7 @@ Ok(
                                         ),
                                     ),
                                 ),
+                                has_default: false,
                             },
                             value: Some(
                                 List(

--- a/cynic-codegen/src/fragment_derive/arguments/snapshots/cynic_codegen__fragment_derive__arguments__tests__case_05_list_wrapping.snap
+++ b/cynic-codegen/src/fragment_derive/arguments/snapshots/cynic_codegen__fragment_derive__arguments__tests__case_05_list_wrapping.snap
@@ -1,7 +1,7 @@
 ---
-source: cynic-codegen/src/fragment_derive_2/arguments/tests.rs
-assertion_line: 30
-expression: "analyse(literals, field, Span::call_site()).map(|o| o.arguments)"
+source: cynic-codegen/src/fragment_derive/arguments/tests.rs
+assertion_line: 32
+expression: "analyse(literals, field, Some(&format_ident!(\"MyArguments\").into()),\n        Span::call_site()).map(|o| o.arguments)"
 
 ---
 Ok(
@@ -15,6 +15,7 @@ Ok(
                 value_type: NamedInputType(
                     "BookFilters",
                 ),
+                has_default: false,
             },
             value: Object(
                 Object {
@@ -34,6 +35,7 @@ Ok(
                                         ),
                                     ),
                                 ),
+                                has_default: false,
                             },
                             InputValue {
                                 description: None,
@@ -45,6 +47,7 @@ Ok(
                                         "BookState",
                                     ),
                                 ),
+                                has_default: false,
                             },
                         ],
                     },
@@ -62,6 +65,7 @@ Ok(
                                         ),
                                     ),
                                 ),
+                                has_default: false,
                             },
                             value: Some(
                                 List(

--- a/cynic-codegen/src/fragment_derive/arguments/snapshots/cynic_codegen__fragment_derive__arguments__tests__case_06_an_enum.snap
+++ b/cynic-codegen/src/fragment_derive/arguments/snapshots/cynic_codegen__fragment_derive__arguments__tests__case_06_an_enum.snap
@@ -1,7 +1,7 @@
 ---
 source: cynic-codegen/src/fragment_derive/arguments/tests.rs
 assertion_line: 32
-expression: "analyse(literals, field, Some(&format_ident!(\"MyArguments\")),\n        Span::call_site()).map(|o| o.arguments)"
+expression: "analyse(literals, field, Some(&format_ident!(\"MyArguments\").into()),\n        Span::call_site()).map(|o| o.arguments)"
 
 ---
 Ok(
@@ -15,6 +15,7 @@ Ok(
                 value_type: NamedInputType(
                     "BookFilters",
                 ),
+                has_default: false,
             },
             value: Object(
                 Object {
@@ -34,6 +35,7 @@ Ok(
                                         ),
                                     ),
                                 ),
+                                has_default: false,
                             },
                             InputValue {
                                 description: None,
@@ -45,6 +47,7 @@ Ok(
                                         "BookState",
                                     ),
                                 ),
+                                has_default: false,
                             },
                         ],
                     },
@@ -60,6 +63,7 @@ Ok(
                                         "BookState",
                                     ),
                                 ),
+                                has_default: false,
                             },
                             value: Some(
                                 Variant(

--- a/cynic-codegen/src/fragment_derive/arguments/snapshots/cynic_codegen__fragment_derive__arguments__tests__case_07_variable_in_object.snap
+++ b/cynic-codegen/src/fragment_derive/arguments/snapshots/cynic_codegen__fragment_derive__arguments__tests__case_07_variable_in_object.snap
@@ -15,6 +15,7 @@ Ok(
                 value_type: NamedInputType(
                     "BookFilters",
                 ),
+                has_default: false,
             },
             value: Object(
                 Object {
@@ -34,6 +35,7 @@ Ok(
                                         ),
                                     ),
                                 ),
+                                has_default: false,
                             },
                             InputValue {
                                 description: None,
@@ -45,6 +47,7 @@ Ok(
                                         "BookState",
                                     ),
                                 ),
+                                has_default: false,
                             },
                         ],
                     },
@@ -60,6 +63,7 @@ Ok(
                                         "BookState",
                                     ),
                                 ),
+                                has_default: false,
                             },
                             value: Variable(
                                 Variable {

--- a/cynic-codegen/src/fragment_derive/arguments/snapshots/cynic_codegen__fragment_derive__arguments__tests__case_08_top_level_variable.snap
+++ b/cynic-codegen/src/fragment_derive/arguments/snapshots/cynic_codegen__fragment_derive__arguments__tests__case_08_top_level_variable.snap
@@ -15,6 +15,7 @@ Ok(
                 value_type: NamedInputType(
                     "BookFilters",
                 ),
+                has_default: false,
             },
             value: Variable(
                 Variable {

--- a/cynic-codegen/src/fragment_derive/arguments/snapshots/cynic_codegen__fragment_derive__arguments__tests__case_09_top_level_variable.snap
+++ b/cynic-codegen/src/fragment_derive/arguments/snapshots/cynic_codegen__fragment_derive__arguments__tests__case_09_top_level_variable.snap
@@ -15,6 +15,7 @@ Ok(
                 value_type: NamedInputType(
                     "BookFilters",
                 ),
+                has_default: false,
             },
             value: Variable(
                 Variable {
@@ -49,6 +50,7 @@ Ok(
                         "BookFilters",
                     ),
                 ),
+                has_default: false,
             },
             value: Variable(
                 Variable {

--- a/cynic-codegen/src/fragment_derive/arguments/snapshots/cynic_codegen__fragment_derive__arguments__tests__case_10_boolean_scalar.snap
+++ b/cynic-codegen/src/fragment_derive/arguments/snapshots/cynic_codegen__fragment_derive__arguments__tests__case_10_boolean_scalar.snap
@@ -1,7 +1,7 @@
 ---
-source: cynic-codegen/src/fragment_derive_2/arguments/tests.rs
-assertion_line: 30
-expression: "analyse(literals, field, Span::call_site()).map(|o| o.arguments)"
+source: cynic-codegen/src/fragment_derive/arguments/tests.rs
+assertion_line: 32
+expression: "analyse(literals, field, Some(&format_ident!(\"MyArguments\").into()),\n        Span::call_site()).map(|o| o.arguments)"
 
 ---
 Ok(
@@ -17,6 +17,7 @@ Ok(
                         "Boolean",
                     ),
                 ),
+                has_default: false,
             },
             value: Some(
                 Literal(

--- a/cynic-codegen/src/input_object_derive/mod.rs
+++ b/cynic-codegen/src/input_object_derive/mod.rs
@@ -6,7 +6,7 @@ use crate::{
     idents::RenameAll,
     load_schema,
     schema::{
-        types::{InputObjectType, InputValue, TypeRef},
+        types::{InputObjectType, InputValue},
         Schema, Unvalidated,
     },
     suggestions::FieldSuggestionError,
@@ -159,7 +159,7 @@ fn pair_fields<'a>(
         input_object_def
             .fields
             .iter()
-            .filter(|f| !matches!(f.value_type, TypeRef::Nullable(_)))
+            .filter(|f| f.is_required())
             .collect::<HashSet<_>>()
     };
 

--- a/cynic-codegen/src/schema/type_index.rs
+++ b/cynic-codegen/src/schema/type_index.rs
@@ -353,6 +353,7 @@ fn convert_input_value<'a>(
             graphql_name: &val.name,
         },
         value_type: build_type_ref::<InputType>(&val.value_type, type_index),
+        has_default: val.default_value.is_some(),
     }
 }
 

--- a/cynic-codegen/src/schema/types.rs
+++ b/cynic-codegen/src/schema/types.rs
@@ -56,7 +56,17 @@ pub struct InputValue<'a> {
     pub description: Option<&'a str>,
     pub name: FieldName<'a>,
     pub value_type: TypeRef<'a, InputType<'a>>,
-    // pub default_value: Option<Value<'a>>,
+    pub has_default: bool,
+}
+
+impl InputValue<'_> {
+    pub fn is_nullable(&self) -> bool {
+        matches!(self.value_type, TypeRef::Nullable(_))
+    }
+
+    pub fn is_required(&self) -> bool {
+        !(self.has_default || matches!(self.value_type, TypeRef::Nullable(_)))
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]

--- a/cynic/tests/test-schema.graphql
+++ b/cynic/tests/test-schema.graphql
@@ -41,6 +41,12 @@ type Query {
   allAuthors: [Author!]!
   allData: [PostOrAuthor!]!
   node(id: ID!): Node
+
+  fieldWithDefaults(
+    anInt: Int! = 1
+    anOptionalInt: Int = 1
+    input: InputWithDefaults
+  ): Int!
 }
 
 union PostOrAuthor = BlogPost | Author
@@ -55,6 +61,11 @@ scalar DateTime
 input PostFilters {
   authorId: ID
   states: [PostState!]
+}
+
+input InputWithDefaults {
+  optionalInt: Int = 1
+  requiredWithDefault: Int! = 1
 }
 
 interface Node {


### PR DESCRIPTION
#### Why are we making this change?

As reported in #519, the GraphQL spec considers inputs with a default
value as _not_ required even if the underlying type is not nullable:

> Arguments can be required. An argument is required if the argument
> type is non-null and does not have a default value. Otherwise, the
> argument is optional.

There is also a similar paragraph for fields on input objects.

Cynic was not written with this in mind - I'd basically just ignored
default values, assuming they were just a server side concern.  Oops.

#### What effects does this change have?

1. It no longer considers arguments/fields with a default value as
   required.
2. The type checking algorith will now accept an `Option` on
   non-nullable input fields with a default.
3. The `skip_serializing_if` attribute is now permitted on input fields
   with a default, even if their underlying type is non-nullable.
4. The `InputObject` derive will automatically skip serializing an
   `Option::None` if it is on a non-nullable field with a default.

Fixes #519
