### PR TITLE
Add support for fallback variants that carry the `__typename` of the union variant

### DIFF
--- a/cynic-codegen/src/inline_fragments_derive/input.rs
+++ b/cynic-codegen/src/inline_fragments_derive/input.rs
@@ -149,7 +149,7 @@ impl InlineFragmentsDeriveVariant {
         if *self.fallback {
             match (mode, self.fields.style, self.fields.len()) {
                 (_, Unit, _) => Ok(()),
-                (Interface, Tuple, 1) => Ok(()),
+                (Interface | Union, Tuple, 1) => Ok(()),
                 (_, Struct, _) => Err(syn::Error::new(
                     span,
                     "The InlineFragments derive doesn't currently support struct variants",
@@ -162,7 +162,7 @@ impl InlineFragmentsDeriveVariant {
                 .into()),
                 (Union, Tuple, _) => Err(syn::Error::new(
                     span,
-                    "InlineFragments fallbacks on a union must be a unit variant",
+                    "InlineFragments fallbacks on a union must be a unit or newtype variant",
                 )
                 .into()),
             }

--- a/cynic-codegen/src/inline_fragments_derive/mod.rs
+++ b/cynic-codegen/src/inline_fragments_derive/mod.rs
@@ -18,6 +18,8 @@ pub use input::InlineFragmentsDeriveInput;
 use crate::suggestions::{format_guess, guess_field};
 use input::InlineFragmentsDeriveVariant;
 
+use self::inline_fragments_impl::Fallback;
+
 pub fn inline_fragments_derive(ast: &syn::DeriveInput) -> Result<TokenStream, Errors> {
     use darling::FromDeriveInput;
 
@@ -136,7 +138,7 @@ fn fragments_from_variants(
 fn check_fallback(
     variants: &[SpannedValue<InlineFragmentsDeriveVariant>],
     target_type: &InlineFragmentType,
-) -> Result<Option<(syn::Ident, Option<syn::Type>)>, Errors> {
+) -> Result<Option<Fallback>, Errors> {
     let fallbacks = variants.iter().filter(|v| *v.fallback).collect::<Vec<_>>();
 
     if fallbacks.is_empty() {
@@ -156,38 +158,32 @@ fn check_fallback(
     }
 
     let fallback = fallbacks[0];
-    match target_type {
-        InlineFragmentType::Interface(_) => match fallback.fields.style {
-            darling::ast::Style::Struct => Err(syn::Error::new(
-                fallback.span(),
-                "InlineFragment fallbacks don't currently support struct variants",
-            )
-            .into()),
-            darling::ast::Style::Tuple => {
-                if fallback.fields.len() != 1 {
-                    return Err(syn::Error::new(
-                        fallback.span(),
-                        "InlineFragments require variants to have one unnamed field",
-                    )
-                    .into());
-                }
-                Ok(Some((
-                    fallback.ident.clone(),
-                    Some(fallback.fields.fields[0].ty.clone()),
-                )))
-            }
-            darling::ast::Style::Unit => Ok(Some((fallback.ident.clone(), None))),
-        },
-        InlineFragmentType::Union(_) => {
-            if fallback.fields.style != darling::ast::Style::Unit {
+
+    match fallback.fields.style {
+        darling::ast::Style::Struct => Err(syn::Error::new(
+            fallback.span(),
+            "InlineFragment fallbacks don't currently support struct variants",
+        )
+        .into()),
+        darling::ast::Style::Tuple => {
+            if fallback.fields.len() != 1 {
                 return Err(syn::Error::new(
                     fallback.span(),
-                    "The fallback for a union type must be a unit variant",
+                    "InlineFragments require variants to have one unnamed field",
                 )
                 .into());
             }
-            Ok(Some((fallback.ident.clone(), None)))
+            Ok(Some(match target_type {
+                InlineFragmentType::Interface(_) => Fallback::InterfaceVariant(
+                    fallback.ident.clone(),
+                    fallback.fields.fields[0].ty.clone(),
+                ),
+                InlineFragmentType::Union(_) => {
+                    Fallback::UnionVariantWithTypename(fallback.ident.clone())
+                }
+            }))
         }
+        darling::ast::Style::Unit => Ok(Some(Fallback::UnionUnitVariant(fallback.ident.clone()))),
     }
 }
 
@@ -197,7 +193,7 @@ struct QueryFragmentImpl<'a> {
     variables: Option<syn::Path>,
     fragments: &'a [Fragment],
     graphql_type_name: String,
-    fallback: Option<(syn::Ident, Option<syn::Type>)>,
+    fallback: Option<Fallback>,
 }
 
 impl quote::ToTokens for QueryFragmentImpl<'_> {
@@ -217,7 +213,7 @@ impl quote::ToTokens for QueryFragmentImpl<'_> {
             .collect();
         let graphql_type = proc_macro2::Literal::string(&self.graphql_type_name);
         let fallback_selection = match &self.fallback {
-            Some((_, Some(fallback_fragment))) => quote! {
+            Some(Fallback::InterfaceVariant(_, fallback_fragment)) => quote! {
                 <#fallback_fragment>::query(builder);
             },
             _ => quote! {},


### PR DESCRIPTION
#### Why are we making this change?

This change allows creating a fallback variant (newtype with a single field) for union types that will be able to carry the name of the variant as a `String`.

#### What effects does this change have?

The following

For a GraphQL type

```graphql
union UnionType = Variant1 | Variant2 | Variant3 | Variant4
```

```rust
#[derive(cynic::InlineFragments, Debug)]
pub enum UnionType {
    Variant1(Variant1Inner),
    Variant2(Variant2Inner),
    #[cynic(fallback)]
    FallbackVariant(String),
}
```

will capture the name of the variant in the field of the `FallbackVariant`.