### PR TITLE
[Merged by Bors] - Add support for `QueryVariables` in `schema_for_derives`

### DIFF
--- a/cynic-codegen/src/schema_for_derives/mod.rs
+++ b/cynic-codegen/src/schema_for_derives/mod.rs
@@ -82,7 +82,7 @@ fn insert_cynic_attrs(args: &AddSchemaAttrParams, item: syn::Item) -> syn::Item 
                 item
             }
         }
-        Derive::QueryFragment | Derive::InputObject | Derive::Scalar => {
+        Derive::QueryFragment | Derive::QueryVariables | Derive::InputObject | Derive::Scalar => {
             if let Item::Struct(mut st) = item {
                 let attrs = required_attrs.with_current_attrs(&st.attrs);
                 attrs.add_missing_attributes(&mut st.attrs, args);
@@ -103,7 +103,7 @@ struct RequiredAttributes {
 impl RequiredAttributes {
     fn for_derive(d: &Derive) -> RequiredAttributes {
         match d {
-            Derive::Scalar => RequiredAttributes {
+            Derive::QueryVariables | Derive::Scalar => RequiredAttributes {
                 needs_schema_path: false,
                 needs_schema_module: true,
             },

--- a/cynic-codegen/src/schema_for_derives/utils.rs
+++ b/cynic-codegen/src/schema_for_derives/utils.rs
@@ -3,6 +3,7 @@ use syn::{Attribute, Item, Meta, NestedMeta};
 #[derive(Debug, PartialEq, Eq)]
 pub enum Derive {
     QueryFragment,
+    QueryVariables,
     InlineFragments,
     Enum,
     Scalar,
@@ -44,6 +45,7 @@ fn derive_for_nested_meta(nested: &NestedMeta) -> Option<Derive> {
         if let Some(last) = path.segments.last() {
             match last.ident.to_string().as_ref() {
                 "QueryFragment" => return Some(Derive::QueryFragment),
+                "QueryVariables" => return Some(Derive::QueryVariables),
                 "InlineFragments" => return Some(Derive::InlineFragments),
                 "Enum" => return Some(Derive::Enum),
                 "Scalar" => return Some(Derive::Scalar),

--- a/cynic-proc-macros/src/lib.rs
+++ b/cynic-proc-macros/src/lib.rs
@@ -73,7 +73,7 @@ pub fn fragment_arguments_derive(input: TokenStream) -> TokenStream {
 /// Derives `cynic::QueryVariables`
 ///
 /// See [the book for usage details](https://cynic-rs.dev/derives/query-fragments.html#passing-arguments)
-#[proc_macro_derive(QueryVariables)]
+#[proc_macro_derive(QueryVariables, attributes(cynic))]
 pub fn query_variables_derive(input: TokenStream) -> TokenStream {
     let ast = syn::parse_macro_input!(input as syn::DeriveInput);
 


### PR DESCRIPTION
#### Why are we making this change?
`schema_for_derives` should apply the `schema_module` attribute on `QueryVariables`, to be consistent with behavior on similar derive types.

#### What effects does this change have?
Fixes missing "cynic" attributes on `QueryVariables` derive macro, and adds `schema_module` attribute to structs deriving `QueryVariables`.
