### PR TITLE
[Merged by Bors] - Allow users to get __typename from union fallbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ## Unreleased - xxxx-xx-xx
 
+### New Features
+
+- `InlineFragments` derives for union types now allow a fallback that receives
+  the `__typename`
+
 ### Bug Fixes
 
 - `schema_for_derives` no longer ignores `QueryVariables` structs.

--- a/cynic-book/src/derives/inline-fragments.md
+++ b/cynic-book/src/derives/inline-fragments.md
@@ -72,6 +72,28 @@ enum ActorFallback {
 This functionality is only available for interfaces as union types have no
 concept of shared fields.
 
+##### Fallbacks for unions
+
+If your `InlineFragments` is querying a union your fallback variant can receive
+the `__typename` of the type that was received.  In the case below, if the
+`Assignee` is not a `Bot` or a `User`, the `String` field of `Other` will be
+populated with the name of the type (the `__typename`) that was actually
+received from the server.
+
+```rust
+#[derive(cynic::InlineFragments)]
+#[cynic(schema_path = "github.graphql")]
+enum Assignee {
+    Bot(Bot),
+    User(User)
+
+    #[cynic(fallback)]
+    Other(String)
+}
+```
+
+This functionality is currently only available for unions.
+
 #### Struct Attributes
 
 An `InlineFragments` can be configured with several attributes on the

--- a/cynic-codegen/src/inline_fragments_derive/input.rs
+++ b/cynic-codegen/src/inline_fragments_derive/input.rs
@@ -309,12 +309,11 @@ mod tests {
             #[cynic(schema_path = "whatever")]
             enum TestStruct {
                 #[cynic(fallback)]
-                FirstFallback(SomeStruct),
+                FirstFallback(String),
             }
         })
         .unwrap();
 
-        insta::assert_display_snapshot!(input.validate(ValidationMode::Union).unwrap_err(), @"InlineFragments fallbacks on a union must be a unit variant
-");
+        input.validate(ValidationMode::Union).unwrap();
     }
 }

--- a/cynic-codegen/src/inline_fragments_derive/input.rs
+++ b/cynic-codegen/src/inline_fragments_derive/input.rs
@@ -149,7 +149,7 @@ impl InlineFragmentsDeriveVariant {
         if *self.fallback {
             match (mode, self.fields.style, self.fields.len()) {
                 (_, Unit, _) => Ok(()),
-                (Interface, Tuple, 1) => Ok(()),
+                (Interface | Union, Tuple, 1) => Ok(()),
                 (_, Struct, _) => Err(syn::Error::new(
                     span,
                     "The InlineFragments derive doesn't currently support struct variants",
@@ -162,7 +162,7 @@ impl InlineFragmentsDeriveVariant {
                 .into()),
                 (Union, Tuple, _) => Err(syn::Error::new(
                     span,
-                    "InlineFragments fallbacks on a union must be a unit variant",
+                    "InlineFragments fallbacks on a union must be a unit or newtype variant",
                 )
                 .into()),
             }

--- a/cynic-codegen/src/inline_fragments_derive/mod.rs
+++ b/cynic-codegen/src/inline_fragments_derive/mod.rs
@@ -163,9 +163,10 @@ fn check_fallback(
                     fallback.ident.clone(),
                     fallback.fields.fields[0].ty.clone(),
                 ),
-                InlineFragmentType::Union(_) => {
-                    Fallback::UnionVariantWithTypename(fallback.ident.clone())
-                }
+                InlineFragmentType::Union(_) => Fallback::UnionVariantWithTypename(
+                    fallback.ident.clone(),
+                    fallback.fields.fields[0].ty.clone(),
+                ),
             }))
         }
         darling::ast::Style::Unit => Ok(Some(Fallback::UnionUnitVariant(fallback.ident.clone()))),

--- a/cynic/src/lib.rs
+++ b/cynic/src/lib.rs
@@ -194,7 +194,7 @@ pub use cynic_proc_macros::{
     QueryFragment, QueryVariables, Scalar,
 };
 
-pub use static_assertions::assert_impl_all as assert_impl;
+pub use static_assertions::{assert_impl_all as assert_impl, assert_type_eq_all};
 
 // We re-export serde as the output from a lot of our derive macros require it,
 // and this way we can point at our copy rather than forcing users to add it to

--- a/tests/ui-tests/tests/cases/inline-fragment-fallback-validation.rs
+++ b/tests/ui-tests/tests/cases/inline-fragment-fallback-validation.rs
@@ -12,6 +12,7 @@ mod schema {
 enum MyFailingUnionType {
     Nested(Nested),
 
+    // This is allowed, but needs to be a string to work.
     #[cynic(fallback)]
     Other(Nested),
 }
@@ -33,4 +34,16 @@ enum MyOkUnionTYpe {
 
     #[cynic(fallback)]
     Other,
+}
+
+#[derive(cynic::InlineFragments)]
+#[cynic(
+    schema_path = "../../../cynic/src/bin/simple.graphql",
+    graphql_type = "MyUnionType"
+)]
+enum UnionTypeWithStringFallback {
+    Nested(Nested),
+
+    #[cynic(fallback)]
+    Other(String),
 }

--- a/tests/ui-tests/tests/cases/inline-fragment-fallback-validation.stderr
+++ b/tests/ui-tests/tests/cases/inline-fragment-fallback-validation.stderr
@@ -22,5 +22,19 @@ note: required by a bound in `<MyFailingUnionType as InlineFragments<'de>>::dese
 error[E0308]: mismatched types
   --> tests/cases/inline-fragment-fallback-validation.rs:17:11
    |
+12 |   enum MyFailingUnionType {
+   |  ______-
+13 | |     Nested(Nested),
+14 | |
+15 | |     // This is allowed, but needs to be a string to work.
+16 | |     #[cynic(fallback)]
+17 | |     Other(Nested),
+   | |         - ^^^^^^ expected struct `Nested`, found struct `std::string::String`
+   | |_________|
+   |           arguments to this enum variant are incorrect
+   |
+note: tuple variant defined here
+  --> tests/cases/inline-fragment-fallback-validation.rs:17:5
+   |
 17 |     Other(Nested),
-   |           ^^^^^^ expected struct `Nested`, found struct `std::string::String`
+   |     ^^^^^

--- a/tests/ui-tests/tests/cases/inline-fragment-fallback-validation.stderr
+++ b/tests/ui-tests/tests/cases/inline-fragment-fallback-validation.stderr
@@ -1,5 +1,26 @@
-error: InlineFragments fallbacks on a union must be a unit variant
-  --> tests/cases/inline-fragment-fallback-validation.rs:15:5
+error[E0271]: type mismatch resolving `<Nested as <MyFailingUnionType as InlineFragments<'de>>::deserialize_variant::_::{closure#0}::TypeEq>::This == std::string::String`
+  --> tests/cases/inline-fragment-fallback-validation.rs:17:11
    |
-15 |     #[cynic(fallback)]
-   |     ^
+17 |     Other(Nested),
+   |           ^^^^^^ type mismatch resolving `<Nested as <MyFailingUnionType as InlineFragments<'de>>::deserialize_variant::_::{closure#0}::TypeEq>::This == std::string::String`
+   |
+note: expected this to be `std::string::String`
+  --> tests/cases/inline-fragment-fallback-validation.rs:17:11
+   |
+17 |     Other(Nested),
+   |           ^^^^^^
+note: required by a bound in `<MyFailingUnionType as InlineFragments<'de>>::deserialize_variant::_::{closure#0}::assert_type_eq_all`
+  --> tests/cases/inline-fragment-fallback-validation.rs:17:11
+   |
+17 |     Other(Nested),
+   |           ^^^^^^
+   |           |
+   |           required by a bound in this
+   |           required by this bound in `<MyFailingUnionType as InlineFragments<'de>>::deserialize_variant::_::{closure#0}::assert_type_eq_all`
+   = note: this error originates in the macro `::cynic::assert_type_eq_all` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+  --> tests/cases/inline-fragment-fallback-validation.rs:17:11
+   |
+17 |     Other(Nested),
+   |           ^^^^^^ expected struct `Nested`, found struct `std::string::String`


### PR DESCRIPTION
#### Why are we making this change?

When a user writes an InlineFragments struct they can provide a fallback
variant.  At present this is just a unit variant, but the user might like to
know which variant they have forgotten to include in their fragments.

#### What effects does this change have?

This change allows users to create a fallback variant for union types that gets
the `__typename` in it's single String field.

For example, for a GraphQL type

```graphql
union UnionType = Variant1 | Variant2 | Variant3 | Variant4
```

The following enum

```rust
#[derive(cynic::InlineFragments, Debug)]
pub enum UnionType {
    Variant1(Variant1Inner),
    Variant2(Variant2Inner),
    #[cynic(fallback)]
    FallbackVariant(String),
}
```

will capture the name of the variant in the field of the `FallbackVariant`.