### PR TITLE
[Merged by Bors] - Don't extract input objects from arguments anymore.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,8 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
   should help with large schema support. (The exception is `impl_scalar`
   invocations which must live in the same crate as the schema)
 - Cynic now allows fields to be `Arc` or `Rc`
+- The generator no longer outputs input types that are provided in argument
+  literals, as these are no longer used in the generated code.
 
 ## v1.0.0 - 2021-12-09
 

--- a/cynic-querygen/src/query_parsing/inputs.rs
+++ b/cynic-querygen/src/query_parsing/inputs.rs
@@ -131,53 +131,21 @@ mod tests {
     use crate::{query_parsing::normalisation::normalise, TypeIndex};
 
     #[test]
-    fn extracts_inline_input_types() {
-        let schema = load_schema();
-        let type_index = Rc::new(TypeIndex::from_schema(&schema));
-        let query = graphql_parser::parse_query::<&str>(
-            r#"
-              query {
-                cynic: repository(owner: "obmarg", name: "cynic") {
-                  issues(filterBy: {labels: ["good first issue"]}) {
-                    nodes {
-                      title
-                    }
-                  }
-                }
-              	kazan: repository(owner: "obmarg", name: "kazan") {
-                  issues(filterBy: {labels: ["good first issue"], mentioned: "obmarg"}) {
-                    nodes {
-                      title
-                   }
-                  }
-                }
-              }
-            "#,
-        )
-        .unwrap();
-
-        let normalised = normalise(&query, &type_index).unwrap();
-        let input_objects = extract_input_objects(&normalised).unwrap();
-
-        assert_eq!(input_objects.len(), 2);
-    }
-
-    #[test]
     fn deduplicates_input_types_if_same() {
         let schema = load_schema();
         let type_index = Rc::new(TypeIndex::from_schema(&schema));
         let query = graphql_parser::parse_query::<&str>(
             r#"
-              query {
+              query ($filterOne: IssueFilters!, $filterTwo: IssueFilters!) {
                 cynic: repository(owner: "obmarg", name: "cynic") {
-                  issues(filterBy: {labels: ["good first issue"]}) {
+                  issues(filterBy: $filterOne) {
                     nodes {
                       title
                     }
                   }
                 }
               	kazan: repository(owner: "obmarg", name: "kazan") {
-                  issues(filterBy: {labels: ["good first issue"]}) {
+                  issues(filterBy: $filterTwo) {
                     nodes {
                       title
                    }

--- a/cynic-querygen/src/query_parsing/leaf_types.rs
+++ b/cynic-querygen/src/query_parsing/leaf_types.rs
@@ -20,6 +20,14 @@ pub fn extract_leaf_types<'query, 'schema>(
         .collect::<HashSet<_>>();
 
     leaf_types.extend(
+        doc.operations
+            .iter()
+            .flat_map(|o| &o.variables)
+            .map(|variables| variables.value_type.inner_ref().clone())
+            .map(TypeRef::from),
+    );
+
+    leaf_types.extend(
         doc.selection_sets
             .iter()
             .flat_map(|selection_set| selection_set.required_input_types())

--- a/cynic-querygen/src/query_parsing/value.rs
+++ b/cynic-querygen/src/query_parsing/value.rs
@@ -119,10 +119,6 @@ impl<'query, 'schema> TypedValue<'query, 'schema> {
         }
     }
 
-    pub fn is_variable(&self) -> bool {
-        matches!(self, TypedValue::Variable { .. })
-    }
-
     pub fn variables(&self) -> Vec<Variable<'query, 'schema>> {
         match &self {
             TypedValue::Variable {

--- a/cynic-querygen/tests/snapshots/github_tests__add_comment_mutation.snap
+++ b/cynic-querygen/tests/snapshots/github_tests__add_comment_mutation.snap
@@ -1,7 +1,7 @@
 ---
 source: cynic-querygen/tests/github-tests.rs
 assertion_line: 25
-expression: "document_to_fragment_structs(query, schema,\n                             &QueryGenOptions::default()).expect(\"QueryGen Failed\")"
+expression: "document_to_fragment_structs(query, schema,\n        &QueryGenOptions::default()).expect(\"QueryGen Failed\")"
 
 ---
 #[cynic::schema_for_derives(
@@ -36,12 +36,6 @@ mod queries {
     #[derive(cynic::QueryFragment, Debug)]
     pub struct IssueComment {
         pub id: cynic::Id,
-    }
-
-    #[derive(cynic::InputObject, Debug)]
-    pub struct AddCommentInput {
-        pub body: String,
-        pub subject_id: cynic::Id,
     }
 
 }

--- a/cynic-querygen/tests/snapshots/github_tests__input_object_literals.snap
+++ b/cynic-querygen/tests/snapshots/github_tests__input_object_literals.snap
@@ -1,7 +1,7 @@
 ---
 source: cynic-querygen/tests/github-tests.rs
 assertion_line: 23
-expression: "document_to_fragment_structs(query, schema,\n                             &QueryGenOptions::default()).expect(\"QueryGen Failed\")"
+expression: "document_to_fragment_structs(query, schema,\n        &QueryGenOptions::default()).expect(\"QueryGen Failed\")"
 
 ---
 #[cynic::schema_for_derives(
@@ -32,25 +32,6 @@ mod queries {
     #[derive(cynic::QueryFragment, Debug)]
     pub struct PullRequest {
         pub title: String,
-    }
-
-    #[derive(cynic::Enum, Clone, Copy, Debug)]
-    pub enum IssueOrderField {
-        Comments,
-        CreatedAt,
-        UpdatedAt,
-    }
-
-    #[derive(cynic::Enum, Clone, Copy, Debug)]
-    pub enum OrderDirection {
-        Asc,
-        Desc,
-    }
-
-    #[derive(cynic::InputObject, Debug)]
-    pub struct IssueOrder {
-        pub direction: OrderDirection,
-        pub field: IssueOrderField,
     }
 
 }

--- a/cynic-querygen/tests/snapshots/misc_tests__mutation_with_scalar_result_and_input.snap
+++ b/cynic-querygen/tests/snapshots/misc_tests__mutation_with_scalar_result_and_input.snap
@@ -1,7 +1,7 @@
 ---
 source: cynic-querygen/tests/misc-tests.rs
 assertion_line: 10
-expression: "document_to_fragment_structs(query, schema,\n                             &QueryGenOptions::default()).expect(\"QueryGen Failed\")"
+expression: "document_to_fragment_structs(query, schema,\n        &QueryGenOptions::default()).expect(\"QueryGen Failed\")"
 
 ---
 #[cynic::schema_for_derives(
@@ -22,12 +22,6 @@ mod queries {
     pub struct SignIn {
         #[arguments(input: { password: $password, username: $username })]
         pub sign_in: String,
-    }
-
-    #[derive(cynic::InputObject, Debug)]
-    pub struct SignInInput {
-        pub password: String,
-        pub username: String,
     }
 
 }


### PR DESCRIPTION
The generator uses the new GraphQL-style syntax for arguments in the
queries it generates.  Theres no reason to extract input types from
arguments when doing this as they're not likely to be used as rust
types - you just write a GraphQL literal instead.

So, this commit stops the generator from including these types in its
output.