### PR TITLE
[Merged by Bors] - Move `cynic_codegen::type_validation` into a types module.

### DIFF
--- a/cynic-codegen/src/fragment_derive/fragment_impl.rs
+++ b/cynic-codegen/src/fragment_derive/fragment_impl.rs
@@ -5,7 +5,7 @@ use syn::spanned::Spanned;
 use crate::{
     error::Errors,
     schema::types::{Field, OutputType},
-    type_validation::{check_spread_type, check_types_are_compatible, CheckMode},
+    types::{check_spread_type, check_types_are_compatible, CheckMode},
     Ident,
 };
 

--- a/cynic-codegen/src/fragment_derive/input.rs
+++ b/cynic-codegen/src/fragment_derive/input.rs
@@ -3,7 +3,7 @@ use std::collections::HashSet;
 use darling::util::SpannedValue;
 use quote::quote_spanned;
 
-use crate::{idents::RenamableFieldIdent, type_validation::CheckMode, Errors};
+use crate::{idents::RenamableFieldIdent, types::CheckMode, Errors};
 use proc_macro2::Span;
 
 #[derive(darling::FromDeriveInput)]

--- a/cynic-codegen/src/input_object_derive/field_serializer.rs
+++ b/cynic-codegen/src/input_object_derive/field_serializer.rs
@@ -5,7 +5,7 @@ use syn::spanned::Spanned;
 use super::InputObjectDeriveField;
 use crate::{
     schema::types::{InputType, InputValue},
-    type_validation::{self, check_input_types_are_compatible},
+    types::{self, check_input_types_are_compatible},
 };
 
 pub struct FieldSerializer<'a> {
@@ -61,7 +61,7 @@ impl<'a> FieldSerializer<'a> {
 
         let mut ty = &self.rust_field.ty;
         if self.should_auto_skip_serializing() {
-            ty = type_validation::outer_type_is_option(ty).expect(
+            ty = types::outer_type_is_option(ty).expect(
                 "should_auto_skip_serializing is returning true when outer type is not option",
             )
         }
@@ -109,6 +109,6 @@ impl<'a> FieldSerializer<'a> {
     fn should_auto_skip_serializing(&self) -> bool {
         self.graphql_field.has_default
             && !self.graphql_field.is_nullable()
-            && type_validation::outer_type_is_option(&self.rust_field.ty).is_some()
+            && types::outer_type_is_option(&self.rust_field.ty).is_some()
     }
 }

--- a/cynic-codegen/src/lib.rs
+++ b/cynic-codegen/src/lib.rs
@@ -11,7 +11,7 @@ mod error;
 mod idents;
 mod schema;
 mod suggestions;
-mod type_validation;
+mod types;
 
 pub use idents::RenameAll;
 

--- a/cynic-codegen/src/types/mod.rs
+++ b/cynic-codegen/src/types/mod.rs
@@ -1,0 +1,12 @@
+//! This module concerns itself with rust types and how they interact
+//! with graphql types.
+
+mod parsing;
+mod validation;
+
+pub use parsing::{parse_rust_type, RustType};
+
+pub use self::validation::{
+    check_input_types_are_compatible, check_spread_type, check_types_are_compatible,
+    outer_type_is_option, CheckMode,
+};

--- a/cynic-codegen/src/types/parsing.rs
+++ b/cynic-codegen/src/types/parsing.rs
@@ -1,0 +1,55 @@
+/// A simplified rust type structure
+#[derive(Debug, PartialEq)]
+pub enum RustType<'a> {
+    Optional(&'a syn::Type),
+    List(&'a syn::Type),
+    Box(&'a syn::Type),
+    SimpleType,
+    Unknown,
+}
+
+#[allow(clippy::cmp_owned)]
+pub fn parse_rust_type(ty: &'_ syn::Type) -> RustType<'_> {
+    if let syn::Type::Path(type_path) = ty {
+        if let Some(last_segment) = type_path.path.segments.last() {
+            if let syn::PathArguments::None = last_segment.arguments {
+                return RustType::SimpleType;
+            }
+
+            match last_segment.ident.to_string().as_ref() {
+                "Box" | "Arc" | "Rc" => {
+                    if let Some(inner_type) = extract_generic_argument(last_segment) {
+                        return RustType::Box(inner_type);
+                    }
+                }
+                "Option" => {
+                    if let Some(inner_type) = extract_generic_argument(last_segment) {
+                        return RustType::Optional(inner_type);
+                    }
+                }
+                "Vec" => {
+                    if let Some(inner_type) = extract_generic_argument(last_segment) {
+                        return RustType::List(inner_type);
+                    }
+                }
+                _ => {}
+            }
+            return RustType::Unknown;
+        }
+    }
+
+    RustType::Unknown
+}
+
+/// Takes a PathSegment like `Vec<T>` and extracts the `T`
+fn extract_generic_argument(segment: &syn::PathSegment) -> Option<&syn::Type> {
+    if let syn::PathArguments::AngleBracketed(angle_bracketed) = &segment.arguments {
+        for arg in &angle_bracketed.args {
+            if let syn::GenericArgument::Type(inner_type) = arg {
+                return Some(inner_type);
+            }
+        }
+    }
+
+    None
+}


### PR DESCRIPTION
The `type_validation` module in cynic-codegen has got pretty big.  Some
of it was private so it's not too bad, but it's got to the point that
the type parsing stuff is actually useful outside of this module.

So, this PR moves the code into a `types` module with two submodules -
one for parsing one for validation.  This should make it easier to do
some of the stuff I'm currently attempting to do.