### PR TITLE
[Merged by Bors] - Re-organise the output of use_schema!

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ## Unreleased - xxxx-xx-xx
 
+### Changes
+
+- The `use_schema` output has been re-organised to reduce the chances of
+  clashes.  This is technically a breaking change, but only if you're writing
+  queries by hand rather than using the derives.
+
 ## v2.1.0 - 2022-11-09
 
 ### New Features

--- a/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__argument_and_rename.snap
+++ b/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__argument_and_rename.snap
@@ -12,7 +12,7 @@ impl<'de> ::cynic::QueryFragment<'de> for MyQuery {
         let mut field_builder = builder . select_field :: < schema :: __fields :: Query :: post , < Option < BlogPostOutput > as :: cynic :: QueryFragment > :: SchemaType > () ;
         {
             field_builder
-                .argument::<schema::__fields::Query::post_arguments::id>()
+                .argument::<schema::__fields::Query::_post_arguments::id>()
                 .literal("1234");
         }
         <Option<BlogPostOutput> as ::cynic::QueryFragment>::query(field_builder.select_children());

--- a/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__argument_and_rename.snap
+++ b/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__argument_and_rename.snap
@@ -1,6 +1,5 @@
 ---
 source: cynic-codegen/src/fragment_derive/tests.rs
-assertion_line: 114
 expression: "format_code(format!(\"{}\", tokens))"
 ---
 #[automatically_derived]
@@ -10,14 +9,14 @@ impl<'de> ::cynic::QueryFragment<'de> for MyQuery {
     const TYPE: Option<&'static str> = Some("Query");
     fn query(mut builder: ::cynic::queries::SelectionBuilder<Self::SchemaType, Self::Variables>) {
         #![allow(unused_mut)]
-        let mut field_builder = builder . select_field :: < schema :: query_fields :: post , < Option < BlogPostOutput > as :: cynic :: QueryFragment > :: SchemaType > () ;
+        let mut field_builder = builder . select_field :: < schema :: __fields :: Query :: post , < Option < BlogPostOutput > as :: cynic :: QueryFragment > :: SchemaType > () ;
         {
             field_builder
-                .argument::<schema::query_fields::post_arguments::id>()
+                .argument::<schema::__fields::Query::post_arguments::id>()
                 .literal("1234");
         }
         <Option<BlogPostOutput> as ::cynic::QueryFragment>::query(field_builder.select_children());
-        let mut field_builder = builder . select_field :: < schema :: query_fields :: allPosts , < Vec < BlogPostOutput > as :: cynic :: QueryFragment > :: SchemaType > () ;
+        let mut field_builder = builder . select_field :: < schema :: __fields :: Query :: allPosts , < Vec < BlogPostOutput > as :: cynic :: QueryFragment > :: SchemaType > () ;
         <Vec<BlogPostOutput> as ::cynic::QueryFragment>::query(field_builder.select_children());
     }
 }

--- a/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__argument_literals.snap
+++ b/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__argument_literals.snap
@@ -22,7 +22,7 @@ impl<'de> ::cynic::QueryFragment<'de> for MyQuery {
             }
             impl ::cynic::coercions::CoercesTo<schema::PostState> for PostStatePosted {};
             field_builder
-                .argument::<schema::__fields::Query::filtered_posts_arguments::filters>()
+                .argument::<schema::__fields::Query::_filtered_posts_arguments::filters>()
                 .value()
                 .object()
                 .field::<schema::__fields::PostFilters::states, _>(|builder| {

--- a/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__argument_literals.snap
+++ b/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__argument_literals.snap
@@ -1,6 +1,5 @@
 ---
 source: cynic-codegen/src/fragment_derive/tests.rs
-assertion_line: 114
 expression: "format_code(format!(\"{}\", tokens))"
 ---
 #[automatically_derived]
@@ -10,7 +9,7 @@ impl<'de> ::cynic::QueryFragment<'de> for MyQuery {
     const TYPE: Option<&'static str> = Some("Query");
     fn query(mut builder: ::cynic::queries::SelectionBuilder<Self::SchemaType, Self::Variables>) {
         #![allow(unused_mut)]
-        let mut field_builder = builder . select_field :: < schema :: query_fields :: filteredPosts , < Vec < BlogPostOutput > as :: cynic :: QueryFragment > :: SchemaType > () ;
+        let mut field_builder = builder . select_field :: < schema :: __fields :: Query :: filteredPosts , < Vec < BlogPostOutput > as :: cynic :: QueryFragment > :: SchemaType > () ;
         {
             struct PostStatePosted;
             impl ::cynic::serde::Serialize for PostStatePosted {
@@ -23,10 +22,10 @@ impl<'de> ::cynic::QueryFragment<'de> for MyQuery {
             }
             impl ::cynic::coercions::CoercesTo<schema::PostState> for PostStatePosted {};
             field_builder
-                .argument::<schema::query_fields::filtered_posts_arguments::filters>()
+                .argument::<schema::__fields::Query::filtered_posts_arguments::filters>()
                 .value()
                 .object()
-                .field::<schema::post_filters_fields::states, _>(|builder| {
+                .field::<schema::__fields::PostFilters::states, _>(|builder| {
                     builder
                         .value()
                         .list()

--- a/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__flatten_attr.snap
+++ b/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__flatten_attr.snap
@@ -1,6 +1,5 @@
 ---
 source: cynic-codegen/src/fragment_derive/tests.rs
-assertion_line: 114
 expression: "format_code(format!(\"{}\", tokens))"
 ---
 #[automatically_derived]
@@ -10,7 +9,7 @@ impl<'de> ::cynic::QueryFragment<'de> for Film {
     const TYPE: Option<&'static str> = Some("Film");
     fn query(mut builder: ::cynic::queries::SelectionBuilder<Self::SchemaType, Self::Variables>) {
         #![allow(unused_mut)]
-        let mut field_builder = builder . select_flattened_field :: < schema :: film_fields :: producers , < Vec < String > as :: cynic :: schema :: IsScalar < < schema :: film_fields :: producers as :: cynic :: schema :: Field > :: Type >> :: SchemaType , < schema :: film_fields :: producers as :: cynic :: schema :: Field > :: Type , > () ;
+        let mut field_builder = builder . select_flattened_field :: < schema :: __fields :: Film :: producers , < Vec < String > as :: cynic :: schema :: IsScalar < < schema :: __fields :: Film :: producers as :: cynic :: schema :: Field > :: Type >> :: SchemaType , < schema :: __fields :: Film :: producers as :: cynic :: schema :: Field > :: Type , > () ;
     }
 }
 #[automatically_derived]

--- a/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__not_sure.snap
+++ b/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__not_sure.snap
@@ -1,6 +1,5 @@
 ---
 source: cynic-codegen/src/fragment_derive/tests.rs
-assertion_line: 114
 expression: "format_code(format!(\"{}\", tokens))"
 ---
 #[automatically_derived]
@@ -10,7 +9,7 @@ impl<'de> ::cynic::QueryFragment<'de> for MyQuery {
     const TYPE: Option<&'static str> = Some("Query");
     fn query(mut builder: ::cynic::queries::SelectionBuilder<Self::SchemaType, Self::Variables>) {
         #![allow(unused_mut)]
-        let mut field_builder = builder . select_field :: < schema :: query_fields :: filteredPosts , < Vec < BlogPostOutput > as :: cynic :: QueryFragment > :: SchemaType > () ;
+        let mut field_builder = builder . select_field :: < schema :: __fields :: Query :: filteredPosts , < Vec < BlogPostOutput > as :: cynic :: QueryFragment > :: SchemaType > () ;
         {
             struct PostStateDraft;
             impl ::cynic::serde::Serialize for PostStateDraft {
@@ -33,10 +32,10 @@ impl<'de> ::cynic::QueryFragment<'de> for MyQuery {
             }
             impl ::cynic::coercions::CoercesTo<schema::PostState> for PostStatePosted {};
             field_builder
-                .argument::<schema::query_fields::filtered_posts_arguments::filters>()
+                .argument::<schema::__fields::Query::filtered_posts_arguments::filters>()
                 .value()
                 .object()
-                .field::<schema::post_filters_fields::states, _>(|builder| {
+                .field::<schema::__fields::PostFilters::states, _>(|builder| {
                     builder
                         .value()
                         .list()

--- a/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__not_sure.snap
+++ b/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__not_sure.snap
@@ -32,7 +32,7 @@ impl<'de> ::cynic::QueryFragment<'de> for MyQuery {
             }
             impl ::cynic::coercions::CoercesTo<schema::PostState> for PostStatePosted {};
             field_builder
-                .argument::<schema::__fields::Query::filtered_posts_arguments::filters>()
+                .argument::<schema::__fields::Query::_filtered_posts_arguments::filters>()
                 .value()
                 .object()
                 .field::<schema::__fields::PostFilters::states, _>(|builder| {

--- a/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__simple_struct.snap
+++ b/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__simple_struct.snap
@@ -1,6 +1,5 @@
 ---
 source: cynic-codegen/src/fragment_derive/tests.rs
-assertion_line: 114
 expression: "format_code(format!(\"{}\", tokens))"
 ---
 #[automatically_derived]
@@ -10,8 +9,8 @@ impl<'de> ::cynic::QueryFragment<'de> for BlogPostOutput {
     const TYPE: Option<&'static str> = Some("BlogPost");
     fn query(mut builder: ::cynic::queries::SelectionBuilder<Self::SchemaType, Self::Variables>) {
         #![allow(unused_mut)]
-        let mut field_builder = builder . select_field :: < schema :: blog_post_fields :: hasMetadata , < Option < bool > as :: cynic :: schema :: IsScalar < < schema :: blog_post_fields :: hasMetadata as :: cynic :: schema :: Field > :: Type >> :: SchemaType > () ;
-        let mut field_builder = builder . select_field :: < schema :: blog_post_fields :: author , < AuthorOutput as :: cynic :: QueryFragment > :: SchemaType > () ;
+        let mut field_builder = builder . select_field :: < schema :: __fields :: BlogPost :: hasMetadata , < Option < bool > as :: cynic :: schema :: IsScalar < < schema :: __fields :: BlogPost :: hasMetadata as :: cynic :: schema :: Field > :: Type >> :: SchemaType > () ;
+        let mut field_builder = builder . select_field :: < schema :: __fields :: BlogPost :: author , < AuthorOutput as :: cynic :: QueryFragment > :: SchemaType > () ;
         <AuthorOutput as ::cynic::QueryFragment>::query(field_builder.select_children());
     }
 }

--- a/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__variable_in_argument.snap
+++ b/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__variable_in_argument.snap
@@ -12,7 +12,7 @@ impl<'de> ::cynic::QueryFragment<'de> for MyQuery {
         let mut field_builder = builder . select_field :: < schema :: __fields :: Query :: filteredPosts , < Vec < BlogPostOutput > as :: cynic :: QueryFragment > :: SchemaType > () ;
         {
             field_builder
-                .argument::<schema::__fields::Query::filtered_posts_arguments::filters>()
+                .argument::<schema::__fields::Query::_filtered_posts_arguments::filters>()
                 .variable(<AnArgumentStruct as ::cynic::QueryVariables>::Fields::filters());
         }
         <Vec<BlogPostOutput> as ::cynic::QueryFragment>::query(field_builder.select_children());

--- a/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__variable_in_argument.snap
+++ b/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__variable_in_argument.snap
@@ -1,6 +1,5 @@
 ---
 source: cynic-codegen/src/fragment_derive/tests.rs
-assertion_line: 114
 expression: "format_code(format!(\"{}\", tokens))"
 ---
 #[automatically_derived]
@@ -10,10 +9,10 @@ impl<'de> ::cynic::QueryFragment<'de> for MyQuery {
     const TYPE: Option<&'static str> = Some("Query");
     fn query(mut builder: ::cynic::queries::SelectionBuilder<Self::SchemaType, Self::Variables>) {
         #![allow(unused_mut)]
-        let mut field_builder = builder . select_field :: < schema :: query_fields :: filteredPosts , < Vec < BlogPostOutput > as :: cynic :: QueryFragment > :: SchemaType > () ;
+        let mut field_builder = builder . select_field :: < schema :: __fields :: Query :: filteredPosts , < Vec < BlogPostOutput > as :: cynic :: QueryFragment > :: SchemaType > () ;
         {
             field_builder
-                .argument::<schema::query_fields::filtered_posts_arguments::filters>()
+                .argument::<schema::__fields::Query::filtered_posts_arguments::filters>()
                 .variable(<AnArgumentStruct as ::cynic::QueryVariables>::Fields::filters());
         }
         <Vec<BlogPostOutput> as ::cynic::QueryFragment>::query(field_builder.select_children());

--- a/cynic-codegen/src/use_schema/fields.rs
+++ b/cynic-codegen/src/use_schema/fields.rs
@@ -23,7 +23,7 @@ impl ToTokens for FieldOutput<'_> {
             .field
             .field_type
             .marker_type()
-            .to_path(&parse_quote! { super });
+            .to_path(&parse_quote! { super::super });
 
         tokens.append_all(quote! {
             pub struct #field_marker;
@@ -34,7 +34,7 @@ impl ToTokens for FieldOutput<'_> {
                 const NAME: &'static str = #field_name_literal;
             }
 
-            impl ::cynic::schema::HasField<#field_marker> for super::#parent_marker {
+            impl ::cynic::schema::HasField<#field_marker> for super::super::#parent_marker {
                 type Type = #field_type_marker;
             }
         });
@@ -65,7 +65,7 @@ impl ToTokens for ArgumentOutput<'_> {
             .argument
             .value_type
             .marker_type()
-            .to_path(&parse_quote! { super::super });
+            .to_path(&parse_quote! { super::super::super  });
 
         tokens.append_all(quote! {
             pub struct #argument_ident;

--- a/cynic-codegen/tests/snapshots/use_schema__books.graphql.snap
+++ b/cynic-codegen/tests/snapshots/use_schema__books.graphql.snap
@@ -89,7 +89,7 @@ pub mod __fields {
         impl ::cynic::schema::HasField<createBook> for super::super::MutationRoot {
             type Type = super::super::ID;
         }
-        pub mod create_book_arguments {
+        pub mod _create_book_arguments {
             pub struct name;
             impl ::cynic::schema::HasArgument<name> for super::createBook {
                 type ArgumentType = super::super::super::String;
@@ -109,7 +109,7 @@ pub mod __fields {
         impl ::cynic::schema::HasField<deleteBook> for super::super::MutationRoot {
             type Type = super::super::Boolean;
         }
-        pub mod delete_book_arguments {
+        pub mod _delete_book_arguments {
             pub struct id;
             impl ::cynic::schema::HasArgument<id> for super::deleteBook {
                 type ArgumentType = super::super::super::ID;
@@ -136,7 +136,7 @@ pub mod __fields {
         impl ::cynic::schema::HasField<interval> for super::super::SubscriptionRoot {
             type Type = super::super::Int;
         }
-        pub mod interval_arguments {
+        pub mod _interval_arguments {
             pub struct n;
             impl ::cynic::schema::HasArgument<n> for super::interval {
                 type ArgumentType = super::super::super::Int;
@@ -151,7 +151,7 @@ pub mod __fields {
         impl ::cynic::schema::HasField<books> for super::super::SubscriptionRoot {
             type Type = super::super::BookChanged;
         }
-        pub mod books_arguments {
+        pub mod _books_arguments {
             pub struct mutationType;
             impl ::cynic::schema::HasArgument<mutationType> for super::books {
                 type ArgumentType = Option<super::super::super::MutationType>;

--- a/cynic-codegen/tests/snapshots/use_schema__books.graphql.snap
+++ b/cynic-codegen/tests/snapshots/use_schema__books.graphql.snap
@@ -1,148 +1,16 @@
 ---
 source: cynic-codegen/tests/use-schema.rs
-assertion_line: 30
 expression: "format_code(format!(\"{}\", tokens))"
 ---
 impl ::cynic::schema::QueryRoot for QueryRoot {}
 impl ::cynic::schema::MutationRoot for MutationRoot {}
 impl ::cynic::schema::SubscriptionRoot for SubscriptionRoot {}
 pub struct Book;
-pub mod book_fields {
-    pub struct id;
-    impl ::cynic::schema::Field for id {
-        type Type = super::String;
-        const NAME: &'static str = "id";
-    }
-    impl ::cynic::schema::HasField<id> for super::Book {
-        type Type = super::String;
-    }
-    pub struct name;
-    impl ::cynic::schema::Field for name {
-        type Type = super::String;
-        const NAME: &'static str = "name";
-    }
-    impl ::cynic::schema::HasField<name> for super::Book {
-        type Type = super::String;
-    }
-    pub struct author;
-    impl ::cynic::schema::Field for author {
-        type Type = super::String;
-        const NAME: &'static str = "author";
-    }
-    impl ::cynic::schema::HasField<author> for super::Book {
-        type Type = super::String;
-    }
-}
 pub struct BookChanged;
-pub mod book_changed_fields {
-    pub struct mutationType;
-    impl ::cynic::schema::Field for mutationType {
-        type Type = super::MutationType;
-        const NAME: &'static str = "mutationType";
-    }
-    impl ::cynic::schema::HasField<mutationType> for super::BookChanged {
-        type Type = super::MutationType;
-    }
-    pub struct id;
-    impl ::cynic::schema::Field for id {
-        type Type = super::ID;
-        const NAME: &'static str = "id";
-    }
-    impl ::cynic::schema::HasField<id> for super::BookChanged {
-        type Type = super::ID;
-    }
-    pub struct book;
-    impl ::cynic::schema::Field for book {
-        type Type = Option<super::Book>;
-        const NAME: &'static str = "book";
-    }
-    impl ::cynic::schema::HasField<book> for super::BookChanged {
-        type Type = Option<super::Book>;
-    }
-}
 pub struct MutationRoot;
-pub mod mutation_root_fields {
-    pub struct createBook;
-    impl ::cynic::schema::Field for createBook {
-        type Type = super::ID;
-        const NAME: &'static str = "createBook";
-    }
-    impl ::cynic::schema::HasField<createBook> for super::MutationRoot {
-        type Type = super::ID;
-    }
-    pub mod create_book_arguments {
-        pub struct name;
-        impl ::cynic::schema::HasArgument<name> for super::createBook {
-            type ArgumentType = super::super::String;
-            const NAME: &'static str = "name";
-        }
-        pub struct author;
-        impl ::cynic::schema::HasArgument<author> for super::createBook {
-            type ArgumentType = super::super::String;
-            const NAME: &'static str = "author";
-        }
-    }
-    pub struct deleteBook;
-    impl ::cynic::schema::Field for deleteBook {
-        type Type = super::Boolean;
-        const NAME: &'static str = "deleteBook";
-    }
-    impl ::cynic::schema::HasField<deleteBook> for super::MutationRoot {
-        type Type = super::Boolean;
-    }
-    pub mod delete_book_arguments {
-        pub struct id;
-        impl ::cynic::schema::HasArgument<id> for super::deleteBook {
-            type ArgumentType = super::super::ID;
-            const NAME: &'static str = "id";
-        }
-    }
-}
 pub struct MutationType {}
 pub struct QueryRoot;
-pub mod query_root_fields {
-    pub struct books;
-    impl ::cynic::schema::Field for books {
-        type Type = Vec<super::Book>;
-        const NAME: &'static str = "books";
-    }
-    impl ::cynic::schema::HasField<books> for super::QueryRoot {
-        type Type = Vec<super::Book>;
-    }
-}
 pub struct SubscriptionRoot;
-pub mod subscription_root_fields {
-    pub struct interval;
-    impl ::cynic::schema::Field for interval {
-        type Type = super::Int;
-        const NAME: &'static str = "interval";
-    }
-    impl ::cynic::schema::HasField<interval> for super::SubscriptionRoot {
-        type Type = super::Int;
-    }
-    pub mod interval_arguments {
-        pub struct n;
-        impl ::cynic::schema::HasArgument<n> for super::interval {
-            type ArgumentType = super::super::Int;
-            const NAME: &'static str = "n";
-        }
-    }
-    pub struct books;
-    impl ::cynic::schema::Field for books {
-        type Type = super::BookChanged;
-        const NAME: &'static str = "books";
-    }
-    impl ::cynic::schema::HasField<books> for super::SubscriptionRoot {
-        type Type = super::BookChanged;
-    }
-    pub mod books_arguments {
-        pub struct mutationType;
-        impl ::cynic::schema::HasArgument<mutationType> for super::books {
-            type ArgumentType = Option<super::super::MutationType>;
-            const NAME: &'static str = "mutationType";
-        }
-    }
-}
 impl ::cynic::schema::NamedType for Book {
     const NAME: &'static str = "Book";
 }
@@ -157,6 +25,140 @@ impl ::cynic::schema::NamedType for QueryRoot {
 }
 impl ::cynic::schema::NamedType for SubscriptionRoot {
     const NAME: &'static str = "SubscriptionRoot";
+}
+#[allow(non_snake_case, non_camel_case_types)]
+pub mod __fields {
+    pub mod Book {
+        pub struct id;
+        impl ::cynic::schema::Field for id {
+            type Type = super::super::String;
+            const NAME: &'static str = "id";
+        }
+        impl ::cynic::schema::HasField<id> for super::super::Book {
+            type Type = super::super::String;
+        }
+        pub struct name;
+        impl ::cynic::schema::Field for name {
+            type Type = super::super::String;
+            const NAME: &'static str = "name";
+        }
+        impl ::cynic::schema::HasField<name> for super::super::Book {
+            type Type = super::super::String;
+        }
+        pub struct author;
+        impl ::cynic::schema::Field for author {
+            type Type = super::super::String;
+            const NAME: &'static str = "author";
+        }
+        impl ::cynic::schema::HasField<author> for super::super::Book {
+            type Type = super::super::String;
+        }
+    }
+    pub mod BookChanged {
+        pub struct mutationType;
+        impl ::cynic::schema::Field for mutationType {
+            type Type = super::super::MutationType;
+            const NAME: &'static str = "mutationType";
+        }
+        impl ::cynic::schema::HasField<mutationType> for super::super::BookChanged {
+            type Type = super::super::MutationType;
+        }
+        pub struct id;
+        impl ::cynic::schema::Field for id {
+            type Type = super::super::ID;
+            const NAME: &'static str = "id";
+        }
+        impl ::cynic::schema::HasField<id> for super::super::BookChanged {
+            type Type = super::super::ID;
+        }
+        pub struct book;
+        impl ::cynic::schema::Field for book {
+            type Type = Option<super::super::Book>;
+            const NAME: &'static str = "book";
+        }
+        impl ::cynic::schema::HasField<book> for super::super::BookChanged {
+            type Type = Option<super::super::Book>;
+        }
+    }
+    pub mod MutationRoot {
+        pub struct createBook;
+        impl ::cynic::schema::Field for createBook {
+            type Type = super::super::ID;
+            const NAME: &'static str = "createBook";
+        }
+        impl ::cynic::schema::HasField<createBook> for super::super::MutationRoot {
+            type Type = super::super::ID;
+        }
+        pub mod create_book_arguments {
+            pub struct name;
+            impl ::cynic::schema::HasArgument<name> for super::createBook {
+                type ArgumentType = super::super::super::String;
+                const NAME: &'static str = "name";
+            }
+            pub struct author;
+            impl ::cynic::schema::HasArgument<author> for super::createBook {
+                type ArgumentType = super::super::super::String;
+                const NAME: &'static str = "author";
+            }
+        }
+        pub struct deleteBook;
+        impl ::cynic::schema::Field for deleteBook {
+            type Type = super::super::Boolean;
+            const NAME: &'static str = "deleteBook";
+        }
+        impl ::cynic::schema::HasField<deleteBook> for super::super::MutationRoot {
+            type Type = super::super::Boolean;
+        }
+        pub mod delete_book_arguments {
+            pub struct id;
+            impl ::cynic::schema::HasArgument<id> for super::deleteBook {
+                type ArgumentType = super::super::super::ID;
+                const NAME: &'static str = "id";
+            }
+        }
+    }
+    pub mod QueryRoot {
+        pub struct books;
+        impl ::cynic::schema::Field for books {
+            type Type = Vec<super::super::Book>;
+            const NAME: &'static str = "books";
+        }
+        impl ::cynic::schema::HasField<books> for super::super::QueryRoot {
+            type Type = Vec<super::super::Book>;
+        }
+    }
+    pub mod SubscriptionRoot {
+        pub struct interval;
+        impl ::cynic::schema::Field for interval {
+            type Type = super::super::Int;
+            const NAME: &'static str = "interval";
+        }
+        impl ::cynic::schema::HasField<interval> for super::super::SubscriptionRoot {
+            type Type = super::super::Int;
+        }
+        pub mod interval_arguments {
+            pub struct n;
+            impl ::cynic::schema::HasArgument<n> for super::interval {
+                type ArgumentType = super::super::super::Int;
+                const NAME: &'static str = "n";
+            }
+        }
+        pub struct books;
+        impl ::cynic::schema::Field for books {
+            type Type = super::super::BookChanged;
+            const NAME: &'static str = "books";
+        }
+        impl ::cynic::schema::HasField<books> for super::super::SubscriptionRoot {
+            type Type = super::super::BookChanged;
+        }
+        pub mod books_arguments {
+            pub struct mutationType;
+            impl ::cynic::schema::HasArgument<mutationType> for super::books {
+                type ArgumentType = Option<super::super::super::MutationType>;
+                const NAME: &'static str = "mutationType";
+            }
+        }
+    }
 }
 pub type Boolean = bool;
 pub type String = std::string::String;

--- a/cynic-codegen/tests/snapshots/use_schema__graphql.jobs.graphql.snap
+++ b/cynic-codegen/tests/snapshots/use_schema__graphql.jobs.graphql.snap
@@ -138,7 +138,7 @@ pub mod __fields {
         impl ::cynic::schema::HasField<jobs> for super::super::City {
             type Type = Option<Vec<super::super::Job>>;
         }
-        pub mod jobs_arguments {
+        pub mod _jobs_arguments {
             pub struct r#where;
             impl ::cynic::schema::HasArgument<r#where> for super::jobs {
                 type ArgumentType = Option<super::super::super::JobWhereInput>;
@@ -935,7 +935,7 @@ pub mod __fields {
         impl ::cynic::schema::HasField<jobs> for super::super::Commitment {
             type Type = Option<Vec<super::super::Job>>;
         }
-        pub mod jobs_arguments {
+        pub mod _jobs_arguments {
             pub struct r#where;
             impl ::cynic::schema::HasArgument<r#where> for super::jobs {
                 type ArgumentType = Option<super::super::super::JobWhereInput>;
@@ -1616,7 +1616,7 @@ pub mod __fields {
         impl ::cynic::schema::HasField<jobs> for super::super::Company {
             type Type = Option<Vec<super::super::Job>>;
         }
-        pub mod jobs_arguments {
+        pub mod _jobs_arguments {
             pub struct r#where;
             impl ::cynic::schema::HasArgument<r#where> for super::jobs {
                 type ArgumentType = Option<super::super::super::JobWhereInput>;
@@ -2710,7 +2710,7 @@ pub mod __fields {
         impl ::cynic::schema::HasField<cities> for super::super::Country {
             type Type = Option<Vec<super::super::City>>;
         }
-        pub mod cities_arguments {
+        pub mod _cities_arguments {
             pub struct r#where;
             impl ::cynic::schema::HasArgument<r#where> for super::cities {
                 type ArgumentType = Option<super::super::super::CityWhereInput>;
@@ -2755,7 +2755,7 @@ pub mod __fields {
         impl ::cynic::schema::HasField<jobs> for super::super::Country {
             type Type = Option<Vec<super::super::Job>>;
         }
-        pub mod jobs_arguments {
+        pub mod _jobs_arguments {
             pub struct r#where;
             impl ::cynic::schema::HasArgument<r#where> for super::jobs {
                 type ArgumentType = Option<super::super::super::JobWhereInput>;
@@ -3707,7 +3707,7 @@ pub mod __fields {
         impl ::cynic::schema::HasField<cities> for super::super::Job {
             type Type = Option<Vec<super::super::City>>;
         }
-        pub mod cities_arguments {
+        pub mod _cities_arguments {
             pub struct r#where;
             impl ::cynic::schema::HasArgument<r#where> for super::cities {
                 type ArgumentType = Option<super::super::super::CityWhereInput>;
@@ -3752,7 +3752,7 @@ pub mod __fields {
         impl ::cynic::schema::HasField<countries> for super::super::Job {
             type Type = Option<Vec<super::super::Country>>;
         }
-        pub mod countries_arguments {
+        pub mod _countries_arguments {
             pub struct r#where;
             impl ::cynic::schema::HasArgument<r#where> for super::countries {
                 type ArgumentType = Option<super::super::super::CountryWhereInput>;
@@ -3797,7 +3797,7 @@ pub mod __fields {
         impl ::cynic::schema::HasField<remotes> for super::super::Job {
             type Type = Option<Vec<super::super::Remote>>;
         }
-        pub mod remotes_arguments {
+        pub mod _remotes_arguments {
             pub struct r#where;
             impl ::cynic::schema::HasArgument<r#where> for super::remotes {
                 type ArgumentType = Option<super::super::super::RemoteWhereInput>;
@@ -3866,7 +3866,7 @@ pub mod __fields {
         impl ::cynic::schema::HasField<tags> for super::super::Job {
             type Type = Option<Vec<super::super::Tag>>;
         }
-        pub mod tags_arguments {
+        pub mod _tags_arguments {
             pub struct r#where;
             impl ::cynic::schema::HasArgument<r#where> for super::tags {
                 type ArgumentType = Option<super::super::super::TagWhereInput>;
@@ -5350,7 +5350,7 @@ pub mod __fields {
         impl ::cynic::schema::HasField<subscribe> for super::super::Mutation {
             type Type = super::super::User;
         }
-        pub mod subscribe_arguments {
+        pub mod _subscribe_arguments {
             pub struct input;
             impl ::cynic::schema::HasArgument<input> for super::subscribe {
                 type ArgumentType = super::super::super::SubscribeInput;
@@ -5365,7 +5365,7 @@ pub mod __fields {
         impl ::cynic::schema::HasField<postJob> for super::super::Mutation {
             type Type = super::super::Job;
         }
-        pub mod post_job_arguments {
+        pub mod _post_job_arguments {
             pub struct input;
             impl ::cynic::schema::HasArgument<input> for super::postJob {
                 type ArgumentType = super::super::super::PostJobInput;
@@ -5380,7 +5380,7 @@ pub mod __fields {
         impl ::cynic::schema::HasField<updateJob> for super::super::Mutation {
             type Type = super::super::Job;
         }
-        pub mod update_job_arguments {
+        pub mod _update_job_arguments {
             pub struct input;
             impl ::cynic::schema::HasArgument<input> for super::updateJob {
                 type ArgumentType = super::super::super::UpdateJobInput;
@@ -5400,7 +5400,7 @@ pub mod __fields {
         impl ::cynic::schema::HasField<updateCompany> for super::super::Mutation {
             type Type = super::super::Company;
         }
-        pub mod update_company_arguments {
+        pub mod _update_company_arguments {
             pub struct input;
             impl ::cynic::schema::HasArgument<input> for super::updateCompany {
                 type ArgumentType = super::super::super::UpdateCompanyInput;
@@ -5478,7 +5478,7 @@ pub mod __fields {
         impl ::cynic::schema::HasField<jobs> for super::super::Query {
             type Type = Vec<super::super::Job>;
         }
-        pub mod jobs_arguments {
+        pub mod _jobs_arguments {
             pub struct input;
             impl ::cynic::schema::HasArgument<input> for super::jobs {
                 type ArgumentType = Option<super::super::super::JobsInput>;
@@ -5493,7 +5493,7 @@ pub mod __fields {
         impl ::cynic::schema::HasField<job> for super::super::Query {
             type Type = super::super::Job;
         }
-        pub mod job_arguments {
+        pub mod _job_arguments {
             pub struct input;
             impl ::cynic::schema::HasArgument<input> for super::job {
                 type ArgumentType = super::super::super::JobInput;
@@ -5508,7 +5508,7 @@ pub mod __fields {
         impl ::cynic::schema::HasField<locations> for super::super::Query {
             type Type = Vec<super::super::Location>;
         }
-        pub mod locations_arguments {
+        pub mod _locations_arguments {
             pub struct input;
             impl ::cynic::schema::HasArgument<input> for super::locations {
                 type ArgumentType = super::super::super::LocationsInput;
@@ -5523,7 +5523,7 @@ pub mod __fields {
         impl ::cynic::schema::HasField<city> for super::super::Query {
             type Type = super::super::City;
         }
-        pub mod city_arguments {
+        pub mod _city_arguments {
             pub struct input;
             impl ::cynic::schema::HasArgument<input> for super::city {
                 type ArgumentType = super::super::super::LocationInput;
@@ -5538,7 +5538,7 @@ pub mod __fields {
         impl ::cynic::schema::HasField<country> for super::super::Query {
             type Type = super::super::Country;
         }
-        pub mod country_arguments {
+        pub mod _country_arguments {
             pub struct input;
             impl ::cynic::schema::HasArgument<input> for super::country {
                 type ArgumentType = super::super::super::LocationInput;
@@ -5553,7 +5553,7 @@ pub mod __fields {
         impl ::cynic::schema::HasField<remote> for super::super::Query {
             type Type = super::super::Remote;
         }
-        pub mod remote_arguments {
+        pub mod _remote_arguments {
             pub struct input;
             impl ::cynic::schema::HasArgument<input> for super::remote {
                 type ArgumentType = super::super::super::LocationInput;
@@ -5642,7 +5642,7 @@ pub mod __fields {
         impl ::cynic::schema::HasField<jobs> for super::super::Remote {
             type Type = Option<Vec<super::super::Job>>;
         }
-        pub mod jobs_arguments {
+        pub mod _jobs_arguments {
             pub struct r#where;
             impl ::cynic::schema::HasArgument<r#where> for super::jobs {
                 type ArgumentType = Option<super::super::super::JobWhereInput>;
@@ -6447,7 +6447,7 @@ pub mod __fields {
         impl ::cynic::schema::HasField<jobs> for super::super::Tag {
             type Type = Option<Vec<super::super::Job>>;
         }
-        pub mod jobs_arguments {
+        pub mod _jobs_arguments {
             pub struct r#where;
             impl ::cynic::schema::HasArgument<r#where> for super::jobs {
                 type ArgumentType = Option<super::super::super::JobWhereInput>;

--- a/cynic-codegen/tests/snapshots/use_schema__graphql.jobs.graphql.snap
+++ b/cynic-codegen/tests/snapshots/use_schema__graphql.jobs.graphql.snap
@@ -5,6481 +5,55 @@ expression: "format_code(format!(\"{}\", tokens))"
 impl ::cynic::schema::QueryRoot for Query {}
 impl ::cynic::schema::MutationRoot for Mutation {}
 pub struct City;
-pub mod city_fields {
-    pub struct id;
-    impl ::cynic::schema::Field for id {
-        type Type = super::ID;
-        const NAME: &'static str = "id";
-    }
-    impl ::cynic::schema::HasField<id> for super::City {
-        type Type = super::ID;
-    }
-    pub struct name;
-    impl ::cynic::schema::Field for name {
-        type Type = super::String;
-        const NAME: &'static str = "name";
-    }
-    impl ::cynic::schema::HasField<name> for super::City {
-        type Type = super::String;
-    }
-    pub struct slug;
-    impl ::cynic::schema::Field for slug {
-        type Type = super::String;
-        const NAME: &'static str = "slug";
-    }
-    impl ::cynic::schema::HasField<slug> for super::City {
-        type Type = super::String;
-    }
-    pub struct country;
-    impl ::cynic::schema::Field for country {
-        type Type = super::Country;
-        const NAME: &'static str = "country";
-    }
-    impl ::cynic::schema::HasField<country> for super::City {
-        type Type = super::Country;
-    }
-    pub struct r#type;
-    impl ::cynic::schema::Field for r#type {
-        type Type = super::String;
-        const NAME: &'static str = "type";
-    }
-    impl ::cynic::schema::HasField<r#type> for super::City {
-        type Type = super::String;
-    }
-    pub struct jobs;
-    impl ::cynic::schema::Field for jobs {
-        type Type = Option<Vec<super::Job>>;
-        const NAME: &'static str = "jobs";
-    }
-    impl ::cynic::schema::HasField<jobs> for super::City {
-        type Type = Option<Vec<super::Job>>;
-    }
-    pub mod jobs_arguments {
-        pub struct r#where;
-        impl ::cynic::schema::HasArgument<r#where> for super::jobs {
-            type ArgumentType = Option<super::super::JobWhereInput>;
-            const NAME: &'static str = "where";
-        }
-        pub struct orderBy;
-        impl ::cynic::schema::HasArgument<orderBy> for super::jobs {
-            type ArgumentType = Option<super::super::JobOrderByInput>;
-            const NAME: &'static str = "orderBy";
-        }
-        pub struct skip;
-        impl ::cynic::schema::HasArgument<skip> for super::jobs {
-            type ArgumentType = Option<super::super::Int>;
-            const NAME: &'static str = "skip";
-        }
-        pub struct after;
-        impl ::cynic::schema::HasArgument<after> for super::jobs {
-            type ArgumentType = Option<super::super::String>;
-            const NAME: &'static str = "after";
-        }
-        pub struct before;
-        impl ::cynic::schema::HasArgument<before> for super::jobs {
-            type ArgumentType = Option<super::super::String>;
-            const NAME: &'static str = "before";
-        }
-        pub struct first;
-        impl ::cynic::schema::HasArgument<first> for super::jobs {
-            type ArgumentType = Option<super::super::Int>;
-            const NAME: &'static str = "first";
-        }
-        pub struct last;
-        impl ::cynic::schema::HasArgument<last> for super::jobs {
-            type ArgumentType = Option<super::super::Int>;
-            const NAME: &'static str = "last";
-        }
-    }
-    pub struct createdAt;
-    impl ::cynic::schema::Field for createdAt {
-        type Type = super::DateTime;
-        const NAME: &'static str = "createdAt";
-    }
-    impl ::cynic::schema::HasField<createdAt> for super::City {
-        type Type = super::DateTime;
-    }
-    pub struct updatedAt;
-    impl ::cynic::schema::Field for updatedAt {
-        type Type = super::DateTime;
-        const NAME: &'static str = "updatedAt";
-    }
-    impl ::cynic::schema::HasField<updatedAt> for super::City {
-        type Type = super::DateTime;
-    }
-}
 pub struct CityOrderByInput {}
 pub struct CityWhereInput;
 impl ::cynic::schema::InputObjectMarker for CityWhereInput {}
-pub mod city_where_input_fields {
-    pub struct id;
-    impl ::cynic::schema::Field for id {
-        type Type = Option<super::ID>;
-        const NAME: &'static str = "id";
-    }
-    impl ::cynic::schema::HasInputField<id, Option<super::ID>> for super::CityWhereInput {}
-    pub struct id_not;
-    impl ::cynic::schema::Field for id_not {
-        type Type = Option<super::ID>;
-        const NAME: &'static str = "id_not";
-    }
-    impl ::cynic::schema::HasInputField<id_not, Option<super::ID>> for super::CityWhereInput {}
-    pub struct id_in;
-    impl ::cynic::schema::Field for id_in {
-        type Type = Option<Vec<super::ID>>;
-        const NAME: &'static str = "id_in";
-    }
-    impl ::cynic::schema::HasInputField<id_in, Option<Vec<super::ID>>> for super::CityWhereInput {}
-    pub struct id_not_in;
-    impl ::cynic::schema::Field for id_not_in {
-        type Type = Option<Vec<super::ID>>;
-        const NAME: &'static str = "id_not_in";
-    }
-    impl ::cynic::schema::HasInputField<id_not_in, Option<Vec<super::ID>>> for super::CityWhereInput {}
-    pub struct id_lt;
-    impl ::cynic::schema::Field for id_lt {
-        type Type = Option<super::ID>;
-        const NAME: &'static str = "id_lt";
-    }
-    impl ::cynic::schema::HasInputField<id_lt, Option<super::ID>> for super::CityWhereInput {}
-    pub struct id_lte;
-    impl ::cynic::schema::Field for id_lte {
-        type Type = Option<super::ID>;
-        const NAME: &'static str = "id_lte";
-    }
-    impl ::cynic::schema::HasInputField<id_lte, Option<super::ID>> for super::CityWhereInput {}
-    pub struct id_gt;
-    impl ::cynic::schema::Field for id_gt {
-        type Type = Option<super::ID>;
-        const NAME: &'static str = "id_gt";
-    }
-    impl ::cynic::schema::HasInputField<id_gt, Option<super::ID>> for super::CityWhereInput {}
-    pub struct id_gte;
-    impl ::cynic::schema::Field for id_gte {
-        type Type = Option<super::ID>;
-        const NAME: &'static str = "id_gte";
-    }
-    impl ::cynic::schema::HasInputField<id_gte, Option<super::ID>> for super::CityWhereInput {}
-    pub struct id_contains;
-    impl ::cynic::schema::Field for id_contains {
-        type Type = Option<super::ID>;
-        const NAME: &'static str = "id_contains";
-    }
-    impl ::cynic::schema::HasInputField<id_contains, Option<super::ID>> for super::CityWhereInput {}
-    pub struct id_not_contains;
-    impl ::cynic::schema::Field for id_not_contains {
-        type Type = Option<super::ID>;
-        const NAME: &'static str = "id_not_contains";
-    }
-    impl ::cynic::schema::HasInputField<id_not_contains, Option<super::ID>> for super::CityWhereInput {}
-    pub struct id_starts_with;
-    impl ::cynic::schema::Field for id_starts_with {
-        type Type = Option<super::ID>;
-        const NAME: &'static str = "id_starts_with";
-    }
-    impl ::cynic::schema::HasInputField<id_starts_with, Option<super::ID>> for super::CityWhereInput {}
-    pub struct id_not_starts_with;
-    impl ::cynic::schema::Field for id_not_starts_with {
-        type Type = Option<super::ID>;
-        const NAME: &'static str = "id_not_starts_with";
-    }
-    impl ::cynic::schema::HasInputField<id_not_starts_with, Option<super::ID>>
-        for super::CityWhereInput
-    {
-    }
-    pub struct id_ends_with;
-    impl ::cynic::schema::Field for id_ends_with {
-        type Type = Option<super::ID>;
-        const NAME: &'static str = "id_ends_with";
-    }
-    impl ::cynic::schema::HasInputField<id_ends_with, Option<super::ID>> for super::CityWhereInput {}
-    pub struct id_not_ends_with;
-    impl ::cynic::schema::Field for id_not_ends_with {
-        type Type = Option<super::ID>;
-        const NAME: &'static str = "id_not_ends_with";
-    }
-    impl ::cynic::schema::HasInputField<id_not_ends_with, Option<super::ID>> for super::CityWhereInput {}
-    pub struct name;
-    impl ::cynic::schema::Field for name {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "name";
-    }
-    impl ::cynic::schema::HasInputField<name, Option<super::String>> for super::CityWhereInput {}
-    pub struct name_not;
-    impl ::cynic::schema::Field for name_not {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "name_not";
-    }
-    impl ::cynic::schema::HasInputField<name_not, Option<super::String>> for super::CityWhereInput {}
-    pub struct name_in;
-    impl ::cynic::schema::Field for name_in {
-        type Type = Option<Vec<super::String>>;
-        const NAME: &'static str = "name_in";
-    }
-    impl ::cynic::schema::HasInputField<name_in, Option<Vec<super::String>>> for super::CityWhereInput {}
-    pub struct name_not_in;
-    impl ::cynic::schema::Field for name_not_in {
-        type Type = Option<Vec<super::String>>;
-        const NAME: &'static str = "name_not_in";
-    }
-    impl ::cynic::schema::HasInputField<name_not_in, Option<Vec<super::String>>>
-        for super::CityWhereInput
-    {
-    }
-    pub struct name_lt;
-    impl ::cynic::schema::Field for name_lt {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "name_lt";
-    }
-    impl ::cynic::schema::HasInputField<name_lt, Option<super::String>> for super::CityWhereInput {}
-    pub struct name_lte;
-    impl ::cynic::schema::Field for name_lte {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "name_lte";
-    }
-    impl ::cynic::schema::HasInputField<name_lte, Option<super::String>> for super::CityWhereInput {}
-    pub struct name_gt;
-    impl ::cynic::schema::Field for name_gt {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "name_gt";
-    }
-    impl ::cynic::schema::HasInputField<name_gt, Option<super::String>> for super::CityWhereInput {}
-    pub struct name_gte;
-    impl ::cynic::schema::Field for name_gte {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "name_gte";
-    }
-    impl ::cynic::schema::HasInputField<name_gte, Option<super::String>> for super::CityWhereInput {}
-    pub struct name_contains;
-    impl ::cynic::schema::Field for name_contains {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "name_contains";
-    }
-    impl ::cynic::schema::HasInputField<name_contains, Option<super::String>>
-        for super::CityWhereInput
-    {
-    }
-    pub struct name_not_contains;
-    impl ::cynic::schema::Field for name_not_contains {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "name_not_contains";
-    }
-    impl ::cynic::schema::HasInputField<name_not_contains, Option<super::String>>
-        for super::CityWhereInput
-    {
-    }
-    pub struct name_starts_with;
-    impl ::cynic::schema::Field for name_starts_with {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "name_starts_with";
-    }
-    impl ::cynic::schema::HasInputField<name_starts_with, Option<super::String>>
-        for super::CityWhereInput
-    {
-    }
-    pub struct name_not_starts_with;
-    impl ::cynic::schema::Field for name_not_starts_with {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "name_not_starts_with";
-    }
-    impl ::cynic::schema::HasInputField<name_not_starts_with, Option<super::String>>
-        for super::CityWhereInput
-    {
-    }
-    pub struct name_ends_with;
-    impl ::cynic::schema::Field for name_ends_with {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "name_ends_with";
-    }
-    impl ::cynic::schema::HasInputField<name_ends_with, Option<super::String>>
-        for super::CityWhereInput
-    {
-    }
-    pub struct name_not_ends_with;
-    impl ::cynic::schema::Field for name_not_ends_with {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "name_not_ends_with";
-    }
-    impl ::cynic::schema::HasInputField<name_not_ends_with, Option<super::String>>
-        for super::CityWhereInput
-    {
-    }
-    pub struct slug;
-    impl ::cynic::schema::Field for slug {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "slug";
-    }
-    impl ::cynic::schema::HasInputField<slug, Option<super::String>> for super::CityWhereInput {}
-    pub struct slug_not;
-    impl ::cynic::schema::Field for slug_not {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "slug_not";
-    }
-    impl ::cynic::schema::HasInputField<slug_not, Option<super::String>> for super::CityWhereInput {}
-    pub struct slug_in;
-    impl ::cynic::schema::Field for slug_in {
-        type Type = Option<Vec<super::String>>;
-        const NAME: &'static str = "slug_in";
-    }
-    impl ::cynic::schema::HasInputField<slug_in, Option<Vec<super::String>>> for super::CityWhereInput {}
-    pub struct slug_not_in;
-    impl ::cynic::schema::Field for slug_not_in {
-        type Type = Option<Vec<super::String>>;
-        const NAME: &'static str = "slug_not_in";
-    }
-    impl ::cynic::schema::HasInputField<slug_not_in, Option<Vec<super::String>>>
-        for super::CityWhereInput
-    {
-    }
-    pub struct slug_lt;
-    impl ::cynic::schema::Field for slug_lt {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "slug_lt";
-    }
-    impl ::cynic::schema::HasInputField<slug_lt, Option<super::String>> for super::CityWhereInput {}
-    pub struct slug_lte;
-    impl ::cynic::schema::Field for slug_lte {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "slug_lte";
-    }
-    impl ::cynic::schema::HasInputField<slug_lte, Option<super::String>> for super::CityWhereInput {}
-    pub struct slug_gt;
-    impl ::cynic::schema::Field for slug_gt {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "slug_gt";
-    }
-    impl ::cynic::schema::HasInputField<slug_gt, Option<super::String>> for super::CityWhereInput {}
-    pub struct slug_gte;
-    impl ::cynic::schema::Field for slug_gte {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "slug_gte";
-    }
-    impl ::cynic::schema::HasInputField<slug_gte, Option<super::String>> for super::CityWhereInput {}
-    pub struct slug_contains;
-    impl ::cynic::schema::Field for slug_contains {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "slug_contains";
-    }
-    impl ::cynic::schema::HasInputField<slug_contains, Option<super::String>>
-        for super::CityWhereInput
-    {
-    }
-    pub struct slug_not_contains;
-    impl ::cynic::schema::Field for slug_not_contains {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "slug_not_contains";
-    }
-    impl ::cynic::schema::HasInputField<slug_not_contains, Option<super::String>>
-        for super::CityWhereInput
-    {
-    }
-    pub struct slug_starts_with;
-    impl ::cynic::schema::Field for slug_starts_with {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "slug_starts_with";
-    }
-    impl ::cynic::schema::HasInputField<slug_starts_with, Option<super::String>>
-        for super::CityWhereInput
-    {
-    }
-    pub struct slug_not_starts_with;
-    impl ::cynic::schema::Field for slug_not_starts_with {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "slug_not_starts_with";
-    }
-    impl ::cynic::schema::HasInputField<slug_not_starts_with, Option<super::String>>
-        for super::CityWhereInput
-    {
-    }
-    pub struct slug_ends_with;
-    impl ::cynic::schema::Field for slug_ends_with {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "slug_ends_with";
-    }
-    impl ::cynic::schema::HasInputField<slug_ends_with, Option<super::String>>
-        for super::CityWhereInput
-    {
-    }
-    pub struct slug_not_ends_with;
-    impl ::cynic::schema::Field for slug_not_ends_with {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "slug_not_ends_with";
-    }
-    impl ::cynic::schema::HasInputField<slug_not_ends_with, Option<super::String>>
-        for super::CityWhereInput
-    {
-    }
-    pub struct country;
-    impl ::cynic::schema::Field for country {
-        type Type = Option<super::CountryWhereInput>;
-        const NAME: &'static str = "country";
-    }
-    impl ::cynic::schema::HasInputField<country, Option<super::CountryWhereInput>>
-        for super::CityWhereInput
-    {
-    }
-    pub struct r#type;
-    impl ::cynic::schema::Field for r#type {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "type";
-    }
-    impl ::cynic::schema::HasInputField<r#type, Option<super::String>> for super::CityWhereInput {}
-    pub struct type_not;
-    impl ::cynic::schema::Field for type_not {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "type_not";
-    }
-    impl ::cynic::schema::HasInputField<type_not, Option<super::String>> for super::CityWhereInput {}
-    pub struct type_in;
-    impl ::cynic::schema::Field for type_in {
-        type Type = Option<Vec<super::String>>;
-        const NAME: &'static str = "type_in";
-    }
-    impl ::cynic::schema::HasInputField<type_in, Option<Vec<super::String>>> for super::CityWhereInput {}
-    pub struct type_not_in;
-    impl ::cynic::schema::Field for type_not_in {
-        type Type = Option<Vec<super::String>>;
-        const NAME: &'static str = "type_not_in";
-    }
-    impl ::cynic::schema::HasInputField<type_not_in, Option<Vec<super::String>>>
-        for super::CityWhereInput
-    {
-    }
-    pub struct type_lt;
-    impl ::cynic::schema::Field for type_lt {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "type_lt";
-    }
-    impl ::cynic::schema::HasInputField<type_lt, Option<super::String>> for super::CityWhereInput {}
-    pub struct type_lte;
-    impl ::cynic::schema::Field for type_lte {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "type_lte";
-    }
-    impl ::cynic::schema::HasInputField<type_lte, Option<super::String>> for super::CityWhereInput {}
-    pub struct type_gt;
-    impl ::cynic::schema::Field for type_gt {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "type_gt";
-    }
-    impl ::cynic::schema::HasInputField<type_gt, Option<super::String>> for super::CityWhereInput {}
-    pub struct type_gte;
-    impl ::cynic::schema::Field for type_gte {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "type_gte";
-    }
-    impl ::cynic::schema::HasInputField<type_gte, Option<super::String>> for super::CityWhereInput {}
-    pub struct type_contains;
-    impl ::cynic::schema::Field for type_contains {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "type_contains";
-    }
-    impl ::cynic::schema::HasInputField<type_contains, Option<super::String>>
-        for super::CityWhereInput
-    {
-    }
-    pub struct type_not_contains;
-    impl ::cynic::schema::Field for type_not_contains {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "type_not_contains";
-    }
-    impl ::cynic::schema::HasInputField<type_not_contains, Option<super::String>>
-        for super::CityWhereInput
-    {
-    }
-    pub struct type_starts_with;
-    impl ::cynic::schema::Field for type_starts_with {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "type_starts_with";
-    }
-    impl ::cynic::schema::HasInputField<type_starts_with, Option<super::String>>
-        for super::CityWhereInput
-    {
-    }
-    pub struct type_not_starts_with;
-    impl ::cynic::schema::Field for type_not_starts_with {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "type_not_starts_with";
-    }
-    impl ::cynic::schema::HasInputField<type_not_starts_with, Option<super::String>>
-        for super::CityWhereInput
-    {
-    }
-    pub struct type_ends_with;
-    impl ::cynic::schema::Field for type_ends_with {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "type_ends_with";
-    }
-    impl ::cynic::schema::HasInputField<type_ends_with, Option<super::String>>
-        for super::CityWhereInput
-    {
-    }
-    pub struct type_not_ends_with;
-    impl ::cynic::schema::Field for type_not_ends_with {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "type_not_ends_with";
-    }
-    impl ::cynic::schema::HasInputField<type_not_ends_with, Option<super::String>>
-        for super::CityWhereInput
-    {
-    }
-    pub struct jobs_every;
-    impl ::cynic::schema::Field for jobs_every {
-        type Type = Option<super::JobWhereInput>;
-        const NAME: &'static str = "jobs_every";
-    }
-    impl ::cynic::schema::HasInputField<jobs_every, Option<super::JobWhereInput>>
-        for super::CityWhereInput
-    {
-    }
-    pub struct jobs_some;
-    impl ::cynic::schema::Field for jobs_some {
-        type Type = Option<super::JobWhereInput>;
-        const NAME: &'static str = "jobs_some";
-    }
-    impl ::cynic::schema::HasInputField<jobs_some, Option<super::JobWhereInput>>
-        for super::CityWhereInput
-    {
-    }
-    pub struct jobs_none;
-    impl ::cynic::schema::Field for jobs_none {
-        type Type = Option<super::JobWhereInput>;
-        const NAME: &'static str = "jobs_none";
-    }
-    impl ::cynic::schema::HasInputField<jobs_none, Option<super::JobWhereInput>>
-        for super::CityWhereInput
-    {
-    }
-    pub struct createdAt;
-    impl ::cynic::schema::Field for createdAt {
-        type Type = Option<super::DateTime>;
-        const NAME: &'static str = "createdAt";
-    }
-    impl ::cynic::schema::HasInputField<createdAt, Option<super::DateTime>> for super::CityWhereInput {}
-    pub struct createdAt_not;
-    impl ::cynic::schema::Field for createdAt_not {
-        type Type = Option<super::DateTime>;
-        const NAME: &'static str = "createdAt_not";
-    }
-    impl ::cynic::schema::HasInputField<createdAt_not, Option<super::DateTime>>
-        for super::CityWhereInput
-    {
-    }
-    pub struct createdAt_in;
-    impl ::cynic::schema::Field for createdAt_in {
-        type Type = Option<Vec<super::DateTime>>;
-        const NAME: &'static str = "createdAt_in";
-    }
-    impl ::cynic::schema::HasInputField<createdAt_in, Option<Vec<super::DateTime>>>
-        for super::CityWhereInput
-    {
-    }
-    pub struct createdAt_not_in;
-    impl ::cynic::schema::Field for createdAt_not_in {
-        type Type = Option<Vec<super::DateTime>>;
-        const NAME: &'static str = "createdAt_not_in";
-    }
-    impl ::cynic::schema::HasInputField<createdAt_not_in, Option<Vec<super::DateTime>>>
-        for super::CityWhereInput
-    {
-    }
-    pub struct createdAt_lt;
-    impl ::cynic::schema::Field for createdAt_lt {
-        type Type = Option<super::DateTime>;
-        const NAME: &'static str = "createdAt_lt";
-    }
-    impl ::cynic::schema::HasInputField<createdAt_lt, Option<super::DateTime>>
-        for super::CityWhereInput
-    {
-    }
-    pub struct createdAt_lte;
-    impl ::cynic::schema::Field for createdAt_lte {
-        type Type = Option<super::DateTime>;
-        const NAME: &'static str = "createdAt_lte";
-    }
-    impl ::cynic::schema::HasInputField<createdAt_lte, Option<super::DateTime>>
-        for super::CityWhereInput
-    {
-    }
-    pub struct createdAt_gt;
-    impl ::cynic::schema::Field for createdAt_gt {
-        type Type = Option<super::DateTime>;
-        const NAME: &'static str = "createdAt_gt";
-    }
-    impl ::cynic::schema::HasInputField<createdAt_gt, Option<super::DateTime>>
-        for super::CityWhereInput
-    {
-    }
-    pub struct createdAt_gte;
-    impl ::cynic::schema::Field for createdAt_gte {
-        type Type = Option<super::DateTime>;
-        const NAME: &'static str = "createdAt_gte";
-    }
-    impl ::cynic::schema::HasInputField<createdAt_gte, Option<super::DateTime>>
-        for super::CityWhereInput
-    {
-    }
-    pub struct updatedAt;
-    impl ::cynic::schema::Field for updatedAt {
-        type Type = Option<super::DateTime>;
-        const NAME: &'static str = "updatedAt";
-    }
-    impl ::cynic::schema::HasInputField<updatedAt, Option<super::DateTime>> for super::CityWhereInput {}
-    pub struct updatedAt_not;
-    impl ::cynic::schema::Field for updatedAt_not {
-        type Type = Option<super::DateTime>;
-        const NAME: &'static str = "updatedAt_not";
-    }
-    impl ::cynic::schema::HasInputField<updatedAt_not, Option<super::DateTime>>
-        for super::CityWhereInput
-    {
-    }
-    pub struct updatedAt_in;
-    impl ::cynic::schema::Field for updatedAt_in {
-        type Type = Option<Vec<super::DateTime>>;
-        const NAME: &'static str = "updatedAt_in";
-    }
-    impl ::cynic::schema::HasInputField<updatedAt_in, Option<Vec<super::DateTime>>>
-        for super::CityWhereInput
-    {
-    }
-    pub struct updatedAt_not_in;
-    impl ::cynic::schema::Field for updatedAt_not_in {
-        type Type = Option<Vec<super::DateTime>>;
-        const NAME: &'static str = "updatedAt_not_in";
-    }
-    impl ::cynic::schema::HasInputField<updatedAt_not_in, Option<Vec<super::DateTime>>>
-        for super::CityWhereInput
-    {
-    }
-    pub struct updatedAt_lt;
-    impl ::cynic::schema::Field for updatedAt_lt {
-        type Type = Option<super::DateTime>;
-        const NAME: &'static str = "updatedAt_lt";
-    }
-    impl ::cynic::schema::HasInputField<updatedAt_lt, Option<super::DateTime>>
-        for super::CityWhereInput
-    {
-    }
-    pub struct updatedAt_lte;
-    impl ::cynic::schema::Field for updatedAt_lte {
-        type Type = Option<super::DateTime>;
-        const NAME: &'static str = "updatedAt_lte";
-    }
-    impl ::cynic::schema::HasInputField<updatedAt_lte, Option<super::DateTime>>
-        for super::CityWhereInput
-    {
-    }
-    pub struct updatedAt_gt;
-    impl ::cynic::schema::Field for updatedAt_gt {
-        type Type = Option<super::DateTime>;
-        const NAME: &'static str = "updatedAt_gt";
-    }
-    impl ::cynic::schema::HasInputField<updatedAt_gt, Option<super::DateTime>>
-        for super::CityWhereInput
-    {
-    }
-    pub struct updatedAt_gte;
-    impl ::cynic::schema::Field for updatedAt_gte {
-        type Type = Option<super::DateTime>;
-        const NAME: &'static str = "updatedAt_gte";
-    }
-    impl ::cynic::schema::HasInputField<updatedAt_gte, Option<super::DateTime>>
-        for super::CityWhereInput
-    {
-    }
-    pub struct AND;
-    impl ::cynic::schema::Field for AND {
-        type Type = Option<Vec<super::CityWhereInput>>;
-        const NAME: &'static str = "AND";
-    }
-    impl ::cynic::schema::HasInputField<AND, Option<Vec<super::CityWhereInput>>>
-        for super::CityWhereInput
-    {
-    }
-    pub struct OR;
-    impl ::cynic::schema::Field for OR {
-        type Type = Option<Vec<super::CityWhereInput>>;
-        const NAME: &'static str = "OR";
-    }
-    impl ::cynic::schema::HasInputField<OR, Option<Vec<super::CityWhereInput>>>
-        for super::CityWhereInput
-    {
-    }
-    pub struct NOT;
-    impl ::cynic::schema::Field for NOT {
-        type Type = Option<Vec<super::CityWhereInput>>;
-        const NAME: &'static str = "NOT";
-    }
-    impl ::cynic::schema::HasInputField<NOT, Option<Vec<super::CityWhereInput>>>
-        for super::CityWhereInput
-    {
-    }
-}
 pub struct Commitment;
-pub mod commitment_fields {
-    pub struct id;
-    impl ::cynic::schema::Field for id {
-        type Type = super::ID;
-        const NAME: &'static str = "id";
-    }
-    impl ::cynic::schema::HasField<id> for super::Commitment {
-        type Type = super::ID;
-    }
-    pub struct title;
-    impl ::cynic::schema::Field for title {
-        type Type = super::String;
-        const NAME: &'static str = "title";
-    }
-    impl ::cynic::schema::HasField<title> for super::Commitment {
-        type Type = super::String;
-    }
-    pub struct slug;
-    impl ::cynic::schema::Field for slug {
-        type Type = super::String;
-        const NAME: &'static str = "slug";
-    }
-    impl ::cynic::schema::HasField<slug> for super::Commitment {
-        type Type = super::String;
-    }
-    pub struct jobs;
-    impl ::cynic::schema::Field for jobs {
-        type Type = Option<Vec<super::Job>>;
-        const NAME: &'static str = "jobs";
-    }
-    impl ::cynic::schema::HasField<jobs> for super::Commitment {
-        type Type = Option<Vec<super::Job>>;
-    }
-    pub mod jobs_arguments {
-        pub struct r#where;
-        impl ::cynic::schema::HasArgument<r#where> for super::jobs {
-            type ArgumentType = Option<super::super::JobWhereInput>;
-            const NAME: &'static str = "where";
-        }
-        pub struct orderBy;
-        impl ::cynic::schema::HasArgument<orderBy> for super::jobs {
-            type ArgumentType = Option<super::super::JobOrderByInput>;
-            const NAME: &'static str = "orderBy";
-        }
-        pub struct skip;
-        impl ::cynic::schema::HasArgument<skip> for super::jobs {
-            type ArgumentType = Option<super::super::Int>;
-            const NAME: &'static str = "skip";
-        }
-        pub struct after;
-        impl ::cynic::schema::HasArgument<after> for super::jobs {
-            type ArgumentType = Option<super::super::String>;
-            const NAME: &'static str = "after";
-        }
-        pub struct before;
-        impl ::cynic::schema::HasArgument<before> for super::jobs {
-            type ArgumentType = Option<super::super::String>;
-            const NAME: &'static str = "before";
-        }
-        pub struct first;
-        impl ::cynic::schema::HasArgument<first> for super::jobs {
-            type ArgumentType = Option<super::super::Int>;
-            const NAME: &'static str = "first";
-        }
-        pub struct last;
-        impl ::cynic::schema::HasArgument<last> for super::jobs {
-            type ArgumentType = Option<super::super::Int>;
-            const NAME: &'static str = "last";
-        }
-    }
-    pub struct createdAt;
-    impl ::cynic::schema::Field for createdAt {
-        type Type = super::DateTime;
-        const NAME: &'static str = "createdAt";
-    }
-    impl ::cynic::schema::HasField<createdAt> for super::Commitment {
-        type Type = super::DateTime;
-    }
-    pub struct updatedAt;
-    impl ::cynic::schema::Field for updatedAt {
-        type Type = super::DateTime;
-        const NAME: &'static str = "updatedAt";
-    }
-    impl ::cynic::schema::HasField<updatedAt> for super::Commitment {
-        type Type = super::DateTime;
-    }
-}
 pub struct CommitmentWhereInput;
 impl ::cynic::schema::InputObjectMarker for CommitmentWhereInput {}
-pub mod commitment_where_input_fields {
-    pub struct id;
-    impl ::cynic::schema::Field for id {
-        type Type = Option<super::ID>;
-        const NAME: &'static str = "id";
-    }
-    impl ::cynic::schema::HasInputField<id, Option<super::ID>> for super::CommitmentWhereInput {}
-    pub struct id_not;
-    impl ::cynic::schema::Field for id_not {
-        type Type = Option<super::ID>;
-        const NAME: &'static str = "id_not";
-    }
-    impl ::cynic::schema::HasInputField<id_not, Option<super::ID>> for super::CommitmentWhereInput {}
-    pub struct id_in;
-    impl ::cynic::schema::Field for id_in {
-        type Type = Option<Vec<super::ID>>;
-        const NAME: &'static str = "id_in";
-    }
-    impl ::cynic::schema::HasInputField<id_in, Option<Vec<super::ID>>> for super::CommitmentWhereInput {}
-    pub struct id_not_in;
-    impl ::cynic::schema::Field for id_not_in {
-        type Type = Option<Vec<super::ID>>;
-        const NAME: &'static str = "id_not_in";
-    }
-    impl ::cynic::schema::HasInputField<id_not_in, Option<Vec<super::ID>>>
-        for super::CommitmentWhereInput
-    {
-    }
-    pub struct id_lt;
-    impl ::cynic::schema::Field for id_lt {
-        type Type = Option<super::ID>;
-        const NAME: &'static str = "id_lt";
-    }
-    impl ::cynic::schema::HasInputField<id_lt, Option<super::ID>> for super::CommitmentWhereInput {}
-    pub struct id_lte;
-    impl ::cynic::schema::Field for id_lte {
-        type Type = Option<super::ID>;
-        const NAME: &'static str = "id_lte";
-    }
-    impl ::cynic::schema::HasInputField<id_lte, Option<super::ID>> for super::CommitmentWhereInput {}
-    pub struct id_gt;
-    impl ::cynic::schema::Field for id_gt {
-        type Type = Option<super::ID>;
-        const NAME: &'static str = "id_gt";
-    }
-    impl ::cynic::schema::HasInputField<id_gt, Option<super::ID>> for super::CommitmentWhereInput {}
-    pub struct id_gte;
-    impl ::cynic::schema::Field for id_gte {
-        type Type = Option<super::ID>;
-        const NAME: &'static str = "id_gte";
-    }
-    impl ::cynic::schema::HasInputField<id_gte, Option<super::ID>> for super::CommitmentWhereInput {}
-    pub struct id_contains;
-    impl ::cynic::schema::Field for id_contains {
-        type Type = Option<super::ID>;
-        const NAME: &'static str = "id_contains";
-    }
-    impl ::cynic::schema::HasInputField<id_contains, Option<super::ID>>
-        for super::CommitmentWhereInput
-    {
-    }
-    pub struct id_not_contains;
-    impl ::cynic::schema::Field for id_not_contains {
-        type Type = Option<super::ID>;
-        const NAME: &'static str = "id_not_contains";
-    }
-    impl ::cynic::schema::HasInputField<id_not_contains, Option<super::ID>>
-        for super::CommitmentWhereInput
-    {
-    }
-    pub struct id_starts_with;
-    impl ::cynic::schema::Field for id_starts_with {
-        type Type = Option<super::ID>;
-        const NAME: &'static str = "id_starts_with";
-    }
-    impl ::cynic::schema::HasInputField<id_starts_with, Option<super::ID>>
-        for super::CommitmentWhereInput
-    {
-    }
-    pub struct id_not_starts_with;
-    impl ::cynic::schema::Field for id_not_starts_with {
-        type Type = Option<super::ID>;
-        const NAME: &'static str = "id_not_starts_with";
-    }
-    impl ::cynic::schema::HasInputField<id_not_starts_with, Option<super::ID>>
-        for super::CommitmentWhereInput
-    {
-    }
-    pub struct id_ends_with;
-    impl ::cynic::schema::Field for id_ends_with {
-        type Type = Option<super::ID>;
-        const NAME: &'static str = "id_ends_with";
-    }
-    impl ::cynic::schema::HasInputField<id_ends_with, Option<super::ID>>
-        for super::CommitmentWhereInput
-    {
-    }
-    pub struct id_not_ends_with;
-    impl ::cynic::schema::Field for id_not_ends_with {
-        type Type = Option<super::ID>;
-        const NAME: &'static str = "id_not_ends_with";
-    }
-    impl ::cynic::schema::HasInputField<id_not_ends_with, Option<super::ID>>
-        for super::CommitmentWhereInput
-    {
-    }
-    pub struct title;
-    impl ::cynic::schema::Field for title {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "title";
-    }
-    impl ::cynic::schema::HasInputField<title, Option<super::String>> for super::CommitmentWhereInput {}
-    pub struct title_not;
-    impl ::cynic::schema::Field for title_not {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "title_not";
-    }
-    impl ::cynic::schema::HasInputField<title_not, Option<super::String>>
-        for super::CommitmentWhereInput
-    {
-    }
-    pub struct title_in;
-    impl ::cynic::schema::Field for title_in {
-        type Type = Option<Vec<super::String>>;
-        const NAME: &'static str = "title_in";
-    }
-    impl ::cynic::schema::HasInputField<title_in, Option<Vec<super::String>>>
-        for super::CommitmentWhereInput
-    {
-    }
-    pub struct title_not_in;
-    impl ::cynic::schema::Field for title_not_in {
-        type Type = Option<Vec<super::String>>;
-        const NAME: &'static str = "title_not_in";
-    }
-    impl ::cynic::schema::HasInputField<title_not_in, Option<Vec<super::String>>>
-        for super::CommitmentWhereInput
-    {
-    }
-    pub struct title_lt;
-    impl ::cynic::schema::Field for title_lt {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "title_lt";
-    }
-    impl ::cynic::schema::HasInputField<title_lt, Option<super::String>>
-        for super::CommitmentWhereInput
-    {
-    }
-    pub struct title_lte;
-    impl ::cynic::schema::Field for title_lte {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "title_lte";
-    }
-    impl ::cynic::schema::HasInputField<title_lte, Option<super::String>>
-        for super::CommitmentWhereInput
-    {
-    }
-    pub struct title_gt;
-    impl ::cynic::schema::Field for title_gt {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "title_gt";
-    }
-    impl ::cynic::schema::HasInputField<title_gt, Option<super::String>>
-        for super::CommitmentWhereInput
-    {
-    }
-    pub struct title_gte;
-    impl ::cynic::schema::Field for title_gte {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "title_gte";
-    }
-    impl ::cynic::schema::HasInputField<title_gte, Option<super::String>>
-        for super::CommitmentWhereInput
-    {
-    }
-    pub struct title_contains;
-    impl ::cynic::schema::Field for title_contains {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "title_contains";
-    }
-    impl ::cynic::schema::HasInputField<title_contains, Option<super::String>>
-        for super::CommitmentWhereInput
-    {
-    }
-    pub struct title_not_contains;
-    impl ::cynic::schema::Field for title_not_contains {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "title_not_contains";
-    }
-    impl ::cynic::schema::HasInputField<title_not_contains, Option<super::String>>
-        for super::CommitmentWhereInput
-    {
-    }
-    pub struct title_starts_with;
-    impl ::cynic::schema::Field for title_starts_with {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "title_starts_with";
-    }
-    impl ::cynic::schema::HasInputField<title_starts_with, Option<super::String>>
-        for super::CommitmentWhereInput
-    {
-    }
-    pub struct title_not_starts_with;
-    impl ::cynic::schema::Field for title_not_starts_with {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "title_not_starts_with";
-    }
-    impl ::cynic::schema::HasInputField<title_not_starts_with, Option<super::String>>
-        for super::CommitmentWhereInput
-    {
-    }
-    pub struct title_ends_with;
-    impl ::cynic::schema::Field for title_ends_with {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "title_ends_with";
-    }
-    impl ::cynic::schema::HasInputField<title_ends_with, Option<super::String>>
-        for super::CommitmentWhereInput
-    {
-    }
-    pub struct title_not_ends_with;
-    impl ::cynic::schema::Field for title_not_ends_with {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "title_not_ends_with";
-    }
-    impl ::cynic::schema::HasInputField<title_not_ends_with, Option<super::String>>
-        for super::CommitmentWhereInput
-    {
-    }
-    pub struct slug;
-    impl ::cynic::schema::Field for slug {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "slug";
-    }
-    impl ::cynic::schema::HasInputField<slug, Option<super::String>> for super::CommitmentWhereInput {}
-    pub struct slug_not;
-    impl ::cynic::schema::Field for slug_not {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "slug_not";
-    }
-    impl ::cynic::schema::HasInputField<slug_not, Option<super::String>>
-        for super::CommitmentWhereInput
-    {
-    }
-    pub struct slug_in;
-    impl ::cynic::schema::Field for slug_in {
-        type Type = Option<Vec<super::String>>;
-        const NAME: &'static str = "slug_in";
-    }
-    impl ::cynic::schema::HasInputField<slug_in, Option<Vec<super::String>>>
-        for super::CommitmentWhereInput
-    {
-    }
-    pub struct slug_not_in;
-    impl ::cynic::schema::Field for slug_not_in {
-        type Type = Option<Vec<super::String>>;
-        const NAME: &'static str = "slug_not_in";
-    }
-    impl ::cynic::schema::HasInputField<slug_not_in, Option<Vec<super::String>>>
-        for super::CommitmentWhereInput
-    {
-    }
-    pub struct slug_lt;
-    impl ::cynic::schema::Field for slug_lt {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "slug_lt";
-    }
-    impl ::cynic::schema::HasInputField<slug_lt, Option<super::String>>
-        for super::CommitmentWhereInput
-    {
-    }
-    pub struct slug_lte;
-    impl ::cynic::schema::Field for slug_lte {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "slug_lte";
-    }
-    impl ::cynic::schema::HasInputField<slug_lte, Option<super::String>>
-        for super::CommitmentWhereInput
-    {
-    }
-    pub struct slug_gt;
-    impl ::cynic::schema::Field for slug_gt {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "slug_gt";
-    }
-    impl ::cynic::schema::HasInputField<slug_gt, Option<super::String>>
-        for super::CommitmentWhereInput
-    {
-    }
-    pub struct slug_gte;
-    impl ::cynic::schema::Field for slug_gte {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "slug_gte";
-    }
-    impl ::cynic::schema::HasInputField<slug_gte, Option<super::String>>
-        for super::CommitmentWhereInput
-    {
-    }
-    pub struct slug_contains;
-    impl ::cynic::schema::Field for slug_contains {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "slug_contains";
-    }
-    impl ::cynic::schema::HasInputField<slug_contains, Option<super::String>>
-        for super::CommitmentWhereInput
-    {
-    }
-    pub struct slug_not_contains;
-    impl ::cynic::schema::Field for slug_not_contains {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "slug_not_contains";
-    }
-    impl ::cynic::schema::HasInputField<slug_not_contains, Option<super::String>>
-        for super::CommitmentWhereInput
-    {
-    }
-    pub struct slug_starts_with;
-    impl ::cynic::schema::Field for slug_starts_with {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "slug_starts_with";
-    }
-    impl ::cynic::schema::HasInputField<slug_starts_with, Option<super::String>>
-        for super::CommitmentWhereInput
-    {
-    }
-    pub struct slug_not_starts_with;
-    impl ::cynic::schema::Field for slug_not_starts_with {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "slug_not_starts_with";
-    }
-    impl ::cynic::schema::HasInputField<slug_not_starts_with, Option<super::String>>
-        for super::CommitmentWhereInput
-    {
-    }
-    pub struct slug_ends_with;
-    impl ::cynic::schema::Field for slug_ends_with {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "slug_ends_with";
-    }
-    impl ::cynic::schema::HasInputField<slug_ends_with, Option<super::String>>
-        for super::CommitmentWhereInput
-    {
-    }
-    pub struct slug_not_ends_with;
-    impl ::cynic::schema::Field for slug_not_ends_with {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "slug_not_ends_with";
-    }
-    impl ::cynic::schema::HasInputField<slug_not_ends_with, Option<super::String>>
-        for super::CommitmentWhereInput
-    {
-    }
-    pub struct jobs_every;
-    impl ::cynic::schema::Field for jobs_every {
-        type Type = Option<super::JobWhereInput>;
-        const NAME: &'static str = "jobs_every";
-    }
-    impl ::cynic::schema::HasInputField<jobs_every, Option<super::JobWhereInput>>
-        for super::CommitmentWhereInput
-    {
-    }
-    pub struct jobs_some;
-    impl ::cynic::schema::Field for jobs_some {
-        type Type = Option<super::JobWhereInput>;
-        const NAME: &'static str = "jobs_some";
-    }
-    impl ::cynic::schema::HasInputField<jobs_some, Option<super::JobWhereInput>>
-        for super::CommitmentWhereInput
-    {
-    }
-    pub struct jobs_none;
-    impl ::cynic::schema::Field for jobs_none {
-        type Type = Option<super::JobWhereInput>;
-        const NAME: &'static str = "jobs_none";
-    }
-    impl ::cynic::schema::HasInputField<jobs_none, Option<super::JobWhereInput>>
-        for super::CommitmentWhereInput
-    {
-    }
-    pub struct createdAt;
-    impl ::cynic::schema::Field for createdAt {
-        type Type = Option<super::DateTime>;
-        const NAME: &'static str = "createdAt";
-    }
-    impl ::cynic::schema::HasInputField<createdAt, Option<super::DateTime>>
-        for super::CommitmentWhereInput
-    {
-    }
-    pub struct createdAt_not;
-    impl ::cynic::schema::Field for createdAt_not {
-        type Type = Option<super::DateTime>;
-        const NAME: &'static str = "createdAt_not";
-    }
-    impl ::cynic::schema::HasInputField<createdAt_not, Option<super::DateTime>>
-        for super::CommitmentWhereInput
-    {
-    }
-    pub struct createdAt_in;
-    impl ::cynic::schema::Field for createdAt_in {
-        type Type = Option<Vec<super::DateTime>>;
-        const NAME: &'static str = "createdAt_in";
-    }
-    impl ::cynic::schema::HasInputField<createdAt_in, Option<Vec<super::DateTime>>>
-        for super::CommitmentWhereInput
-    {
-    }
-    pub struct createdAt_not_in;
-    impl ::cynic::schema::Field for createdAt_not_in {
-        type Type = Option<Vec<super::DateTime>>;
-        const NAME: &'static str = "createdAt_not_in";
-    }
-    impl ::cynic::schema::HasInputField<createdAt_not_in, Option<Vec<super::DateTime>>>
-        for super::CommitmentWhereInput
-    {
-    }
-    pub struct createdAt_lt;
-    impl ::cynic::schema::Field for createdAt_lt {
-        type Type = Option<super::DateTime>;
-        const NAME: &'static str = "createdAt_lt";
-    }
-    impl ::cynic::schema::HasInputField<createdAt_lt, Option<super::DateTime>>
-        for super::CommitmentWhereInput
-    {
-    }
-    pub struct createdAt_lte;
-    impl ::cynic::schema::Field for createdAt_lte {
-        type Type = Option<super::DateTime>;
-        const NAME: &'static str = "createdAt_lte";
-    }
-    impl ::cynic::schema::HasInputField<createdAt_lte, Option<super::DateTime>>
-        for super::CommitmentWhereInput
-    {
-    }
-    pub struct createdAt_gt;
-    impl ::cynic::schema::Field for createdAt_gt {
-        type Type = Option<super::DateTime>;
-        const NAME: &'static str = "createdAt_gt";
-    }
-    impl ::cynic::schema::HasInputField<createdAt_gt, Option<super::DateTime>>
-        for super::CommitmentWhereInput
-    {
-    }
-    pub struct createdAt_gte;
-    impl ::cynic::schema::Field for createdAt_gte {
-        type Type = Option<super::DateTime>;
-        const NAME: &'static str = "createdAt_gte";
-    }
-    impl ::cynic::schema::HasInputField<createdAt_gte, Option<super::DateTime>>
-        for super::CommitmentWhereInput
-    {
-    }
-    pub struct updatedAt;
-    impl ::cynic::schema::Field for updatedAt {
-        type Type = Option<super::DateTime>;
-        const NAME: &'static str = "updatedAt";
-    }
-    impl ::cynic::schema::HasInputField<updatedAt, Option<super::DateTime>>
-        for super::CommitmentWhereInput
-    {
-    }
-    pub struct updatedAt_not;
-    impl ::cynic::schema::Field for updatedAt_not {
-        type Type = Option<super::DateTime>;
-        const NAME: &'static str = "updatedAt_not";
-    }
-    impl ::cynic::schema::HasInputField<updatedAt_not, Option<super::DateTime>>
-        for super::CommitmentWhereInput
-    {
-    }
-    pub struct updatedAt_in;
-    impl ::cynic::schema::Field for updatedAt_in {
-        type Type = Option<Vec<super::DateTime>>;
-        const NAME: &'static str = "updatedAt_in";
-    }
-    impl ::cynic::schema::HasInputField<updatedAt_in, Option<Vec<super::DateTime>>>
-        for super::CommitmentWhereInput
-    {
-    }
-    pub struct updatedAt_not_in;
-    impl ::cynic::schema::Field for updatedAt_not_in {
-        type Type = Option<Vec<super::DateTime>>;
-        const NAME: &'static str = "updatedAt_not_in";
-    }
-    impl ::cynic::schema::HasInputField<updatedAt_not_in, Option<Vec<super::DateTime>>>
-        for super::CommitmentWhereInput
-    {
-    }
-    pub struct updatedAt_lt;
-    impl ::cynic::schema::Field for updatedAt_lt {
-        type Type = Option<super::DateTime>;
-        const NAME: &'static str = "updatedAt_lt";
-    }
-    impl ::cynic::schema::HasInputField<updatedAt_lt, Option<super::DateTime>>
-        for super::CommitmentWhereInput
-    {
-    }
-    pub struct updatedAt_lte;
-    impl ::cynic::schema::Field for updatedAt_lte {
-        type Type = Option<super::DateTime>;
-        const NAME: &'static str = "updatedAt_lte";
-    }
-    impl ::cynic::schema::HasInputField<updatedAt_lte, Option<super::DateTime>>
-        for super::CommitmentWhereInput
-    {
-    }
-    pub struct updatedAt_gt;
-    impl ::cynic::schema::Field for updatedAt_gt {
-        type Type = Option<super::DateTime>;
-        const NAME: &'static str = "updatedAt_gt";
-    }
-    impl ::cynic::schema::HasInputField<updatedAt_gt, Option<super::DateTime>>
-        for super::CommitmentWhereInput
-    {
-    }
-    pub struct updatedAt_gte;
-    impl ::cynic::schema::Field for updatedAt_gte {
-        type Type = Option<super::DateTime>;
-        const NAME: &'static str = "updatedAt_gte";
-    }
-    impl ::cynic::schema::HasInputField<updatedAt_gte, Option<super::DateTime>>
-        for super::CommitmentWhereInput
-    {
-    }
-    pub struct AND;
-    impl ::cynic::schema::Field for AND {
-        type Type = Option<Vec<super::CommitmentWhereInput>>;
-        const NAME: &'static str = "AND";
-    }
-    impl ::cynic::schema::HasInputField<AND, Option<Vec<super::CommitmentWhereInput>>>
-        for super::CommitmentWhereInput
-    {
-    }
-    pub struct OR;
-    impl ::cynic::schema::Field for OR {
-        type Type = Option<Vec<super::CommitmentWhereInput>>;
-        const NAME: &'static str = "OR";
-    }
-    impl ::cynic::schema::HasInputField<OR, Option<Vec<super::CommitmentWhereInput>>>
-        for super::CommitmentWhereInput
-    {
-    }
-    pub struct NOT;
-    impl ::cynic::schema::Field for NOT {
-        type Type = Option<Vec<super::CommitmentWhereInput>>;
-        const NAME: &'static str = "NOT";
-    }
-    impl ::cynic::schema::HasInputField<NOT, Option<Vec<super::CommitmentWhereInput>>>
-        for super::CommitmentWhereInput
-    {
-    }
-}
 pub struct Company;
-pub mod company_fields {
-    pub struct id;
-    impl ::cynic::schema::Field for id {
-        type Type = super::ID;
-        const NAME: &'static str = "id";
-    }
-    impl ::cynic::schema::HasField<id> for super::Company {
-        type Type = super::ID;
-    }
-    pub struct name;
-    impl ::cynic::schema::Field for name {
-        type Type = super::String;
-        const NAME: &'static str = "name";
-    }
-    impl ::cynic::schema::HasField<name> for super::Company {
-        type Type = super::String;
-    }
-    pub struct slug;
-    impl ::cynic::schema::Field for slug {
-        type Type = super::String;
-        const NAME: &'static str = "slug";
-    }
-    impl ::cynic::schema::HasField<slug> for super::Company {
-        type Type = super::String;
-    }
-    pub struct websiteUrl;
-    impl ::cynic::schema::Field for websiteUrl {
-        type Type = super::String;
-        const NAME: &'static str = "websiteUrl";
-    }
-    impl ::cynic::schema::HasField<websiteUrl> for super::Company {
-        type Type = super::String;
-    }
-    pub struct logoUrl;
-    impl ::cynic::schema::Field for logoUrl {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "logoUrl";
-    }
-    impl ::cynic::schema::HasField<logoUrl> for super::Company {
-        type Type = Option<super::String>;
-    }
-    pub struct jobs;
-    impl ::cynic::schema::Field for jobs {
-        type Type = Option<Vec<super::Job>>;
-        const NAME: &'static str = "jobs";
-    }
-    impl ::cynic::schema::HasField<jobs> for super::Company {
-        type Type = Option<Vec<super::Job>>;
-    }
-    pub mod jobs_arguments {
-        pub struct r#where;
-        impl ::cynic::schema::HasArgument<r#where> for super::jobs {
-            type ArgumentType = Option<super::super::JobWhereInput>;
-            const NAME: &'static str = "where";
-        }
-        pub struct orderBy;
-        impl ::cynic::schema::HasArgument<orderBy> for super::jobs {
-            type ArgumentType = Option<super::super::JobOrderByInput>;
-            const NAME: &'static str = "orderBy";
-        }
-        pub struct skip;
-        impl ::cynic::schema::HasArgument<skip> for super::jobs {
-            type ArgumentType = Option<super::super::Int>;
-            const NAME: &'static str = "skip";
-        }
-        pub struct after;
-        impl ::cynic::schema::HasArgument<after> for super::jobs {
-            type ArgumentType = Option<super::super::String>;
-            const NAME: &'static str = "after";
-        }
-        pub struct before;
-        impl ::cynic::schema::HasArgument<before> for super::jobs {
-            type ArgumentType = Option<super::super::String>;
-            const NAME: &'static str = "before";
-        }
-        pub struct first;
-        impl ::cynic::schema::HasArgument<first> for super::jobs {
-            type ArgumentType = Option<super::super::Int>;
-            const NAME: &'static str = "first";
-        }
-        pub struct last;
-        impl ::cynic::schema::HasArgument<last> for super::jobs {
-            type ArgumentType = Option<super::super::Int>;
-            const NAME: &'static str = "last";
-        }
-    }
-    pub struct twitter;
-    impl ::cynic::schema::Field for twitter {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "twitter";
-    }
-    impl ::cynic::schema::HasField<twitter> for super::Company {
-        type Type = Option<super::String>;
-    }
-    pub struct emailed;
-    impl ::cynic::schema::Field for emailed {
-        type Type = Option<super::Boolean>;
-        const NAME: &'static str = "emailed";
-    }
-    impl ::cynic::schema::HasField<emailed> for super::Company {
-        type Type = Option<super::Boolean>;
-    }
-    pub struct createdAt;
-    impl ::cynic::schema::Field for createdAt {
-        type Type = super::DateTime;
-        const NAME: &'static str = "createdAt";
-    }
-    impl ::cynic::schema::HasField<createdAt> for super::Company {
-        type Type = super::DateTime;
-    }
-    pub struct updatedAt;
-    impl ::cynic::schema::Field for updatedAt {
-        type Type = super::DateTime;
-        const NAME: &'static str = "updatedAt";
-    }
-    impl ::cynic::schema::HasField<updatedAt> for super::Company {
-        type Type = super::DateTime;
-    }
-}
 pub struct CompanyWhereInput;
 impl ::cynic::schema::InputObjectMarker for CompanyWhereInput {}
-pub mod company_where_input_fields {
-    pub struct id;
-    impl ::cynic::schema::Field for id {
-        type Type = Option<super::ID>;
-        const NAME: &'static str = "id";
-    }
-    impl ::cynic::schema::HasInputField<id, Option<super::ID>> for super::CompanyWhereInput {}
-    pub struct id_not;
-    impl ::cynic::schema::Field for id_not {
-        type Type = Option<super::ID>;
-        const NAME: &'static str = "id_not";
-    }
-    impl ::cynic::schema::HasInputField<id_not, Option<super::ID>> for super::CompanyWhereInput {}
-    pub struct id_in;
-    impl ::cynic::schema::Field for id_in {
-        type Type = Option<Vec<super::ID>>;
-        const NAME: &'static str = "id_in";
-    }
-    impl ::cynic::schema::HasInputField<id_in, Option<Vec<super::ID>>> for super::CompanyWhereInput {}
-    pub struct id_not_in;
-    impl ::cynic::schema::Field for id_not_in {
-        type Type = Option<Vec<super::ID>>;
-        const NAME: &'static str = "id_not_in";
-    }
-    impl ::cynic::schema::HasInputField<id_not_in, Option<Vec<super::ID>>>
-        for super::CompanyWhereInput
-    {
-    }
-    pub struct id_lt;
-    impl ::cynic::schema::Field for id_lt {
-        type Type = Option<super::ID>;
-        const NAME: &'static str = "id_lt";
-    }
-    impl ::cynic::schema::HasInputField<id_lt, Option<super::ID>> for super::CompanyWhereInput {}
-    pub struct id_lte;
-    impl ::cynic::schema::Field for id_lte {
-        type Type = Option<super::ID>;
-        const NAME: &'static str = "id_lte";
-    }
-    impl ::cynic::schema::HasInputField<id_lte, Option<super::ID>> for super::CompanyWhereInput {}
-    pub struct id_gt;
-    impl ::cynic::schema::Field for id_gt {
-        type Type = Option<super::ID>;
-        const NAME: &'static str = "id_gt";
-    }
-    impl ::cynic::schema::HasInputField<id_gt, Option<super::ID>> for super::CompanyWhereInput {}
-    pub struct id_gte;
-    impl ::cynic::schema::Field for id_gte {
-        type Type = Option<super::ID>;
-        const NAME: &'static str = "id_gte";
-    }
-    impl ::cynic::schema::HasInputField<id_gte, Option<super::ID>> for super::CompanyWhereInput {}
-    pub struct id_contains;
-    impl ::cynic::schema::Field for id_contains {
-        type Type = Option<super::ID>;
-        const NAME: &'static str = "id_contains";
-    }
-    impl ::cynic::schema::HasInputField<id_contains, Option<super::ID>> for super::CompanyWhereInput {}
-    pub struct id_not_contains;
-    impl ::cynic::schema::Field for id_not_contains {
-        type Type = Option<super::ID>;
-        const NAME: &'static str = "id_not_contains";
-    }
-    impl ::cynic::schema::HasInputField<id_not_contains, Option<super::ID>>
-        for super::CompanyWhereInput
-    {
-    }
-    pub struct id_starts_with;
-    impl ::cynic::schema::Field for id_starts_with {
-        type Type = Option<super::ID>;
-        const NAME: &'static str = "id_starts_with";
-    }
-    impl ::cynic::schema::HasInputField<id_starts_with, Option<super::ID>>
-        for super::CompanyWhereInput
-    {
-    }
-    pub struct id_not_starts_with;
-    impl ::cynic::schema::Field for id_not_starts_with {
-        type Type = Option<super::ID>;
-        const NAME: &'static str = "id_not_starts_with";
-    }
-    impl ::cynic::schema::HasInputField<id_not_starts_with, Option<super::ID>>
-        for super::CompanyWhereInput
-    {
-    }
-    pub struct id_ends_with;
-    impl ::cynic::schema::Field for id_ends_with {
-        type Type = Option<super::ID>;
-        const NAME: &'static str = "id_ends_with";
-    }
-    impl ::cynic::schema::HasInputField<id_ends_with, Option<super::ID>> for super::CompanyWhereInput {}
-    pub struct id_not_ends_with;
-    impl ::cynic::schema::Field for id_not_ends_with {
-        type Type = Option<super::ID>;
-        const NAME: &'static str = "id_not_ends_with";
-    }
-    impl ::cynic::schema::HasInputField<id_not_ends_with, Option<super::ID>>
-        for super::CompanyWhereInput
-    {
-    }
-    pub struct name;
-    impl ::cynic::schema::Field for name {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "name";
-    }
-    impl ::cynic::schema::HasInputField<name, Option<super::String>> for super::CompanyWhereInput {}
-    pub struct name_not;
-    impl ::cynic::schema::Field for name_not {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "name_not";
-    }
-    impl ::cynic::schema::HasInputField<name_not, Option<super::String>> for super::CompanyWhereInput {}
-    pub struct name_in;
-    impl ::cynic::schema::Field for name_in {
-        type Type = Option<Vec<super::String>>;
-        const NAME: &'static str = "name_in";
-    }
-    impl ::cynic::schema::HasInputField<name_in, Option<Vec<super::String>>>
-        for super::CompanyWhereInput
-    {
-    }
-    pub struct name_not_in;
-    impl ::cynic::schema::Field for name_not_in {
-        type Type = Option<Vec<super::String>>;
-        const NAME: &'static str = "name_not_in";
-    }
-    impl ::cynic::schema::HasInputField<name_not_in, Option<Vec<super::String>>>
-        for super::CompanyWhereInput
-    {
-    }
-    pub struct name_lt;
-    impl ::cynic::schema::Field for name_lt {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "name_lt";
-    }
-    impl ::cynic::schema::HasInputField<name_lt, Option<super::String>> for super::CompanyWhereInput {}
-    pub struct name_lte;
-    impl ::cynic::schema::Field for name_lte {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "name_lte";
-    }
-    impl ::cynic::schema::HasInputField<name_lte, Option<super::String>> for super::CompanyWhereInput {}
-    pub struct name_gt;
-    impl ::cynic::schema::Field for name_gt {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "name_gt";
-    }
-    impl ::cynic::schema::HasInputField<name_gt, Option<super::String>> for super::CompanyWhereInput {}
-    pub struct name_gte;
-    impl ::cynic::schema::Field for name_gte {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "name_gte";
-    }
-    impl ::cynic::schema::HasInputField<name_gte, Option<super::String>> for super::CompanyWhereInput {}
-    pub struct name_contains;
-    impl ::cynic::schema::Field for name_contains {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "name_contains";
-    }
-    impl ::cynic::schema::HasInputField<name_contains, Option<super::String>>
-        for super::CompanyWhereInput
-    {
-    }
-    pub struct name_not_contains;
-    impl ::cynic::schema::Field for name_not_contains {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "name_not_contains";
-    }
-    impl ::cynic::schema::HasInputField<name_not_contains, Option<super::String>>
-        for super::CompanyWhereInput
-    {
-    }
-    pub struct name_starts_with;
-    impl ::cynic::schema::Field for name_starts_with {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "name_starts_with";
-    }
-    impl ::cynic::schema::HasInputField<name_starts_with, Option<super::String>>
-        for super::CompanyWhereInput
-    {
-    }
-    pub struct name_not_starts_with;
-    impl ::cynic::schema::Field for name_not_starts_with {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "name_not_starts_with";
-    }
-    impl ::cynic::schema::HasInputField<name_not_starts_with, Option<super::String>>
-        for super::CompanyWhereInput
-    {
-    }
-    pub struct name_ends_with;
-    impl ::cynic::schema::Field for name_ends_with {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "name_ends_with";
-    }
-    impl ::cynic::schema::HasInputField<name_ends_with, Option<super::String>>
-        for super::CompanyWhereInput
-    {
-    }
-    pub struct name_not_ends_with;
-    impl ::cynic::schema::Field for name_not_ends_with {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "name_not_ends_with";
-    }
-    impl ::cynic::schema::HasInputField<name_not_ends_with, Option<super::String>>
-        for super::CompanyWhereInput
-    {
-    }
-    pub struct slug;
-    impl ::cynic::schema::Field for slug {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "slug";
-    }
-    impl ::cynic::schema::HasInputField<slug, Option<super::String>> for super::CompanyWhereInput {}
-    pub struct slug_not;
-    impl ::cynic::schema::Field for slug_not {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "slug_not";
-    }
-    impl ::cynic::schema::HasInputField<slug_not, Option<super::String>> for super::CompanyWhereInput {}
-    pub struct slug_in;
-    impl ::cynic::schema::Field for slug_in {
-        type Type = Option<Vec<super::String>>;
-        const NAME: &'static str = "slug_in";
-    }
-    impl ::cynic::schema::HasInputField<slug_in, Option<Vec<super::String>>>
-        for super::CompanyWhereInput
-    {
-    }
-    pub struct slug_not_in;
-    impl ::cynic::schema::Field for slug_not_in {
-        type Type = Option<Vec<super::String>>;
-        const NAME: &'static str = "slug_not_in";
-    }
-    impl ::cynic::schema::HasInputField<slug_not_in, Option<Vec<super::String>>>
-        for super::CompanyWhereInput
-    {
-    }
-    pub struct slug_lt;
-    impl ::cynic::schema::Field for slug_lt {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "slug_lt";
-    }
-    impl ::cynic::schema::HasInputField<slug_lt, Option<super::String>> for super::CompanyWhereInput {}
-    pub struct slug_lte;
-    impl ::cynic::schema::Field for slug_lte {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "slug_lte";
-    }
-    impl ::cynic::schema::HasInputField<slug_lte, Option<super::String>> for super::CompanyWhereInput {}
-    pub struct slug_gt;
-    impl ::cynic::schema::Field for slug_gt {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "slug_gt";
-    }
-    impl ::cynic::schema::HasInputField<slug_gt, Option<super::String>> for super::CompanyWhereInput {}
-    pub struct slug_gte;
-    impl ::cynic::schema::Field for slug_gte {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "slug_gte";
-    }
-    impl ::cynic::schema::HasInputField<slug_gte, Option<super::String>> for super::CompanyWhereInput {}
-    pub struct slug_contains;
-    impl ::cynic::schema::Field for slug_contains {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "slug_contains";
-    }
-    impl ::cynic::schema::HasInputField<slug_contains, Option<super::String>>
-        for super::CompanyWhereInput
-    {
-    }
-    pub struct slug_not_contains;
-    impl ::cynic::schema::Field for slug_not_contains {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "slug_not_contains";
-    }
-    impl ::cynic::schema::HasInputField<slug_not_contains, Option<super::String>>
-        for super::CompanyWhereInput
-    {
-    }
-    pub struct slug_starts_with;
-    impl ::cynic::schema::Field for slug_starts_with {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "slug_starts_with";
-    }
-    impl ::cynic::schema::HasInputField<slug_starts_with, Option<super::String>>
-        for super::CompanyWhereInput
-    {
-    }
-    pub struct slug_not_starts_with;
-    impl ::cynic::schema::Field for slug_not_starts_with {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "slug_not_starts_with";
-    }
-    impl ::cynic::schema::HasInputField<slug_not_starts_with, Option<super::String>>
-        for super::CompanyWhereInput
-    {
-    }
-    pub struct slug_ends_with;
-    impl ::cynic::schema::Field for slug_ends_with {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "slug_ends_with";
-    }
-    impl ::cynic::schema::HasInputField<slug_ends_with, Option<super::String>>
-        for super::CompanyWhereInput
-    {
-    }
-    pub struct slug_not_ends_with;
-    impl ::cynic::schema::Field for slug_not_ends_with {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "slug_not_ends_with";
-    }
-    impl ::cynic::schema::HasInputField<slug_not_ends_with, Option<super::String>>
-        for super::CompanyWhereInput
-    {
-    }
-    pub struct websiteUrl;
-    impl ::cynic::schema::Field for websiteUrl {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "websiteUrl";
-    }
-    impl ::cynic::schema::HasInputField<websiteUrl, Option<super::String>>
-        for super::CompanyWhereInput
-    {
-    }
-    pub struct websiteUrl_not;
-    impl ::cynic::schema::Field for websiteUrl_not {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "websiteUrl_not";
-    }
-    impl ::cynic::schema::HasInputField<websiteUrl_not, Option<super::String>>
-        for super::CompanyWhereInput
-    {
-    }
-    pub struct websiteUrl_in;
-    impl ::cynic::schema::Field for websiteUrl_in {
-        type Type = Option<Vec<super::String>>;
-        const NAME: &'static str = "websiteUrl_in";
-    }
-    impl ::cynic::schema::HasInputField<websiteUrl_in, Option<Vec<super::String>>>
-        for super::CompanyWhereInput
-    {
-    }
-    pub struct websiteUrl_not_in;
-    impl ::cynic::schema::Field for websiteUrl_not_in {
-        type Type = Option<Vec<super::String>>;
-        const NAME: &'static str = "websiteUrl_not_in";
-    }
-    impl ::cynic::schema::HasInputField<websiteUrl_not_in, Option<Vec<super::String>>>
-        for super::CompanyWhereInput
-    {
-    }
-    pub struct websiteUrl_lt;
-    impl ::cynic::schema::Field for websiteUrl_lt {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "websiteUrl_lt";
-    }
-    impl ::cynic::schema::HasInputField<websiteUrl_lt, Option<super::String>>
-        for super::CompanyWhereInput
-    {
-    }
-    pub struct websiteUrl_lte;
-    impl ::cynic::schema::Field for websiteUrl_lte {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "websiteUrl_lte";
-    }
-    impl ::cynic::schema::HasInputField<websiteUrl_lte, Option<super::String>>
-        for super::CompanyWhereInput
-    {
-    }
-    pub struct websiteUrl_gt;
-    impl ::cynic::schema::Field for websiteUrl_gt {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "websiteUrl_gt";
-    }
-    impl ::cynic::schema::HasInputField<websiteUrl_gt, Option<super::String>>
-        for super::CompanyWhereInput
-    {
-    }
-    pub struct websiteUrl_gte;
-    impl ::cynic::schema::Field for websiteUrl_gte {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "websiteUrl_gte";
-    }
-    impl ::cynic::schema::HasInputField<websiteUrl_gte, Option<super::String>>
-        for super::CompanyWhereInput
-    {
-    }
-    pub struct websiteUrl_contains;
-    impl ::cynic::schema::Field for websiteUrl_contains {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "websiteUrl_contains";
-    }
-    impl ::cynic::schema::HasInputField<websiteUrl_contains, Option<super::String>>
-        for super::CompanyWhereInput
-    {
-    }
-    pub struct websiteUrl_not_contains;
-    impl ::cynic::schema::Field for websiteUrl_not_contains {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "websiteUrl_not_contains";
-    }
-    impl ::cynic::schema::HasInputField<websiteUrl_not_contains, Option<super::String>>
-        for super::CompanyWhereInput
-    {
-    }
-    pub struct websiteUrl_starts_with;
-    impl ::cynic::schema::Field for websiteUrl_starts_with {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "websiteUrl_starts_with";
-    }
-    impl ::cynic::schema::HasInputField<websiteUrl_starts_with, Option<super::String>>
-        for super::CompanyWhereInput
-    {
-    }
-    pub struct websiteUrl_not_starts_with;
-    impl ::cynic::schema::Field for websiteUrl_not_starts_with {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "websiteUrl_not_starts_with";
-    }
-    impl ::cynic::schema::HasInputField<websiteUrl_not_starts_with, Option<super::String>>
-        for super::CompanyWhereInput
-    {
-    }
-    pub struct websiteUrl_ends_with;
-    impl ::cynic::schema::Field for websiteUrl_ends_with {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "websiteUrl_ends_with";
-    }
-    impl ::cynic::schema::HasInputField<websiteUrl_ends_with, Option<super::String>>
-        for super::CompanyWhereInput
-    {
-    }
-    pub struct websiteUrl_not_ends_with;
-    impl ::cynic::schema::Field for websiteUrl_not_ends_with {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "websiteUrl_not_ends_with";
-    }
-    impl ::cynic::schema::HasInputField<websiteUrl_not_ends_with, Option<super::String>>
-        for super::CompanyWhereInput
-    {
-    }
-    pub struct logoUrl;
-    impl ::cynic::schema::Field for logoUrl {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "logoUrl";
-    }
-    impl ::cynic::schema::HasInputField<logoUrl, Option<super::String>> for super::CompanyWhereInput {}
-    pub struct logoUrl_not;
-    impl ::cynic::schema::Field for logoUrl_not {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "logoUrl_not";
-    }
-    impl ::cynic::schema::HasInputField<logoUrl_not, Option<super::String>>
-        for super::CompanyWhereInput
-    {
-    }
-    pub struct logoUrl_in;
-    impl ::cynic::schema::Field for logoUrl_in {
-        type Type = Option<Vec<super::String>>;
-        const NAME: &'static str = "logoUrl_in";
-    }
-    impl ::cynic::schema::HasInputField<logoUrl_in, Option<Vec<super::String>>>
-        for super::CompanyWhereInput
-    {
-    }
-    pub struct logoUrl_not_in;
-    impl ::cynic::schema::Field for logoUrl_not_in {
-        type Type = Option<Vec<super::String>>;
-        const NAME: &'static str = "logoUrl_not_in";
-    }
-    impl ::cynic::schema::HasInputField<logoUrl_not_in, Option<Vec<super::String>>>
-        for super::CompanyWhereInput
-    {
-    }
-    pub struct logoUrl_lt;
-    impl ::cynic::schema::Field for logoUrl_lt {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "logoUrl_lt";
-    }
-    impl ::cynic::schema::HasInputField<logoUrl_lt, Option<super::String>>
-        for super::CompanyWhereInput
-    {
-    }
-    pub struct logoUrl_lte;
-    impl ::cynic::schema::Field for logoUrl_lte {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "logoUrl_lte";
-    }
-    impl ::cynic::schema::HasInputField<logoUrl_lte, Option<super::String>>
-        for super::CompanyWhereInput
-    {
-    }
-    pub struct logoUrl_gt;
-    impl ::cynic::schema::Field for logoUrl_gt {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "logoUrl_gt";
-    }
-    impl ::cynic::schema::HasInputField<logoUrl_gt, Option<super::String>>
-        for super::CompanyWhereInput
-    {
-    }
-    pub struct logoUrl_gte;
-    impl ::cynic::schema::Field for logoUrl_gte {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "logoUrl_gte";
-    }
-    impl ::cynic::schema::HasInputField<logoUrl_gte, Option<super::String>>
-        for super::CompanyWhereInput
-    {
-    }
-    pub struct logoUrl_contains;
-    impl ::cynic::schema::Field for logoUrl_contains {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "logoUrl_contains";
-    }
-    impl ::cynic::schema::HasInputField<logoUrl_contains, Option<super::String>>
-        for super::CompanyWhereInput
-    {
-    }
-    pub struct logoUrl_not_contains;
-    impl ::cynic::schema::Field for logoUrl_not_contains {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "logoUrl_not_contains";
-    }
-    impl ::cynic::schema::HasInputField<logoUrl_not_contains, Option<super::String>>
-        for super::CompanyWhereInput
-    {
-    }
-    pub struct logoUrl_starts_with;
-    impl ::cynic::schema::Field for logoUrl_starts_with {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "logoUrl_starts_with";
-    }
-    impl ::cynic::schema::HasInputField<logoUrl_starts_with, Option<super::String>>
-        for super::CompanyWhereInput
-    {
-    }
-    pub struct logoUrl_not_starts_with;
-    impl ::cynic::schema::Field for logoUrl_not_starts_with {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "logoUrl_not_starts_with";
-    }
-    impl ::cynic::schema::HasInputField<logoUrl_not_starts_with, Option<super::String>>
-        for super::CompanyWhereInput
-    {
-    }
-    pub struct logoUrl_ends_with;
-    impl ::cynic::schema::Field for logoUrl_ends_with {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "logoUrl_ends_with";
-    }
-    impl ::cynic::schema::HasInputField<logoUrl_ends_with, Option<super::String>>
-        for super::CompanyWhereInput
-    {
-    }
-    pub struct logoUrl_not_ends_with;
-    impl ::cynic::schema::Field for logoUrl_not_ends_with {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "logoUrl_not_ends_with";
-    }
-    impl ::cynic::schema::HasInputField<logoUrl_not_ends_with, Option<super::String>>
-        for super::CompanyWhereInput
-    {
-    }
-    pub struct jobs_every;
-    impl ::cynic::schema::Field for jobs_every {
-        type Type = Option<super::JobWhereInput>;
-        const NAME: &'static str = "jobs_every";
-    }
-    impl ::cynic::schema::HasInputField<jobs_every, Option<super::JobWhereInput>>
-        for super::CompanyWhereInput
-    {
-    }
-    pub struct jobs_some;
-    impl ::cynic::schema::Field for jobs_some {
-        type Type = Option<super::JobWhereInput>;
-        const NAME: &'static str = "jobs_some";
-    }
-    impl ::cynic::schema::HasInputField<jobs_some, Option<super::JobWhereInput>>
-        for super::CompanyWhereInput
-    {
-    }
-    pub struct jobs_none;
-    impl ::cynic::schema::Field for jobs_none {
-        type Type = Option<super::JobWhereInput>;
-        const NAME: &'static str = "jobs_none";
-    }
-    impl ::cynic::schema::HasInputField<jobs_none, Option<super::JobWhereInput>>
-        for super::CompanyWhereInput
-    {
-    }
-    pub struct twitter;
-    impl ::cynic::schema::Field for twitter {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "twitter";
-    }
-    impl ::cynic::schema::HasInputField<twitter, Option<super::String>> for super::CompanyWhereInput {}
-    pub struct twitter_not;
-    impl ::cynic::schema::Field for twitter_not {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "twitter_not";
-    }
-    impl ::cynic::schema::HasInputField<twitter_not, Option<super::String>>
-        for super::CompanyWhereInput
-    {
-    }
-    pub struct twitter_in;
-    impl ::cynic::schema::Field for twitter_in {
-        type Type = Option<Vec<super::String>>;
-        const NAME: &'static str = "twitter_in";
-    }
-    impl ::cynic::schema::HasInputField<twitter_in, Option<Vec<super::String>>>
-        for super::CompanyWhereInput
-    {
-    }
-    pub struct twitter_not_in;
-    impl ::cynic::schema::Field for twitter_not_in {
-        type Type = Option<Vec<super::String>>;
-        const NAME: &'static str = "twitter_not_in";
-    }
-    impl ::cynic::schema::HasInputField<twitter_not_in, Option<Vec<super::String>>>
-        for super::CompanyWhereInput
-    {
-    }
-    pub struct twitter_lt;
-    impl ::cynic::schema::Field for twitter_lt {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "twitter_lt";
-    }
-    impl ::cynic::schema::HasInputField<twitter_lt, Option<super::String>>
-        for super::CompanyWhereInput
-    {
-    }
-    pub struct twitter_lte;
-    impl ::cynic::schema::Field for twitter_lte {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "twitter_lte";
-    }
-    impl ::cynic::schema::HasInputField<twitter_lte, Option<super::String>>
-        for super::CompanyWhereInput
-    {
-    }
-    pub struct twitter_gt;
-    impl ::cynic::schema::Field for twitter_gt {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "twitter_gt";
-    }
-    impl ::cynic::schema::HasInputField<twitter_gt, Option<super::String>>
-        for super::CompanyWhereInput
-    {
-    }
-    pub struct twitter_gte;
-    impl ::cynic::schema::Field for twitter_gte {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "twitter_gte";
-    }
-    impl ::cynic::schema::HasInputField<twitter_gte, Option<super::String>>
-        for super::CompanyWhereInput
-    {
-    }
-    pub struct twitter_contains;
-    impl ::cynic::schema::Field for twitter_contains {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "twitter_contains";
-    }
-    impl ::cynic::schema::HasInputField<twitter_contains, Option<super::String>>
-        for super::CompanyWhereInput
-    {
-    }
-    pub struct twitter_not_contains;
-    impl ::cynic::schema::Field for twitter_not_contains {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "twitter_not_contains";
-    }
-    impl ::cynic::schema::HasInputField<twitter_not_contains, Option<super::String>>
-        for super::CompanyWhereInput
-    {
-    }
-    pub struct twitter_starts_with;
-    impl ::cynic::schema::Field for twitter_starts_with {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "twitter_starts_with";
-    }
-    impl ::cynic::schema::HasInputField<twitter_starts_with, Option<super::String>>
-        for super::CompanyWhereInput
-    {
-    }
-    pub struct twitter_not_starts_with;
-    impl ::cynic::schema::Field for twitter_not_starts_with {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "twitter_not_starts_with";
-    }
-    impl ::cynic::schema::HasInputField<twitter_not_starts_with, Option<super::String>>
-        for super::CompanyWhereInput
-    {
-    }
-    pub struct twitter_ends_with;
-    impl ::cynic::schema::Field for twitter_ends_with {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "twitter_ends_with";
-    }
-    impl ::cynic::schema::HasInputField<twitter_ends_with, Option<super::String>>
-        for super::CompanyWhereInput
-    {
-    }
-    pub struct twitter_not_ends_with;
-    impl ::cynic::schema::Field for twitter_not_ends_with {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "twitter_not_ends_with";
-    }
-    impl ::cynic::schema::HasInputField<twitter_not_ends_with, Option<super::String>>
-        for super::CompanyWhereInput
-    {
-    }
-    pub struct emailed;
-    impl ::cynic::schema::Field for emailed {
-        type Type = Option<super::Boolean>;
-        const NAME: &'static str = "emailed";
-    }
-    impl ::cynic::schema::HasInputField<emailed, Option<super::Boolean>> for super::CompanyWhereInput {}
-    pub struct emailed_not;
-    impl ::cynic::schema::Field for emailed_not {
-        type Type = Option<super::Boolean>;
-        const NAME: &'static str = "emailed_not";
-    }
-    impl ::cynic::schema::HasInputField<emailed_not, Option<super::Boolean>>
-        for super::CompanyWhereInput
-    {
-    }
-    pub struct createdAt;
-    impl ::cynic::schema::Field for createdAt {
-        type Type = Option<super::DateTime>;
-        const NAME: &'static str = "createdAt";
-    }
-    impl ::cynic::schema::HasInputField<createdAt, Option<super::DateTime>>
-        for super::CompanyWhereInput
-    {
-    }
-    pub struct createdAt_not;
-    impl ::cynic::schema::Field for createdAt_not {
-        type Type = Option<super::DateTime>;
-        const NAME: &'static str = "createdAt_not";
-    }
-    impl ::cynic::schema::HasInputField<createdAt_not, Option<super::DateTime>>
-        for super::CompanyWhereInput
-    {
-    }
-    pub struct createdAt_in;
-    impl ::cynic::schema::Field for createdAt_in {
-        type Type = Option<Vec<super::DateTime>>;
-        const NAME: &'static str = "createdAt_in";
-    }
-    impl ::cynic::schema::HasInputField<createdAt_in, Option<Vec<super::DateTime>>>
-        for super::CompanyWhereInput
-    {
-    }
-    pub struct createdAt_not_in;
-    impl ::cynic::schema::Field for createdAt_not_in {
-        type Type = Option<Vec<super::DateTime>>;
-        const NAME: &'static str = "createdAt_not_in";
-    }
-    impl ::cynic::schema::HasInputField<createdAt_not_in, Option<Vec<super::DateTime>>>
-        for super::CompanyWhereInput
-    {
-    }
-    pub struct createdAt_lt;
-    impl ::cynic::schema::Field for createdAt_lt {
-        type Type = Option<super::DateTime>;
-        const NAME: &'static str = "createdAt_lt";
-    }
-    impl ::cynic::schema::HasInputField<createdAt_lt, Option<super::DateTime>>
-        for super::CompanyWhereInput
-    {
-    }
-    pub struct createdAt_lte;
-    impl ::cynic::schema::Field for createdAt_lte {
-        type Type = Option<super::DateTime>;
-        const NAME: &'static str = "createdAt_lte";
-    }
-    impl ::cynic::schema::HasInputField<createdAt_lte, Option<super::DateTime>>
-        for super::CompanyWhereInput
-    {
-    }
-    pub struct createdAt_gt;
-    impl ::cynic::schema::Field for createdAt_gt {
-        type Type = Option<super::DateTime>;
-        const NAME: &'static str = "createdAt_gt";
-    }
-    impl ::cynic::schema::HasInputField<createdAt_gt, Option<super::DateTime>>
-        for super::CompanyWhereInput
-    {
-    }
-    pub struct createdAt_gte;
-    impl ::cynic::schema::Field for createdAt_gte {
-        type Type = Option<super::DateTime>;
-        const NAME: &'static str = "createdAt_gte";
-    }
-    impl ::cynic::schema::HasInputField<createdAt_gte, Option<super::DateTime>>
-        for super::CompanyWhereInput
-    {
-    }
-    pub struct updatedAt;
-    impl ::cynic::schema::Field for updatedAt {
-        type Type = Option<super::DateTime>;
-        const NAME: &'static str = "updatedAt";
-    }
-    impl ::cynic::schema::HasInputField<updatedAt, Option<super::DateTime>>
-        for super::CompanyWhereInput
-    {
-    }
-    pub struct updatedAt_not;
-    impl ::cynic::schema::Field for updatedAt_not {
-        type Type = Option<super::DateTime>;
-        const NAME: &'static str = "updatedAt_not";
-    }
-    impl ::cynic::schema::HasInputField<updatedAt_not, Option<super::DateTime>>
-        for super::CompanyWhereInput
-    {
-    }
-    pub struct updatedAt_in;
-    impl ::cynic::schema::Field for updatedAt_in {
-        type Type = Option<Vec<super::DateTime>>;
-        const NAME: &'static str = "updatedAt_in";
-    }
-    impl ::cynic::schema::HasInputField<updatedAt_in, Option<Vec<super::DateTime>>>
-        for super::CompanyWhereInput
-    {
-    }
-    pub struct updatedAt_not_in;
-    impl ::cynic::schema::Field for updatedAt_not_in {
-        type Type = Option<Vec<super::DateTime>>;
-        const NAME: &'static str = "updatedAt_not_in";
-    }
-    impl ::cynic::schema::HasInputField<updatedAt_not_in, Option<Vec<super::DateTime>>>
-        for super::CompanyWhereInput
-    {
-    }
-    pub struct updatedAt_lt;
-    impl ::cynic::schema::Field for updatedAt_lt {
-        type Type = Option<super::DateTime>;
-        const NAME: &'static str = "updatedAt_lt";
-    }
-    impl ::cynic::schema::HasInputField<updatedAt_lt, Option<super::DateTime>>
-        for super::CompanyWhereInput
-    {
-    }
-    pub struct updatedAt_lte;
-    impl ::cynic::schema::Field for updatedAt_lte {
-        type Type = Option<super::DateTime>;
-        const NAME: &'static str = "updatedAt_lte";
-    }
-    impl ::cynic::schema::HasInputField<updatedAt_lte, Option<super::DateTime>>
-        for super::CompanyWhereInput
-    {
-    }
-    pub struct updatedAt_gt;
-    impl ::cynic::schema::Field for updatedAt_gt {
-        type Type = Option<super::DateTime>;
-        const NAME: &'static str = "updatedAt_gt";
-    }
-    impl ::cynic::schema::HasInputField<updatedAt_gt, Option<super::DateTime>>
-        for super::CompanyWhereInput
-    {
-    }
-    pub struct updatedAt_gte;
-    impl ::cynic::schema::Field for updatedAt_gte {
-        type Type = Option<super::DateTime>;
-        const NAME: &'static str = "updatedAt_gte";
-    }
-    impl ::cynic::schema::HasInputField<updatedAt_gte, Option<super::DateTime>>
-        for super::CompanyWhereInput
-    {
-    }
-    pub struct AND;
-    impl ::cynic::schema::Field for AND {
-        type Type = Option<Vec<super::CompanyWhereInput>>;
-        const NAME: &'static str = "AND";
-    }
-    impl ::cynic::schema::HasInputField<AND, Option<Vec<super::CompanyWhereInput>>>
-        for super::CompanyWhereInput
-    {
-    }
-    pub struct OR;
-    impl ::cynic::schema::Field for OR {
-        type Type = Option<Vec<super::CompanyWhereInput>>;
-        const NAME: &'static str = "OR";
-    }
-    impl ::cynic::schema::HasInputField<OR, Option<Vec<super::CompanyWhereInput>>>
-        for super::CompanyWhereInput
-    {
-    }
-    pub struct NOT;
-    impl ::cynic::schema::Field for NOT {
-        type Type = Option<Vec<super::CompanyWhereInput>>;
-        const NAME: &'static str = "NOT";
-    }
-    impl ::cynic::schema::HasInputField<NOT, Option<Vec<super::CompanyWhereInput>>>
-        for super::CompanyWhereInput
-    {
-    }
-}
 pub struct Country;
-pub mod country_fields {
-    pub struct id;
-    impl ::cynic::schema::Field for id {
-        type Type = super::ID;
-        const NAME: &'static str = "id";
-    }
-    impl ::cynic::schema::HasField<id> for super::Country {
-        type Type = super::ID;
-    }
-    pub struct name;
-    impl ::cynic::schema::Field for name {
-        type Type = super::String;
-        const NAME: &'static str = "name";
-    }
-    impl ::cynic::schema::HasField<name> for super::Country {
-        type Type = super::String;
-    }
-    pub struct slug;
-    impl ::cynic::schema::Field for slug {
-        type Type = super::String;
-        const NAME: &'static str = "slug";
-    }
-    impl ::cynic::schema::HasField<slug> for super::Country {
-        type Type = super::String;
-    }
-    pub struct r#type;
-    impl ::cynic::schema::Field for r#type {
-        type Type = super::String;
-        const NAME: &'static str = "type";
-    }
-    impl ::cynic::schema::HasField<r#type> for super::Country {
-        type Type = super::String;
-    }
-    pub struct isoCode;
-    impl ::cynic::schema::Field for isoCode {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "isoCode";
-    }
-    impl ::cynic::schema::HasField<isoCode> for super::Country {
-        type Type = Option<super::String>;
-    }
-    pub struct cities;
-    impl ::cynic::schema::Field for cities {
-        type Type = Option<Vec<super::City>>;
-        const NAME: &'static str = "cities";
-    }
-    impl ::cynic::schema::HasField<cities> for super::Country {
-        type Type = Option<Vec<super::City>>;
-    }
-    pub mod cities_arguments {
-        pub struct r#where;
-        impl ::cynic::schema::HasArgument<r#where> for super::cities {
-            type ArgumentType = Option<super::super::CityWhereInput>;
-            const NAME: &'static str = "where";
-        }
-        pub struct orderBy;
-        impl ::cynic::schema::HasArgument<orderBy> for super::cities {
-            type ArgumentType = Option<super::super::CityOrderByInput>;
-            const NAME: &'static str = "orderBy";
-        }
-        pub struct skip;
-        impl ::cynic::schema::HasArgument<skip> for super::cities {
-            type ArgumentType = Option<super::super::Int>;
-            const NAME: &'static str = "skip";
-        }
-        pub struct after;
-        impl ::cynic::schema::HasArgument<after> for super::cities {
-            type ArgumentType = Option<super::super::String>;
-            const NAME: &'static str = "after";
-        }
-        pub struct before;
-        impl ::cynic::schema::HasArgument<before> for super::cities {
-            type ArgumentType = Option<super::super::String>;
-            const NAME: &'static str = "before";
-        }
-        pub struct first;
-        impl ::cynic::schema::HasArgument<first> for super::cities {
-            type ArgumentType = Option<super::super::Int>;
-            const NAME: &'static str = "first";
-        }
-        pub struct last;
-        impl ::cynic::schema::HasArgument<last> for super::cities {
-            type ArgumentType = Option<super::super::Int>;
-            const NAME: &'static str = "last";
-        }
-    }
-    pub struct jobs;
-    impl ::cynic::schema::Field for jobs {
-        type Type = Option<Vec<super::Job>>;
-        const NAME: &'static str = "jobs";
-    }
-    impl ::cynic::schema::HasField<jobs> for super::Country {
-        type Type = Option<Vec<super::Job>>;
-    }
-    pub mod jobs_arguments {
-        pub struct r#where;
-        impl ::cynic::schema::HasArgument<r#where> for super::jobs {
-            type ArgumentType = Option<super::super::JobWhereInput>;
-            const NAME: &'static str = "where";
-        }
-        pub struct orderBy;
-        impl ::cynic::schema::HasArgument<orderBy> for super::jobs {
-            type ArgumentType = Option<super::super::JobOrderByInput>;
-            const NAME: &'static str = "orderBy";
-        }
-        pub struct skip;
-        impl ::cynic::schema::HasArgument<skip> for super::jobs {
-            type ArgumentType = Option<super::super::Int>;
-            const NAME: &'static str = "skip";
-        }
-        pub struct after;
-        impl ::cynic::schema::HasArgument<after> for super::jobs {
-            type ArgumentType = Option<super::super::String>;
-            const NAME: &'static str = "after";
-        }
-        pub struct before;
-        impl ::cynic::schema::HasArgument<before> for super::jobs {
-            type ArgumentType = Option<super::super::String>;
-            const NAME: &'static str = "before";
-        }
-        pub struct first;
-        impl ::cynic::schema::HasArgument<first> for super::jobs {
-            type ArgumentType = Option<super::super::Int>;
-            const NAME: &'static str = "first";
-        }
-        pub struct last;
-        impl ::cynic::schema::HasArgument<last> for super::jobs {
-            type ArgumentType = Option<super::super::Int>;
-            const NAME: &'static str = "last";
-        }
-    }
-    pub struct createdAt;
-    impl ::cynic::schema::Field for createdAt {
-        type Type = super::DateTime;
-        const NAME: &'static str = "createdAt";
-    }
-    impl ::cynic::schema::HasField<createdAt> for super::Country {
-        type Type = super::DateTime;
-    }
-    pub struct updatedAt;
-    impl ::cynic::schema::Field for updatedAt {
-        type Type = super::DateTime;
-        const NAME: &'static str = "updatedAt";
-    }
-    impl ::cynic::schema::HasField<updatedAt> for super::Country {
-        type Type = super::DateTime;
-    }
-}
 pub struct CountryOrderByInput {}
 pub struct CountryWhereInput;
 impl ::cynic::schema::InputObjectMarker for CountryWhereInput {}
-pub mod country_where_input_fields {
-    pub struct id;
-    impl ::cynic::schema::Field for id {
-        type Type = Option<super::ID>;
-        const NAME: &'static str = "id";
-    }
-    impl ::cynic::schema::HasInputField<id, Option<super::ID>> for super::CountryWhereInput {}
-    pub struct id_not;
-    impl ::cynic::schema::Field for id_not {
-        type Type = Option<super::ID>;
-        const NAME: &'static str = "id_not";
-    }
-    impl ::cynic::schema::HasInputField<id_not, Option<super::ID>> for super::CountryWhereInput {}
-    pub struct id_in;
-    impl ::cynic::schema::Field for id_in {
-        type Type = Option<Vec<super::ID>>;
-        const NAME: &'static str = "id_in";
-    }
-    impl ::cynic::schema::HasInputField<id_in, Option<Vec<super::ID>>> for super::CountryWhereInput {}
-    pub struct id_not_in;
-    impl ::cynic::schema::Field for id_not_in {
-        type Type = Option<Vec<super::ID>>;
-        const NAME: &'static str = "id_not_in";
-    }
-    impl ::cynic::schema::HasInputField<id_not_in, Option<Vec<super::ID>>>
-        for super::CountryWhereInput
-    {
-    }
-    pub struct id_lt;
-    impl ::cynic::schema::Field for id_lt {
-        type Type = Option<super::ID>;
-        const NAME: &'static str = "id_lt";
-    }
-    impl ::cynic::schema::HasInputField<id_lt, Option<super::ID>> for super::CountryWhereInput {}
-    pub struct id_lte;
-    impl ::cynic::schema::Field for id_lte {
-        type Type = Option<super::ID>;
-        const NAME: &'static str = "id_lte";
-    }
-    impl ::cynic::schema::HasInputField<id_lte, Option<super::ID>> for super::CountryWhereInput {}
-    pub struct id_gt;
-    impl ::cynic::schema::Field for id_gt {
-        type Type = Option<super::ID>;
-        const NAME: &'static str = "id_gt";
-    }
-    impl ::cynic::schema::HasInputField<id_gt, Option<super::ID>> for super::CountryWhereInput {}
-    pub struct id_gte;
-    impl ::cynic::schema::Field for id_gte {
-        type Type = Option<super::ID>;
-        const NAME: &'static str = "id_gte";
-    }
-    impl ::cynic::schema::HasInputField<id_gte, Option<super::ID>> for super::CountryWhereInput {}
-    pub struct id_contains;
-    impl ::cynic::schema::Field for id_contains {
-        type Type = Option<super::ID>;
-        const NAME: &'static str = "id_contains";
-    }
-    impl ::cynic::schema::HasInputField<id_contains, Option<super::ID>> for super::CountryWhereInput {}
-    pub struct id_not_contains;
-    impl ::cynic::schema::Field for id_not_contains {
-        type Type = Option<super::ID>;
-        const NAME: &'static str = "id_not_contains";
-    }
-    impl ::cynic::schema::HasInputField<id_not_contains, Option<super::ID>>
-        for super::CountryWhereInput
-    {
-    }
-    pub struct id_starts_with;
-    impl ::cynic::schema::Field for id_starts_with {
-        type Type = Option<super::ID>;
-        const NAME: &'static str = "id_starts_with";
-    }
-    impl ::cynic::schema::HasInputField<id_starts_with, Option<super::ID>>
-        for super::CountryWhereInput
-    {
-    }
-    pub struct id_not_starts_with;
-    impl ::cynic::schema::Field for id_not_starts_with {
-        type Type = Option<super::ID>;
-        const NAME: &'static str = "id_not_starts_with";
-    }
-    impl ::cynic::schema::HasInputField<id_not_starts_with, Option<super::ID>>
-        for super::CountryWhereInput
-    {
-    }
-    pub struct id_ends_with;
-    impl ::cynic::schema::Field for id_ends_with {
-        type Type = Option<super::ID>;
-        const NAME: &'static str = "id_ends_with";
-    }
-    impl ::cynic::schema::HasInputField<id_ends_with, Option<super::ID>> for super::CountryWhereInput {}
-    pub struct id_not_ends_with;
-    impl ::cynic::schema::Field for id_not_ends_with {
-        type Type = Option<super::ID>;
-        const NAME: &'static str = "id_not_ends_with";
-    }
-    impl ::cynic::schema::HasInputField<id_not_ends_with, Option<super::ID>>
-        for super::CountryWhereInput
-    {
-    }
-    pub struct name;
-    impl ::cynic::schema::Field for name {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "name";
-    }
-    impl ::cynic::schema::HasInputField<name, Option<super::String>> for super::CountryWhereInput {}
-    pub struct name_not;
-    impl ::cynic::schema::Field for name_not {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "name_not";
-    }
-    impl ::cynic::schema::HasInputField<name_not, Option<super::String>> for super::CountryWhereInput {}
-    pub struct name_in;
-    impl ::cynic::schema::Field for name_in {
-        type Type = Option<Vec<super::String>>;
-        const NAME: &'static str = "name_in";
-    }
-    impl ::cynic::schema::HasInputField<name_in, Option<Vec<super::String>>>
-        for super::CountryWhereInput
-    {
-    }
-    pub struct name_not_in;
-    impl ::cynic::schema::Field for name_not_in {
-        type Type = Option<Vec<super::String>>;
-        const NAME: &'static str = "name_not_in";
-    }
-    impl ::cynic::schema::HasInputField<name_not_in, Option<Vec<super::String>>>
-        for super::CountryWhereInput
-    {
-    }
-    pub struct name_lt;
-    impl ::cynic::schema::Field for name_lt {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "name_lt";
-    }
-    impl ::cynic::schema::HasInputField<name_lt, Option<super::String>> for super::CountryWhereInput {}
-    pub struct name_lte;
-    impl ::cynic::schema::Field for name_lte {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "name_lte";
-    }
-    impl ::cynic::schema::HasInputField<name_lte, Option<super::String>> for super::CountryWhereInput {}
-    pub struct name_gt;
-    impl ::cynic::schema::Field for name_gt {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "name_gt";
-    }
-    impl ::cynic::schema::HasInputField<name_gt, Option<super::String>> for super::CountryWhereInput {}
-    pub struct name_gte;
-    impl ::cynic::schema::Field for name_gte {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "name_gte";
-    }
-    impl ::cynic::schema::HasInputField<name_gte, Option<super::String>> for super::CountryWhereInput {}
-    pub struct name_contains;
-    impl ::cynic::schema::Field for name_contains {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "name_contains";
-    }
-    impl ::cynic::schema::HasInputField<name_contains, Option<super::String>>
-        for super::CountryWhereInput
-    {
-    }
-    pub struct name_not_contains;
-    impl ::cynic::schema::Field for name_not_contains {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "name_not_contains";
-    }
-    impl ::cynic::schema::HasInputField<name_not_contains, Option<super::String>>
-        for super::CountryWhereInput
-    {
-    }
-    pub struct name_starts_with;
-    impl ::cynic::schema::Field for name_starts_with {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "name_starts_with";
-    }
-    impl ::cynic::schema::HasInputField<name_starts_with, Option<super::String>>
-        for super::CountryWhereInput
-    {
-    }
-    pub struct name_not_starts_with;
-    impl ::cynic::schema::Field for name_not_starts_with {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "name_not_starts_with";
-    }
-    impl ::cynic::schema::HasInputField<name_not_starts_with, Option<super::String>>
-        for super::CountryWhereInput
-    {
-    }
-    pub struct name_ends_with;
-    impl ::cynic::schema::Field for name_ends_with {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "name_ends_with";
-    }
-    impl ::cynic::schema::HasInputField<name_ends_with, Option<super::String>>
-        for super::CountryWhereInput
-    {
-    }
-    pub struct name_not_ends_with;
-    impl ::cynic::schema::Field for name_not_ends_with {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "name_not_ends_with";
-    }
-    impl ::cynic::schema::HasInputField<name_not_ends_with, Option<super::String>>
-        for super::CountryWhereInput
-    {
-    }
-    pub struct slug;
-    impl ::cynic::schema::Field for slug {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "slug";
-    }
-    impl ::cynic::schema::HasInputField<slug, Option<super::String>> for super::CountryWhereInput {}
-    pub struct slug_not;
-    impl ::cynic::schema::Field for slug_not {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "slug_not";
-    }
-    impl ::cynic::schema::HasInputField<slug_not, Option<super::String>> for super::CountryWhereInput {}
-    pub struct slug_in;
-    impl ::cynic::schema::Field for slug_in {
-        type Type = Option<Vec<super::String>>;
-        const NAME: &'static str = "slug_in";
-    }
-    impl ::cynic::schema::HasInputField<slug_in, Option<Vec<super::String>>>
-        for super::CountryWhereInput
-    {
-    }
-    pub struct slug_not_in;
-    impl ::cynic::schema::Field for slug_not_in {
-        type Type = Option<Vec<super::String>>;
-        const NAME: &'static str = "slug_not_in";
-    }
-    impl ::cynic::schema::HasInputField<slug_not_in, Option<Vec<super::String>>>
-        for super::CountryWhereInput
-    {
-    }
-    pub struct slug_lt;
-    impl ::cynic::schema::Field for slug_lt {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "slug_lt";
-    }
-    impl ::cynic::schema::HasInputField<slug_lt, Option<super::String>> for super::CountryWhereInput {}
-    pub struct slug_lte;
-    impl ::cynic::schema::Field for slug_lte {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "slug_lte";
-    }
-    impl ::cynic::schema::HasInputField<slug_lte, Option<super::String>> for super::CountryWhereInput {}
-    pub struct slug_gt;
-    impl ::cynic::schema::Field for slug_gt {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "slug_gt";
-    }
-    impl ::cynic::schema::HasInputField<slug_gt, Option<super::String>> for super::CountryWhereInput {}
-    pub struct slug_gte;
-    impl ::cynic::schema::Field for slug_gte {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "slug_gte";
-    }
-    impl ::cynic::schema::HasInputField<slug_gte, Option<super::String>> for super::CountryWhereInput {}
-    pub struct slug_contains;
-    impl ::cynic::schema::Field for slug_contains {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "slug_contains";
-    }
-    impl ::cynic::schema::HasInputField<slug_contains, Option<super::String>>
-        for super::CountryWhereInput
-    {
-    }
-    pub struct slug_not_contains;
-    impl ::cynic::schema::Field for slug_not_contains {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "slug_not_contains";
-    }
-    impl ::cynic::schema::HasInputField<slug_not_contains, Option<super::String>>
-        for super::CountryWhereInput
-    {
-    }
-    pub struct slug_starts_with;
-    impl ::cynic::schema::Field for slug_starts_with {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "slug_starts_with";
-    }
-    impl ::cynic::schema::HasInputField<slug_starts_with, Option<super::String>>
-        for super::CountryWhereInput
-    {
-    }
-    pub struct slug_not_starts_with;
-    impl ::cynic::schema::Field for slug_not_starts_with {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "slug_not_starts_with";
-    }
-    impl ::cynic::schema::HasInputField<slug_not_starts_with, Option<super::String>>
-        for super::CountryWhereInput
-    {
-    }
-    pub struct slug_ends_with;
-    impl ::cynic::schema::Field for slug_ends_with {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "slug_ends_with";
-    }
-    impl ::cynic::schema::HasInputField<slug_ends_with, Option<super::String>>
-        for super::CountryWhereInput
-    {
-    }
-    pub struct slug_not_ends_with;
-    impl ::cynic::schema::Field for slug_not_ends_with {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "slug_not_ends_with";
-    }
-    impl ::cynic::schema::HasInputField<slug_not_ends_with, Option<super::String>>
-        for super::CountryWhereInput
-    {
-    }
-    pub struct r#type;
-    impl ::cynic::schema::Field for r#type {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "type";
-    }
-    impl ::cynic::schema::HasInputField<r#type, Option<super::String>> for super::CountryWhereInput {}
-    pub struct type_not;
-    impl ::cynic::schema::Field for type_not {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "type_not";
-    }
-    impl ::cynic::schema::HasInputField<type_not, Option<super::String>> for super::CountryWhereInput {}
-    pub struct type_in;
-    impl ::cynic::schema::Field for type_in {
-        type Type = Option<Vec<super::String>>;
-        const NAME: &'static str = "type_in";
-    }
-    impl ::cynic::schema::HasInputField<type_in, Option<Vec<super::String>>>
-        for super::CountryWhereInput
-    {
-    }
-    pub struct type_not_in;
-    impl ::cynic::schema::Field for type_not_in {
-        type Type = Option<Vec<super::String>>;
-        const NAME: &'static str = "type_not_in";
-    }
-    impl ::cynic::schema::HasInputField<type_not_in, Option<Vec<super::String>>>
-        for super::CountryWhereInput
-    {
-    }
-    pub struct type_lt;
-    impl ::cynic::schema::Field for type_lt {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "type_lt";
-    }
-    impl ::cynic::schema::HasInputField<type_lt, Option<super::String>> for super::CountryWhereInput {}
-    pub struct type_lte;
-    impl ::cynic::schema::Field for type_lte {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "type_lte";
-    }
-    impl ::cynic::schema::HasInputField<type_lte, Option<super::String>> for super::CountryWhereInput {}
-    pub struct type_gt;
-    impl ::cynic::schema::Field for type_gt {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "type_gt";
-    }
-    impl ::cynic::schema::HasInputField<type_gt, Option<super::String>> for super::CountryWhereInput {}
-    pub struct type_gte;
-    impl ::cynic::schema::Field for type_gte {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "type_gte";
-    }
-    impl ::cynic::schema::HasInputField<type_gte, Option<super::String>> for super::CountryWhereInput {}
-    pub struct type_contains;
-    impl ::cynic::schema::Field for type_contains {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "type_contains";
-    }
-    impl ::cynic::schema::HasInputField<type_contains, Option<super::String>>
-        for super::CountryWhereInput
-    {
-    }
-    pub struct type_not_contains;
-    impl ::cynic::schema::Field for type_not_contains {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "type_not_contains";
-    }
-    impl ::cynic::schema::HasInputField<type_not_contains, Option<super::String>>
-        for super::CountryWhereInput
-    {
-    }
-    pub struct type_starts_with;
-    impl ::cynic::schema::Field for type_starts_with {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "type_starts_with";
-    }
-    impl ::cynic::schema::HasInputField<type_starts_with, Option<super::String>>
-        for super::CountryWhereInput
-    {
-    }
-    pub struct type_not_starts_with;
-    impl ::cynic::schema::Field for type_not_starts_with {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "type_not_starts_with";
-    }
-    impl ::cynic::schema::HasInputField<type_not_starts_with, Option<super::String>>
-        for super::CountryWhereInput
-    {
-    }
-    pub struct type_ends_with;
-    impl ::cynic::schema::Field for type_ends_with {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "type_ends_with";
-    }
-    impl ::cynic::schema::HasInputField<type_ends_with, Option<super::String>>
-        for super::CountryWhereInput
-    {
-    }
-    pub struct type_not_ends_with;
-    impl ::cynic::schema::Field for type_not_ends_with {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "type_not_ends_with";
-    }
-    impl ::cynic::schema::HasInputField<type_not_ends_with, Option<super::String>>
-        for super::CountryWhereInput
-    {
-    }
-    pub struct isoCode;
-    impl ::cynic::schema::Field for isoCode {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "isoCode";
-    }
-    impl ::cynic::schema::HasInputField<isoCode, Option<super::String>> for super::CountryWhereInput {}
-    pub struct isoCode_not;
-    impl ::cynic::schema::Field for isoCode_not {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "isoCode_not";
-    }
-    impl ::cynic::schema::HasInputField<isoCode_not, Option<super::String>>
-        for super::CountryWhereInput
-    {
-    }
-    pub struct isoCode_in;
-    impl ::cynic::schema::Field for isoCode_in {
-        type Type = Option<Vec<super::String>>;
-        const NAME: &'static str = "isoCode_in";
-    }
-    impl ::cynic::schema::HasInputField<isoCode_in, Option<Vec<super::String>>>
-        for super::CountryWhereInput
-    {
-    }
-    pub struct isoCode_not_in;
-    impl ::cynic::schema::Field for isoCode_not_in {
-        type Type = Option<Vec<super::String>>;
-        const NAME: &'static str = "isoCode_not_in";
-    }
-    impl ::cynic::schema::HasInputField<isoCode_not_in, Option<Vec<super::String>>>
-        for super::CountryWhereInput
-    {
-    }
-    pub struct isoCode_lt;
-    impl ::cynic::schema::Field for isoCode_lt {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "isoCode_lt";
-    }
-    impl ::cynic::schema::HasInputField<isoCode_lt, Option<super::String>>
-        for super::CountryWhereInput
-    {
-    }
-    pub struct isoCode_lte;
-    impl ::cynic::schema::Field for isoCode_lte {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "isoCode_lte";
-    }
-    impl ::cynic::schema::HasInputField<isoCode_lte, Option<super::String>>
-        for super::CountryWhereInput
-    {
-    }
-    pub struct isoCode_gt;
-    impl ::cynic::schema::Field for isoCode_gt {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "isoCode_gt";
-    }
-    impl ::cynic::schema::HasInputField<isoCode_gt, Option<super::String>>
-        for super::CountryWhereInput
-    {
-    }
-    pub struct isoCode_gte;
-    impl ::cynic::schema::Field for isoCode_gte {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "isoCode_gte";
-    }
-    impl ::cynic::schema::HasInputField<isoCode_gte, Option<super::String>>
-        for super::CountryWhereInput
-    {
-    }
-    pub struct isoCode_contains;
-    impl ::cynic::schema::Field for isoCode_contains {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "isoCode_contains";
-    }
-    impl ::cynic::schema::HasInputField<isoCode_contains, Option<super::String>>
-        for super::CountryWhereInput
-    {
-    }
-    pub struct isoCode_not_contains;
-    impl ::cynic::schema::Field for isoCode_not_contains {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "isoCode_not_contains";
-    }
-    impl ::cynic::schema::HasInputField<isoCode_not_contains, Option<super::String>>
-        for super::CountryWhereInput
-    {
-    }
-    pub struct isoCode_starts_with;
-    impl ::cynic::schema::Field for isoCode_starts_with {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "isoCode_starts_with";
-    }
-    impl ::cynic::schema::HasInputField<isoCode_starts_with, Option<super::String>>
-        for super::CountryWhereInput
-    {
-    }
-    pub struct isoCode_not_starts_with;
-    impl ::cynic::schema::Field for isoCode_not_starts_with {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "isoCode_not_starts_with";
-    }
-    impl ::cynic::schema::HasInputField<isoCode_not_starts_with, Option<super::String>>
-        for super::CountryWhereInput
-    {
-    }
-    pub struct isoCode_ends_with;
-    impl ::cynic::schema::Field for isoCode_ends_with {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "isoCode_ends_with";
-    }
-    impl ::cynic::schema::HasInputField<isoCode_ends_with, Option<super::String>>
-        for super::CountryWhereInput
-    {
-    }
-    pub struct isoCode_not_ends_with;
-    impl ::cynic::schema::Field for isoCode_not_ends_with {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "isoCode_not_ends_with";
-    }
-    impl ::cynic::schema::HasInputField<isoCode_not_ends_with, Option<super::String>>
-        for super::CountryWhereInput
-    {
-    }
-    pub struct cities_every;
-    impl ::cynic::schema::Field for cities_every {
-        type Type = Option<super::CityWhereInput>;
-        const NAME: &'static str = "cities_every";
-    }
-    impl ::cynic::schema::HasInputField<cities_every, Option<super::CityWhereInput>>
-        for super::CountryWhereInput
-    {
-    }
-    pub struct cities_some;
-    impl ::cynic::schema::Field for cities_some {
-        type Type = Option<super::CityWhereInput>;
-        const NAME: &'static str = "cities_some";
-    }
-    impl ::cynic::schema::HasInputField<cities_some, Option<super::CityWhereInput>>
-        for super::CountryWhereInput
-    {
-    }
-    pub struct cities_none;
-    impl ::cynic::schema::Field for cities_none {
-        type Type = Option<super::CityWhereInput>;
-        const NAME: &'static str = "cities_none";
-    }
-    impl ::cynic::schema::HasInputField<cities_none, Option<super::CityWhereInput>>
-        for super::CountryWhereInput
-    {
-    }
-    pub struct jobs_every;
-    impl ::cynic::schema::Field for jobs_every {
-        type Type = Option<super::JobWhereInput>;
-        const NAME: &'static str = "jobs_every";
-    }
-    impl ::cynic::schema::HasInputField<jobs_every, Option<super::JobWhereInput>>
-        for super::CountryWhereInput
-    {
-    }
-    pub struct jobs_some;
-    impl ::cynic::schema::Field for jobs_some {
-        type Type = Option<super::JobWhereInput>;
-        const NAME: &'static str = "jobs_some";
-    }
-    impl ::cynic::schema::HasInputField<jobs_some, Option<super::JobWhereInput>>
-        for super::CountryWhereInput
-    {
-    }
-    pub struct jobs_none;
-    impl ::cynic::schema::Field for jobs_none {
-        type Type = Option<super::JobWhereInput>;
-        const NAME: &'static str = "jobs_none";
-    }
-    impl ::cynic::schema::HasInputField<jobs_none, Option<super::JobWhereInput>>
-        for super::CountryWhereInput
-    {
-    }
-    pub struct createdAt;
-    impl ::cynic::schema::Field for createdAt {
-        type Type = Option<super::DateTime>;
-        const NAME: &'static str = "createdAt";
-    }
-    impl ::cynic::schema::HasInputField<createdAt, Option<super::DateTime>>
-        for super::CountryWhereInput
-    {
-    }
-    pub struct createdAt_not;
-    impl ::cynic::schema::Field for createdAt_not {
-        type Type = Option<super::DateTime>;
-        const NAME: &'static str = "createdAt_not";
-    }
-    impl ::cynic::schema::HasInputField<createdAt_not, Option<super::DateTime>>
-        for super::CountryWhereInput
-    {
-    }
-    pub struct createdAt_in;
-    impl ::cynic::schema::Field for createdAt_in {
-        type Type = Option<Vec<super::DateTime>>;
-        const NAME: &'static str = "createdAt_in";
-    }
-    impl ::cynic::schema::HasInputField<createdAt_in, Option<Vec<super::DateTime>>>
-        for super::CountryWhereInput
-    {
-    }
-    pub struct createdAt_not_in;
-    impl ::cynic::schema::Field for createdAt_not_in {
-        type Type = Option<Vec<super::DateTime>>;
-        const NAME: &'static str = "createdAt_not_in";
-    }
-    impl ::cynic::schema::HasInputField<createdAt_not_in, Option<Vec<super::DateTime>>>
-        for super::CountryWhereInput
-    {
-    }
-    pub struct createdAt_lt;
-    impl ::cynic::schema::Field for createdAt_lt {
-        type Type = Option<super::DateTime>;
-        const NAME: &'static str = "createdAt_lt";
-    }
-    impl ::cynic::schema::HasInputField<createdAt_lt, Option<super::DateTime>>
-        for super::CountryWhereInput
-    {
-    }
-    pub struct createdAt_lte;
-    impl ::cynic::schema::Field for createdAt_lte {
-        type Type = Option<super::DateTime>;
-        const NAME: &'static str = "createdAt_lte";
-    }
-    impl ::cynic::schema::HasInputField<createdAt_lte, Option<super::DateTime>>
-        for super::CountryWhereInput
-    {
-    }
-    pub struct createdAt_gt;
-    impl ::cynic::schema::Field for createdAt_gt {
-        type Type = Option<super::DateTime>;
-        const NAME: &'static str = "createdAt_gt";
-    }
-    impl ::cynic::schema::HasInputField<createdAt_gt, Option<super::DateTime>>
-        for super::CountryWhereInput
-    {
-    }
-    pub struct createdAt_gte;
-    impl ::cynic::schema::Field for createdAt_gte {
-        type Type = Option<super::DateTime>;
-        const NAME: &'static str = "createdAt_gte";
-    }
-    impl ::cynic::schema::HasInputField<createdAt_gte, Option<super::DateTime>>
-        for super::CountryWhereInput
-    {
-    }
-    pub struct updatedAt;
-    impl ::cynic::schema::Field for updatedAt {
-        type Type = Option<super::DateTime>;
-        const NAME: &'static str = "updatedAt";
-    }
-    impl ::cynic::schema::HasInputField<updatedAt, Option<super::DateTime>>
-        for super::CountryWhereInput
-    {
-    }
-    pub struct updatedAt_not;
-    impl ::cynic::schema::Field for updatedAt_not {
-        type Type = Option<super::DateTime>;
-        const NAME: &'static str = "updatedAt_not";
-    }
-    impl ::cynic::schema::HasInputField<updatedAt_not, Option<super::DateTime>>
-        for super::CountryWhereInput
-    {
-    }
-    pub struct updatedAt_in;
-    impl ::cynic::schema::Field for updatedAt_in {
-        type Type = Option<Vec<super::DateTime>>;
-        const NAME: &'static str = "updatedAt_in";
-    }
-    impl ::cynic::schema::HasInputField<updatedAt_in, Option<Vec<super::DateTime>>>
-        for super::CountryWhereInput
-    {
-    }
-    pub struct updatedAt_not_in;
-    impl ::cynic::schema::Field for updatedAt_not_in {
-        type Type = Option<Vec<super::DateTime>>;
-        const NAME: &'static str = "updatedAt_not_in";
-    }
-    impl ::cynic::schema::HasInputField<updatedAt_not_in, Option<Vec<super::DateTime>>>
-        for super::CountryWhereInput
-    {
-    }
-    pub struct updatedAt_lt;
-    impl ::cynic::schema::Field for updatedAt_lt {
-        type Type = Option<super::DateTime>;
-        const NAME: &'static str = "updatedAt_lt";
-    }
-    impl ::cynic::schema::HasInputField<updatedAt_lt, Option<super::DateTime>>
-        for super::CountryWhereInput
-    {
-    }
-    pub struct updatedAt_lte;
-    impl ::cynic::schema::Field for updatedAt_lte {
-        type Type = Option<super::DateTime>;
-        const NAME: &'static str = "updatedAt_lte";
-    }
-    impl ::cynic::schema::HasInputField<updatedAt_lte, Option<super::DateTime>>
-        for super::CountryWhereInput
-    {
-    }
-    pub struct updatedAt_gt;
-    impl ::cynic::schema::Field for updatedAt_gt {
-        type Type = Option<super::DateTime>;
-        const NAME: &'static str = "updatedAt_gt";
-    }
-    impl ::cynic::schema::HasInputField<updatedAt_gt, Option<super::DateTime>>
-        for super::CountryWhereInput
-    {
-    }
-    pub struct updatedAt_gte;
-    impl ::cynic::schema::Field for updatedAt_gte {
-        type Type = Option<super::DateTime>;
-        const NAME: &'static str = "updatedAt_gte";
-    }
-    impl ::cynic::schema::HasInputField<updatedAt_gte, Option<super::DateTime>>
-        for super::CountryWhereInput
-    {
-    }
-    pub struct AND;
-    impl ::cynic::schema::Field for AND {
-        type Type = Option<Vec<super::CountryWhereInput>>;
-        const NAME: &'static str = "AND";
-    }
-    impl ::cynic::schema::HasInputField<AND, Option<Vec<super::CountryWhereInput>>>
-        for super::CountryWhereInput
-    {
-    }
-    pub struct OR;
-    impl ::cynic::schema::Field for OR {
-        type Type = Option<Vec<super::CountryWhereInput>>;
-        const NAME: &'static str = "OR";
-    }
-    impl ::cynic::schema::HasInputField<OR, Option<Vec<super::CountryWhereInput>>>
-        for super::CountryWhereInput
-    {
-    }
-    pub struct NOT;
-    impl ::cynic::schema::Field for NOT {
-        type Type = Option<Vec<super::CountryWhereInput>>;
-        const NAME: &'static str = "NOT";
-    }
-    impl ::cynic::schema::HasInputField<NOT, Option<Vec<super::CountryWhereInput>>>
-        for super::CountryWhereInput
-    {
-    }
-}
 pub struct DateTime {}
 impl ::cynic::schema::NamedType for DateTime {
     const NAME: &'static str = "DateTime";
 }
 pub struct Job;
-pub mod job_fields {
-    pub struct id;
-    impl ::cynic::schema::Field for id {
-        type Type = super::ID;
-        const NAME: &'static str = "id";
-    }
-    impl ::cynic::schema::HasField<id> for super::Job {
-        type Type = super::ID;
-    }
-    pub struct title;
-    impl ::cynic::schema::Field for title {
-        type Type = super::String;
-        const NAME: &'static str = "title";
-    }
-    impl ::cynic::schema::HasField<title> for super::Job {
-        type Type = super::String;
-    }
-    pub struct slug;
-    impl ::cynic::schema::Field for slug {
-        type Type = super::String;
-        const NAME: &'static str = "slug";
-    }
-    impl ::cynic::schema::HasField<slug> for super::Job {
-        type Type = super::String;
-    }
-    pub struct commitment;
-    impl ::cynic::schema::Field for commitment {
-        type Type = super::Commitment;
-        const NAME: &'static str = "commitment";
-    }
-    impl ::cynic::schema::HasField<commitment> for super::Job {
-        type Type = super::Commitment;
-    }
-    pub struct cities;
-    impl ::cynic::schema::Field for cities {
-        type Type = Option<Vec<super::City>>;
-        const NAME: &'static str = "cities";
-    }
-    impl ::cynic::schema::HasField<cities> for super::Job {
-        type Type = Option<Vec<super::City>>;
-    }
-    pub mod cities_arguments {
-        pub struct r#where;
-        impl ::cynic::schema::HasArgument<r#where> for super::cities {
-            type ArgumentType = Option<super::super::CityWhereInput>;
-            const NAME: &'static str = "where";
-        }
-        pub struct orderBy;
-        impl ::cynic::schema::HasArgument<orderBy> for super::cities {
-            type ArgumentType = Option<super::super::CityOrderByInput>;
-            const NAME: &'static str = "orderBy";
-        }
-        pub struct skip;
-        impl ::cynic::schema::HasArgument<skip> for super::cities {
-            type ArgumentType = Option<super::super::Int>;
-            const NAME: &'static str = "skip";
-        }
-        pub struct after;
-        impl ::cynic::schema::HasArgument<after> for super::cities {
-            type ArgumentType = Option<super::super::String>;
-            const NAME: &'static str = "after";
-        }
-        pub struct before;
-        impl ::cynic::schema::HasArgument<before> for super::cities {
-            type ArgumentType = Option<super::super::String>;
-            const NAME: &'static str = "before";
-        }
-        pub struct first;
-        impl ::cynic::schema::HasArgument<first> for super::cities {
-            type ArgumentType = Option<super::super::Int>;
-            const NAME: &'static str = "first";
-        }
-        pub struct last;
-        impl ::cynic::schema::HasArgument<last> for super::cities {
-            type ArgumentType = Option<super::super::Int>;
-            const NAME: &'static str = "last";
-        }
-    }
-    pub struct countries;
-    impl ::cynic::schema::Field for countries {
-        type Type = Option<Vec<super::Country>>;
-        const NAME: &'static str = "countries";
-    }
-    impl ::cynic::schema::HasField<countries> for super::Job {
-        type Type = Option<Vec<super::Country>>;
-    }
-    pub mod countries_arguments {
-        pub struct r#where;
-        impl ::cynic::schema::HasArgument<r#where> for super::countries {
-            type ArgumentType = Option<super::super::CountryWhereInput>;
-            const NAME: &'static str = "where";
-        }
-        pub struct orderBy;
-        impl ::cynic::schema::HasArgument<orderBy> for super::countries {
-            type ArgumentType = Option<super::super::CountryOrderByInput>;
-            const NAME: &'static str = "orderBy";
-        }
-        pub struct skip;
-        impl ::cynic::schema::HasArgument<skip> for super::countries {
-            type ArgumentType = Option<super::super::Int>;
-            const NAME: &'static str = "skip";
-        }
-        pub struct after;
-        impl ::cynic::schema::HasArgument<after> for super::countries {
-            type ArgumentType = Option<super::super::String>;
-            const NAME: &'static str = "after";
-        }
-        pub struct before;
-        impl ::cynic::schema::HasArgument<before> for super::countries {
-            type ArgumentType = Option<super::super::String>;
-            const NAME: &'static str = "before";
-        }
-        pub struct first;
-        impl ::cynic::schema::HasArgument<first> for super::countries {
-            type ArgumentType = Option<super::super::Int>;
-            const NAME: &'static str = "first";
-        }
-        pub struct last;
-        impl ::cynic::schema::HasArgument<last> for super::countries {
-            type ArgumentType = Option<super::super::Int>;
-            const NAME: &'static str = "last";
-        }
-    }
-    pub struct remotes;
-    impl ::cynic::schema::Field for remotes {
-        type Type = Option<Vec<super::Remote>>;
-        const NAME: &'static str = "remotes";
-    }
-    impl ::cynic::schema::HasField<remotes> for super::Job {
-        type Type = Option<Vec<super::Remote>>;
-    }
-    pub mod remotes_arguments {
-        pub struct r#where;
-        impl ::cynic::schema::HasArgument<r#where> for super::remotes {
-            type ArgumentType = Option<super::super::RemoteWhereInput>;
-            const NAME: &'static str = "where";
-        }
-        pub struct orderBy;
-        impl ::cynic::schema::HasArgument<orderBy> for super::remotes {
-            type ArgumentType = Option<super::super::RemoteOrderByInput>;
-            const NAME: &'static str = "orderBy";
-        }
-        pub struct skip;
-        impl ::cynic::schema::HasArgument<skip> for super::remotes {
-            type ArgumentType = Option<super::super::Int>;
-            const NAME: &'static str = "skip";
-        }
-        pub struct after;
-        impl ::cynic::schema::HasArgument<after> for super::remotes {
-            type ArgumentType = Option<super::super::String>;
-            const NAME: &'static str = "after";
-        }
-        pub struct before;
-        impl ::cynic::schema::HasArgument<before> for super::remotes {
-            type ArgumentType = Option<super::super::String>;
-            const NAME: &'static str = "before";
-        }
-        pub struct first;
-        impl ::cynic::schema::HasArgument<first> for super::remotes {
-            type ArgumentType = Option<super::super::Int>;
-            const NAME: &'static str = "first";
-        }
-        pub struct last;
-        impl ::cynic::schema::HasArgument<last> for super::remotes {
-            type ArgumentType = Option<super::super::Int>;
-            const NAME: &'static str = "last";
-        }
-    }
-    pub struct description;
-    impl ::cynic::schema::Field for description {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "description";
-    }
-    impl ::cynic::schema::HasField<description> for super::Job {
-        type Type = Option<super::String>;
-    }
-    pub struct applyUrl;
-    impl ::cynic::schema::Field for applyUrl {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "applyUrl";
-    }
-    impl ::cynic::schema::HasField<applyUrl> for super::Job {
-        type Type = Option<super::String>;
-    }
-    pub struct company;
-    impl ::cynic::schema::Field for company {
-        type Type = Option<super::Company>;
-        const NAME: &'static str = "company";
-    }
-    impl ::cynic::schema::HasField<company> for super::Job {
-        type Type = Option<super::Company>;
-    }
-    pub struct tags;
-    impl ::cynic::schema::Field for tags {
-        type Type = Option<Vec<super::Tag>>;
-        const NAME: &'static str = "tags";
-    }
-    impl ::cynic::schema::HasField<tags> for super::Job {
-        type Type = Option<Vec<super::Tag>>;
-    }
-    pub mod tags_arguments {
-        pub struct r#where;
-        impl ::cynic::schema::HasArgument<r#where> for super::tags {
-            type ArgumentType = Option<super::super::TagWhereInput>;
-            const NAME: &'static str = "where";
-        }
-        pub struct orderBy;
-        impl ::cynic::schema::HasArgument<orderBy> for super::tags {
-            type ArgumentType = Option<super::super::TagOrderByInput>;
-            const NAME: &'static str = "orderBy";
-        }
-        pub struct skip;
-        impl ::cynic::schema::HasArgument<skip> for super::tags {
-            type ArgumentType = Option<super::super::Int>;
-            const NAME: &'static str = "skip";
-        }
-        pub struct after;
-        impl ::cynic::schema::HasArgument<after> for super::tags {
-            type ArgumentType = Option<super::super::String>;
-            const NAME: &'static str = "after";
-        }
-        pub struct before;
-        impl ::cynic::schema::HasArgument<before> for super::tags {
-            type ArgumentType = Option<super::super::String>;
-            const NAME: &'static str = "before";
-        }
-        pub struct first;
-        impl ::cynic::schema::HasArgument<first> for super::tags {
-            type ArgumentType = Option<super::super::Int>;
-            const NAME: &'static str = "first";
-        }
-        pub struct last;
-        impl ::cynic::schema::HasArgument<last> for super::tags {
-            type ArgumentType = Option<super::super::Int>;
-            const NAME: &'static str = "last";
-        }
-    }
-    pub struct isPublished;
-    impl ::cynic::schema::Field for isPublished {
-        type Type = Option<super::Boolean>;
-        const NAME: &'static str = "isPublished";
-    }
-    impl ::cynic::schema::HasField<isPublished> for super::Job {
-        type Type = Option<super::Boolean>;
-    }
-    pub struct isFeatured;
-    impl ::cynic::schema::Field for isFeatured {
-        type Type = Option<super::Boolean>;
-        const NAME: &'static str = "isFeatured";
-    }
-    impl ::cynic::schema::HasField<isFeatured> for super::Job {
-        type Type = Option<super::Boolean>;
-    }
-    pub struct locationNames;
-    impl ::cynic::schema::Field for locationNames {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "locationNames";
-    }
-    impl ::cynic::schema::HasField<locationNames> for super::Job {
-        type Type = Option<super::String>;
-    }
-    pub struct userEmail;
-    impl ::cynic::schema::Field for userEmail {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "userEmail";
-    }
-    impl ::cynic::schema::HasField<userEmail> for super::Job {
-        type Type = Option<super::String>;
-    }
-    pub struct postedAt;
-    impl ::cynic::schema::Field for postedAt {
-        type Type = super::DateTime;
-        const NAME: &'static str = "postedAt";
-    }
-    impl ::cynic::schema::HasField<postedAt> for super::Job {
-        type Type = super::DateTime;
-    }
-    pub struct createdAt;
-    impl ::cynic::schema::Field for createdAt {
-        type Type = super::DateTime;
-        const NAME: &'static str = "createdAt";
-    }
-    impl ::cynic::schema::HasField<createdAt> for super::Job {
-        type Type = super::DateTime;
-    }
-    pub struct updatedAt;
-    impl ::cynic::schema::Field for updatedAt {
-        type Type = super::DateTime;
-        const NAME: &'static str = "updatedAt";
-    }
-    impl ::cynic::schema::HasField<updatedAt> for super::Job {
-        type Type = super::DateTime;
-    }
-}
 pub struct JobInput;
 impl ::cynic::schema::InputObjectMarker for JobInput {}
-pub mod job_input_fields {
-    pub struct companySlug;
-    impl ::cynic::schema::Field for companySlug {
-        type Type = super::String;
-        const NAME: &'static str = "companySlug";
-    }
-    impl ::cynic::schema::HasInputField<companySlug, super::String> for super::JobInput {}
-    pub struct jobSlug;
-    impl ::cynic::schema::Field for jobSlug {
-        type Type = super::String;
-        const NAME: &'static str = "jobSlug";
-    }
-    impl ::cynic::schema::HasInputField<jobSlug, super::String> for super::JobInput {}
-}
 pub struct JobOrderByInput {}
 pub struct JobWhereInput;
 impl ::cynic::schema::InputObjectMarker for JobWhereInput {}
-pub mod job_where_input_fields {
-    pub struct id;
-    impl ::cynic::schema::Field for id {
-        type Type = Option<super::ID>;
-        const NAME: &'static str = "id";
-    }
-    impl ::cynic::schema::HasInputField<id, Option<super::ID>> for super::JobWhereInput {}
-    pub struct id_not;
-    impl ::cynic::schema::Field for id_not {
-        type Type = Option<super::ID>;
-        const NAME: &'static str = "id_not";
-    }
-    impl ::cynic::schema::HasInputField<id_not, Option<super::ID>> for super::JobWhereInput {}
-    pub struct id_in;
-    impl ::cynic::schema::Field for id_in {
-        type Type = Option<Vec<super::ID>>;
-        const NAME: &'static str = "id_in";
-    }
-    impl ::cynic::schema::HasInputField<id_in, Option<Vec<super::ID>>> for super::JobWhereInput {}
-    pub struct id_not_in;
-    impl ::cynic::schema::Field for id_not_in {
-        type Type = Option<Vec<super::ID>>;
-        const NAME: &'static str = "id_not_in";
-    }
-    impl ::cynic::schema::HasInputField<id_not_in, Option<Vec<super::ID>>> for super::JobWhereInput {}
-    pub struct id_lt;
-    impl ::cynic::schema::Field for id_lt {
-        type Type = Option<super::ID>;
-        const NAME: &'static str = "id_lt";
-    }
-    impl ::cynic::schema::HasInputField<id_lt, Option<super::ID>> for super::JobWhereInput {}
-    pub struct id_lte;
-    impl ::cynic::schema::Field for id_lte {
-        type Type = Option<super::ID>;
-        const NAME: &'static str = "id_lte";
-    }
-    impl ::cynic::schema::HasInputField<id_lte, Option<super::ID>> for super::JobWhereInput {}
-    pub struct id_gt;
-    impl ::cynic::schema::Field for id_gt {
-        type Type = Option<super::ID>;
-        const NAME: &'static str = "id_gt";
-    }
-    impl ::cynic::schema::HasInputField<id_gt, Option<super::ID>> for super::JobWhereInput {}
-    pub struct id_gte;
-    impl ::cynic::schema::Field for id_gte {
-        type Type = Option<super::ID>;
-        const NAME: &'static str = "id_gte";
-    }
-    impl ::cynic::schema::HasInputField<id_gte, Option<super::ID>> for super::JobWhereInput {}
-    pub struct id_contains;
-    impl ::cynic::schema::Field for id_contains {
-        type Type = Option<super::ID>;
-        const NAME: &'static str = "id_contains";
-    }
-    impl ::cynic::schema::HasInputField<id_contains, Option<super::ID>> for super::JobWhereInput {}
-    pub struct id_not_contains;
-    impl ::cynic::schema::Field for id_not_contains {
-        type Type = Option<super::ID>;
-        const NAME: &'static str = "id_not_contains";
-    }
-    impl ::cynic::schema::HasInputField<id_not_contains, Option<super::ID>> for super::JobWhereInput {}
-    pub struct id_starts_with;
-    impl ::cynic::schema::Field for id_starts_with {
-        type Type = Option<super::ID>;
-        const NAME: &'static str = "id_starts_with";
-    }
-    impl ::cynic::schema::HasInputField<id_starts_with, Option<super::ID>> for super::JobWhereInput {}
-    pub struct id_not_starts_with;
-    impl ::cynic::schema::Field for id_not_starts_with {
-        type Type = Option<super::ID>;
-        const NAME: &'static str = "id_not_starts_with";
-    }
-    impl ::cynic::schema::HasInputField<id_not_starts_with, Option<super::ID>>
-        for super::JobWhereInput
-    {
-    }
-    pub struct id_ends_with;
-    impl ::cynic::schema::Field for id_ends_with {
-        type Type = Option<super::ID>;
-        const NAME: &'static str = "id_ends_with";
-    }
-    impl ::cynic::schema::HasInputField<id_ends_with, Option<super::ID>> for super::JobWhereInput {}
-    pub struct id_not_ends_with;
-    impl ::cynic::schema::Field for id_not_ends_with {
-        type Type = Option<super::ID>;
-        const NAME: &'static str = "id_not_ends_with";
-    }
-    impl ::cynic::schema::HasInputField<id_not_ends_with, Option<super::ID>> for super::JobWhereInput {}
-    pub struct title;
-    impl ::cynic::schema::Field for title {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "title";
-    }
-    impl ::cynic::schema::HasInputField<title, Option<super::String>> for super::JobWhereInput {}
-    pub struct title_not;
-    impl ::cynic::schema::Field for title_not {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "title_not";
-    }
-    impl ::cynic::schema::HasInputField<title_not, Option<super::String>> for super::JobWhereInput {}
-    pub struct title_in;
-    impl ::cynic::schema::Field for title_in {
-        type Type = Option<Vec<super::String>>;
-        const NAME: &'static str = "title_in";
-    }
-    impl ::cynic::schema::HasInputField<title_in, Option<Vec<super::String>>> for super::JobWhereInput {}
-    pub struct title_not_in;
-    impl ::cynic::schema::Field for title_not_in {
-        type Type = Option<Vec<super::String>>;
-        const NAME: &'static str = "title_not_in";
-    }
-    impl ::cynic::schema::HasInputField<title_not_in, Option<Vec<super::String>>>
-        for super::JobWhereInput
-    {
-    }
-    pub struct title_lt;
-    impl ::cynic::schema::Field for title_lt {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "title_lt";
-    }
-    impl ::cynic::schema::HasInputField<title_lt, Option<super::String>> for super::JobWhereInput {}
-    pub struct title_lte;
-    impl ::cynic::schema::Field for title_lte {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "title_lte";
-    }
-    impl ::cynic::schema::HasInputField<title_lte, Option<super::String>> for super::JobWhereInput {}
-    pub struct title_gt;
-    impl ::cynic::schema::Field for title_gt {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "title_gt";
-    }
-    impl ::cynic::schema::HasInputField<title_gt, Option<super::String>> for super::JobWhereInput {}
-    pub struct title_gte;
-    impl ::cynic::schema::Field for title_gte {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "title_gte";
-    }
-    impl ::cynic::schema::HasInputField<title_gte, Option<super::String>> for super::JobWhereInput {}
-    pub struct title_contains;
-    impl ::cynic::schema::Field for title_contains {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "title_contains";
-    }
-    impl ::cynic::schema::HasInputField<title_contains, Option<super::String>>
-        for super::JobWhereInput
-    {
-    }
-    pub struct title_not_contains;
-    impl ::cynic::schema::Field for title_not_contains {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "title_not_contains";
-    }
-    impl ::cynic::schema::HasInputField<title_not_contains, Option<super::String>>
-        for super::JobWhereInput
-    {
-    }
-    pub struct title_starts_with;
-    impl ::cynic::schema::Field for title_starts_with {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "title_starts_with";
-    }
-    impl ::cynic::schema::HasInputField<title_starts_with, Option<super::String>>
-        for super::JobWhereInput
-    {
-    }
-    pub struct title_not_starts_with;
-    impl ::cynic::schema::Field for title_not_starts_with {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "title_not_starts_with";
-    }
-    impl ::cynic::schema::HasInputField<title_not_starts_with, Option<super::String>>
-        for super::JobWhereInput
-    {
-    }
-    pub struct title_ends_with;
-    impl ::cynic::schema::Field for title_ends_with {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "title_ends_with";
-    }
-    impl ::cynic::schema::HasInputField<title_ends_with, Option<super::String>>
-        for super::JobWhereInput
-    {
-    }
-    pub struct title_not_ends_with;
-    impl ::cynic::schema::Field for title_not_ends_with {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "title_not_ends_with";
-    }
-    impl ::cynic::schema::HasInputField<title_not_ends_with, Option<super::String>>
-        for super::JobWhereInput
-    {
-    }
-    pub struct slug;
-    impl ::cynic::schema::Field for slug {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "slug";
-    }
-    impl ::cynic::schema::HasInputField<slug, Option<super::String>> for super::JobWhereInput {}
-    pub struct slug_not;
-    impl ::cynic::schema::Field for slug_not {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "slug_not";
-    }
-    impl ::cynic::schema::HasInputField<slug_not, Option<super::String>> for super::JobWhereInput {}
-    pub struct slug_in;
-    impl ::cynic::schema::Field for slug_in {
-        type Type = Option<Vec<super::String>>;
-        const NAME: &'static str = "slug_in";
-    }
-    impl ::cynic::schema::HasInputField<slug_in, Option<Vec<super::String>>> for super::JobWhereInput {}
-    pub struct slug_not_in;
-    impl ::cynic::schema::Field for slug_not_in {
-        type Type = Option<Vec<super::String>>;
-        const NAME: &'static str = "slug_not_in";
-    }
-    impl ::cynic::schema::HasInputField<slug_not_in, Option<Vec<super::String>>>
-        for super::JobWhereInput
-    {
-    }
-    pub struct slug_lt;
-    impl ::cynic::schema::Field for slug_lt {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "slug_lt";
-    }
-    impl ::cynic::schema::HasInputField<slug_lt, Option<super::String>> for super::JobWhereInput {}
-    pub struct slug_lte;
-    impl ::cynic::schema::Field for slug_lte {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "slug_lte";
-    }
-    impl ::cynic::schema::HasInputField<slug_lte, Option<super::String>> for super::JobWhereInput {}
-    pub struct slug_gt;
-    impl ::cynic::schema::Field for slug_gt {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "slug_gt";
-    }
-    impl ::cynic::schema::HasInputField<slug_gt, Option<super::String>> for super::JobWhereInput {}
-    pub struct slug_gte;
-    impl ::cynic::schema::Field for slug_gte {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "slug_gte";
-    }
-    impl ::cynic::schema::HasInputField<slug_gte, Option<super::String>> for super::JobWhereInput {}
-    pub struct slug_contains;
-    impl ::cynic::schema::Field for slug_contains {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "slug_contains";
-    }
-    impl ::cynic::schema::HasInputField<slug_contains, Option<super::String>> for super::JobWhereInput {}
-    pub struct slug_not_contains;
-    impl ::cynic::schema::Field for slug_not_contains {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "slug_not_contains";
-    }
-    impl ::cynic::schema::HasInputField<slug_not_contains, Option<super::String>>
-        for super::JobWhereInput
-    {
-    }
-    pub struct slug_starts_with;
-    impl ::cynic::schema::Field for slug_starts_with {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "slug_starts_with";
-    }
-    impl ::cynic::schema::HasInputField<slug_starts_with, Option<super::String>>
-        for super::JobWhereInput
-    {
-    }
-    pub struct slug_not_starts_with;
-    impl ::cynic::schema::Field for slug_not_starts_with {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "slug_not_starts_with";
-    }
-    impl ::cynic::schema::HasInputField<slug_not_starts_with, Option<super::String>>
-        for super::JobWhereInput
-    {
-    }
-    pub struct slug_ends_with;
-    impl ::cynic::schema::Field for slug_ends_with {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "slug_ends_with";
-    }
-    impl ::cynic::schema::HasInputField<slug_ends_with, Option<super::String>>
-        for super::JobWhereInput
-    {
-    }
-    pub struct slug_not_ends_with;
-    impl ::cynic::schema::Field for slug_not_ends_with {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "slug_not_ends_with";
-    }
-    impl ::cynic::schema::HasInputField<slug_not_ends_with, Option<super::String>>
-        for super::JobWhereInput
-    {
-    }
-    pub struct commitment;
-    impl ::cynic::schema::Field for commitment {
-        type Type = Option<super::CommitmentWhereInput>;
-        const NAME: &'static str = "commitment";
-    }
-    impl ::cynic::schema::HasInputField<commitment, Option<super::CommitmentWhereInput>>
-        for super::JobWhereInput
-    {
-    }
-    pub struct cities_every;
-    impl ::cynic::schema::Field for cities_every {
-        type Type = Option<super::CityWhereInput>;
-        const NAME: &'static str = "cities_every";
-    }
-    impl ::cynic::schema::HasInputField<cities_every, Option<super::CityWhereInput>>
-        for super::JobWhereInput
-    {
-    }
-    pub struct cities_some;
-    impl ::cynic::schema::Field for cities_some {
-        type Type = Option<super::CityWhereInput>;
-        const NAME: &'static str = "cities_some";
-    }
-    impl ::cynic::schema::HasInputField<cities_some, Option<super::CityWhereInput>>
-        for super::JobWhereInput
-    {
-    }
-    pub struct cities_none;
-    impl ::cynic::schema::Field for cities_none {
-        type Type = Option<super::CityWhereInput>;
-        const NAME: &'static str = "cities_none";
-    }
-    impl ::cynic::schema::HasInputField<cities_none, Option<super::CityWhereInput>>
-        for super::JobWhereInput
-    {
-    }
-    pub struct countries_every;
-    impl ::cynic::schema::Field for countries_every {
-        type Type = Option<super::CountryWhereInput>;
-        const NAME: &'static str = "countries_every";
-    }
-    impl ::cynic::schema::HasInputField<countries_every, Option<super::CountryWhereInput>>
-        for super::JobWhereInput
-    {
-    }
-    pub struct countries_some;
-    impl ::cynic::schema::Field for countries_some {
-        type Type = Option<super::CountryWhereInput>;
-        const NAME: &'static str = "countries_some";
-    }
-    impl ::cynic::schema::HasInputField<countries_some, Option<super::CountryWhereInput>>
-        for super::JobWhereInput
-    {
-    }
-    pub struct countries_none;
-    impl ::cynic::schema::Field for countries_none {
-        type Type = Option<super::CountryWhereInput>;
-        const NAME: &'static str = "countries_none";
-    }
-    impl ::cynic::schema::HasInputField<countries_none, Option<super::CountryWhereInput>>
-        for super::JobWhereInput
-    {
-    }
-    pub struct remotes_every;
-    impl ::cynic::schema::Field for remotes_every {
-        type Type = Option<super::RemoteWhereInput>;
-        const NAME: &'static str = "remotes_every";
-    }
-    impl ::cynic::schema::HasInputField<remotes_every, Option<super::RemoteWhereInput>>
-        for super::JobWhereInput
-    {
-    }
-    pub struct remotes_some;
-    impl ::cynic::schema::Field for remotes_some {
-        type Type = Option<super::RemoteWhereInput>;
-        const NAME: &'static str = "remotes_some";
-    }
-    impl ::cynic::schema::HasInputField<remotes_some, Option<super::RemoteWhereInput>>
-        for super::JobWhereInput
-    {
-    }
-    pub struct remotes_none;
-    impl ::cynic::schema::Field for remotes_none {
-        type Type = Option<super::RemoteWhereInput>;
-        const NAME: &'static str = "remotes_none";
-    }
-    impl ::cynic::schema::HasInputField<remotes_none, Option<super::RemoteWhereInput>>
-        for super::JobWhereInput
-    {
-    }
-    pub struct description;
-    impl ::cynic::schema::Field for description {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "description";
-    }
-    impl ::cynic::schema::HasInputField<description, Option<super::String>> for super::JobWhereInput {}
-    pub struct description_not;
-    impl ::cynic::schema::Field for description_not {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "description_not";
-    }
-    impl ::cynic::schema::HasInputField<description_not, Option<super::String>>
-        for super::JobWhereInput
-    {
-    }
-    pub struct description_in;
-    impl ::cynic::schema::Field for description_in {
-        type Type = Option<Vec<super::String>>;
-        const NAME: &'static str = "description_in";
-    }
-    impl ::cynic::schema::HasInputField<description_in, Option<Vec<super::String>>>
-        for super::JobWhereInput
-    {
-    }
-    pub struct description_not_in;
-    impl ::cynic::schema::Field for description_not_in {
-        type Type = Option<Vec<super::String>>;
-        const NAME: &'static str = "description_not_in";
-    }
-    impl ::cynic::schema::HasInputField<description_not_in, Option<Vec<super::String>>>
-        for super::JobWhereInput
-    {
-    }
-    pub struct description_lt;
-    impl ::cynic::schema::Field for description_lt {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "description_lt";
-    }
-    impl ::cynic::schema::HasInputField<description_lt, Option<super::String>>
-        for super::JobWhereInput
-    {
-    }
-    pub struct description_lte;
-    impl ::cynic::schema::Field for description_lte {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "description_lte";
-    }
-    impl ::cynic::schema::HasInputField<description_lte, Option<super::String>>
-        for super::JobWhereInput
-    {
-    }
-    pub struct description_gt;
-    impl ::cynic::schema::Field for description_gt {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "description_gt";
-    }
-    impl ::cynic::schema::HasInputField<description_gt, Option<super::String>>
-        for super::JobWhereInput
-    {
-    }
-    pub struct description_gte;
-    impl ::cynic::schema::Field for description_gte {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "description_gte";
-    }
-    impl ::cynic::schema::HasInputField<description_gte, Option<super::String>>
-        for super::JobWhereInput
-    {
-    }
-    pub struct description_contains;
-    impl ::cynic::schema::Field for description_contains {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "description_contains";
-    }
-    impl ::cynic::schema::HasInputField<description_contains, Option<super::String>>
-        for super::JobWhereInput
-    {
-    }
-    pub struct description_not_contains;
-    impl ::cynic::schema::Field for description_not_contains {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "description_not_contains";
-    }
-    impl ::cynic::schema::HasInputField<description_not_contains, Option<super::String>>
-        for super::JobWhereInput
-    {
-    }
-    pub struct description_starts_with;
-    impl ::cynic::schema::Field for description_starts_with {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "description_starts_with";
-    }
-    impl ::cynic::schema::HasInputField<description_starts_with, Option<super::String>>
-        for super::JobWhereInput
-    {
-    }
-    pub struct description_not_starts_with;
-    impl ::cynic::schema::Field for description_not_starts_with {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "description_not_starts_with";
-    }
-    impl ::cynic::schema::HasInputField<description_not_starts_with, Option<super::String>>
-        for super::JobWhereInput
-    {
-    }
-    pub struct description_ends_with;
-    impl ::cynic::schema::Field for description_ends_with {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "description_ends_with";
-    }
-    impl ::cynic::schema::HasInputField<description_ends_with, Option<super::String>>
-        for super::JobWhereInput
-    {
-    }
-    pub struct description_not_ends_with;
-    impl ::cynic::schema::Field for description_not_ends_with {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "description_not_ends_with";
-    }
-    impl ::cynic::schema::HasInputField<description_not_ends_with, Option<super::String>>
-        for super::JobWhereInput
-    {
-    }
-    pub struct applyUrl;
-    impl ::cynic::schema::Field for applyUrl {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "applyUrl";
-    }
-    impl ::cynic::schema::HasInputField<applyUrl, Option<super::String>> for super::JobWhereInput {}
-    pub struct applyUrl_not;
-    impl ::cynic::schema::Field for applyUrl_not {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "applyUrl_not";
-    }
-    impl ::cynic::schema::HasInputField<applyUrl_not, Option<super::String>> for super::JobWhereInput {}
-    pub struct applyUrl_in;
-    impl ::cynic::schema::Field for applyUrl_in {
-        type Type = Option<Vec<super::String>>;
-        const NAME: &'static str = "applyUrl_in";
-    }
-    impl ::cynic::schema::HasInputField<applyUrl_in, Option<Vec<super::String>>>
-        for super::JobWhereInput
-    {
-    }
-    pub struct applyUrl_not_in;
-    impl ::cynic::schema::Field for applyUrl_not_in {
-        type Type = Option<Vec<super::String>>;
-        const NAME: &'static str = "applyUrl_not_in";
-    }
-    impl ::cynic::schema::HasInputField<applyUrl_not_in, Option<Vec<super::String>>>
-        for super::JobWhereInput
-    {
-    }
-    pub struct applyUrl_lt;
-    impl ::cynic::schema::Field for applyUrl_lt {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "applyUrl_lt";
-    }
-    impl ::cynic::schema::HasInputField<applyUrl_lt, Option<super::String>> for super::JobWhereInput {}
-    pub struct applyUrl_lte;
-    impl ::cynic::schema::Field for applyUrl_lte {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "applyUrl_lte";
-    }
-    impl ::cynic::schema::HasInputField<applyUrl_lte, Option<super::String>> for super::JobWhereInput {}
-    pub struct applyUrl_gt;
-    impl ::cynic::schema::Field for applyUrl_gt {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "applyUrl_gt";
-    }
-    impl ::cynic::schema::HasInputField<applyUrl_gt, Option<super::String>> for super::JobWhereInput {}
-    pub struct applyUrl_gte;
-    impl ::cynic::schema::Field for applyUrl_gte {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "applyUrl_gte";
-    }
-    impl ::cynic::schema::HasInputField<applyUrl_gte, Option<super::String>> for super::JobWhereInput {}
-    pub struct applyUrl_contains;
-    impl ::cynic::schema::Field for applyUrl_contains {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "applyUrl_contains";
-    }
-    impl ::cynic::schema::HasInputField<applyUrl_contains, Option<super::String>>
-        for super::JobWhereInput
-    {
-    }
-    pub struct applyUrl_not_contains;
-    impl ::cynic::schema::Field for applyUrl_not_contains {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "applyUrl_not_contains";
-    }
-    impl ::cynic::schema::HasInputField<applyUrl_not_contains, Option<super::String>>
-        for super::JobWhereInput
-    {
-    }
-    pub struct applyUrl_starts_with;
-    impl ::cynic::schema::Field for applyUrl_starts_with {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "applyUrl_starts_with";
-    }
-    impl ::cynic::schema::HasInputField<applyUrl_starts_with, Option<super::String>>
-        for super::JobWhereInput
-    {
-    }
-    pub struct applyUrl_not_starts_with;
-    impl ::cynic::schema::Field for applyUrl_not_starts_with {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "applyUrl_not_starts_with";
-    }
-    impl ::cynic::schema::HasInputField<applyUrl_not_starts_with, Option<super::String>>
-        for super::JobWhereInput
-    {
-    }
-    pub struct applyUrl_ends_with;
-    impl ::cynic::schema::Field for applyUrl_ends_with {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "applyUrl_ends_with";
-    }
-    impl ::cynic::schema::HasInputField<applyUrl_ends_with, Option<super::String>>
-        for super::JobWhereInput
-    {
-    }
-    pub struct applyUrl_not_ends_with;
-    impl ::cynic::schema::Field for applyUrl_not_ends_with {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "applyUrl_not_ends_with";
-    }
-    impl ::cynic::schema::HasInputField<applyUrl_not_ends_with, Option<super::String>>
-        for super::JobWhereInput
-    {
-    }
-    pub struct company;
-    impl ::cynic::schema::Field for company {
-        type Type = Option<super::CompanyWhereInput>;
-        const NAME: &'static str = "company";
-    }
-    impl ::cynic::schema::HasInputField<company, Option<super::CompanyWhereInput>>
-        for super::JobWhereInput
-    {
-    }
-    pub struct tags_every;
-    impl ::cynic::schema::Field for tags_every {
-        type Type = Option<super::TagWhereInput>;
-        const NAME: &'static str = "tags_every";
-    }
-    impl ::cynic::schema::HasInputField<tags_every, Option<super::TagWhereInput>>
-        for super::JobWhereInput
-    {
-    }
-    pub struct tags_some;
-    impl ::cynic::schema::Field for tags_some {
-        type Type = Option<super::TagWhereInput>;
-        const NAME: &'static str = "tags_some";
-    }
-    impl ::cynic::schema::HasInputField<tags_some, Option<super::TagWhereInput>>
-        for super::JobWhereInput
-    {
-    }
-    pub struct tags_none;
-    impl ::cynic::schema::Field for tags_none {
-        type Type = Option<super::TagWhereInput>;
-        const NAME: &'static str = "tags_none";
-    }
-    impl ::cynic::schema::HasInputField<tags_none, Option<super::TagWhereInput>>
-        for super::JobWhereInput
-    {
-    }
-    pub struct isPublished;
-    impl ::cynic::schema::Field for isPublished {
-        type Type = Option<super::Boolean>;
-        const NAME: &'static str = "isPublished";
-    }
-    impl ::cynic::schema::HasInputField<isPublished, Option<super::Boolean>> for super::JobWhereInput {}
-    pub struct isPublished_not;
-    impl ::cynic::schema::Field for isPublished_not {
-        type Type = Option<super::Boolean>;
-        const NAME: &'static str = "isPublished_not";
-    }
-    impl ::cynic::schema::HasInputField<isPublished_not, Option<super::Boolean>>
-        for super::JobWhereInput
-    {
-    }
-    pub struct isFeatured;
-    impl ::cynic::schema::Field for isFeatured {
-        type Type = Option<super::Boolean>;
-        const NAME: &'static str = "isFeatured";
-    }
-    impl ::cynic::schema::HasInputField<isFeatured, Option<super::Boolean>> for super::JobWhereInput {}
-    pub struct isFeatured_not;
-    impl ::cynic::schema::Field for isFeatured_not {
-        type Type = Option<super::Boolean>;
-        const NAME: &'static str = "isFeatured_not";
-    }
-    impl ::cynic::schema::HasInputField<isFeatured_not, Option<super::Boolean>>
-        for super::JobWhereInput
-    {
-    }
-    pub struct locationNames;
-    impl ::cynic::schema::Field for locationNames {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "locationNames";
-    }
-    impl ::cynic::schema::HasInputField<locationNames, Option<super::String>> for super::JobWhereInput {}
-    pub struct locationNames_not;
-    impl ::cynic::schema::Field for locationNames_not {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "locationNames_not";
-    }
-    impl ::cynic::schema::HasInputField<locationNames_not, Option<super::String>>
-        for super::JobWhereInput
-    {
-    }
-    pub struct locationNames_in;
-    impl ::cynic::schema::Field for locationNames_in {
-        type Type = Option<Vec<super::String>>;
-        const NAME: &'static str = "locationNames_in";
-    }
-    impl ::cynic::schema::HasInputField<locationNames_in, Option<Vec<super::String>>>
-        for super::JobWhereInput
-    {
-    }
-    pub struct locationNames_not_in;
-    impl ::cynic::schema::Field for locationNames_not_in {
-        type Type = Option<Vec<super::String>>;
-        const NAME: &'static str = "locationNames_not_in";
-    }
-    impl ::cynic::schema::HasInputField<locationNames_not_in, Option<Vec<super::String>>>
-        for super::JobWhereInput
-    {
-    }
-    pub struct locationNames_lt;
-    impl ::cynic::schema::Field for locationNames_lt {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "locationNames_lt";
-    }
-    impl ::cynic::schema::HasInputField<locationNames_lt, Option<super::String>>
-        for super::JobWhereInput
-    {
-    }
-    pub struct locationNames_lte;
-    impl ::cynic::schema::Field for locationNames_lte {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "locationNames_lte";
-    }
-    impl ::cynic::schema::HasInputField<locationNames_lte, Option<super::String>>
-        for super::JobWhereInput
-    {
-    }
-    pub struct locationNames_gt;
-    impl ::cynic::schema::Field for locationNames_gt {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "locationNames_gt";
-    }
-    impl ::cynic::schema::HasInputField<locationNames_gt, Option<super::String>>
-        for super::JobWhereInput
-    {
-    }
-    pub struct locationNames_gte;
-    impl ::cynic::schema::Field for locationNames_gte {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "locationNames_gte";
-    }
-    impl ::cynic::schema::HasInputField<locationNames_gte, Option<super::String>>
-        for super::JobWhereInput
-    {
-    }
-    pub struct locationNames_contains;
-    impl ::cynic::schema::Field for locationNames_contains {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "locationNames_contains";
-    }
-    impl ::cynic::schema::HasInputField<locationNames_contains, Option<super::String>>
-        for super::JobWhereInput
-    {
-    }
-    pub struct locationNames_not_contains;
-    impl ::cynic::schema::Field for locationNames_not_contains {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "locationNames_not_contains";
-    }
-    impl ::cynic::schema::HasInputField<locationNames_not_contains, Option<super::String>>
-        for super::JobWhereInput
-    {
-    }
-    pub struct locationNames_starts_with;
-    impl ::cynic::schema::Field for locationNames_starts_with {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "locationNames_starts_with";
-    }
-    impl ::cynic::schema::HasInputField<locationNames_starts_with, Option<super::String>>
-        for super::JobWhereInput
-    {
-    }
-    pub struct locationNames_not_starts_with;
-    impl ::cynic::schema::Field for locationNames_not_starts_with {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "locationNames_not_starts_with";
-    }
-    impl ::cynic::schema::HasInputField<locationNames_not_starts_with, Option<super::String>>
-        for super::JobWhereInput
-    {
-    }
-    pub struct locationNames_ends_with;
-    impl ::cynic::schema::Field for locationNames_ends_with {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "locationNames_ends_with";
-    }
-    impl ::cynic::schema::HasInputField<locationNames_ends_with, Option<super::String>>
-        for super::JobWhereInput
-    {
-    }
-    pub struct locationNames_not_ends_with;
-    impl ::cynic::schema::Field for locationNames_not_ends_with {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "locationNames_not_ends_with";
-    }
-    impl ::cynic::schema::HasInputField<locationNames_not_ends_with, Option<super::String>>
-        for super::JobWhereInput
-    {
-    }
-    pub struct userEmail;
-    impl ::cynic::schema::Field for userEmail {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "userEmail";
-    }
-    impl ::cynic::schema::HasInputField<userEmail, Option<super::String>> for super::JobWhereInput {}
-    pub struct userEmail_not;
-    impl ::cynic::schema::Field for userEmail_not {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "userEmail_not";
-    }
-    impl ::cynic::schema::HasInputField<userEmail_not, Option<super::String>> for super::JobWhereInput {}
-    pub struct userEmail_in;
-    impl ::cynic::schema::Field for userEmail_in {
-        type Type = Option<Vec<super::String>>;
-        const NAME: &'static str = "userEmail_in";
-    }
-    impl ::cynic::schema::HasInputField<userEmail_in, Option<Vec<super::String>>>
-        for super::JobWhereInput
-    {
-    }
-    pub struct userEmail_not_in;
-    impl ::cynic::schema::Field for userEmail_not_in {
-        type Type = Option<Vec<super::String>>;
-        const NAME: &'static str = "userEmail_not_in";
-    }
-    impl ::cynic::schema::HasInputField<userEmail_not_in, Option<Vec<super::String>>>
-        for super::JobWhereInput
-    {
-    }
-    pub struct userEmail_lt;
-    impl ::cynic::schema::Field for userEmail_lt {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "userEmail_lt";
-    }
-    impl ::cynic::schema::HasInputField<userEmail_lt, Option<super::String>> for super::JobWhereInput {}
-    pub struct userEmail_lte;
-    impl ::cynic::schema::Field for userEmail_lte {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "userEmail_lte";
-    }
-    impl ::cynic::schema::HasInputField<userEmail_lte, Option<super::String>> for super::JobWhereInput {}
-    pub struct userEmail_gt;
-    impl ::cynic::schema::Field for userEmail_gt {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "userEmail_gt";
-    }
-    impl ::cynic::schema::HasInputField<userEmail_gt, Option<super::String>> for super::JobWhereInput {}
-    pub struct userEmail_gte;
-    impl ::cynic::schema::Field for userEmail_gte {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "userEmail_gte";
-    }
-    impl ::cynic::schema::HasInputField<userEmail_gte, Option<super::String>> for super::JobWhereInput {}
-    pub struct userEmail_contains;
-    impl ::cynic::schema::Field for userEmail_contains {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "userEmail_contains";
-    }
-    impl ::cynic::schema::HasInputField<userEmail_contains, Option<super::String>>
-        for super::JobWhereInput
-    {
-    }
-    pub struct userEmail_not_contains;
-    impl ::cynic::schema::Field for userEmail_not_contains {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "userEmail_not_contains";
-    }
-    impl ::cynic::schema::HasInputField<userEmail_not_contains, Option<super::String>>
-        for super::JobWhereInput
-    {
-    }
-    pub struct userEmail_starts_with;
-    impl ::cynic::schema::Field for userEmail_starts_with {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "userEmail_starts_with";
-    }
-    impl ::cynic::schema::HasInputField<userEmail_starts_with, Option<super::String>>
-        for super::JobWhereInput
-    {
-    }
-    pub struct userEmail_not_starts_with;
-    impl ::cynic::schema::Field for userEmail_not_starts_with {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "userEmail_not_starts_with";
-    }
-    impl ::cynic::schema::HasInputField<userEmail_not_starts_with, Option<super::String>>
-        for super::JobWhereInput
-    {
-    }
-    pub struct userEmail_ends_with;
-    impl ::cynic::schema::Field for userEmail_ends_with {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "userEmail_ends_with";
-    }
-    impl ::cynic::schema::HasInputField<userEmail_ends_with, Option<super::String>>
-        for super::JobWhereInput
-    {
-    }
-    pub struct userEmail_not_ends_with;
-    impl ::cynic::schema::Field for userEmail_not_ends_with {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "userEmail_not_ends_with";
-    }
-    impl ::cynic::schema::HasInputField<userEmail_not_ends_with, Option<super::String>>
-        for super::JobWhereInput
-    {
-    }
-    pub struct postedAt;
-    impl ::cynic::schema::Field for postedAt {
-        type Type = Option<super::DateTime>;
-        const NAME: &'static str = "postedAt";
-    }
-    impl ::cynic::schema::HasInputField<postedAt, Option<super::DateTime>> for super::JobWhereInput {}
-    pub struct postedAt_not;
-    impl ::cynic::schema::Field for postedAt_not {
-        type Type = Option<super::DateTime>;
-        const NAME: &'static str = "postedAt_not";
-    }
-    impl ::cynic::schema::HasInputField<postedAt_not, Option<super::DateTime>>
-        for super::JobWhereInput
-    {
-    }
-    pub struct postedAt_in;
-    impl ::cynic::schema::Field for postedAt_in {
-        type Type = Option<Vec<super::DateTime>>;
-        const NAME: &'static str = "postedAt_in";
-    }
-    impl ::cynic::schema::HasInputField<postedAt_in, Option<Vec<super::DateTime>>>
-        for super::JobWhereInput
-    {
-    }
-    pub struct postedAt_not_in;
-    impl ::cynic::schema::Field for postedAt_not_in {
-        type Type = Option<Vec<super::DateTime>>;
-        const NAME: &'static str = "postedAt_not_in";
-    }
-    impl ::cynic::schema::HasInputField<postedAt_not_in, Option<Vec<super::DateTime>>>
-        for super::JobWhereInput
-    {
-    }
-    pub struct postedAt_lt;
-    impl ::cynic::schema::Field for postedAt_lt {
-        type Type = Option<super::DateTime>;
-        const NAME: &'static str = "postedAt_lt";
-    }
-    impl ::cynic::schema::HasInputField<postedAt_lt, Option<super::DateTime>> for super::JobWhereInput {}
-    pub struct postedAt_lte;
-    impl ::cynic::schema::Field for postedAt_lte {
-        type Type = Option<super::DateTime>;
-        const NAME: &'static str = "postedAt_lte";
-    }
-    impl ::cynic::schema::HasInputField<postedAt_lte, Option<super::DateTime>>
-        for super::JobWhereInput
-    {
-    }
-    pub struct postedAt_gt;
-    impl ::cynic::schema::Field for postedAt_gt {
-        type Type = Option<super::DateTime>;
-        const NAME: &'static str = "postedAt_gt";
-    }
-    impl ::cynic::schema::HasInputField<postedAt_gt, Option<super::DateTime>> for super::JobWhereInput {}
-    pub struct postedAt_gte;
-    impl ::cynic::schema::Field for postedAt_gte {
-        type Type = Option<super::DateTime>;
-        const NAME: &'static str = "postedAt_gte";
-    }
-    impl ::cynic::schema::HasInputField<postedAt_gte, Option<super::DateTime>>
-        for super::JobWhereInput
-    {
-    }
-    pub struct createdAt;
-    impl ::cynic::schema::Field for createdAt {
-        type Type = Option<super::DateTime>;
-        const NAME: &'static str = "createdAt";
-    }
-    impl ::cynic::schema::HasInputField<createdAt, Option<super::DateTime>> for super::JobWhereInput {}
-    pub struct createdAt_not;
-    impl ::cynic::schema::Field for createdAt_not {
-        type Type = Option<super::DateTime>;
-        const NAME: &'static str = "createdAt_not";
-    }
-    impl ::cynic::schema::HasInputField<createdAt_not, Option<super::DateTime>>
-        for super::JobWhereInput
-    {
-    }
-    pub struct createdAt_in;
-    impl ::cynic::schema::Field for createdAt_in {
-        type Type = Option<Vec<super::DateTime>>;
-        const NAME: &'static str = "createdAt_in";
-    }
-    impl ::cynic::schema::HasInputField<createdAt_in, Option<Vec<super::DateTime>>>
-        for super::JobWhereInput
-    {
-    }
-    pub struct createdAt_not_in;
-    impl ::cynic::schema::Field for createdAt_not_in {
-        type Type = Option<Vec<super::DateTime>>;
-        const NAME: &'static str = "createdAt_not_in";
-    }
-    impl ::cynic::schema::HasInputField<createdAt_not_in, Option<Vec<super::DateTime>>>
-        for super::JobWhereInput
-    {
-    }
-    pub struct createdAt_lt;
-    impl ::cynic::schema::Field for createdAt_lt {
-        type Type = Option<super::DateTime>;
-        const NAME: &'static str = "createdAt_lt";
-    }
-    impl ::cynic::schema::HasInputField<createdAt_lt, Option<super::DateTime>>
-        for super::JobWhereInput
-    {
-    }
-    pub struct createdAt_lte;
-    impl ::cynic::schema::Field for createdAt_lte {
-        type Type = Option<super::DateTime>;
-        const NAME: &'static str = "createdAt_lte";
-    }
-    impl ::cynic::schema::HasInputField<createdAt_lte, Option<super::DateTime>>
-        for super::JobWhereInput
-    {
-    }
-    pub struct createdAt_gt;
-    impl ::cynic::schema::Field for createdAt_gt {
-        type Type = Option<super::DateTime>;
-        const NAME: &'static str = "createdAt_gt";
-    }
-    impl ::cynic::schema::HasInputField<createdAt_gt, Option<super::DateTime>>
-        for super::JobWhereInput
-    {
-    }
-    pub struct createdAt_gte;
-    impl ::cynic::schema::Field for createdAt_gte {
-        type Type = Option<super::DateTime>;
-        const NAME: &'static str = "createdAt_gte";
-    }
-    impl ::cynic::schema::HasInputField<createdAt_gte, Option<super::DateTime>>
-        for super::JobWhereInput
-    {
-    }
-    pub struct updatedAt;
-    impl ::cynic::schema::Field for updatedAt {
-        type Type = Option<super::DateTime>;
-        const NAME: &'static str = "updatedAt";
-    }
-    impl ::cynic::schema::HasInputField<updatedAt, Option<super::DateTime>> for super::JobWhereInput {}
-    pub struct updatedAt_not;
-    impl ::cynic::schema::Field for updatedAt_not {
-        type Type = Option<super::DateTime>;
-        const NAME: &'static str = "updatedAt_not";
-    }
-    impl ::cynic::schema::HasInputField<updatedAt_not, Option<super::DateTime>>
-        for super::JobWhereInput
-    {
-    }
-    pub struct updatedAt_in;
-    impl ::cynic::schema::Field for updatedAt_in {
-        type Type = Option<Vec<super::DateTime>>;
-        const NAME: &'static str = "updatedAt_in";
-    }
-    impl ::cynic::schema::HasInputField<updatedAt_in, Option<Vec<super::DateTime>>>
-        for super::JobWhereInput
-    {
-    }
-    pub struct updatedAt_not_in;
-    impl ::cynic::schema::Field for updatedAt_not_in {
-        type Type = Option<Vec<super::DateTime>>;
-        const NAME: &'static str = "updatedAt_not_in";
-    }
-    impl ::cynic::schema::HasInputField<updatedAt_not_in, Option<Vec<super::DateTime>>>
-        for super::JobWhereInput
-    {
-    }
-    pub struct updatedAt_lt;
-    impl ::cynic::schema::Field for updatedAt_lt {
-        type Type = Option<super::DateTime>;
-        const NAME: &'static str = "updatedAt_lt";
-    }
-    impl ::cynic::schema::HasInputField<updatedAt_lt, Option<super::DateTime>>
-        for super::JobWhereInput
-    {
-    }
-    pub struct updatedAt_lte;
-    impl ::cynic::schema::Field for updatedAt_lte {
-        type Type = Option<super::DateTime>;
-        const NAME: &'static str = "updatedAt_lte";
-    }
-    impl ::cynic::schema::HasInputField<updatedAt_lte, Option<super::DateTime>>
-        for super::JobWhereInput
-    {
-    }
-    pub struct updatedAt_gt;
-    impl ::cynic::schema::Field for updatedAt_gt {
-        type Type = Option<super::DateTime>;
-        const NAME: &'static str = "updatedAt_gt";
-    }
-    impl ::cynic::schema::HasInputField<updatedAt_gt, Option<super::DateTime>>
-        for super::JobWhereInput
-    {
-    }
-    pub struct updatedAt_gte;
-    impl ::cynic::schema::Field for updatedAt_gte {
-        type Type = Option<super::DateTime>;
-        const NAME: &'static str = "updatedAt_gte";
-    }
-    impl ::cynic::schema::HasInputField<updatedAt_gte, Option<super::DateTime>>
-        for super::JobWhereInput
-    {
-    }
-    pub struct AND;
-    impl ::cynic::schema::Field for AND {
-        type Type = Option<Vec<super::JobWhereInput>>;
-        const NAME: &'static str = "AND";
-    }
-    impl ::cynic::schema::HasInputField<AND, Option<Vec<super::JobWhereInput>>>
-        for super::JobWhereInput
-    {
-    }
-    pub struct OR;
-    impl ::cynic::schema::Field for OR {
-        type Type = Option<Vec<super::JobWhereInput>>;
-        const NAME: &'static str = "OR";
-    }
-    impl ::cynic::schema::HasInputField<OR, Option<Vec<super::JobWhereInput>>>
-        for super::JobWhereInput
-    {
-    }
-    pub struct NOT;
-    impl ::cynic::schema::Field for NOT {
-        type Type = Option<Vec<super::JobWhereInput>>;
-        const NAME: &'static str = "NOT";
-    }
-    impl ::cynic::schema::HasInputField<NOT, Option<Vec<super::JobWhereInput>>>
-        for super::JobWhereInput
-    {
-    }
-}
 pub struct JobsInput;
 impl ::cynic::schema::InputObjectMarker for JobsInput {}
-pub mod jobs_input_fields {
-    pub struct r#type;
-    impl ::cynic::schema::Field for r#type {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "type";
-    }
-    impl ::cynic::schema::HasInputField<r#type, Option<super::String>> for super::JobsInput {}
-    pub struct slug;
-    impl ::cynic::schema::Field for slug {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "slug";
-    }
-    impl ::cynic::schema::HasInputField<slug, Option<super::String>> for super::JobsInput {}
-}
 pub struct Location;
-pub mod location_fields {
-    pub struct id;
-    impl ::cynic::schema::Field for id {
-        type Type = super::ID;
-        const NAME: &'static str = "id";
-    }
-    impl ::cynic::schema::HasField<id> for super::Location {
-        type Type = super::ID;
-    }
-    pub struct slug;
-    impl ::cynic::schema::Field for slug {
-        type Type = super::String;
-        const NAME: &'static str = "slug";
-    }
-    impl ::cynic::schema::HasField<slug> for super::Location {
-        type Type = super::String;
-    }
-    pub struct name;
-    impl ::cynic::schema::Field for name {
-        type Type = super::String;
-        const NAME: &'static str = "name";
-    }
-    impl ::cynic::schema::HasField<name> for super::Location {
-        type Type = super::String;
-    }
-    pub struct r#type;
-    impl ::cynic::schema::Field for r#type {
-        type Type = super::String;
-        const NAME: &'static str = "type";
-    }
-    impl ::cynic::schema::HasField<r#type> for super::Location {
-        type Type = super::String;
-    }
-}
 pub struct LocationInput;
 impl ::cynic::schema::InputObjectMarker for LocationInput {}
-pub mod location_input_fields {
-    pub struct slug;
-    impl ::cynic::schema::Field for slug {
-        type Type = super::String;
-        const NAME: &'static str = "slug";
-    }
-    impl ::cynic::schema::HasInputField<slug, super::String> for super::LocationInput {}
-}
 pub struct LocationsInput;
 impl ::cynic::schema::InputObjectMarker for LocationsInput {}
-pub mod locations_input_fields {
-    pub struct value;
-    impl ::cynic::schema::Field for value {
-        type Type = super::String;
-        const NAME: &'static str = "value";
-    }
-    impl ::cynic::schema::HasInputField<value, super::String> for super::LocationsInput {}
-}
 pub struct Mutation;
-pub mod mutation_fields {
-    pub struct subscribe;
-    impl ::cynic::schema::Field for subscribe {
-        type Type = super::User;
-        const NAME: &'static str = "subscribe";
-    }
-    impl ::cynic::schema::HasField<subscribe> for super::Mutation {
-        type Type = super::User;
-    }
-    pub mod subscribe_arguments {
-        pub struct input;
-        impl ::cynic::schema::HasArgument<input> for super::subscribe {
-            type ArgumentType = super::super::SubscribeInput;
-            const NAME: &'static str = "input";
-        }
-    }
-    pub struct postJob;
-    impl ::cynic::schema::Field for postJob {
-        type Type = super::Job;
-        const NAME: &'static str = "postJob";
-    }
-    impl ::cynic::schema::HasField<postJob> for super::Mutation {
-        type Type = super::Job;
-    }
-    pub mod post_job_arguments {
-        pub struct input;
-        impl ::cynic::schema::HasArgument<input> for super::postJob {
-            type ArgumentType = super::super::PostJobInput;
-            const NAME: &'static str = "input";
-        }
-    }
-    pub struct updateJob;
-    impl ::cynic::schema::Field for updateJob {
-        type Type = super::Job;
-        const NAME: &'static str = "updateJob";
-    }
-    impl ::cynic::schema::HasField<updateJob> for super::Mutation {
-        type Type = super::Job;
-    }
-    pub mod update_job_arguments {
-        pub struct input;
-        impl ::cynic::schema::HasArgument<input> for super::updateJob {
-            type ArgumentType = super::super::UpdateJobInput;
-            const NAME: &'static str = "input";
-        }
-        pub struct adminSecret;
-        impl ::cynic::schema::HasArgument<adminSecret> for super::updateJob {
-            type ArgumentType = super::super::String;
-            const NAME: &'static str = "adminSecret";
-        }
-    }
-    pub struct updateCompany;
-    impl ::cynic::schema::Field for updateCompany {
-        type Type = super::Company;
-        const NAME: &'static str = "updateCompany";
-    }
-    impl ::cynic::schema::HasField<updateCompany> for super::Mutation {
-        type Type = super::Company;
-    }
-    pub mod update_company_arguments {
-        pub struct input;
-        impl ::cynic::schema::HasArgument<input> for super::updateCompany {
-            type ArgumentType = super::super::UpdateCompanyInput;
-            const NAME: &'static str = "input";
-        }
-        pub struct adminSecret;
-        impl ::cynic::schema::HasArgument<adminSecret> for super::updateCompany {
-            type ArgumentType = super::super::String;
-            const NAME: &'static str = "adminSecret";
-        }
-    }
-}
 pub struct PostJobInput;
 impl ::cynic::schema::InputObjectMarker for PostJobInput {}
-pub mod post_job_input_fields {
-    pub struct title;
-    impl ::cynic::schema::Field for title {
-        type Type = super::String;
-        const NAME: &'static str = "title";
-    }
-    impl ::cynic::schema::HasInputField<title, super::String> for super::PostJobInput {}
-    pub struct commitmentId;
-    impl ::cynic::schema::Field for commitmentId {
-        type Type = super::ID;
-        const NAME: &'static str = "commitmentId";
-    }
-    impl ::cynic::schema::HasInputField<commitmentId, super::ID> for super::PostJobInput {}
-    pub struct companyName;
-    impl ::cynic::schema::Field for companyName {
-        type Type = super::String;
-        const NAME: &'static str = "companyName";
-    }
-    impl ::cynic::schema::HasInputField<companyName, super::String> for super::PostJobInput {}
-    pub struct locationNames;
-    impl ::cynic::schema::Field for locationNames {
-        type Type = super::String;
-        const NAME: &'static str = "locationNames";
-    }
-    impl ::cynic::schema::HasInputField<locationNames, super::String> for super::PostJobInput {}
-    pub struct userEmail;
-    impl ::cynic::schema::Field for userEmail {
-        type Type = super::String;
-        const NAME: &'static str = "userEmail";
-    }
-    impl ::cynic::schema::HasInputField<userEmail, super::String> for super::PostJobInput {}
-    pub struct description;
-    impl ::cynic::schema::Field for description {
-        type Type = super::String;
-        const NAME: &'static str = "description";
-    }
-    impl ::cynic::schema::HasInputField<description, super::String> for super::PostJobInput {}
-    pub struct applyUrl;
-    impl ::cynic::schema::Field for applyUrl {
-        type Type = super::String;
-        const NAME: &'static str = "applyUrl";
-    }
-    impl ::cynic::schema::HasInputField<applyUrl, super::String> for super::PostJobInput {}
-}
 pub struct Query;
-pub mod query_fields {
-    pub struct jobs;
-    impl ::cynic::schema::Field for jobs {
-        type Type = Vec<super::Job>;
-        const NAME: &'static str = "jobs";
-    }
-    impl ::cynic::schema::HasField<jobs> for super::Query {
-        type Type = Vec<super::Job>;
-    }
-    pub mod jobs_arguments {
-        pub struct input;
-        impl ::cynic::schema::HasArgument<input> for super::jobs {
-            type ArgumentType = Option<super::super::JobsInput>;
-            const NAME: &'static str = "input";
-        }
-    }
-    pub struct job;
-    impl ::cynic::schema::Field for job {
-        type Type = super::Job;
-        const NAME: &'static str = "job";
-    }
-    impl ::cynic::schema::HasField<job> for super::Query {
-        type Type = super::Job;
-    }
-    pub mod job_arguments {
-        pub struct input;
-        impl ::cynic::schema::HasArgument<input> for super::job {
-            type ArgumentType = super::super::JobInput;
-            const NAME: &'static str = "input";
-        }
-    }
-    pub struct locations;
-    impl ::cynic::schema::Field for locations {
-        type Type = Vec<super::Location>;
-        const NAME: &'static str = "locations";
-    }
-    impl ::cynic::schema::HasField<locations> for super::Query {
-        type Type = Vec<super::Location>;
-    }
-    pub mod locations_arguments {
-        pub struct input;
-        impl ::cynic::schema::HasArgument<input> for super::locations {
-            type ArgumentType = super::super::LocationsInput;
-            const NAME: &'static str = "input";
-        }
-    }
-    pub struct city;
-    impl ::cynic::schema::Field for city {
-        type Type = super::City;
-        const NAME: &'static str = "city";
-    }
-    impl ::cynic::schema::HasField<city> for super::Query {
-        type Type = super::City;
-    }
-    pub mod city_arguments {
-        pub struct input;
-        impl ::cynic::schema::HasArgument<input> for super::city {
-            type ArgumentType = super::super::LocationInput;
-            const NAME: &'static str = "input";
-        }
-    }
-    pub struct country;
-    impl ::cynic::schema::Field for country {
-        type Type = super::Country;
-        const NAME: &'static str = "country";
-    }
-    impl ::cynic::schema::HasField<country> for super::Query {
-        type Type = super::Country;
-    }
-    pub mod country_arguments {
-        pub struct input;
-        impl ::cynic::schema::HasArgument<input> for super::country {
-            type ArgumentType = super::super::LocationInput;
-            const NAME: &'static str = "input";
-        }
-    }
-    pub struct remote;
-    impl ::cynic::schema::Field for remote {
-        type Type = super::Remote;
-        const NAME: &'static str = "remote";
-    }
-    impl ::cynic::schema::HasField<remote> for super::Query {
-        type Type = super::Remote;
-    }
-    pub mod remote_arguments {
-        pub struct input;
-        impl ::cynic::schema::HasArgument<input> for super::remote {
-            type ArgumentType = super::super::LocationInput;
-            const NAME: &'static str = "input";
-        }
-    }
-    pub struct commitments;
-    impl ::cynic::schema::Field for commitments {
-        type Type = Vec<super::Commitment>;
-        const NAME: &'static str = "commitments";
-    }
-    impl ::cynic::schema::HasField<commitments> for super::Query {
-        type Type = Vec<super::Commitment>;
-    }
-    pub struct cities;
-    impl ::cynic::schema::Field for cities {
-        type Type = Vec<super::City>;
-        const NAME: &'static str = "cities";
-    }
-    impl ::cynic::schema::HasField<cities> for super::Query {
-        type Type = Vec<super::City>;
-    }
-    pub struct countries;
-    impl ::cynic::schema::Field for countries {
-        type Type = Vec<super::Country>;
-        const NAME: &'static str = "countries";
-    }
-    impl ::cynic::schema::HasField<countries> for super::Query {
-        type Type = Vec<super::Country>;
-    }
-    pub struct remotes;
-    impl ::cynic::schema::Field for remotes {
-        type Type = Vec<super::Remote>;
-        const NAME: &'static str = "remotes";
-    }
-    impl ::cynic::schema::HasField<remotes> for super::Query {
-        type Type = Vec<super::Remote>;
-    }
-    pub struct companies;
-    impl ::cynic::schema::Field for companies {
-        type Type = Vec<super::Company>;
-        const NAME: &'static str = "companies";
-    }
-    impl ::cynic::schema::HasField<companies> for super::Query {
-        type Type = Vec<super::Company>;
-    }
-}
 pub struct Remote;
-pub mod remote_fields {
-    pub struct id;
-    impl ::cynic::schema::Field for id {
-        type Type = super::ID;
-        const NAME: &'static str = "id";
-    }
-    impl ::cynic::schema::HasField<id> for super::Remote {
-        type Type = super::ID;
-    }
-    pub struct name;
-    impl ::cynic::schema::Field for name {
-        type Type = super::String;
-        const NAME: &'static str = "name";
-    }
-    impl ::cynic::schema::HasField<name> for super::Remote {
-        type Type = super::String;
-    }
-    pub struct slug;
-    impl ::cynic::schema::Field for slug {
-        type Type = super::String;
-        const NAME: &'static str = "slug";
-    }
-    impl ::cynic::schema::HasField<slug> for super::Remote {
-        type Type = super::String;
-    }
-    pub struct r#type;
-    impl ::cynic::schema::Field for r#type {
-        type Type = super::String;
-        const NAME: &'static str = "type";
-    }
-    impl ::cynic::schema::HasField<r#type> for super::Remote {
-        type Type = super::String;
-    }
-    pub struct jobs;
-    impl ::cynic::schema::Field for jobs {
-        type Type = Option<Vec<super::Job>>;
-        const NAME: &'static str = "jobs";
-    }
-    impl ::cynic::schema::HasField<jobs> for super::Remote {
-        type Type = Option<Vec<super::Job>>;
-    }
-    pub mod jobs_arguments {
-        pub struct r#where;
-        impl ::cynic::schema::HasArgument<r#where> for super::jobs {
-            type ArgumentType = Option<super::super::JobWhereInput>;
-            const NAME: &'static str = "where";
-        }
-        pub struct orderBy;
-        impl ::cynic::schema::HasArgument<orderBy> for super::jobs {
-            type ArgumentType = Option<super::super::JobOrderByInput>;
-            const NAME: &'static str = "orderBy";
-        }
-        pub struct skip;
-        impl ::cynic::schema::HasArgument<skip> for super::jobs {
-            type ArgumentType = Option<super::super::Int>;
-            const NAME: &'static str = "skip";
-        }
-        pub struct after;
-        impl ::cynic::schema::HasArgument<after> for super::jobs {
-            type ArgumentType = Option<super::super::String>;
-            const NAME: &'static str = "after";
-        }
-        pub struct before;
-        impl ::cynic::schema::HasArgument<before> for super::jobs {
-            type ArgumentType = Option<super::super::String>;
-            const NAME: &'static str = "before";
-        }
-        pub struct first;
-        impl ::cynic::schema::HasArgument<first> for super::jobs {
-            type ArgumentType = Option<super::super::Int>;
-            const NAME: &'static str = "first";
-        }
-        pub struct last;
-        impl ::cynic::schema::HasArgument<last> for super::jobs {
-            type ArgumentType = Option<super::super::Int>;
-            const NAME: &'static str = "last";
-        }
-    }
-    pub struct createdAt;
-    impl ::cynic::schema::Field for createdAt {
-        type Type = super::DateTime;
-        const NAME: &'static str = "createdAt";
-    }
-    impl ::cynic::schema::HasField<createdAt> for super::Remote {
-        type Type = super::DateTime;
-    }
-    pub struct updatedAt;
-    impl ::cynic::schema::Field for updatedAt {
-        type Type = super::DateTime;
-        const NAME: &'static str = "updatedAt";
-    }
-    impl ::cynic::schema::HasField<updatedAt> for super::Remote {
-        type Type = super::DateTime;
-    }
-}
 pub struct RemoteOrderByInput {}
 pub struct RemoteWhereInput;
 impl ::cynic::schema::InputObjectMarker for RemoteWhereInput {}
-pub mod remote_where_input_fields {
-    pub struct id;
-    impl ::cynic::schema::Field for id {
-        type Type = Option<super::ID>;
-        const NAME: &'static str = "id";
-    }
-    impl ::cynic::schema::HasInputField<id, Option<super::ID>> for super::RemoteWhereInput {}
-    pub struct id_not;
-    impl ::cynic::schema::Field for id_not {
-        type Type = Option<super::ID>;
-        const NAME: &'static str = "id_not";
-    }
-    impl ::cynic::schema::HasInputField<id_not, Option<super::ID>> for super::RemoteWhereInput {}
-    pub struct id_in;
-    impl ::cynic::schema::Field for id_in {
-        type Type = Option<Vec<super::ID>>;
-        const NAME: &'static str = "id_in";
-    }
-    impl ::cynic::schema::HasInputField<id_in, Option<Vec<super::ID>>> for super::RemoteWhereInput {}
-    pub struct id_not_in;
-    impl ::cynic::schema::Field for id_not_in {
-        type Type = Option<Vec<super::ID>>;
-        const NAME: &'static str = "id_not_in";
-    }
-    impl ::cynic::schema::HasInputField<id_not_in, Option<Vec<super::ID>>> for super::RemoteWhereInput {}
-    pub struct id_lt;
-    impl ::cynic::schema::Field for id_lt {
-        type Type = Option<super::ID>;
-        const NAME: &'static str = "id_lt";
-    }
-    impl ::cynic::schema::HasInputField<id_lt, Option<super::ID>> for super::RemoteWhereInput {}
-    pub struct id_lte;
-    impl ::cynic::schema::Field for id_lte {
-        type Type = Option<super::ID>;
-        const NAME: &'static str = "id_lte";
-    }
-    impl ::cynic::schema::HasInputField<id_lte, Option<super::ID>> for super::RemoteWhereInput {}
-    pub struct id_gt;
-    impl ::cynic::schema::Field for id_gt {
-        type Type = Option<super::ID>;
-        const NAME: &'static str = "id_gt";
-    }
-    impl ::cynic::schema::HasInputField<id_gt, Option<super::ID>> for super::RemoteWhereInput {}
-    pub struct id_gte;
-    impl ::cynic::schema::Field for id_gte {
-        type Type = Option<super::ID>;
-        const NAME: &'static str = "id_gte";
-    }
-    impl ::cynic::schema::HasInputField<id_gte, Option<super::ID>> for super::RemoteWhereInput {}
-    pub struct id_contains;
-    impl ::cynic::schema::Field for id_contains {
-        type Type = Option<super::ID>;
-        const NAME: &'static str = "id_contains";
-    }
-    impl ::cynic::schema::HasInputField<id_contains, Option<super::ID>> for super::RemoteWhereInput {}
-    pub struct id_not_contains;
-    impl ::cynic::schema::Field for id_not_contains {
-        type Type = Option<super::ID>;
-        const NAME: &'static str = "id_not_contains";
-    }
-    impl ::cynic::schema::HasInputField<id_not_contains, Option<super::ID>>
-        for super::RemoteWhereInput
-    {
-    }
-    pub struct id_starts_with;
-    impl ::cynic::schema::Field for id_starts_with {
-        type Type = Option<super::ID>;
-        const NAME: &'static str = "id_starts_with";
-    }
-    impl ::cynic::schema::HasInputField<id_starts_with, Option<super::ID>> for super::RemoteWhereInput {}
-    pub struct id_not_starts_with;
-    impl ::cynic::schema::Field for id_not_starts_with {
-        type Type = Option<super::ID>;
-        const NAME: &'static str = "id_not_starts_with";
-    }
-    impl ::cynic::schema::HasInputField<id_not_starts_with, Option<super::ID>>
-        for super::RemoteWhereInput
-    {
-    }
-    pub struct id_ends_with;
-    impl ::cynic::schema::Field for id_ends_with {
-        type Type = Option<super::ID>;
-        const NAME: &'static str = "id_ends_with";
-    }
-    impl ::cynic::schema::HasInputField<id_ends_with, Option<super::ID>> for super::RemoteWhereInput {}
-    pub struct id_not_ends_with;
-    impl ::cynic::schema::Field for id_not_ends_with {
-        type Type = Option<super::ID>;
-        const NAME: &'static str = "id_not_ends_with";
-    }
-    impl ::cynic::schema::HasInputField<id_not_ends_with, Option<super::ID>>
-        for super::RemoteWhereInput
-    {
-    }
-    pub struct name;
-    impl ::cynic::schema::Field for name {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "name";
-    }
-    impl ::cynic::schema::HasInputField<name, Option<super::String>> for super::RemoteWhereInput {}
-    pub struct name_not;
-    impl ::cynic::schema::Field for name_not {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "name_not";
-    }
-    impl ::cynic::schema::HasInputField<name_not, Option<super::String>> for super::RemoteWhereInput {}
-    pub struct name_in;
-    impl ::cynic::schema::Field for name_in {
-        type Type = Option<Vec<super::String>>;
-        const NAME: &'static str = "name_in";
-    }
-    impl ::cynic::schema::HasInputField<name_in, Option<Vec<super::String>>>
-        for super::RemoteWhereInput
-    {
-    }
-    pub struct name_not_in;
-    impl ::cynic::schema::Field for name_not_in {
-        type Type = Option<Vec<super::String>>;
-        const NAME: &'static str = "name_not_in";
-    }
-    impl ::cynic::schema::HasInputField<name_not_in, Option<Vec<super::String>>>
-        for super::RemoteWhereInput
-    {
-    }
-    pub struct name_lt;
-    impl ::cynic::schema::Field for name_lt {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "name_lt";
-    }
-    impl ::cynic::schema::HasInputField<name_lt, Option<super::String>> for super::RemoteWhereInput {}
-    pub struct name_lte;
-    impl ::cynic::schema::Field for name_lte {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "name_lte";
-    }
-    impl ::cynic::schema::HasInputField<name_lte, Option<super::String>> for super::RemoteWhereInput {}
-    pub struct name_gt;
-    impl ::cynic::schema::Field for name_gt {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "name_gt";
-    }
-    impl ::cynic::schema::HasInputField<name_gt, Option<super::String>> for super::RemoteWhereInput {}
-    pub struct name_gte;
-    impl ::cynic::schema::Field for name_gte {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "name_gte";
-    }
-    impl ::cynic::schema::HasInputField<name_gte, Option<super::String>> for super::RemoteWhereInput {}
-    pub struct name_contains;
-    impl ::cynic::schema::Field for name_contains {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "name_contains";
-    }
-    impl ::cynic::schema::HasInputField<name_contains, Option<super::String>>
-        for super::RemoteWhereInput
-    {
-    }
-    pub struct name_not_contains;
-    impl ::cynic::schema::Field for name_not_contains {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "name_not_contains";
-    }
-    impl ::cynic::schema::HasInputField<name_not_contains, Option<super::String>>
-        for super::RemoteWhereInput
-    {
-    }
-    pub struct name_starts_with;
-    impl ::cynic::schema::Field for name_starts_with {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "name_starts_with";
-    }
-    impl ::cynic::schema::HasInputField<name_starts_with, Option<super::String>>
-        for super::RemoteWhereInput
-    {
-    }
-    pub struct name_not_starts_with;
-    impl ::cynic::schema::Field for name_not_starts_with {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "name_not_starts_with";
-    }
-    impl ::cynic::schema::HasInputField<name_not_starts_with, Option<super::String>>
-        for super::RemoteWhereInput
-    {
-    }
-    pub struct name_ends_with;
-    impl ::cynic::schema::Field for name_ends_with {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "name_ends_with";
-    }
-    impl ::cynic::schema::HasInputField<name_ends_with, Option<super::String>>
-        for super::RemoteWhereInput
-    {
-    }
-    pub struct name_not_ends_with;
-    impl ::cynic::schema::Field for name_not_ends_with {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "name_not_ends_with";
-    }
-    impl ::cynic::schema::HasInputField<name_not_ends_with, Option<super::String>>
-        for super::RemoteWhereInput
-    {
-    }
-    pub struct slug;
-    impl ::cynic::schema::Field for slug {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "slug";
-    }
-    impl ::cynic::schema::HasInputField<slug, Option<super::String>> for super::RemoteWhereInput {}
-    pub struct slug_not;
-    impl ::cynic::schema::Field for slug_not {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "slug_not";
-    }
-    impl ::cynic::schema::HasInputField<slug_not, Option<super::String>> for super::RemoteWhereInput {}
-    pub struct slug_in;
-    impl ::cynic::schema::Field for slug_in {
-        type Type = Option<Vec<super::String>>;
-        const NAME: &'static str = "slug_in";
-    }
-    impl ::cynic::schema::HasInputField<slug_in, Option<Vec<super::String>>>
-        for super::RemoteWhereInput
-    {
-    }
-    pub struct slug_not_in;
-    impl ::cynic::schema::Field for slug_not_in {
-        type Type = Option<Vec<super::String>>;
-        const NAME: &'static str = "slug_not_in";
-    }
-    impl ::cynic::schema::HasInputField<slug_not_in, Option<Vec<super::String>>>
-        for super::RemoteWhereInput
-    {
-    }
-    pub struct slug_lt;
-    impl ::cynic::schema::Field for slug_lt {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "slug_lt";
-    }
-    impl ::cynic::schema::HasInputField<slug_lt, Option<super::String>> for super::RemoteWhereInput {}
-    pub struct slug_lte;
-    impl ::cynic::schema::Field for slug_lte {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "slug_lte";
-    }
-    impl ::cynic::schema::HasInputField<slug_lte, Option<super::String>> for super::RemoteWhereInput {}
-    pub struct slug_gt;
-    impl ::cynic::schema::Field for slug_gt {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "slug_gt";
-    }
-    impl ::cynic::schema::HasInputField<slug_gt, Option<super::String>> for super::RemoteWhereInput {}
-    pub struct slug_gte;
-    impl ::cynic::schema::Field for slug_gte {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "slug_gte";
-    }
-    impl ::cynic::schema::HasInputField<slug_gte, Option<super::String>> for super::RemoteWhereInput {}
-    pub struct slug_contains;
-    impl ::cynic::schema::Field for slug_contains {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "slug_contains";
-    }
-    impl ::cynic::schema::HasInputField<slug_contains, Option<super::String>>
-        for super::RemoteWhereInput
-    {
-    }
-    pub struct slug_not_contains;
-    impl ::cynic::schema::Field for slug_not_contains {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "slug_not_contains";
-    }
-    impl ::cynic::schema::HasInputField<slug_not_contains, Option<super::String>>
-        for super::RemoteWhereInput
-    {
-    }
-    pub struct slug_starts_with;
-    impl ::cynic::schema::Field for slug_starts_with {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "slug_starts_with";
-    }
-    impl ::cynic::schema::HasInputField<slug_starts_with, Option<super::String>>
-        for super::RemoteWhereInput
-    {
-    }
-    pub struct slug_not_starts_with;
-    impl ::cynic::schema::Field for slug_not_starts_with {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "slug_not_starts_with";
-    }
-    impl ::cynic::schema::HasInputField<slug_not_starts_with, Option<super::String>>
-        for super::RemoteWhereInput
-    {
-    }
-    pub struct slug_ends_with;
-    impl ::cynic::schema::Field for slug_ends_with {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "slug_ends_with";
-    }
-    impl ::cynic::schema::HasInputField<slug_ends_with, Option<super::String>>
-        for super::RemoteWhereInput
-    {
-    }
-    pub struct slug_not_ends_with;
-    impl ::cynic::schema::Field for slug_not_ends_with {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "slug_not_ends_with";
-    }
-    impl ::cynic::schema::HasInputField<slug_not_ends_with, Option<super::String>>
-        for super::RemoteWhereInput
-    {
-    }
-    pub struct r#type;
-    impl ::cynic::schema::Field for r#type {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "type";
-    }
-    impl ::cynic::schema::HasInputField<r#type, Option<super::String>> for super::RemoteWhereInput {}
-    pub struct type_not;
-    impl ::cynic::schema::Field for type_not {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "type_not";
-    }
-    impl ::cynic::schema::HasInputField<type_not, Option<super::String>> for super::RemoteWhereInput {}
-    pub struct type_in;
-    impl ::cynic::schema::Field for type_in {
-        type Type = Option<Vec<super::String>>;
-        const NAME: &'static str = "type_in";
-    }
-    impl ::cynic::schema::HasInputField<type_in, Option<Vec<super::String>>>
-        for super::RemoteWhereInput
-    {
-    }
-    pub struct type_not_in;
-    impl ::cynic::schema::Field for type_not_in {
-        type Type = Option<Vec<super::String>>;
-        const NAME: &'static str = "type_not_in";
-    }
-    impl ::cynic::schema::HasInputField<type_not_in, Option<Vec<super::String>>>
-        for super::RemoteWhereInput
-    {
-    }
-    pub struct type_lt;
-    impl ::cynic::schema::Field for type_lt {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "type_lt";
-    }
-    impl ::cynic::schema::HasInputField<type_lt, Option<super::String>> for super::RemoteWhereInput {}
-    pub struct type_lte;
-    impl ::cynic::schema::Field for type_lte {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "type_lte";
-    }
-    impl ::cynic::schema::HasInputField<type_lte, Option<super::String>> for super::RemoteWhereInput {}
-    pub struct type_gt;
-    impl ::cynic::schema::Field for type_gt {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "type_gt";
-    }
-    impl ::cynic::schema::HasInputField<type_gt, Option<super::String>> for super::RemoteWhereInput {}
-    pub struct type_gte;
-    impl ::cynic::schema::Field for type_gte {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "type_gte";
-    }
-    impl ::cynic::schema::HasInputField<type_gte, Option<super::String>> for super::RemoteWhereInput {}
-    pub struct type_contains;
-    impl ::cynic::schema::Field for type_contains {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "type_contains";
-    }
-    impl ::cynic::schema::HasInputField<type_contains, Option<super::String>>
-        for super::RemoteWhereInput
-    {
-    }
-    pub struct type_not_contains;
-    impl ::cynic::schema::Field for type_not_contains {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "type_not_contains";
-    }
-    impl ::cynic::schema::HasInputField<type_not_contains, Option<super::String>>
-        for super::RemoteWhereInput
-    {
-    }
-    pub struct type_starts_with;
-    impl ::cynic::schema::Field for type_starts_with {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "type_starts_with";
-    }
-    impl ::cynic::schema::HasInputField<type_starts_with, Option<super::String>>
-        for super::RemoteWhereInput
-    {
-    }
-    pub struct type_not_starts_with;
-    impl ::cynic::schema::Field for type_not_starts_with {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "type_not_starts_with";
-    }
-    impl ::cynic::schema::HasInputField<type_not_starts_with, Option<super::String>>
-        for super::RemoteWhereInput
-    {
-    }
-    pub struct type_ends_with;
-    impl ::cynic::schema::Field for type_ends_with {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "type_ends_with";
-    }
-    impl ::cynic::schema::HasInputField<type_ends_with, Option<super::String>>
-        for super::RemoteWhereInput
-    {
-    }
-    pub struct type_not_ends_with;
-    impl ::cynic::schema::Field for type_not_ends_with {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "type_not_ends_with";
-    }
-    impl ::cynic::schema::HasInputField<type_not_ends_with, Option<super::String>>
-        for super::RemoteWhereInput
-    {
-    }
-    pub struct jobs_every;
-    impl ::cynic::schema::Field for jobs_every {
-        type Type = Option<super::JobWhereInput>;
-        const NAME: &'static str = "jobs_every";
-    }
-    impl ::cynic::schema::HasInputField<jobs_every, Option<super::JobWhereInput>>
-        for super::RemoteWhereInput
-    {
-    }
-    pub struct jobs_some;
-    impl ::cynic::schema::Field for jobs_some {
-        type Type = Option<super::JobWhereInput>;
-        const NAME: &'static str = "jobs_some";
-    }
-    impl ::cynic::schema::HasInputField<jobs_some, Option<super::JobWhereInput>>
-        for super::RemoteWhereInput
-    {
-    }
-    pub struct jobs_none;
-    impl ::cynic::schema::Field for jobs_none {
-        type Type = Option<super::JobWhereInput>;
-        const NAME: &'static str = "jobs_none";
-    }
-    impl ::cynic::schema::HasInputField<jobs_none, Option<super::JobWhereInput>>
-        for super::RemoteWhereInput
-    {
-    }
-    pub struct createdAt;
-    impl ::cynic::schema::Field for createdAt {
-        type Type = Option<super::DateTime>;
-        const NAME: &'static str = "createdAt";
-    }
-    impl ::cynic::schema::HasInputField<createdAt, Option<super::DateTime>>
-        for super::RemoteWhereInput
-    {
-    }
-    pub struct createdAt_not;
-    impl ::cynic::schema::Field for createdAt_not {
-        type Type = Option<super::DateTime>;
-        const NAME: &'static str = "createdAt_not";
-    }
-    impl ::cynic::schema::HasInputField<createdAt_not, Option<super::DateTime>>
-        for super::RemoteWhereInput
-    {
-    }
-    pub struct createdAt_in;
-    impl ::cynic::schema::Field for createdAt_in {
-        type Type = Option<Vec<super::DateTime>>;
-        const NAME: &'static str = "createdAt_in";
-    }
-    impl ::cynic::schema::HasInputField<createdAt_in, Option<Vec<super::DateTime>>>
-        for super::RemoteWhereInput
-    {
-    }
-    pub struct createdAt_not_in;
-    impl ::cynic::schema::Field for createdAt_not_in {
-        type Type = Option<Vec<super::DateTime>>;
-        const NAME: &'static str = "createdAt_not_in";
-    }
-    impl ::cynic::schema::HasInputField<createdAt_not_in, Option<Vec<super::DateTime>>>
-        for super::RemoteWhereInput
-    {
-    }
-    pub struct createdAt_lt;
-    impl ::cynic::schema::Field for createdAt_lt {
-        type Type = Option<super::DateTime>;
-        const NAME: &'static str = "createdAt_lt";
-    }
-    impl ::cynic::schema::HasInputField<createdAt_lt, Option<super::DateTime>>
-        for super::RemoteWhereInput
-    {
-    }
-    pub struct createdAt_lte;
-    impl ::cynic::schema::Field for createdAt_lte {
-        type Type = Option<super::DateTime>;
-        const NAME: &'static str = "createdAt_lte";
-    }
-    impl ::cynic::schema::HasInputField<createdAt_lte, Option<super::DateTime>>
-        for super::RemoteWhereInput
-    {
-    }
-    pub struct createdAt_gt;
-    impl ::cynic::schema::Field for createdAt_gt {
-        type Type = Option<super::DateTime>;
-        const NAME: &'static str = "createdAt_gt";
-    }
-    impl ::cynic::schema::HasInputField<createdAt_gt, Option<super::DateTime>>
-        for super::RemoteWhereInput
-    {
-    }
-    pub struct createdAt_gte;
-    impl ::cynic::schema::Field for createdAt_gte {
-        type Type = Option<super::DateTime>;
-        const NAME: &'static str = "createdAt_gte";
-    }
-    impl ::cynic::schema::HasInputField<createdAt_gte, Option<super::DateTime>>
-        for super::RemoteWhereInput
-    {
-    }
-    pub struct updatedAt;
-    impl ::cynic::schema::Field for updatedAt {
-        type Type = Option<super::DateTime>;
-        const NAME: &'static str = "updatedAt";
-    }
-    impl ::cynic::schema::HasInputField<updatedAt, Option<super::DateTime>>
-        for super::RemoteWhereInput
-    {
-    }
-    pub struct updatedAt_not;
-    impl ::cynic::schema::Field for updatedAt_not {
-        type Type = Option<super::DateTime>;
-        const NAME: &'static str = "updatedAt_not";
-    }
-    impl ::cynic::schema::HasInputField<updatedAt_not, Option<super::DateTime>>
-        for super::RemoteWhereInput
-    {
-    }
-    pub struct updatedAt_in;
-    impl ::cynic::schema::Field for updatedAt_in {
-        type Type = Option<Vec<super::DateTime>>;
-        const NAME: &'static str = "updatedAt_in";
-    }
-    impl ::cynic::schema::HasInputField<updatedAt_in, Option<Vec<super::DateTime>>>
-        for super::RemoteWhereInput
-    {
-    }
-    pub struct updatedAt_not_in;
-    impl ::cynic::schema::Field for updatedAt_not_in {
-        type Type = Option<Vec<super::DateTime>>;
-        const NAME: &'static str = "updatedAt_not_in";
-    }
-    impl ::cynic::schema::HasInputField<updatedAt_not_in, Option<Vec<super::DateTime>>>
-        for super::RemoteWhereInput
-    {
-    }
-    pub struct updatedAt_lt;
-    impl ::cynic::schema::Field for updatedAt_lt {
-        type Type = Option<super::DateTime>;
-        const NAME: &'static str = "updatedAt_lt";
-    }
-    impl ::cynic::schema::HasInputField<updatedAt_lt, Option<super::DateTime>>
-        for super::RemoteWhereInput
-    {
-    }
-    pub struct updatedAt_lte;
-    impl ::cynic::schema::Field for updatedAt_lte {
-        type Type = Option<super::DateTime>;
-        const NAME: &'static str = "updatedAt_lte";
-    }
-    impl ::cynic::schema::HasInputField<updatedAt_lte, Option<super::DateTime>>
-        for super::RemoteWhereInput
-    {
-    }
-    pub struct updatedAt_gt;
-    impl ::cynic::schema::Field for updatedAt_gt {
-        type Type = Option<super::DateTime>;
-        const NAME: &'static str = "updatedAt_gt";
-    }
-    impl ::cynic::schema::HasInputField<updatedAt_gt, Option<super::DateTime>>
-        for super::RemoteWhereInput
-    {
-    }
-    pub struct updatedAt_gte;
-    impl ::cynic::schema::Field for updatedAt_gte {
-        type Type = Option<super::DateTime>;
-        const NAME: &'static str = "updatedAt_gte";
-    }
-    impl ::cynic::schema::HasInputField<updatedAt_gte, Option<super::DateTime>>
-        for super::RemoteWhereInput
-    {
-    }
-    pub struct AND;
-    impl ::cynic::schema::Field for AND {
-        type Type = Option<Vec<super::RemoteWhereInput>>;
-        const NAME: &'static str = "AND";
-    }
-    impl ::cynic::schema::HasInputField<AND, Option<Vec<super::RemoteWhereInput>>>
-        for super::RemoteWhereInput
-    {
-    }
-    pub struct OR;
-    impl ::cynic::schema::Field for OR {
-        type Type = Option<Vec<super::RemoteWhereInput>>;
-        const NAME: &'static str = "OR";
-    }
-    impl ::cynic::schema::HasInputField<OR, Option<Vec<super::RemoteWhereInput>>>
-        for super::RemoteWhereInput
-    {
-    }
-    pub struct NOT;
-    impl ::cynic::schema::Field for NOT {
-        type Type = Option<Vec<super::RemoteWhereInput>>;
-        const NAME: &'static str = "NOT";
-    }
-    impl ::cynic::schema::HasInputField<NOT, Option<Vec<super::RemoteWhereInput>>>
-        for super::RemoteWhereInput
-    {
-    }
-}
 pub struct SubscribeInput;
 impl ::cynic::schema::InputObjectMarker for SubscribeInput {}
-pub mod subscribe_input_fields {
-    pub struct name;
-    impl ::cynic::schema::Field for name {
-        type Type = super::String;
-        const NAME: &'static str = "name";
-    }
-    impl ::cynic::schema::HasInputField<name, super::String> for super::SubscribeInput {}
-    pub struct email;
-    impl ::cynic::schema::Field for email {
-        type Type = super::String;
-        const NAME: &'static str = "email";
-    }
-    impl ::cynic::schema::HasInputField<email, super::String> for super::SubscribeInput {}
-}
 pub struct Tag;
-pub mod tag_fields {
-    pub struct id;
-    impl ::cynic::schema::Field for id {
-        type Type = super::ID;
-        const NAME: &'static str = "id";
-    }
-    impl ::cynic::schema::HasField<id> for super::Tag {
-        type Type = super::ID;
-    }
-    pub struct name;
-    impl ::cynic::schema::Field for name {
-        type Type = super::String;
-        const NAME: &'static str = "name";
-    }
-    impl ::cynic::schema::HasField<name> for super::Tag {
-        type Type = super::String;
-    }
-    pub struct slug;
-    impl ::cynic::schema::Field for slug {
-        type Type = super::String;
-        const NAME: &'static str = "slug";
-    }
-    impl ::cynic::schema::HasField<slug> for super::Tag {
-        type Type = super::String;
-    }
-    pub struct jobs;
-    impl ::cynic::schema::Field for jobs {
-        type Type = Option<Vec<super::Job>>;
-        const NAME: &'static str = "jobs";
-    }
-    impl ::cynic::schema::HasField<jobs> for super::Tag {
-        type Type = Option<Vec<super::Job>>;
-    }
-    pub mod jobs_arguments {
-        pub struct r#where;
-        impl ::cynic::schema::HasArgument<r#where> for super::jobs {
-            type ArgumentType = Option<super::super::JobWhereInput>;
-            const NAME: &'static str = "where";
-        }
-        pub struct orderBy;
-        impl ::cynic::schema::HasArgument<orderBy> for super::jobs {
-            type ArgumentType = Option<super::super::JobOrderByInput>;
-            const NAME: &'static str = "orderBy";
-        }
-        pub struct skip;
-        impl ::cynic::schema::HasArgument<skip> for super::jobs {
-            type ArgumentType = Option<super::super::Int>;
-            const NAME: &'static str = "skip";
-        }
-        pub struct after;
-        impl ::cynic::schema::HasArgument<after> for super::jobs {
-            type ArgumentType = Option<super::super::String>;
-            const NAME: &'static str = "after";
-        }
-        pub struct before;
-        impl ::cynic::schema::HasArgument<before> for super::jobs {
-            type ArgumentType = Option<super::super::String>;
-            const NAME: &'static str = "before";
-        }
-        pub struct first;
-        impl ::cynic::schema::HasArgument<first> for super::jobs {
-            type ArgumentType = Option<super::super::Int>;
-            const NAME: &'static str = "first";
-        }
-        pub struct last;
-        impl ::cynic::schema::HasArgument<last> for super::jobs {
-            type ArgumentType = Option<super::super::Int>;
-            const NAME: &'static str = "last";
-        }
-    }
-    pub struct createdAt;
-    impl ::cynic::schema::Field for createdAt {
-        type Type = super::DateTime;
-        const NAME: &'static str = "createdAt";
-    }
-    impl ::cynic::schema::HasField<createdAt> for super::Tag {
-        type Type = super::DateTime;
-    }
-    pub struct updatedAt;
-    impl ::cynic::schema::Field for updatedAt {
-        type Type = super::DateTime;
-        const NAME: &'static str = "updatedAt";
-    }
-    impl ::cynic::schema::HasField<updatedAt> for super::Tag {
-        type Type = super::DateTime;
-    }
-}
 pub struct TagOrderByInput {}
 pub struct TagWhereInput;
 impl ::cynic::schema::InputObjectMarker for TagWhereInput {}
-pub mod tag_where_input_fields {
-    pub struct id;
-    impl ::cynic::schema::Field for id {
-        type Type = Option<super::ID>;
-        const NAME: &'static str = "id";
-    }
-    impl ::cynic::schema::HasInputField<id, Option<super::ID>> for super::TagWhereInput {}
-    pub struct id_not;
-    impl ::cynic::schema::Field for id_not {
-        type Type = Option<super::ID>;
-        const NAME: &'static str = "id_not";
-    }
-    impl ::cynic::schema::HasInputField<id_not, Option<super::ID>> for super::TagWhereInput {}
-    pub struct id_in;
-    impl ::cynic::schema::Field for id_in {
-        type Type = Option<Vec<super::ID>>;
-        const NAME: &'static str = "id_in";
-    }
-    impl ::cynic::schema::HasInputField<id_in, Option<Vec<super::ID>>> for super::TagWhereInput {}
-    pub struct id_not_in;
-    impl ::cynic::schema::Field for id_not_in {
-        type Type = Option<Vec<super::ID>>;
-        const NAME: &'static str = "id_not_in";
-    }
-    impl ::cynic::schema::HasInputField<id_not_in, Option<Vec<super::ID>>> for super::TagWhereInput {}
-    pub struct id_lt;
-    impl ::cynic::schema::Field for id_lt {
-        type Type = Option<super::ID>;
-        const NAME: &'static str = "id_lt";
-    }
-    impl ::cynic::schema::HasInputField<id_lt, Option<super::ID>> for super::TagWhereInput {}
-    pub struct id_lte;
-    impl ::cynic::schema::Field for id_lte {
-        type Type = Option<super::ID>;
-        const NAME: &'static str = "id_lte";
-    }
-    impl ::cynic::schema::HasInputField<id_lte, Option<super::ID>> for super::TagWhereInput {}
-    pub struct id_gt;
-    impl ::cynic::schema::Field for id_gt {
-        type Type = Option<super::ID>;
-        const NAME: &'static str = "id_gt";
-    }
-    impl ::cynic::schema::HasInputField<id_gt, Option<super::ID>> for super::TagWhereInput {}
-    pub struct id_gte;
-    impl ::cynic::schema::Field for id_gte {
-        type Type = Option<super::ID>;
-        const NAME: &'static str = "id_gte";
-    }
-    impl ::cynic::schema::HasInputField<id_gte, Option<super::ID>> for super::TagWhereInput {}
-    pub struct id_contains;
-    impl ::cynic::schema::Field for id_contains {
-        type Type = Option<super::ID>;
-        const NAME: &'static str = "id_contains";
-    }
-    impl ::cynic::schema::HasInputField<id_contains, Option<super::ID>> for super::TagWhereInput {}
-    pub struct id_not_contains;
-    impl ::cynic::schema::Field for id_not_contains {
-        type Type = Option<super::ID>;
-        const NAME: &'static str = "id_not_contains";
-    }
-    impl ::cynic::schema::HasInputField<id_not_contains, Option<super::ID>> for super::TagWhereInput {}
-    pub struct id_starts_with;
-    impl ::cynic::schema::Field for id_starts_with {
-        type Type = Option<super::ID>;
-        const NAME: &'static str = "id_starts_with";
-    }
-    impl ::cynic::schema::HasInputField<id_starts_with, Option<super::ID>> for super::TagWhereInput {}
-    pub struct id_not_starts_with;
-    impl ::cynic::schema::Field for id_not_starts_with {
-        type Type = Option<super::ID>;
-        const NAME: &'static str = "id_not_starts_with";
-    }
-    impl ::cynic::schema::HasInputField<id_not_starts_with, Option<super::ID>>
-        for super::TagWhereInput
-    {
-    }
-    pub struct id_ends_with;
-    impl ::cynic::schema::Field for id_ends_with {
-        type Type = Option<super::ID>;
-        const NAME: &'static str = "id_ends_with";
-    }
-    impl ::cynic::schema::HasInputField<id_ends_with, Option<super::ID>> for super::TagWhereInput {}
-    pub struct id_not_ends_with;
-    impl ::cynic::schema::Field for id_not_ends_with {
-        type Type = Option<super::ID>;
-        const NAME: &'static str = "id_not_ends_with";
-    }
-    impl ::cynic::schema::HasInputField<id_not_ends_with, Option<super::ID>> for super::TagWhereInput {}
-    pub struct name;
-    impl ::cynic::schema::Field for name {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "name";
-    }
-    impl ::cynic::schema::HasInputField<name, Option<super::String>> for super::TagWhereInput {}
-    pub struct name_not;
-    impl ::cynic::schema::Field for name_not {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "name_not";
-    }
-    impl ::cynic::schema::HasInputField<name_not, Option<super::String>> for super::TagWhereInput {}
-    pub struct name_in;
-    impl ::cynic::schema::Field for name_in {
-        type Type = Option<Vec<super::String>>;
-        const NAME: &'static str = "name_in";
-    }
-    impl ::cynic::schema::HasInputField<name_in, Option<Vec<super::String>>> for super::TagWhereInput {}
-    pub struct name_not_in;
-    impl ::cynic::schema::Field for name_not_in {
-        type Type = Option<Vec<super::String>>;
-        const NAME: &'static str = "name_not_in";
-    }
-    impl ::cynic::schema::HasInputField<name_not_in, Option<Vec<super::String>>>
-        for super::TagWhereInput
-    {
-    }
-    pub struct name_lt;
-    impl ::cynic::schema::Field for name_lt {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "name_lt";
-    }
-    impl ::cynic::schema::HasInputField<name_lt, Option<super::String>> for super::TagWhereInput {}
-    pub struct name_lte;
-    impl ::cynic::schema::Field for name_lte {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "name_lte";
-    }
-    impl ::cynic::schema::HasInputField<name_lte, Option<super::String>> for super::TagWhereInput {}
-    pub struct name_gt;
-    impl ::cynic::schema::Field for name_gt {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "name_gt";
-    }
-    impl ::cynic::schema::HasInputField<name_gt, Option<super::String>> for super::TagWhereInput {}
-    pub struct name_gte;
-    impl ::cynic::schema::Field for name_gte {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "name_gte";
-    }
-    impl ::cynic::schema::HasInputField<name_gte, Option<super::String>> for super::TagWhereInput {}
-    pub struct name_contains;
-    impl ::cynic::schema::Field for name_contains {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "name_contains";
-    }
-    impl ::cynic::schema::HasInputField<name_contains, Option<super::String>> for super::TagWhereInput {}
-    pub struct name_not_contains;
-    impl ::cynic::schema::Field for name_not_contains {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "name_not_contains";
-    }
-    impl ::cynic::schema::HasInputField<name_not_contains, Option<super::String>>
-        for super::TagWhereInput
-    {
-    }
-    pub struct name_starts_with;
-    impl ::cynic::schema::Field for name_starts_with {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "name_starts_with";
-    }
-    impl ::cynic::schema::HasInputField<name_starts_with, Option<super::String>>
-        for super::TagWhereInput
-    {
-    }
-    pub struct name_not_starts_with;
-    impl ::cynic::schema::Field for name_not_starts_with {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "name_not_starts_with";
-    }
-    impl ::cynic::schema::HasInputField<name_not_starts_with, Option<super::String>>
-        for super::TagWhereInput
-    {
-    }
-    pub struct name_ends_with;
-    impl ::cynic::schema::Field for name_ends_with {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "name_ends_with";
-    }
-    impl ::cynic::schema::HasInputField<name_ends_with, Option<super::String>>
-        for super::TagWhereInput
-    {
-    }
-    pub struct name_not_ends_with;
-    impl ::cynic::schema::Field for name_not_ends_with {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "name_not_ends_with";
-    }
-    impl ::cynic::schema::HasInputField<name_not_ends_with, Option<super::String>>
-        for super::TagWhereInput
-    {
-    }
-    pub struct slug;
-    impl ::cynic::schema::Field for slug {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "slug";
-    }
-    impl ::cynic::schema::HasInputField<slug, Option<super::String>> for super::TagWhereInput {}
-    pub struct slug_not;
-    impl ::cynic::schema::Field for slug_not {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "slug_not";
-    }
-    impl ::cynic::schema::HasInputField<slug_not, Option<super::String>> for super::TagWhereInput {}
-    pub struct slug_in;
-    impl ::cynic::schema::Field for slug_in {
-        type Type = Option<Vec<super::String>>;
-        const NAME: &'static str = "slug_in";
-    }
-    impl ::cynic::schema::HasInputField<slug_in, Option<Vec<super::String>>> for super::TagWhereInput {}
-    pub struct slug_not_in;
-    impl ::cynic::schema::Field for slug_not_in {
-        type Type = Option<Vec<super::String>>;
-        const NAME: &'static str = "slug_not_in";
-    }
-    impl ::cynic::schema::HasInputField<slug_not_in, Option<Vec<super::String>>>
-        for super::TagWhereInput
-    {
-    }
-    pub struct slug_lt;
-    impl ::cynic::schema::Field for slug_lt {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "slug_lt";
-    }
-    impl ::cynic::schema::HasInputField<slug_lt, Option<super::String>> for super::TagWhereInput {}
-    pub struct slug_lte;
-    impl ::cynic::schema::Field for slug_lte {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "slug_lte";
-    }
-    impl ::cynic::schema::HasInputField<slug_lte, Option<super::String>> for super::TagWhereInput {}
-    pub struct slug_gt;
-    impl ::cynic::schema::Field for slug_gt {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "slug_gt";
-    }
-    impl ::cynic::schema::HasInputField<slug_gt, Option<super::String>> for super::TagWhereInput {}
-    pub struct slug_gte;
-    impl ::cynic::schema::Field for slug_gte {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "slug_gte";
-    }
-    impl ::cynic::schema::HasInputField<slug_gte, Option<super::String>> for super::TagWhereInput {}
-    pub struct slug_contains;
-    impl ::cynic::schema::Field for slug_contains {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "slug_contains";
-    }
-    impl ::cynic::schema::HasInputField<slug_contains, Option<super::String>> for super::TagWhereInput {}
-    pub struct slug_not_contains;
-    impl ::cynic::schema::Field for slug_not_contains {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "slug_not_contains";
-    }
-    impl ::cynic::schema::HasInputField<slug_not_contains, Option<super::String>>
-        for super::TagWhereInput
-    {
-    }
-    pub struct slug_starts_with;
-    impl ::cynic::schema::Field for slug_starts_with {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "slug_starts_with";
-    }
-    impl ::cynic::schema::HasInputField<slug_starts_with, Option<super::String>>
-        for super::TagWhereInput
-    {
-    }
-    pub struct slug_not_starts_with;
-    impl ::cynic::schema::Field for slug_not_starts_with {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "slug_not_starts_with";
-    }
-    impl ::cynic::schema::HasInputField<slug_not_starts_with, Option<super::String>>
-        for super::TagWhereInput
-    {
-    }
-    pub struct slug_ends_with;
-    impl ::cynic::schema::Field for slug_ends_with {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "slug_ends_with";
-    }
-    impl ::cynic::schema::HasInputField<slug_ends_with, Option<super::String>>
-        for super::TagWhereInput
-    {
-    }
-    pub struct slug_not_ends_with;
-    impl ::cynic::schema::Field for slug_not_ends_with {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "slug_not_ends_with";
-    }
-    impl ::cynic::schema::HasInputField<slug_not_ends_with, Option<super::String>>
-        for super::TagWhereInput
-    {
-    }
-    pub struct jobs_every;
-    impl ::cynic::schema::Field for jobs_every {
-        type Type = Option<super::JobWhereInput>;
-        const NAME: &'static str = "jobs_every";
-    }
-    impl ::cynic::schema::HasInputField<jobs_every, Option<super::JobWhereInput>>
-        for super::TagWhereInput
-    {
-    }
-    pub struct jobs_some;
-    impl ::cynic::schema::Field for jobs_some {
-        type Type = Option<super::JobWhereInput>;
-        const NAME: &'static str = "jobs_some";
-    }
-    impl ::cynic::schema::HasInputField<jobs_some, Option<super::JobWhereInput>>
-        for super::TagWhereInput
-    {
-    }
-    pub struct jobs_none;
-    impl ::cynic::schema::Field for jobs_none {
-        type Type = Option<super::JobWhereInput>;
-        const NAME: &'static str = "jobs_none";
-    }
-    impl ::cynic::schema::HasInputField<jobs_none, Option<super::JobWhereInput>>
-        for super::TagWhereInput
-    {
-    }
-    pub struct createdAt;
-    impl ::cynic::schema::Field for createdAt {
-        type Type = Option<super::DateTime>;
-        const NAME: &'static str = "createdAt";
-    }
-    impl ::cynic::schema::HasInputField<createdAt, Option<super::DateTime>> for super::TagWhereInput {}
-    pub struct createdAt_not;
-    impl ::cynic::schema::Field for createdAt_not {
-        type Type = Option<super::DateTime>;
-        const NAME: &'static str = "createdAt_not";
-    }
-    impl ::cynic::schema::HasInputField<createdAt_not, Option<super::DateTime>>
-        for super::TagWhereInput
-    {
-    }
-    pub struct createdAt_in;
-    impl ::cynic::schema::Field for createdAt_in {
-        type Type = Option<Vec<super::DateTime>>;
-        const NAME: &'static str = "createdAt_in";
-    }
-    impl ::cynic::schema::HasInputField<createdAt_in, Option<Vec<super::DateTime>>>
-        for super::TagWhereInput
-    {
-    }
-    pub struct createdAt_not_in;
-    impl ::cynic::schema::Field for createdAt_not_in {
-        type Type = Option<Vec<super::DateTime>>;
-        const NAME: &'static str = "createdAt_not_in";
-    }
-    impl ::cynic::schema::HasInputField<createdAt_not_in, Option<Vec<super::DateTime>>>
-        for super::TagWhereInput
-    {
-    }
-    pub struct createdAt_lt;
-    impl ::cynic::schema::Field for createdAt_lt {
-        type Type = Option<super::DateTime>;
-        const NAME: &'static str = "createdAt_lt";
-    }
-    impl ::cynic::schema::HasInputField<createdAt_lt, Option<super::DateTime>>
-        for super::TagWhereInput
-    {
-    }
-    pub struct createdAt_lte;
-    impl ::cynic::schema::Field for createdAt_lte {
-        type Type = Option<super::DateTime>;
-        const NAME: &'static str = "createdAt_lte";
-    }
-    impl ::cynic::schema::HasInputField<createdAt_lte, Option<super::DateTime>>
-        for super::TagWhereInput
-    {
-    }
-    pub struct createdAt_gt;
-    impl ::cynic::schema::Field for createdAt_gt {
-        type Type = Option<super::DateTime>;
-        const NAME: &'static str = "createdAt_gt";
-    }
-    impl ::cynic::schema::HasInputField<createdAt_gt, Option<super::DateTime>>
-        for super::TagWhereInput
-    {
-    }
-    pub struct createdAt_gte;
-    impl ::cynic::schema::Field for createdAt_gte {
-        type Type = Option<super::DateTime>;
-        const NAME: &'static str = "createdAt_gte";
-    }
-    impl ::cynic::schema::HasInputField<createdAt_gte, Option<super::DateTime>>
-        for super::TagWhereInput
-    {
-    }
-    pub struct updatedAt;
-    impl ::cynic::schema::Field for updatedAt {
-        type Type = Option<super::DateTime>;
-        const NAME: &'static str = "updatedAt";
-    }
-    impl ::cynic::schema::HasInputField<updatedAt, Option<super::DateTime>> for super::TagWhereInput {}
-    pub struct updatedAt_not;
-    impl ::cynic::schema::Field for updatedAt_not {
-        type Type = Option<super::DateTime>;
-        const NAME: &'static str = "updatedAt_not";
-    }
-    impl ::cynic::schema::HasInputField<updatedAt_not, Option<super::DateTime>>
-        for super::TagWhereInput
-    {
-    }
-    pub struct updatedAt_in;
-    impl ::cynic::schema::Field for updatedAt_in {
-        type Type = Option<Vec<super::DateTime>>;
-        const NAME: &'static str = "updatedAt_in";
-    }
-    impl ::cynic::schema::HasInputField<updatedAt_in, Option<Vec<super::DateTime>>>
-        for super::TagWhereInput
-    {
-    }
-    pub struct updatedAt_not_in;
-    impl ::cynic::schema::Field for updatedAt_not_in {
-        type Type = Option<Vec<super::DateTime>>;
-        const NAME: &'static str = "updatedAt_not_in";
-    }
-    impl ::cynic::schema::HasInputField<updatedAt_not_in, Option<Vec<super::DateTime>>>
-        for super::TagWhereInput
-    {
-    }
-    pub struct updatedAt_lt;
-    impl ::cynic::schema::Field for updatedAt_lt {
-        type Type = Option<super::DateTime>;
-        const NAME: &'static str = "updatedAt_lt";
-    }
-    impl ::cynic::schema::HasInputField<updatedAt_lt, Option<super::DateTime>>
-        for super::TagWhereInput
-    {
-    }
-    pub struct updatedAt_lte;
-    impl ::cynic::schema::Field for updatedAt_lte {
-        type Type = Option<super::DateTime>;
-        const NAME: &'static str = "updatedAt_lte";
-    }
-    impl ::cynic::schema::HasInputField<updatedAt_lte, Option<super::DateTime>>
-        for super::TagWhereInput
-    {
-    }
-    pub struct updatedAt_gt;
-    impl ::cynic::schema::Field for updatedAt_gt {
-        type Type = Option<super::DateTime>;
-        const NAME: &'static str = "updatedAt_gt";
-    }
-    impl ::cynic::schema::HasInputField<updatedAt_gt, Option<super::DateTime>>
-        for super::TagWhereInput
-    {
-    }
-    pub struct updatedAt_gte;
-    impl ::cynic::schema::Field for updatedAt_gte {
-        type Type = Option<super::DateTime>;
-        const NAME: &'static str = "updatedAt_gte";
-    }
-    impl ::cynic::schema::HasInputField<updatedAt_gte, Option<super::DateTime>>
-        for super::TagWhereInput
-    {
-    }
-    pub struct AND;
-    impl ::cynic::schema::Field for AND {
-        type Type = Option<Vec<super::TagWhereInput>>;
-        const NAME: &'static str = "AND";
-    }
-    impl ::cynic::schema::HasInputField<AND, Option<Vec<super::TagWhereInput>>>
-        for super::TagWhereInput
-    {
-    }
-    pub struct OR;
-    impl ::cynic::schema::Field for OR {
-        type Type = Option<Vec<super::TagWhereInput>>;
-        const NAME: &'static str = "OR";
-    }
-    impl ::cynic::schema::HasInputField<OR, Option<Vec<super::TagWhereInput>>>
-        for super::TagWhereInput
-    {
-    }
-    pub struct NOT;
-    impl ::cynic::schema::Field for NOT {
-        type Type = Option<Vec<super::TagWhereInput>>;
-        const NAME: &'static str = "NOT";
-    }
-    impl ::cynic::schema::HasInputField<NOT, Option<Vec<super::TagWhereInput>>>
-        for super::TagWhereInput
-    {
-    }
-}
 pub struct UpdateCompanyInput;
 impl ::cynic::schema::InputObjectMarker for UpdateCompanyInput {}
-pub mod update_company_input_fields {
-    pub struct id;
-    impl ::cynic::schema::Field for id {
-        type Type = super::ID;
-        const NAME: &'static str = "id";
-    }
-    impl ::cynic::schema::HasInputField<id, super::ID> for super::UpdateCompanyInput {}
-    pub struct logoUrl;
-    impl ::cynic::schema::Field for logoUrl {
-        type Type = super::String;
-        const NAME: &'static str = "logoUrl";
-    }
-    impl ::cynic::schema::HasInputField<logoUrl, super::String> for super::UpdateCompanyInput {}
-}
 pub struct UpdateJobInput;
 impl ::cynic::schema::InputObjectMarker for UpdateJobInput {}
-pub mod update_job_input_fields {
-    pub struct id;
-    impl ::cynic::schema::Field for id {
-        type Type = super::ID;
-        const NAME: &'static str = "id";
-    }
-    impl ::cynic::schema::HasInputField<id, super::ID> for super::UpdateJobInput {}
-    pub struct description;
-    impl ::cynic::schema::Field for description {
-        type Type = super::String;
-        const NAME: &'static str = "description";
-    }
-    impl ::cynic::schema::HasInputField<description, super::String> for super::UpdateJobInput {}
-}
 pub struct User;
-pub mod user_fields {
-    pub struct id;
-    impl ::cynic::schema::Field for id {
-        type Type = super::ID;
-        const NAME: &'static str = "id";
-    }
-    impl ::cynic::schema::HasField<id> for super::User {
-        type Type = super::ID;
-    }
-    pub struct name;
-    impl ::cynic::schema::Field for name {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "name";
-    }
-    impl ::cynic::schema::HasField<name> for super::User {
-        type Type = Option<super::String>;
-    }
-    pub struct email;
-    impl ::cynic::schema::Field for email {
-        type Type = super::String;
-        const NAME: &'static str = "email";
-    }
-    impl ::cynic::schema::HasField<email> for super::User {
-        type Type = super::String;
-    }
-    pub struct subscribe;
-    impl ::cynic::schema::Field for subscribe {
-        type Type = super::Boolean;
-        const NAME: &'static str = "subscribe";
-    }
-    impl ::cynic::schema::HasField<subscribe> for super::User {
-        type Type = super::Boolean;
-    }
-    pub struct createdAt;
-    impl ::cynic::schema::Field for createdAt {
-        type Type = super::DateTime;
-        const NAME: &'static str = "createdAt";
-    }
-    impl ::cynic::schema::HasField<createdAt> for super::User {
-        type Type = super::DateTime;
-    }
-    pub struct updatedAt;
-    impl ::cynic::schema::Field for updatedAt {
-        type Type = super::DateTime;
-        const NAME: &'static str = "updatedAt";
-    }
-    impl ::cynic::schema::HasField<updatedAt> for super::User {
-        type Type = super::DateTime;
-    }
-}
 impl ::cynic::schema::NamedType for City {
     const NAME: &'static str = "City";
 }
@@ -6512,6 +86,7080 @@ impl ::cynic::schema::NamedType for Tag {
 }
 impl ::cynic::schema::NamedType for User {
     const NAME: &'static str = "User";
+}
+#[allow(non_snake_case, non_camel_case_types)]
+pub mod __fields {
+    pub mod City {
+        pub struct id;
+        impl ::cynic::schema::Field for id {
+            type Type = super::super::ID;
+            const NAME: &'static str = "id";
+        }
+        impl ::cynic::schema::HasField<id> for super::super::City {
+            type Type = super::super::ID;
+        }
+        pub struct name;
+        impl ::cynic::schema::Field for name {
+            type Type = super::super::String;
+            const NAME: &'static str = "name";
+        }
+        impl ::cynic::schema::HasField<name> for super::super::City {
+            type Type = super::super::String;
+        }
+        pub struct slug;
+        impl ::cynic::schema::Field for slug {
+            type Type = super::super::String;
+            const NAME: &'static str = "slug";
+        }
+        impl ::cynic::schema::HasField<slug> for super::super::City {
+            type Type = super::super::String;
+        }
+        pub struct country;
+        impl ::cynic::schema::Field for country {
+            type Type = super::super::Country;
+            const NAME: &'static str = "country";
+        }
+        impl ::cynic::schema::HasField<country> for super::super::City {
+            type Type = super::super::Country;
+        }
+        pub struct r#type;
+        impl ::cynic::schema::Field for r#type {
+            type Type = super::super::String;
+            const NAME: &'static str = "type";
+        }
+        impl ::cynic::schema::HasField<r#type> for super::super::City {
+            type Type = super::super::String;
+        }
+        pub struct jobs;
+        impl ::cynic::schema::Field for jobs {
+            type Type = Option<Vec<super::super::Job>>;
+            const NAME: &'static str = "jobs";
+        }
+        impl ::cynic::schema::HasField<jobs> for super::super::City {
+            type Type = Option<Vec<super::super::Job>>;
+        }
+        pub mod jobs_arguments {
+            pub struct r#where;
+            impl ::cynic::schema::HasArgument<r#where> for super::jobs {
+                type ArgumentType = Option<super::super::super::JobWhereInput>;
+                const NAME: &'static str = "where";
+            }
+            pub struct orderBy;
+            impl ::cynic::schema::HasArgument<orderBy> for super::jobs {
+                type ArgumentType = Option<super::super::super::JobOrderByInput>;
+                const NAME: &'static str = "orderBy";
+            }
+            pub struct skip;
+            impl ::cynic::schema::HasArgument<skip> for super::jobs {
+                type ArgumentType = Option<super::super::super::Int>;
+                const NAME: &'static str = "skip";
+            }
+            pub struct after;
+            impl ::cynic::schema::HasArgument<after> for super::jobs {
+                type ArgumentType = Option<super::super::super::String>;
+                const NAME: &'static str = "after";
+            }
+            pub struct before;
+            impl ::cynic::schema::HasArgument<before> for super::jobs {
+                type ArgumentType = Option<super::super::super::String>;
+                const NAME: &'static str = "before";
+            }
+            pub struct first;
+            impl ::cynic::schema::HasArgument<first> for super::jobs {
+                type ArgumentType = Option<super::super::super::Int>;
+                const NAME: &'static str = "first";
+            }
+            pub struct last;
+            impl ::cynic::schema::HasArgument<last> for super::jobs {
+                type ArgumentType = Option<super::super::super::Int>;
+                const NAME: &'static str = "last";
+            }
+        }
+        pub struct createdAt;
+        impl ::cynic::schema::Field for createdAt {
+            type Type = super::super::DateTime;
+            const NAME: &'static str = "createdAt";
+        }
+        impl ::cynic::schema::HasField<createdAt> for super::super::City {
+            type Type = super::super::DateTime;
+        }
+        pub struct updatedAt;
+        impl ::cynic::schema::Field for updatedAt {
+            type Type = super::super::DateTime;
+            const NAME: &'static str = "updatedAt";
+        }
+        impl ::cynic::schema::HasField<updatedAt> for super::super::City {
+            type Type = super::super::DateTime;
+        }
+    }
+    pub mod CityWhereInput {
+        pub struct id;
+        impl ::cynic::schema::Field for id {
+            type Type = Option<super::super::ID>;
+            const NAME: &'static str = "id";
+        }
+        impl ::cynic::schema::HasInputField<id, Option<super::super::ID>> for super::super::CityWhereInput {}
+        pub struct id_not;
+        impl ::cynic::schema::Field for id_not {
+            type Type = Option<super::super::ID>;
+            const NAME: &'static str = "id_not";
+        }
+        impl ::cynic::schema::HasInputField<id_not, Option<super::super::ID>>
+            for super::super::CityWhereInput
+        {
+        }
+        pub struct id_in;
+        impl ::cynic::schema::Field for id_in {
+            type Type = Option<Vec<super::super::ID>>;
+            const NAME: &'static str = "id_in";
+        }
+        impl ::cynic::schema::HasInputField<id_in, Option<Vec<super::super::ID>>>
+            for super::super::CityWhereInput
+        {
+        }
+        pub struct id_not_in;
+        impl ::cynic::schema::Field for id_not_in {
+            type Type = Option<Vec<super::super::ID>>;
+            const NAME: &'static str = "id_not_in";
+        }
+        impl ::cynic::schema::HasInputField<id_not_in, Option<Vec<super::super::ID>>>
+            for super::super::CityWhereInput
+        {
+        }
+        pub struct id_lt;
+        impl ::cynic::schema::Field for id_lt {
+            type Type = Option<super::super::ID>;
+            const NAME: &'static str = "id_lt";
+        }
+        impl ::cynic::schema::HasInputField<id_lt, Option<super::super::ID>>
+            for super::super::CityWhereInput
+        {
+        }
+        pub struct id_lte;
+        impl ::cynic::schema::Field for id_lte {
+            type Type = Option<super::super::ID>;
+            const NAME: &'static str = "id_lte";
+        }
+        impl ::cynic::schema::HasInputField<id_lte, Option<super::super::ID>>
+            for super::super::CityWhereInput
+        {
+        }
+        pub struct id_gt;
+        impl ::cynic::schema::Field for id_gt {
+            type Type = Option<super::super::ID>;
+            const NAME: &'static str = "id_gt";
+        }
+        impl ::cynic::schema::HasInputField<id_gt, Option<super::super::ID>>
+            for super::super::CityWhereInput
+        {
+        }
+        pub struct id_gte;
+        impl ::cynic::schema::Field for id_gte {
+            type Type = Option<super::super::ID>;
+            const NAME: &'static str = "id_gte";
+        }
+        impl ::cynic::schema::HasInputField<id_gte, Option<super::super::ID>>
+            for super::super::CityWhereInput
+        {
+        }
+        pub struct id_contains;
+        impl ::cynic::schema::Field for id_contains {
+            type Type = Option<super::super::ID>;
+            const NAME: &'static str = "id_contains";
+        }
+        impl ::cynic::schema::HasInputField<id_contains, Option<super::super::ID>>
+            for super::super::CityWhereInput
+        {
+        }
+        pub struct id_not_contains;
+        impl ::cynic::schema::Field for id_not_contains {
+            type Type = Option<super::super::ID>;
+            const NAME: &'static str = "id_not_contains";
+        }
+        impl ::cynic::schema::HasInputField<id_not_contains, Option<super::super::ID>>
+            for super::super::CityWhereInput
+        {
+        }
+        pub struct id_starts_with;
+        impl ::cynic::schema::Field for id_starts_with {
+            type Type = Option<super::super::ID>;
+            const NAME: &'static str = "id_starts_with";
+        }
+        impl ::cynic::schema::HasInputField<id_starts_with, Option<super::super::ID>>
+            for super::super::CityWhereInput
+        {
+        }
+        pub struct id_not_starts_with;
+        impl ::cynic::schema::Field for id_not_starts_with {
+            type Type = Option<super::super::ID>;
+            const NAME: &'static str = "id_not_starts_with";
+        }
+        impl ::cynic::schema::HasInputField<id_not_starts_with, Option<super::super::ID>>
+            for super::super::CityWhereInput
+        {
+        }
+        pub struct id_ends_with;
+        impl ::cynic::schema::Field for id_ends_with {
+            type Type = Option<super::super::ID>;
+            const NAME: &'static str = "id_ends_with";
+        }
+        impl ::cynic::schema::HasInputField<id_ends_with, Option<super::super::ID>>
+            for super::super::CityWhereInput
+        {
+        }
+        pub struct id_not_ends_with;
+        impl ::cynic::schema::Field for id_not_ends_with {
+            type Type = Option<super::super::ID>;
+            const NAME: &'static str = "id_not_ends_with";
+        }
+        impl ::cynic::schema::HasInputField<id_not_ends_with, Option<super::super::ID>>
+            for super::super::CityWhereInput
+        {
+        }
+        pub struct name;
+        impl ::cynic::schema::Field for name {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "name";
+        }
+        impl ::cynic::schema::HasInputField<name, Option<super::super::String>>
+            for super::super::CityWhereInput
+        {
+        }
+        pub struct name_not;
+        impl ::cynic::schema::Field for name_not {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "name_not";
+        }
+        impl ::cynic::schema::HasInputField<name_not, Option<super::super::String>>
+            for super::super::CityWhereInput
+        {
+        }
+        pub struct name_in;
+        impl ::cynic::schema::Field for name_in {
+            type Type = Option<Vec<super::super::String>>;
+            const NAME: &'static str = "name_in";
+        }
+        impl ::cynic::schema::HasInputField<name_in, Option<Vec<super::super::String>>>
+            for super::super::CityWhereInput
+        {
+        }
+        pub struct name_not_in;
+        impl ::cynic::schema::Field for name_not_in {
+            type Type = Option<Vec<super::super::String>>;
+            const NAME: &'static str = "name_not_in";
+        }
+        impl ::cynic::schema::HasInputField<name_not_in, Option<Vec<super::super::String>>>
+            for super::super::CityWhereInput
+        {
+        }
+        pub struct name_lt;
+        impl ::cynic::schema::Field for name_lt {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "name_lt";
+        }
+        impl ::cynic::schema::HasInputField<name_lt, Option<super::super::String>>
+            for super::super::CityWhereInput
+        {
+        }
+        pub struct name_lte;
+        impl ::cynic::schema::Field for name_lte {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "name_lte";
+        }
+        impl ::cynic::schema::HasInputField<name_lte, Option<super::super::String>>
+            for super::super::CityWhereInput
+        {
+        }
+        pub struct name_gt;
+        impl ::cynic::schema::Field for name_gt {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "name_gt";
+        }
+        impl ::cynic::schema::HasInputField<name_gt, Option<super::super::String>>
+            for super::super::CityWhereInput
+        {
+        }
+        pub struct name_gte;
+        impl ::cynic::schema::Field for name_gte {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "name_gte";
+        }
+        impl ::cynic::schema::HasInputField<name_gte, Option<super::super::String>>
+            for super::super::CityWhereInput
+        {
+        }
+        pub struct name_contains;
+        impl ::cynic::schema::Field for name_contains {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "name_contains";
+        }
+        impl ::cynic::schema::HasInputField<name_contains, Option<super::super::String>>
+            for super::super::CityWhereInput
+        {
+        }
+        pub struct name_not_contains;
+        impl ::cynic::schema::Field for name_not_contains {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "name_not_contains";
+        }
+        impl ::cynic::schema::HasInputField<name_not_contains, Option<super::super::String>>
+            for super::super::CityWhereInput
+        {
+        }
+        pub struct name_starts_with;
+        impl ::cynic::schema::Field for name_starts_with {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "name_starts_with";
+        }
+        impl ::cynic::schema::HasInputField<name_starts_with, Option<super::super::String>>
+            for super::super::CityWhereInput
+        {
+        }
+        pub struct name_not_starts_with;
+        impl ::cynic::schema::Field for name_not_starts_with {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "name_not_starts_with";
+        }
+        impl ::cynic::schema::HasInputField<name_not_starts_with, Option<super::super::String>>
+            for super::super::CityWhereInput
+        {
+        }
+        pub struct name_ends_with;
+        impl ::cynic::schema::Field for name_ends_with {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "name_ends_with";
+        }
+        impl ::cynic::schema::HasInputField<name_ends_with, Option<super::super::String>>
+            for super::super::CityWhereInput
+        {
+        }
+        pub struct name_not_ends_with;
+        impl ::cynic::schema::Field for name_not_ends_with {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "name_not_ends_with";
+        }
+        impl ::cynic::schema::HasInputField<name_not_ends_with, Option<super::super::String>>
+            for super::super::CityWhereInput
+        {
+        }
+        pub struct slug;
+        impl ::cynic::schema::Field for slug {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "slug";
+        }
+        impl ::cynic::schema::HasInputField<slug, Option<super::super::String>>
+            for super::super::CityWhereInput
+        {
+        }
+        pub struct slug_not;
+        impl ::cynic::schema::Field for slug_not {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "slug_not";
+        }
+        impl ::cynic::schema::HasInputField<slug_not, Option<super::super::String>>
+            for super::super::CityWhereInput
+        {
+        }
+        pub struct slug_in;
+        impl ::cynic::schema::Field for slug_in {
+            type Type = Option<Vec<super::super::String>>;
+            const NAME: &'static str = "slug_in";
+        }
+        impl ::cynic::schema::HasInputField<slug_in, Option<Vec<super::super::String>>>
+            for super::super::CityWhereInput
+        {
+        }
+        pub struct slug_not_in;
+        impl ::cynic::schema::Field for slug_not_in {
+            type Type = Option<Vec<super::super::String>>;
+            const NAME: &'static str = "slug_not_in";
+        }
+        impl ::cynic::schema::HasInputField<slug_not_in, Option<Vec<super::super::String>>>
+            for super::super::CityWhereInput
+        {
+        }
+        pub struct slug_lt;
+        impl ::cynic::schema::Field for slug_lt {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "slug_lt";
+        }
+        impl ::cynic::schema::HasInputField<slug_lt, Option<super::super::String>>
+            for super::super::CityWhereInput
+        {
+        }
+        pub struct slug_lte;
+        impl ::cynic::schema::Field for slug_lte {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "slug_lte";
+        }
+        impl ::cynic::schema::HasInputField<slug_lte, Option<super::super::String>>
+            for super::super::CityWhereInput
+        {
+        }
+        pub struct slug_gt;
+        impl ::cynic::schema::Field for slug_gt {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "slug_gt";
+        }
+        impl ::cynic::schema::HasInputField<slug_gt, Option<super::super::String>>
+            for super::super::CityWhereInput
+        {
+        }
+        pub struct slug_gte;
+        impl ::cynic::schema::Field for slug_gte {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "slug_gte";
+        }
+        impl ::cynic::schema::HasInputField<slug_gte, Option<super::super::String>>
+            for super::super::CityWhereInput
+        {
+        }
+        pub struct slug_contains;
+        impl ::cynic::schema::Field for slug_contains {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "slug_contains";
+        }
+        impl ::cynic::schema::HasInputField<slug_contains, Option<super::super::String>>
+            for super::super::CityWhereInput
+        {
+        }
+        pub struct slug_not_contains;
+        impl ::cynic::schema::Field for slug_not_contains {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "slug_not_contains";
+        }
+        impl ::cynic::schema::HasInputField<slug_not_contains, Option<super::super::String>>
+            for super::super::CityWhereInput
+        {
+        }
+        pub struct slug_starts_with;
+        impl ::cynic::schema::Field for slug_starts_with {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "slug_starts_with";
+        }
+        impl ::cynic::schema::HasInputField<slug_starts_with, Option<super::super::String>>
+            for super::super::CityWhereInput
+        {
+        }
+        pub struct slug_not_starts_with;
+        impl ::cynic::schema::Field for slug_not_starts_with {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "slug_not_starts_with";
+        }
+        impl ::cynic::schema::HasInputField<slug_not_starts_with, Option<super::super::String>>
+            for super::super::CityWhereInput
+        {
+        }
+        pub struct slug_ends_with;
+        impl ::cynic::schema::Field for slug_ends_with {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "slug_ends_with";
+        }
+        impl ::cynic::schema::HasInputField<slug_ends_with, Option<super::super::String>>
+            for super::super::CityWhereInput
+        {
+        }
+        pub struct slug_not_ends_with;
+        impl ::cynic::schema::Field for slug_not_ends_with {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "slug_not_ends_with";
+        }
+        impl ::cynic::schema::HasInputField<slug_not_ends_with, Option<super::super::String>>
+            for super::super::CityWhereInput
+        {
+        }
+        pub struct country;
+        impl ::cynic::schema::Field for country {
+            type Type = Option<super::super::CountryWhereInput>;
+            const NAME: &'static str = "country";
+        }
+        impl ::cynic::schema::HasInputField<country, Option<super::super::CountryWhereInput>>
+            for super::super::CityWhereInput
+        {
+        }
+        pub struct r#type;
+        impl ::cynic::schema::Field for r#type {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "type";
+        }
+        impl ::cynic::schema::HasInputField<r#type, Option<super::super::String>>
+            for super::super::CityWhereInput
+        {
+        }
+        pub struct type_not;
+        impl ::cynic::schema::Field for type_not {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "type_not";
+        }
+        impl ::cynic::schema::HasInputField<type_not, Option<super::super::String>>
+            for super::super::CityWhereInput
+        {
+        }
+        pub struct type_in;
+        impl ::cynic::schema::Field for type_in {
+            type Type = Option<Vec<super::super::String>>;
+            const NAME: &'static str = "type_in";
+        }
+        impl ::cynic::schema::HasInputField<type_in, Option<Vec<super::super::String>>>
+            for super::super::CityWhereInput
+        {
+        }
+        pub struct type_not_in;
+        impl ::cynic::schema::Field for type_not_in {
+            type Type = Option<Vec<super::super::String>>;
+            const NAME: &'static str = "type_not_in";
+        }
+        impl ::cynic::schema::HasInputField<type_not_in, Option<Vec<super::super::String>>>
+            for super::super::CityWhereInput
+        {
+        }
+        pub struct type_lt;
+        impl ::cynic::schema::Field for type_lt {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "type_lt";
+        }
+        impl ::cynic::schema::HasInputField<type_lt, Option<super::super::String>>
+            for super::super::CityWhereInput
+        {
+        }
+        pub struct type_lte;
+        impl ::cynic::schema::Field for type_lte {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "type_lte";
+        }
+        impl ::cynic::schema::HasInputField<type_lte, Option<super::super::String>>
+            for super::super::CityWhereInput
+        {
+        }
+        pub struct type_gt;
+        impl ::cynic::schema::Field for type_gt {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "type_gt";
+        }
+        impl ::cynic::schema::HasInputField<type_gt, Option<super::super::String>>
+            for super::super::CityWhereInput
+        {
+        }
+        pub struct type_gte;
+        impl ::cynic::schema::Field for type_gte {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "type_gte";
+        }
+        impl ::cynic::schema::HasInputField<type_gte, Option<super::super::String>>
+            for super::super::CityWhereInput
+        {
+        }
+        pub struct type_contains;
+        impl ::cynic::schema::Field for type_contains {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "type_contains";
+        }
+        impl ::cynic::schema::HasInputField<type_contains, Option<super::super::String>>
+            for super::super::CityWhereInput
+        {
+        }
+        pub struct type_not_contains;
+        impl ::cynic::schema::Field for type_not_contains {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "type_not_contains";
+        }
+        impl ::cynic::schema::HasInputField<type_not_contains, Option<super::super::String>>
+            for super::super::CityWhereInput
+        {
+        }
+        pub struct type_starts_with;
+        impl ::cynic::schema::Field for type_starts_with {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "type_starts_with";
+        }
+        impl ::cynic::schema::HasInputField<type_starts_with, Option<super::super::String>>
+            for super::super::CityWhereInput
+        {
+        }
+        pub struct type_not_starts_with;
+        impl ::cynic::schema::Field for type_not_starts_with {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "type_not_starts_with";
+        }
+        impl ::cynic::schema::HasInputField<type_not_starts_with, Option<super::super::String>>
+            for super::super::CityWhereInput
+        {
+        }
+        pub struct type_ends_with;
+        impl ::cynic::schema::Field for type_ends_with {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "type_ends_with";
+        }
+        impl ::cynic::schema::HasInputField<type_ends_with, Option<super::super::String>>
+            for super::super::CityWhereInput
+        {
+        }
+        pub struct type_not_ends_with;
+        impl ::cynic::schema::Field for type_not_ends_with {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "type_not_ends_with";
+        }
+        impl ::cynic::schema::HasInputField<type_not_ends_with, Option<super::super::String>>
+            for super::super::CityWhereInput
+        {
+        }
+        pub struct jobs_every;
+        impl ::cynic::schema::Field for jobs_every {
+            type Type = Option<super::super::JobWhereInput>;
+            const NAME: &'static str = "jobs_every";
+        }
+        impl ::cynic::schema::HasInputField<jobs_every, Option<super::super::JobWhereInput>>
+            for super::super::CityWhereInput
+        {
+        }
+        pub struct jobs_some;
+        impl ::cynic::schema::Field for jobs_some {
+            type Type = Option<super::super::JobWhereInput>;
+            const NAME: &'static str = "jobs_some";
+        }
+        impl ::cynic::schema::HasInputField<jobs_some, Option<super::super::JobWhereInput>>
+            for super::super::CityWhereInput
+        {
+        }
+        pub struct jobs_none;
+        impl ::cynic::schema::Field for jobs_none {
+            type Type = Option<super::super::JobWhereInput>;
+            const NAME: &'static str = "jobs_none";
+        }
+        impl ::cynic::schema::HasInputField<jobs_none, Option<super::super::JobWhereInput>>
+            for super::super::CityWhereInput
+        {
+        }
+        pub struct createdAt;
+        impl ::cynic::schema::Field for createdAt {
+            type Type = Option<super::super::DateTime>;
+            const NAME: &'static str = "createdAt";
+        }
+        impl ::cynic::schema::HasInputField<createdAt, Option<super::super::DateTime>>
+            for super::super::CityWhereInput
+        {
+        }
+        pub struct createdAt_not;
+        impl ::cynic::schema::Field for createdAt_not {
+            type Type = Option<super::super::DateTime>;
+            const NAME: &'static str = "createdAt_not";
+        }
+        impl ::cynic::schema::HasInputField<createdAt_not, Option<super::super::DateTime>>
+            for super::super::CityWhereInput
+        {
+        }
+        pub struct createdAt_in;
+        impl ::cynic::schema::Field for createdAt_in {
+            type Type = Option<Vec<super::super::DateTime>>;
+            const NAME: &'static str = "createdAt_in";
+        }
+        impl ::cynic::schema::HasInputField<createdAt_in, Option<Vec<super::super::DateTime>>>
+            for super::super::CityWhereInput
+        {
+        }
+        pub struct createdAt_not_in;
+        impl ::cynic::schema::Field for createdAt_not_in {
+            type Type = Option<Vec<super::super::DateTime>>;
+            const NAME: &'static str = "createdAt_not_in";
+        }
+        impl ::cynic::schema::HasInputField<createdAt_not_in, Option<Vec<super::super::DateTime>>>
+            for super::super::CityWhereInput
+        {
+        }
+        pub struct createdAt_lt;
+        impl ::cynic::schema::Field for createdAt_lt {
+            type Type = Option<super::super::DateTime>;
+            const NAME: &'static str = "createdAt_lt";
+        }
+        impl ::cynic::schema::HasInputField<createdAt_lt, Option<super::super::DateTime>>
+            for super::super::CityWhereInput
+        {
+        }
+        pub struct createdAt_lte;
+        impl ::cynic::schema::Field for createdAt_lte {
+            type Type = Option<super::super::DateTime>;
+            const NAME: &'static str = "createdAt_lte";
+        }
+        impl ::cynic::schema::HasInputField<createdAt_lte, Option<super::super::DateTime>>
+            for super::super::CityWhereInput
+        {
+        }
+        pub struct createdAt_gt;
+        impl ::cynic::schema::Field for createdAt_gt {
+            type Type = Option<super::super::DateTime>;
+            const NAME: &'static str = "createdAt_gt";
+        }
+        impl ::cynic::schema::HasInputField<createdAt_gt, Option<super::super::DateTime>>
+            for super::super::CityWhereInput
+        {
+        }
+        pub struct createdAt_gte;
+        impl ::cynic::schema::Field for createdAt_gte {
+            type Type = Option<super::super::DateTime>;
+            const NAME: &'static str = "createdAt_gte";
+        }
+        impl ::cynic::schema::HasInputField<createdAt_gte, Option<super::super::DateTime>>
+            for super::super::CityWhereInput
+        {
+        }
+        pub struct updatedAt;
+        impl ::cynic::schema::Field for updatedAt {
+            type Type = Option<super::super::DateTime>;
+            const NAME: &'static str = "updatedAt";
+        }
+        impl ::cynic::schema::HasInputField<updatedAt, Option<super::super::DateTime>>
+            for super::super::CityWhereInput
+        {
+        }
+        pub struct updatedAt_not;
+        impl ::cynic::schema::Field for updatedAt_not {
+            type Type = Option<super::super::DateTime>;
+            const NAME: &'static str = "updatedAt_not";
+        }
+        impl ::cynic::schema::HasInputField<updatedAt_not, Option<super::super::DateTime>>
+            for super::super::CityWhereInput
+        {
+        }
+        pub struct updatedAt_in;
+        impl ::cynic::schema::Field for updatedAt_in {
+            type Type = Option<Vec<super::super::DateTime>>;
+            const NAME: &'static str = "updatedAt_in";
+        }
+        impl ::cynic::schema::HasInputField<updatedAt_in, Option<Vec<super::super::DateTime>>>
+            for super::super::CityWhereInput
+        {
+        }
+        pub struct updatedAt_not_in;
+        impl ::cynic::schema::Field for updatedAt_not_in {
+            type Type = Option<Vec<super::super::DateTime>>;
+            const NAME: &'static str = "updatedAt_not_in";
+        }
+        impl ::cynic::schema::HasInputField<updatedAt_not_in, Option<Vec<super::super::DateTime>>>
+            for super::super::CityWhereInput
+        {
+        }
+        pub struct updatedAt_lt;
+        impl ::cynic::schema::Field for updatedAt_lt {
+            type Type = Option<super::super::DateTime>;
+            const NAME: &'static str = "updatedAt_lt";
+        }
+        impl ::cynic::schema::HasInputField<updatedAt_lt, Option<super::super::DateTime>>
+            for super::super::CityWhereInput
+        {
+        }
+        pub struct updatedAt_lte;
+        impl ::cynic::schema::Field for updatedAt_lte {
+            type Type = Option<super::super::DateTime>;
+            const NAME: &'static str = "updatedAt_lte";
+        }
+        impl ::cynic::schema::HasInputField<updatedAt_lte, Option<super::super::DateTime>>
+            for super::super::CityWhereInput
+        {
+        }
+        pub struct updatedAt_gt;
+        impl ::cynic::schema::Field for updatedAt_gt {
+            type Type = Option<super::super::DateTime>;
+            const NAME: &'static str = "updatedAt_gt";
+        }
+        impl ::cynic::schema::HasInputField<updatedAt_gt, Option<super::super::DateTime>>
+            for super::super::CityWhereInput
+        {
+        }
+        pub struct updatedAt_gte;
+        impl ::cynic::schema::Field for updatedAt_gte {
+            type Type = Option<super::super::DateTime>;
+            const NAME: &'static str = "updatedAt_gte";
+        }
+        impl ::cynic::schema::HasInputField<updatedAt_gte, Option<super::super::DateTime>>
+            for super::super::CityWhereInput
+        {
+        }
+        pub struct AND;
+        impl ::cynic::schema::Field for AND {
+            type Type = Option<Vec<super::super::CityWhereInput>>;
+            const NAME: &'static str = "AND";
+        }
+        impl ::cynic::schema::HasInputField<AND, Option<Vec<super::super::CityWhereInput>>>
+            for super::super::CityWhereInput
+        {
+        }
+        pub struct OR;
+        impl ::cynic::schema::Field for OR {
+            type Type = Option<Vec<super::super::CityWhereInput>>;
+            const NAME: &'static str = "OR";
+        }
+        impl ::cynic::schema::HasInputField<OR, Option<Vec<super::super::CityWhereInput>>>
+            for super::super::CityWhereInput
+        {
+        }
+        pub struct NOT;
+        impl ::cynic::schema::Field for NOT {
+            type Type = Option<Vec<super::super::CityWhereInput>>;
+            const NAME: &'static str = "NOT";
+        }
+        impl ::cynic::schema::HasInputField<NOT, Option<Vec<super::super::CityWhereInput>>>
+            for super::super::CityWhereInput
+        {
+        }
+    }
+    pub mod Commitment {
+        pub struct id;
+        impl ::cynic::schema::Field for id {
+            type Type = super::super::ID;
+            const NAME: &'static str = "id";
+        }
+        impl ::cynic::schema::HasField<id> for super::super::Commitment {
+            type Type = super::super::ID;
+        }
+        pub struct title;
+        impl ::cynic::schema::Field for title {
+            type Type = super::super::String;
+            const NAME: &'static str = "title";
+        }
+        impl ::cynic::schema::HasField<title> for super::super::Commitment {
+            type Type = super::super::String;
+        }
+        pub struct slug;
+        impl ::cynic::schema::Field for slug {
+            type Type = super::super::String;
+            const NAME: &'static str = "slug";
+        }
+        impl ::cynic::schema::HasField<slug> for super::super::Commitment {
+            type Type = super::super::String;
+        }
+        pub struct jobs;
+        impl ::cynic::schema::Field for jobs {
+            type Type = Option<Vec<super::super::Job>>;
+            const NAME: &'static str = "jobs";
+        }
+        impl ::cynic::schema::HasField<jobs> for super::super::Commitment {
+            type Type = Option<Vec<super::super::Job>>;
+        }
+        pub mod jobs_arguments {
+            pub struct r#where;
+            impl ::cynic::schema::HasArgument<r#where> for super::jobs {
+                type ArgumentType = Option<super::super::super::JobWhereInput>;
+                const NAME: &'static str = "where";
+            }
+            pub struct orderBy;
+            impl ::cynic::schema::HasArgument<orderBy> for super::jobs {
+                type ArgumentType = Option<super::super::super::JobOrderByInput>;
+                const NAME: &'static str = "orderBy";
+            }
+            pub struct skip;
+            impl ::cynic::schema::HasArgument<skip> for super::jobs {
+                type ArgumentType = Option<super::super::super::Int>;
+                const NAME: &'static str = "skip";
+            }
+            pub struct after;
+            impl ::cynic::schema::HasArgument<after> for super::jobs {
+                type ArgumentType = Option<super::super::super::String>;
+                const NAME: &'static str = "after";
+            }
+            pub struct before;
+            impl ::cynic::schema::HasArgument<before> for super::jobs {
+                type ArgumentType = Option<super::super::super::String>;
+                const NAME: &'static str = "before";
+            }
+            pub struct first;
+            impl ::cynic::schema::HasArgument<first> for super::jobs {
+                type ArgumentType = Option<super::super::super::Int>;
+                const NAME: &'static str = "first";
+            }
+            pub struct last;
+            impl ::cynic::schema::HasArgument<last> for super::jobs {
+                type ArgumentType = Option<super::super::super::Int>;
+                const NAME: &'static str = "last";
+            }
+        }
+        pub struct createdAt;
+        impl ::cynic::schema::Field for createdAt {
+            type Type = super::super::DateTime;
+            const NAME: &'static str = "createdAt";
+        }
+        impl ::cynic::schema::HasField<createdAt> for super::super::Commitment {
+            type Type = super::super::DateTime;
+        }
+        pub struct updatedAt;
+        impl ::cynic::schema::Field for updatedAt {
+            type Type = super::super::DateTime;
+            const NAME: &'static str = "updatedAt";
+        }
+        impl ::cynic::schema::HasField<updatedAt> for super::super::Commitment {
+            type Type = super::super::DateTime;
+        }
+    }
+    pub mod CommitmentWhereInput {
+        pub struct id;
+        impl ::cynic::schema::Field for id {
+            type Type = Option<super::super::ID>;
+            const NAME: &'static str = "id";
+        }
+        impl ::cynic::schema::HasInputField<id, Option<super::super::ID>>
+            for super::super::CommitmentWhereInput
+        {
+        }
+        pub struct id_not;
+        impl ::cynic::schema::Field for id_not {
+            type Type = Option<super::super::ID>;
+            const NAME: &'static str = "id_not";
+        }
+        impl ::cynic::schema::HasInputField<id_not, Option<super::super::ID>>
+            for super::super::CommitmentWhereInput
+        {
+        }
+        pub struct id_in;
+        impl ::cynic::schema::Field for id_in {
+            type Type = Option<Vec<super::super::ID>>;
+            const NAME: &'static str = "id_in";
+        }
+        impl ::cynic::schema::HasInputField<id_in, Option<Vec<super::super::ID>>>
+            for super::super::CommitmentWhereInput
+        {
+        }
+        pub struct id_not_in;
+        impl ::cynic::schema::Field for id_not_in {
+            type Type = Option<Vec<super::super::ID>>;
+            const NAME: &'static str = "id_not_in";
+        }
+        impl ::cynic::schema::HasInputField<id_not_in, Option<Vec<super::super::ID>>>
+            for super::super::CommitmentWhereInput
+        {
+        }
+        pub struct id_lt;
+        impl ::cynic::schema::Field for id_lt {
+            type Type = Option<super::super::ID>;
+            const NAME: &'static str = "id_lt";
+        }
+        impl ::cynic::schema::HasInputField<id_lt, Option<super::super::ID>>
+            for super::super::CommitmentWhereInput
+        {
+        }
+        pub struct id_lte;
+        impl ::cynic::schema::Field for id_lte {
+            type Type = Option<super::super::ID>;
+            const NAME: &'static str = "id_lte";
+        }
+        impl ::cynic::schema::HasInputField<id_lte, Option<super::super::ID>>
+            for super::super::CommitmentWhereInput
+        {
+        }
+        pub struct id_gt;
+        impl ::cynic::schema::Field for id_gt {
+            type Type = Option<super::super::ID>;
+            const NAME: &'static str = "id_gt";
+        }
+        impl ::cynic::schema::HasInputField<id_gt, Option<super::super::ID>>
+            for super::super::CommitmentWhereInput
+        {
+        }
+        pub struct id_gte;
+        impl ::cynic::schema::Field for id_gte {
+            type Type = Option<super::super::ID>;
+            const NAME: &'static str = "id_gte";
+        }
+        impl ::cynic::schema::HasInputField<id_gte, Option<super::super::ID>>
+            for super::super::CommitmentWhereInput
+        {
+        }
+        pub struct id_contains;
+        impl ::cynic::schema::Field for id_contains {
+            type Type = Option<super::super::ID>;
+            const NAME: &'static str = "id_contains";
+        }
+        impl ::cynic::schema::HasInputField<id_contains, Option<super::super::ID>>
+            for super::super::CommitmentWhereInput
+        {
+        }
+        pub struct id_not_contains;
+        impl ::cynic::schema::Field for id_not_contains {
+            type Type = Option<super::super::ID>;
+            const NAME: &'static str = "id_not_contains";
+        }
+        impl ::cynic::schema::HasInputField<id_not_contains, Option<super::super::ID>>
+            for super::super::CommitmentWhereInput
+        {
+        }
+        pub struct id_starts_with;
+        impl ::cynic::schema::Field for id_starts_with {
+            type Type = Option<super::super::ID>;
+            const NAME: &'static str = "id_starts_with";
+        }
+        impl ::cynic::schema::HasInputField<id_starts_with, Option<super::super::ID>>
+            for super::super::CommitmentWhereInput
+        {
+        }
+        pub struct id_not_starts_with;
+        impl ::cynic::schema::Field for id_not_starts_with {
+            type Type = Option<super::super::ID>;
+            const NAME: &'static str = "id_not_starts_with";
+        }
+        impl ::cynic::schema::HasInputField<id_not_starts_with, Option<super::super::ID>>
+            for super::super::CommitmentWhereInput
+        {
+        }
+        pub struct id_ends_with;
+        impl ::cynic::schema::Field for id_ends_with {
+            type Type = Option<super::super::ID>;
+            const NAME: &'static str = "id_ends_with";
+        }
+        impl ::cynic::schema::HasInputField<id_ends_with, Option<super::super::ID>>
+            for super::super::CommitmentWhereInput
+        {
+        }
+        pub struct id_not_ends_with;
+        impl ::cynic::schema::Field for id_not_ends_with {
+            type Type = Option<super::super::ID>;
+            const NAME: &'static str = "id_not_ends_with";
+        }
+        impl ::cynic::schema::HasInputField<id_not_ends_with, Option<super::super::ID>>
+            for super::super::CommitmentWhereInput
+        {
+        }
+        pub struct title;
+        impl ::cynic::schema::Field for title {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "title";
+        }
+        impl ::cynic::schema::HasInputField<title, Option<super::super::String>>
+            for super::super::CommitmentWhereInput
+        {
+        }
+        pub struct title_not;
+        impl ::cynic::schema::Field for title_not {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "title_not";
+        }
+        impl ::cynic::schema::HasInputField<title_not, Option<super::super::String>>
+            for super::super::CommitmentWhereInput
+        {
+        }
+        pub struct title_in;
+        impl ::cynic::schema::Field for title_in {
+            type Type = Option<Vec<super::super::String>>;
+            const NAME: &'static str = "title_in";
+        }
+        impl ::cynic::schema::HasInputField<title_in, Option<Vec<super::super::String>>>
+            for super::super::CommitmentWhereInput
+        {
+        }
+        pub struct title_not_in;
+        impl ::cynic::schema::Field for title_not_in {
+            type Type = Option<Vec<super::super::String>>;
+            const NAME: &'static str = "title_not_in";
+        }
+        impl ::cynic::schema::HasInputField<title_not_in, Option<Vec<super::super::String>>>
+            for super::super::CommitmentWhereInput
+        {
+        }
+        pub struct title_lt;
+        impl ::cynic::schema::Field for title_lt {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "title_lt";
+        }
+        impl ::cynic::schema::HasInputField<title_lt, Option<super::super::String>>
+            for super::super::CommitmentWhereInput
+        {
+        }
+        pub struct title_lte;
+        impl ::cynic::schema::Field for title_lte {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "title_lte";
+        }
+        impl ::cynic::schema::HasInputField<title_lte, Option<super::super::String>>
+            for super::super::CommitmentWhereInput
+        {
+        }
+        pub struct title_gt;
+        impl ::cynic::schema::Field for title_gt {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "title_gt";
+        }
+        impl ::cynic::schema::HasInputField<title_gt, Option<super::super::String>>
+            for super::super::CommitmentWhereInput
+        {
+        }
+        pub struct title_gte;
+        impl ::cynic::schema::Field for title_gte {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "title_gte";
+        }
+        impl ::cynic::schema::HasInputField<title_gte, Option<super::super::String>>
+            for super::super::CommitmentWhereInput
+        {
+        }
+        pub struct title_contains;
+        impl ::cynic::schema::Field for title_contains {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "title_contains";
+        }
+        impl ::cynic::schema::HasInputField<title_contains, Option<super::super::String>>
+            for super::super::CommitmentWhereInput
+        {
+        }
+        pub struct title_not_contains;
+        impl ::cynic::schema::Field for title_not_contains {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "title_not_contains";
+        }
+        impl ::cynic::schema::HasInputField<title_not_contains, Option<super::super::String>>
+            for super::super::CommitmentWhereInput
+        {
+        }
+        pub struct title_starts_with;
+        impl ::cynic::schema::Field for title_starts_with {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "title_starts_with";
+        }
+        impl ::cynic::schema::HasInputField<title_starts_with, Option<super::super::String>>
+            for super::super::CommitmentWhereInput
+        {
+        }
+        pub struct title_not_starts_with;
+        impl ::cynic::schema::Field for title_not_starts_with {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "title_not_starts_with";
+        }
+        impl ::cynic::schema::HasInputField<title_not_starts_with, Option<super::super::String>>
+            for super::super::CommitmentWhereInput
+        {
+        }
+        pub struct title_ends_with;
+        impl ::cynic::schema::Field for title_ends_with {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "title_ends_with";
+        }
+        impl ::cynic::schema::HasInputField<title_ends_with, Option<super::super::String>>
+            for super::super::CommitmentWhereInput
+        {
+        }
+        pub struct title_not_ends_with;
+        impl ::cynic::schema::Field for title_not_ends_with {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "title_not_ends_with";
+        }
+        impl ::cynic::schema::HasInputField<title_not_ends_with, Option<super::super::String>>
+            for super::super::CommitmentWhereInput
+        {
+        }
+        pub struct slug;
+        impl ::cynic::schema::Field for slug {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "slug";
+        }
+        impl ::cynic::schema::HasInputField<slug, Option<super::super::String>>
+            for super::super::CommitmentWhereInput
+        {
+        }
+        pub struct slug_not;
+        impl ::cynic::schema::Field for slug_not {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "slug_not";
+        }
+        impl ::cynic::schema::HasInputField<slug_not, Option<super::super::String>>
+            for super::super::CommitmentWhereInput
+        {
+        }
+        pub struct slug_in;
+        impl ::cynic::schema::Field for slug_in {
+            type Type = Option<Vec<super::super::String>>;
+            const NAME: &'static str = "slug_in";
+        }
+        impl ::cynic::schema::HasInputField<slug_in, Option<Vec<super::super::String>>>
+            for super::super::CommitmentWhereInput
+        {
+        }
+        pub struct slug_not_in;
+        impl ::cynic::schema::Field for slug_not_in {
+            type Type = Option<Vec<super::super::String>>;
+            const NAME: &'static str = "slug_not_in";
+        }
+        impl ::cynic::schema::HasInputField<slug_not_in, Option<Vec<super::super::String>>>
+            for super::super::CommitmentWhereInput
+        {
+        }
+        pub struct slug_lt;
+        impl ::cynic::schema::Field for slug_lt {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "slug_lt";
+        }
+        impl ::cynic::schema::HasInputField<slug_lt, Option<super::super::String>>
+            for super::super::CommitmentWhereInput
+        {
+        }
+        pub struct slug_lte;
+        impl ::cynic::schema::Field for slug_lte {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "slug_lte";
+        }
+        impl ::cynic::schema::HasInputField<slug_lte, Option<super::super::String>>
+            for super::super::CommitmentWhereInput
+        {
+        }
+        pub struct slug_gt;
+        impl ::cynic::schema::Field for slug_gt {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "slug_gt";
+        }
+        impl ::cynic::schema::HasInputField<slug_gt, Option<super::super::String>>
+            for super::super::CommitmentWhereInput
+        {
+        }
+        pub struct slug_gte;
+        impl ::cynic::schema::Field for slug_gte {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "slug_gte";
+        }
+        impl ::cynic::schema::HasInputField<slug_gte, Option<super::super::String>>
+            for super::super::CommitmentWhereInput
+        {
+        }
+        pub struct slug_contains;
+        impl ::cynic::schema::Field for slug_contains {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "slug_contains";
+        }
+        impl ::cynic::schema::HasInputField<slug_contains, Option<super::super::String>>
+            for super::super::CommitmentWhereInput
+        {
+        }
+        pub struct slug_not_contains;
+        impl ::cynic::schema::Field for slug_not_contains {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "slug_not_contains";
+        }
+        impl ::cynic::schema::HasInputField<slug_not_contains, Option<super::super::String>>
+            for super::super::CommitmentWhereInput
+        {
+        }
+        pub struct slug_starts_with;
+        impl ::cynic::schema::Field for slug_starts_with {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "slug_starts_with";
+        }
+        impl ::cynic::schema::HasInputField<slug_starts_with, Option<super::super::String>>
+            for super::super::CommitmentWhereInput
+        {
+        }
+        pub struct slug_not_starts_with;
+        impl ::cynic::schema::Field for slug_not_starts_with {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "slug_not_starts_with";
+        }
+        impl ::cynic::schema::HasInputField<slug_not_starts_with, Option<super::super::String>>
+            for super::super::CommitmentWhereInput
+        {
+        }
+        pub struct slug_ends_with;
+        impl ::cynic::schema::Field for slug_ends_with {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "slug_ends_with";
+        }
+        impl ::cynic::schema::HasInputField<slug_ends_with, Option<super::super::String>>
+            for super::super::CommitmentWhereInput
+        {
+        }
+        pub struct slug_not_ends_with;
+        impl ::cynic::schema::Field for slug_not_ends_with {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "slug_not_ends_with";
+        }
+        impl ::cynic::schema::HasInputField<slug_not_ends_with, Option<super::super::String>>
+            for super::super::CommitmentWhereInput
+        {
+        }
+        pub struct jobs_every;
+        impl ::cynic::schema::Field for jobs_every {
+            type Type = Option<super::super::JobWhereInput>;
+            const NAME: &'static str = "jobs_every";
+        }
+        impl ::cynic::schema::HasInputField<jobs_every, Option<super::super::JobWhereInput>>
+            for super::super::CommitmentWhereInput
+        {
+        }
+        pub struct jobs_some;
+        impl ::cynic::schema::Field for jobs_some {
+            type Type = Option<super::super::JobWhereInput>;
+            const NAME: &'static str = "jobs_some";
+        }
+        impl ::cynic::schema::HasInputField<jobs_some, Option<super::super::JobWhereInput>>
+            for super::super::CommitmentWhereInput
+        {
+        }
+        pub struct jobs_none;
+        impl ::cynic::schema::Field for jobs_none {
+            type Type = Option<super::super::JobWhereInput>;
+            const NAME: &'static str = "jobs_none";
+        }
+        impl ::cynic::schema::HasInputField<jobs_none, Option<super::super::JobWhereInput>>
+            for super::super::CommitmentWhereInput
+        {
+        }
+        pub struct createdAt;
+        impl ::cynic::schema::Field for createdAt {
+            type Type = Option<super::super::DateTime>;
+            const NAME: &'static str = "createdAt";
+        }
+        impl ::cynic::schema::HasInputField<createdAt, Option<super::super::DateTime>>
+            for super::super::CommitmentWhereInput
+        {
+        }
+        pub struct createdAt_not;
+        impl ::cynic::schema::Field for createdAt_not {
+            type Type = Option<super::super::DateTime>;
+            const NAME: &'static str = "createdAt_not";
+        }
+        impl ::cynic::schema::HasInputField<createdAt_not, Option<super::super::DateTime>>
+            for super::super::CommitmentWhereInput
+        {
+        }
+        pub struct createdAt_in;
+        impl ::cynic::schema::Field for createdAt_in {
+            type Type = Option<Vec<super::super::DateTime>>;
+            const NAME: &'static str = "createdAt_in";
+        }
+        impl ::cynic::schema::HasInputField<createdAt_in, Option<Vec<super::super::DateTime>>>
+            for super::super::CommitmentWhereInput
+        {
+        }
+        pub struct createdAt_not_in;
+        impl ::cynic::schema::Field for createdAt_not_in {
+            type Type = Option<Vec<super::super::DateTime>>;
+            const NAME: &'static str = "createdAt_not_in";
+        }
+        impl ::cynic::schema::HasInputField<createdAt_not_in, Option<Vec<super::super::DateTime>>>
+            for super::super::CommitmentWhereInput
+        {
+        }
+        pub struct createdAt_lt;
+        impl ::cynic::schema::Field for createdAt_lt {
+            type Type = Option<super::super::DateTime>;
+            const NAME: &'static str = "createdAt_lt";
+        }
+        impl ::cynic::schema::HasInputField<createdAt_lt, Option<super::super::DateTime>>
+            for super::super::CommitmentWhereInput
+        {
+        }
+        pub struct createdAt_lte;
+        impl ::cynic::schema::Field for createdAt_lte {
+            type Type = Option<super::super::DateTime>;
+            const NAME: &'static str = "createdAt_lte";
+        }
+        impl ::cynic::schema::HasInputField<createdAt_lte, Option<super::super::DateTime>>
+            for super::super::CommitmentWhereInput
+        {
+        }
+        pub struct createdAt_gt;
+        impl ::cynic::schema::Field for createdAt_gt {
+            type Type = Option<super::super::DateTime>;
+            const NAME: &'static str = "createdAt_gt";
+        }
+        impl ::cynic::schema::HasInputField<createdAt_gt, Option<super::super::DateTime>>
+            for super::super::CommitmentWhereInput
+        {
+        }
+        pub struct createdAt_gte;
+        impl ::cynic::schema::Field for createdAt_gte {
+            type Type = Option<super::super::DateTime>;
+            const NAME: &'static str = "createdAt_gte";
+        }
+        impl ::cynic::schema::HasInputField<createdAt_gte, Option<super::super::DateTime>>
+            for super::super::CommitmentWhereInput
+        {
+        }
+        pub struct updatedAt;
+        impl ::cynic::schema::Field for updatedAt {
+            type Type = Option<super::super::DateTime>;
+            const NAME: &'static str = "updatedAt";
+        }
+        impl ::cynic::schema::HasInputField<updatedAt, Option<super::super::DateTime>>
+            for super::super::CommitmentWhereInput
+        {
+        }
+        pub struct updatedAt_not;
+        impl ::cynic::schema::Field for updatedAt_not {
+            type Type = Option<super::super::DateTime>;
+            const NAME: &'static str = "updatedAt_not";
+        }
+        impl ::cynic::schema::HasInputField<updatedAt_not, Option<super::super::DateTime>>
+            for super::super::CommitmentWhereInput
+        {
+        }
+        pub struct updatedAt_in;
+        impl ::cynic::schema::Field for updatedAt_in {
+            type Type = Option<Vec<super::super::DateTime>>;
+            const NAME: &'static str = "updatedAt_in";
+        }
+        impl ::cynic::schema::HasInputField<updatedAt_in, Option<Vec<super::super::DateTime>>>
+            for super::super::CommitmentWhereInput
+        {
+        }
+        pub struct updatedAt_not_in;
+        impl ::cynic::schema::Field for updatedAt_not_in {
+            type Type = Option<Vec<super::super::DateTime>>;
+            const NAME: &'static str = "updatedAt_not_in";
+        }
+        impl ::cynic::schema::HasInputField<updatedAt_not_in, Option<Vec<super::super::DateTime>>>
+            for super::super::CommitmentWhereInput
+        {
+        }
+        pub struct updatedAt_lt;
+        impl ::cynic::schema::Field for updatedAt_lt {
+            type Type = Option<super::super::DateTime>;
+            const NAME: &'static str = "updatedAt_lt";
+        }
+        impl ::cynic::schema::HasInputField<updatedAt_lt, Option<super::super::DateTime>>
+            for super::super::CommitmentWhereInput
+        {
+        }
+        pub struct updatedAt_lte;
+        impl ::cynic::schema::Field for updatedAt_lte {
+            type Type = Option<super::super::DateTime>;
+            const NAME: &'static str = "updatedAt_lte";
+        }
+        impl ::cynic::schema::HasInputField<updatedAt_lte, Option<super::super::DateTime>>
+            for super::super::CommitmentWhereInput
+        {
+        }
+        pub struct updatedAt_gt;
+        impl ::cynic::schema::Field for updatedAt_gt {
+            type Type = Option<super::super::DateTime>;
+            const NAME: &'static str = "updatedAt_gt";
+        }
+        impl ::cynic::schema::HasInputField<updatedAt_gt, Option<super::super::DateTime>>
+            for super::super::CommitmentWhereInput
+        {
+        }
+        pub struct updatedAt_gte;
+        impl ::cynic::schema::Field for updatedAt_gte {
+            type Type = Option<super::super::DateTime>;
+            const NAME: &'static str = "updatedAt_gte";
+        }
+        impl ::cynic::schema::HasInputField<updatedAt_gte, Option<super::super::DateTime>>
+            for super::super::CommitmentWhereInput
+        {
+        }
+        pub struct AND;
+        impl ::cynic::schema::Field for AND {
+            type Type = Option<Vec<super::super::CommitmentWhereInput>>;
+            const NAME: &'static str = "AND";
+        }
+        impl ::cynic::schema::HasInputField<AND, Option<Vec<super::super::CommitmentWhereInput>>>
+            for super::super::CommitmentWhereInput
+        {
+        }
+        pub struct OR;
+        impl ::cynic::schema::Field for OR {
+            type Type = Option<Vec<super::super::CommitmentWhereInput>>;
+            const NAME: &'static str = "OR";
+        }
+        impl ::cynic::schema::HasInputField<OR, Option<Vec<super::super::CommitmentWhereInput>>>
+            for super::super::CommitmentWhereInput
+        {
+        }
+        pub struct NOT;
+        impl ::cynic::schema::Field for NOT {
+            type Type = Option<Vec<super::super::CommitmentWhereInput>>;
+            const NAME: &'static str = "NOT";
+        }
+        impl ::cynic::schema::HasInputField<NOT, Option<Vec<super::super::CommitmentWhereInput>>>
+            for super::super::CommitmentWhereInput
+        {
+        }
+    }
+    pub mod Company {
+        pub struct id;
+        impl ::cynic::schema::Field for id {
+            type Type = super::super::ID;
+            const NAME: &'static str = "id";
+        }
+        impl ::cynic::schema::HasField<id> for super::super::Company {
+            type Type = super::super::ID;
+        }
+        pub struct name;
+        impl ::cynic::schema::Field for name {
+            type Type = super::super::String;
+            const NAME: &'static str = "name";
+        }
+        impl ::cynic::schema::HasField<name> for super::super::Company {
+            type Type = super::super::String;
+        }
+        pub struct slug;
+        impl ::cynic::schema::Field for slug {
+            type Type = super::super::String;
+            const NAME: &'static str = "slug";
+        }
+        impl ::cynic::schema::HasField<slug> for super::super::Company {
+            type Type = super::super::String;
+        }
+        pub struct websiteUrl;
+        impl ::cynic::schema::Field for websiteUrl {
+            type Type = super::super::String;
+            const NAME: &'static str = "websiteUrl";
+        }
+        impl ::cynic::schema::HasField<websiteUrl> for super::super::Company {
+            type Type = super::super::String;
+        }
+        pub struct logoUrl;
+        impl ::cynic::schema::Field for logoUrl {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "logoUrl";
+        }
+        impl ::cynic::schema::HasField<logoUrl> for super::super::Company {
+            type Type = Option<super::super::String>;
+        }
+        pub struct jobs;
+        impl ::cynic::schema::Field for jobs {
+            type Type = Option<Vec<super::super::Job>>;
+            const NAME: &'static str = "jobs";
+        }
+        impl ::cynic::schema::HasField<jobs> for super::super::Company {
+            type Type = Option<Vec<super::super::Job>>;
+        }
+        pub mod jobs_arguments {
+            pub struct r#where;
+            impl ::cynic::schema::HasArgument<r#where> for super::jobs {
+                type ArgumentType = Option<super::super::super::JobWhereInput>;
+                const NAME: &'static str = "where";
+            }
+            pub struct orderBy;
+            impl ::cynic::schema::HasArgument<orderBy> for super::jobs {
+                type ArgumentType = Option<super::super::super::JobOrderByInput>;
+                const NAME: &'static str = "orderBy";
+            }
+            pub struct skip;
+            impl ::cynic::schema::HasArgument<skip> for super::jobs {
+                type ArgumentType = Option<super::super::super::Int>;
+                const NAME: &'static str = "skip";
+            }
+            pub struct after;
+            impl ::cynic::schema::HasArgument<after> for super::jobs {
+                type ArgumentType = Option<super::super::super::String>;
+                const NAME: &'static str = "after";
+            }
+            pub struct before;
+            impl ::cynic::schema::HasArgument<before> for super::jobs {
+                type ArgumentType = Option<super::super::super::String>;
+                const NAME: &'static str = "before";
+            }
+            pub struct first;
+            impl ::cynic::schema::HasArgument<first> for super::jobs {
+                type ArgumentType = Option<super::super::super::Int>;
+                const NAME: &'static str = "first";
+            }
+            pub struct last;
+            impl ::cynic::schema::HasArgument<last> for super::jobs {
+                type ArgumentType = Option<super::super::super::Int>;
+                const NAME: &'static str = "last";
+            }
+        }
+        pub struct twitter;
+        impl ::cynic::schema::Field for twitter {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "twitter";
+        }
+        impl ::cynic::schema::HasField<twitter> for super::super::Company {
+            type Type = Option<super::super::String>;
+        }
+        pub struct emailed;
+        impl ::cynic::schema::Field for emailed {
+            type Type = Option<super::super::Boolean>;
+            const NAME: &'static str = "emailed";
+        }
+        impl ::cynic::schema::HasField<emailed> for super::super::Company {
+            type Type = Option<super::super::Boolean>;
+        }
+        pub struct createdAt;
+        impl ::cynic::schema::Field for createdAt {
+            type Type = super::super::DateTime;
+            const NAME: &'static str = "createdAt";
+        }
+        impl ::cynic::schema::HasField<createdAt> for super::super::Company {
+            type Type = super::super::DateTime;
+        }
+        pub struct updatedAt;
+        impl ::cynic::schema::Field for updatedAt {
+            type Type = super::super::DateTime;
+            const NAME: &'static str = "updatedAt";
+        }
+        impl ::cynic::schema::HasField<updatedAt> for super::super::Company {
+            type Type = super::super::DateTime;
+        }
+    }
+    pub mod CompanyWhereInput {
+        pub struct id;
+        impl ::cynic::schema::Field for id {
+            type Type = Option<super::super::ID>;
+            const NAME: &'static str = "id";
+        }
+        impl ::cynic::schema::HasInputField<id, Option<super::super::ID>>
+            for super::super::CompanyWhereInput
+        {
+        }
+        pub struct id_not;
+        impl ::cynic::schema::Field for id_not {
+            type Type = Option<super::super::ID>;
+            const NAME: &'static str = "id_not";
+        }
+        impl ::cynic::schema::HasInputField<id_not, Option<super::super::ID>>
+            for super::super::CompanyWhereInput
+        {
+        }
+        pub struct id_in;
+        impl ::cynic::schema::Field for id_in {
+            type Type = Option<Vec<super::super::ID>>;
+            const NAME: &'static str = "id_in";
+        }
+        impl ::cynic::schema::HasInputField<id_in, Option<Vec<super::super::ID>>>
+            for super::super::CompanyWhereInput
+        {
+        }
+        pub struct id_not_in;
+        impl ::cynic::schema::Field for id_not_in {
+            type Type = Option<Vec<super::super::ID>>;
+            const NAME: &'static str = "id_not_in";
+        }
+        impl ::cynic::schema::HasInputField<id_not_in, Option<Vec<super::super::ID>>>
+            for super::super::CompanyWhereInput
+        {
+        }
+        pub struct id_lt;
+        impl ::cynic::schema::Field for id_lt {
+            type Type = Option<super::super::ID>;
+            const NAME: &'static str = "id_lt";
+        }
+        impl ::cynic::schema::HasInputField<id_lt, Option<super::super::ID>>
+            for super::super::CompanyWhereInput
+        {
+        }
+        pub struct id_lte;
+        impl ::cynic::schema::Field for id_lte {
+            type Type = Option<super::super::ID>;
+            const NAME: &'static str = "id_lte";
+        }
+        impl ::cynic::schema::HasInputField<id_lte, Option<super::super::ID>>
+            for super::super::CompanyWhereInput
+        {
+        }
+        pub struct id_gt;
+        impl ::cynic::schema::Field for id_gt {
+            type Type = Option<super::super::ID>;
+            const NAME: &'static str = "id_gt";
+        }
+        impl ::cynic::schema::HasInputField<id_gt, Option<super::super::ID>>
+            for super::super::CompanyWhereInput
+        {
+        }
+        pub struct id_gte;
+        impl ::cynic::schema::Field for id_gte {
+            type Type = Option<super::super::ID>;
+            const NAME: &'static str = "id_gte";
+        }
+        impl ::cynic::schema::HasInputField<id_gte, Option<super::super::ID>>
+            for super::super::CompanyWhereInput
+        {
+        }
+        pub struct id_contains;
+        impl ::cynic::schema::Field for id_contains {
+            type Type = Option<super::super::ID>;
+            const NAME: &'static str = "id_contains";
+        }
+        impl ::cynic::schema::HasInputField<id_contains, Option<super::super::ID>>
+            for super::super::CompanyWhereInput
+        {
+        }
+        pub struct id_not_contains;
+        impl ::cynic::schema::Field for id_not_contains {
+            type Type = Option<super::super::ID>;
+            const NAME: &'static str = "id_not_contains";
+        }
+        impl ::cynic::schema::HasInputField<id_not_contains, Option<super::super::ID>>
+            for super::super::CompanyWhereInput
+        {
+        }
+        pub struct id_starts_with;
+        impl ::cynic::schema::Field for id_starts_with {
+            type Type = Option<super::super::ID>;
+            const NAME: &'static str = "id_starts_with";
+        }
+        impl ::cynic::schema::HasInputField<id_starts_with, Option<super::super::ID>>
+            for super::super::CompanyWhereInput
+        {
+        }
+        pub struct id_not_starts_with;
+        impl ::cynic::schema::Field for id_not_starts_with {
+            type Type = Option<super::super::ID>;
+            const NAME: &'static str = "id_not_starts_with";
+        }
+        impl ::cynic::schema::HasInputField<id_not_starts_with, Option<super::super::ID>>
+            for super::super::CompanyWhereInput
+        {
+        }
+        pub struct id_ends_with;
+        impl ::cynic::schema::Field for id_ends_with {
+            type Type = Option<super::super::ID>;
+            const NAME: &'static str = "id_ends_with";
+        }
+        impl ::cynic::schema::HasInputField<id_ends_with, Option<super::super::ID>>
+            for super::super::CompanyWhereInput
+        {
+        }
+        pub struct id_not_ends_with;
+        impl ::cynic::schema::Field for id_not_ends_with {
+            type Type = Option<super::super::ID>;
+            const NAME: &'static str = "id_not_ends_with";
+        }
+        impl ::cynic::schema::HasInputField<id_not_ends_with, Option<super::super::ID>>
+            for super::super::CompanyWhereInput
+        {
+        }
+        pub struct name;
+        impl ::cynic::schema::Field for name {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "name";
+        }
+        impl ::cynic::schema::HasInputField<name, Option<super::super::String>>
+            for super::super::CompanyWhereInput
+        {
+        }
+        pub struct name_not;
+        impl ::cynic::schema::Field for name_not {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "name_not";
+        }
+        impl ::cynic::schema::HasInputField<name_not, Option<super::super::String>>
+            for super::super::CompanyWhereInput
+        {
+        }
+        pub struct name_in;
+        impl ::cynic::schema::Field for name_in {
+            type Type = Option<Vec<super::super::String>>;
+            const NAME: &'static str = "name_in";
+        }
+        impl ::cynic::schema::HasInputField<name_in, Option<Vec<super::super::String>>>
+            for super::super::CompanyWhereInput
+        {
+        }
+        pub struct name_not_in;
+        impl ::cynic::schema::Field for name_not_in {
+            type Type = Option<Vec<super::super::String>>;
+            const NAME: &'static str = "name_not_in";
+        }
+        impl ::cynic::schema::HasInputField<name_not_in, Option<Vec<super::super::String>>>
+            for super::super::CompanyWhereInput
+        {
+        }
+        pub struct name_lt;
+        impl ::cynic::schema::Field for name_lt {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "name_lt";
+        }
+        impl ::cynic::schema::HasInputField<name_lt, Option<super::super::String>>
+            for super::super::CompanyWhereInput
+        {
+        }
+        pub struct name_lte;
+        impl ::cynic::schema::Field for name_lte {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "name_lte";
+        }
+        impl ::cynic::schema::HasInputField<name_lte, Option<super::super::String>>
+            for super::super::CompanyWhereInput
+        {
+        }
+        pub struct name_gt;
+        impl ::cynic::schema::Field for name_gt {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "name_gt";
+        }
+        impl ::cynic::schema::HasInputField<name_gt, Option<super::super::String>>
+            for super::super::CompanyWhereInput
+        {
+        }
+        pub struct name_gte;
+        impl ::cynic::schema::Field for name_gte {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "name_gte";
+        }
+        impl ::cynic::schema::HasInputField<name_gte, Option<super::super::String>>
+            for super::super::CompanyWhereInput
+        {
+        }
+        pub struct name_contains;
+        impl ::cynic::schema::Field for name_contains {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "name_contains";
+        }
+        impl ::cynic::schema::HasInputField<name_contains, Option<super::super::String>>
+            for super::super::CompanyWhereInput
+        {
+        }
+        pub struct name_not_contains;
+        impl ::cynic::schema::Field for name_not_contains {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "name_not_contains";
+        }
+        impl ::cynic::schema::HasInputField<name_not_contains, Option<super::super::String>>
+            for super::super::CompanyWhereInput
+        {
+        }
+        pub struct name_starts_with;
+        impl ::cynic::schema::Field for name_starts_with {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "name_starts_with";
+        }
+        impl ::cynic::schema::HasInputField<name_starts_with, Option<super::super::String>>
+            for super::super::CompanyWhereInput
+        {
+        }
+        pub struct name_not_starts_with;
+        impl ::cynic::schema::Field for name_not_starts_with {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "name_not_starts_with";
+        }
+        impl ::cynic::schema::HasInputField<name_not_starts_with, Option<super::super::String>>
+            for super::super::CompanyWhereInput
+        {
+        }
+        pub struct name_ends_with;
+        impl ::cynic::schema::Field for name_ends_with {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "name_ends_with";
+        }
+        impl ::cynic::schema::HasInputField<name_ends_with, Option<super::super::String>>
+            for super::super::CompanyWhereInput
+        {
+        }
+        pub struct name_not_ends_with;
+        impl ::cynic::schema::Field for name_not_ends_with {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "name_not_ends_with";
+        }
+        impl ::cynic::schema::HasInputField<name_not_ends_with, Option<super::super::String>>
+            for super::super::CompanyWhereInput
+        {
+        }
+        pub struct slug;
+        impl ::cynic::schema::Field for slug {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "slug";
+        }
+        impl ::cynic::schema::HasInputField<slug, Option<super::super::String>>
+            for super::super::CompanyWhereInput
+        {
+        }
+        pub struct slug_not;
+        impl ::cynic::schema::Field for slug_not {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "slug_not";
+        }
+        impl ::cynic::schema::HasInputField<slug_not, Option<super::super::String>>
+            for super::super::CompanyWhereInput
+        {
+        }
+        pub struct slug_in;
+        impl ::cynic::schema::Field for slug_in {
+            type Type = Option<Vec<super::super::String>>;
+            const NAME: &'static str = "slug_in";
+        }
+        impl ::cynic::schema::HasInputField<slug_in, Option<Vec<super::super::String>>>
+            for super::super::CompanyWhereInput
+        {
+        }
+        pub struct slug_not_in;
+        impl ::cynic::schema::Field for slug_not_in {
+            type Type = Option<Vec<super::super::String>>;
+            const NAME: &'static str = "slug_not_in";
+        }
+        impl ::cynic::schema::HasInputField<slug_not_in, Option<Vec<super::super::String>>>
+            for super::super::CompanyWhereInput
+        {
+        }
+        pub struct slug_lt;
+        impl ::cynic::schema::Field for slug_lt {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "slug_lt";
+        }
+        impl ::cynic::schema::HasInputField<slug_lt, Option<super::super::String>>
+            for super::super::CompanyWhereInput
+        {
+        }
+        pub struct slug_lte;
+        impl ::cynic::schema::Field for slug_lte {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "slug_lte";
+        }
+        impl ::cynic::schema::HasInputField<slug_lte, Option<super::super::String>>
+            for super::super::CompanyWhereInput
+        {
+        }
+        pub struct slug_gt;
+        impl ::cynic::schema::Field for slug_gt {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "slug_gt";
+        }
+        impl ::cynic::schema::HasInputField<slug_gt, Option<super::super::String>>
+            for super::super::CompanyWhereInput
+        {
+        }
+        pub struct slug_gte;
+        impl ::cynic::schema::Field for slug_gte {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "slug_gte";
+        }
+        impl ::cynic::schema::HasInputField<slug_gte, Option<super::super::String>>
+            for super::super::CompanyWhereInput
+        {
+        }
+        pub struct slug_contains;
+        impl ::cynic::schema::Field for slug_contains {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "slug_contains";
+        }
+        impl ::cynic::schema::HasInputField<slug_contains, Option<super::super::String>>
+            for super::super::CompanyWhereInput
+        {
+        }
+        pub struct slug_not_contains;
+        impl ::cynic::schema::Field for slug_not_contains {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "slug_not_contains";
+        }
+        impl ::cynic::schema::HasInputField<slug_not_contains, Option<super::super::String>>
+            for super::super::CompanyWhereInput
+        {
+        }
+        pub struct slug_starts_with;
+        impl ::cynic::schema::Field for slug_starts_with {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "slug_starts_with";
+        }
+        impl ::cynic::schema::HasInputField<slug_starts_with, Option<super::super::String>>
+            for super::super::CompanyWhereInput
+        {
+        }
+        pub struct slug_not_starts_with;
+        impl ::cynic::schema::Field for slug_not_starts_with {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "slug_not_starts_with";
+        }
+        impl ::cynic::schema::HasInputField<slug_not_starts_with, Option<super::super::String>>
+            for super::super::CompanyWhereInput
+        {
+        }
+        pub struct slug_ends_with;
+        impl ::cynic::schema::Field for slug_ends_with {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "slug_ends_with";
+        }
+        impl ::cynic::schema::HasInputField<slug_ends_with, Option<super::super::String>>
+            for super::super::CompanyWhereInput
+        {
+        }
+        pub struct slug_not_ends_with;
+        impl ::cynic::schema::Field for slug_not_ends_with {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "slug_not_ends_with";
+        }
+        impl ::cynic::schema::HasInputField<slug_not_ends_with, Option<super::super::String>>
+            for super::super::CompanyWhereInput
+        {
+        }
+        pub struct websiteUrl;
+        impl ::cynic::schema::Field for websiteUrl {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "websiteUrl";
+        }
+        impl ::cynic::schema::HasInputField<websiteUrl, Option<super::super::String>>
+            for super::super::CompanyWhereInput
+        {
+        }
+        pub struct websiteUrl_not;
+        impl ::cynic::schema::Field for websiteUrl_not {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "websiteUrl_not";
+        }
+        impl ::cynic::schema::HasInputField<websiteUrl_not, Option<super::super::String>>
+            for super::super::CompanyWhereInput
+        {
+        }
+        pub struct websiteUrl_in;
+        impl ::cynic::schema::Field for websiteUrl_in {
+            type Type = Option<Vec<super::super::String>>;
+            const NAME: &'static str = "websiteUrl_in";
+        }
+        impl ::cynic::schema::HasInputField<websiteUrl_in, Option<Vec<super::super::String>>>
+            for super::super::CompanyWhereInput
+        {
+        }
+        pub struct websiteUrl_not_in;
+        impl ::cynic::schema::Field for websiteUrl_not_in {
+            type Type = Option<Vec<super::super::String>>;
+            const NAME: &'static str = "websiteUrl_not_in";
+        }
+        impl ::cynic::schema::HasInputField<websiteUrl_not_in, Option<Vec<super::super::String>>>
+            for super::super::CompanyWhereInput
+        {
+        }
+        pub struct websiteUrl_lt;
+        impl ::cynic::schema::Field for websiteUrl_lt {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "websiteUrl_lt";
+        }
+        impl ::cynic::schema::HasInputField<websiteUrl_lt, Option<super::super::String>>
+            for super::super::CompanyWhereInput
+        {
+        }
+        pub struct websiteUrl_lte;
+        impl ::cynic::schema::Field for websiteUrl_lte {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "websiteUrl_lte";
+        }
+        impl ::cynic::schema::HasInputField<websiteUrl_lte, Option<super::super::String>>
+            for super::super::CompanyWhereInput
+        {
+        }
+        pub struct websiteUrl_gt;
+        impl ::cynic::schema::Field for websiteUrl_gt {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "websiteUrl_gt";
+        }
+        impl ::cynic::schema::HasInputField<websiteUrl_gt, Option<super::super::String>>
+            for super::super::CompanyWhereInput
+        {
+        }
+        pub struct websiteUrl_gte;
+        impl ::cynic::schema::Field for websiteUrl_gte {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "websiteUrl_gte";
+        }
+        impl ::cynic::schema::HasInputField<websiteUrl_gte, Option<super::super::String>>
+            for super::super::CompanyWhereInput
+        {
+        }
+        pub struct websiteUrl_contains;
+        impl ::cynic::schema::Field for websiteUrl_contains {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "websiteUrl_contains";
+        }
+        impl ::cynic::schema::HasInputField<websiteUrl_contains, Option<super::super::String>>
+            for super::super::CompanyWhereInput
+        {
+        }
+        pub struct websiteUrl_not_contains;
+        impl ::cynic::schema::Field for websiteUrl_not_contains {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "websiteUrl_not_contains";
+        }
+        impl ::cynic::schema::HasInputField<websiteUrl_not_contains, Option<super::super::String>>
+            for super::super::CompanyWhereInput
+        {
+        }
+        pub struct websiteUrl_starts_with;
+        impl ::cynic::schema::Field for websiteUrl_starts_with {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "websiteUrl_starts_with";
+        }
+        impl ::cynic::schema::HasInputField<websiteUrl_starts_with, Option<super::super::String>>
+            for super::super::CompanyWhereInput
+        {
+        }
+        pub struct websiteUrl_not_starts_with;
+        impl ::cynic::schema::Field for websiteUrl_not_starts_with {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "websiteUrl_not_starts_with";
+        }
+        impl
+            ::cynic::schema::HasInputField<websiteUrl_not_starts_with, Option<super::super::String>>
+            for super::super::CompanyWhereInput
+        {
+        }
+        pub struct websiteUrl_ends_with;
+        impl ::cynic::schema::Field for websiteUrl_ends_with {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "websiteUrl_ends_with";
+        }
+        impl ::cynic::schema::HasInputField<websiteUrl_ends_with, Option<super::super::String>>
+            for super::super::CompanyWhereInput
+        {
+        }
+        pub struct websiteUrl_not_ends_with;
+        impl ::cynic::schema::Field for websiteUrl_not_ends_with {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "websiteUrl_not_ends_with";
+        }
+        impl ::cynic::schema::HasInputField<websiteUrl_not_ends_with, Option<super::super::String>>
+            for super::super::CompanyWhereInput
+        {
+        }
+        pub struct logoUrl;
+        impl ::cynic::schema::Field for logoUrl {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "logoUrl";
+        }
+        impl ::cynic::schema::HasInputField<logoUrl, Option<super::super::String>>
+            for super::super::CompanyWhereInput
+        {
+        }
+        pub struct logoUrl_not;
+        impl ::cynic::schema::Field for logoUrl_not {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "logoUrl_not";
+        }
+        impl ::cynic::schema::HasInputField<logoUrl_not, Option<super::super::String>>
+            for super::super::CompanyWhereInput
+        {
+        }
+        pub struct logoUrl_in;
+        impl ::cynic::schema::Field for logoUrl_in {
+            type Type = Option<Vec<super::super::String>>;
+            const NAME: &'static str = "logoUrl_in";
+        }
+        impl ::cynic::schema::HasInputField<logoUrl_in, Option<Vec<super::super::String>>>
+            for super::super::CompanyWhereInput
+        {
+        }
+        pub struct logoUrl_not_in;
+        impl ::cynic::schema::Field for logoUrl_not_in {
+            type Type = Option<Vec<super::super::String>>;
+            const NAME: &'static str = "logoUrl_not_in";
+        }
+        impl ::cynic::schema::HasInputField<logoUrl_not_in, Option<Vec<super::super::String>>>
+            for super::super::CompanyWhereInput
+        {
+        }
+        pub struct logoUrl_lt;
+        impl ::cynic::schema::Field for logoUrl_lt {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "logoUrl_lt";
+        }
+        impl ::cynic::schema::HasInputField<logoUrl_lt, Option<super::super::String>>
+            for super::super::CompanyWhereInput
+        {
+        }
+        pub struct logoUrl_lte;
+        impl ::cynic::schema::Field for logoUrl_lte {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "logoUrl_lte";
+        }
+        impl ::cynic::schema::HasInputField<logoUrl_lte, Option<super::super::String>>
+            for super::super::CompanyWhereInput
+        {
+        }
+        pub struct logoUrl_gt;
+        impl ::cynic::schema::Field for logoUrl_gt {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "logoUrl_gt";
+        }
+        impl ::cynic::schema::HasInputField<logoUrl_gt, Option<super::super::String>>
+            for super::super::CompanyWhereInput
+        {
+        }
+        pub struct logoUrl_gte;
+        impl ::cynic::schema::Field for logoUrl_gte {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "logoUrl_gte";
+        }
+        impl ::cynic::schema::HasInputField<logoUrl_gte, Option<super::super::String>>
+            for super::super::CompanyWhereInput
+        {
+        }
+        pub struct logoUrl_contains;
+        impl ::cynic::schema::Field for logoUrl_contains {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "logoUrl_contains";
+        }
+        impl ::cynic::schema::HasInputField<logoUrl_contains, Option<super::super::String>>
+            for super::super::CompanyWhereInput
+        {
+        }
+        pub struct logoUrl_not_contains;
+        impl ::cynic::schema::Field for logoUrl_not_contains {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "logoUrl_not_contains";
+        }
+        impl ::cynic::schema::HasInputField<logoUrl_not_contains, Option<super::super::String>>
+            for super::super::CompanyWhereInput
+        {
+        }
+        pub struct logoUrl_starts_with;
+        impl ::cynic::schema::Field for logoUrl_starts_with {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "logoUrl_starts_with";
+        }
+        impl ::cynic::schema::HasInputField<logoUrl_starts_with, Option<super::super::String>>
+            for super::super::CompanyWhereInput
+        {
+        }
+        pub struct logoUrl_not_starts_with;
+        impl ::cynic::schema::Field for logoUrl_not_starts_with {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "logoUrl_not_starts_with";
+        }
+        impl ::cynic::schema::HasInputField<logoUrl_not_starts_with, Option<super::super::String>>
+            for super::super::CompanyWhereInput
+        {
+        }
+        pub struct logoUrl_ends_with;
+        impl ::cynic::schema::Field for logoUrl_ends_with {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "logoUrl_ends_with";
+        }
+        impl ::cynic::schema::HasInputField<logoUrl_ends_with, Option<super::super::String>>
+            for super::super::CompanyWhereInput
+        {
+        }
+        pub struct logoUrl_not_ends_with;
+        impl ::cynic::schema::Field for logoUrl_not_ends_with {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "logoUrl_not_ends_with";
+        }
+        impl ::cynic::schema::HasInputField<logoUrl_not_ends_with, Option<super::super::String>>
+            for super::super::CompanyWhereInput
+        {
+        }
+        pub struct jobs_every;
+        impl ::cynic::schema::Field for jobs_every {
+            type Type = Option<super::super::JobWhereInput>;
+            const NAME: &'static str = "jobs_every";
+        }
+        impl ::cynic::schema::HasInputField<jobs_every, Option<super::super::JobWhereInput>>
+            for super::super::CompanyWhereInput
+        {
+        }
+        pub struct jobs_some;
+        impl ::cynic::schema::Field for jobs_some {
+            type Type = Option<super::super::JobWhereInput>;
+            const NAME: &'static str = "jobs_some";
+        }
+        impl ::cynic::schema::HasInputField<jobs_some, Option<super::super::JobWhereInput>>
+            for super::super::CompanyWhereInput
+        {
+        }
+        pub struct jobs_none;
+        impl ::cynic::schema::Field for jobs_none {
+            type Type = Option<super::super::JobWhereInput>;
+            const NAME: &'static str = "jobs_none";
+        }
+        impl ::cynic::schema::HasInputField<jobs_none, Option<super::super::JobWhereInput>>
+            for super::super::CompanyWhereInput
+        {
+        }
+        pub struct twitter;
+        impl ::cynic::schema::Field for twitter {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "twitter";
+        }
+        impl ::cynic::schema::HasInputField<twitter, Option<super::super::String>>
+            for super::super::CompanyWhereInput
+        {
+        }
+        pub struct twitter_not;
+        impl ::cynic::schema::Field for twitter_not {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "twitter_not";
+        }
+        impl ::cynic::schema::HasInputField<twitter_not, Option<super::super::String>>
+            for super::super::CompanyWhereInput
+        {
+        }
+        pub struct twitter_in;
+        impl ::cynic::schema::Field for twitter_in {
+            type Type = Option<Vec<super::super::String>>;
+            const NAME: &'static str = "twitter_in";
+        }
+        impl ::cynic::schema::HasInputField<twitter_in, Option<Vec<super::super::String>>>
+            for super::super::CompanyWhereInput
+        {
+        }
+        pub struct twitter_not_in;
+        impl ::cynic::schema::Field for twitter_not_in {
+            type Type = Option<Vec<super::super::String>>;
+            const NAME: &'static str = "twitter_not_in";
+        }
+        impl ::cynic::schema::HasInputField<twitter_not_in, Option<Vec<super::super::String>>>
+            for super::super::CompanyWhereInput
+        {
+        }
+        pub struct twitter_lt;
+        impl ::cynic::schema::Field for twitter_lt {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "twitter_lt";
+        }
+        impl ::cynic::schema::HasInputField<twitter_lt, Option<super::super::String>>
+            for super::super::CompanyWhereInput
+        {
+        }
+        pub struct twitter_lte;
+        impl ::cynic::schema::Field for twitter_lte {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "twitter_lte";
+        }
+        impl ::cynic::schema::HasInputField<twitter_lte, Option<super::super::String>>
+            for super::super::CompanyWhereInput
+        {
+        }
+        pub struct twitter_gt;
+        impl ::cynic::schema::Field for twitter_gt {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "twitter_gt";
+        }
+        impl ::cynic::schema::HasInputField<twitter_gt, Option<super::super::String>>
+            for super::super::CompanyWhereInput
+        {
+        }
+        pub struct twitter_gte;
+        impl ::cynic::schema::Field for twitter_gte {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "twitter_gte";
+        }
+        impl ::cynic::schema::HasInputField<twitter_gte, Option<super::super::String>>
+            for super::super::CompanyWhereInput
+        {
+        }
+        pub struct twitter_contains;
+        impl ::cynic::schema::Field for twitter_contains {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "twitter_contains";
+        }
+        impl ::cynic::schema::HasInputField<twitter_contains, Option<super::super::String>>
+            for super::super::CompanyWhereInput
+        {
+        }
+        pub struct twitter_not_contains;
+        impl ::cynic::schema::Field for twitter_not_contains {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "twitter_not_contains";
+        }
+        impl ::cynic::schema::HasInputField<twitter_not_contains, Option<super::super::String>>
+            for super::super::CompanyWhereInput
+        {
+        }
+        pub struct twitter_starts_with;
+        impl ::cynic::schema::Field for twitter_starts_with {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "twitter_starts_with";
+        }
+        impl ::cynic::schema::HasInputField<twitter_starts_with, Option<super::super::String>>
+            for super::super::CompanyWhereInput
+        {
+        }
+        pub struct twitter_not_starts_with;
+        impl ::cynic::schema::Field for twitter_not_starts_with {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "twitter_not_starts_with";
+        }
+        impl ::cynic::schema::HasInputField<twitter_not_starts_with, Option<super::super::String>>
+            for super::super::CompanyWhereInput
+        {
+        }
+        pub struct twitter_ends_with;
+        impl ::cynic::schema::Field for twitter_ends_with {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "twitter_ends_with";
+        }
+        impl ::cynic::schema::HasInputField<twitter_ends_with, Option<super::super::String>>
+            for super::super::CompanyWhereInput
+        {
+        }
+        pub struct twitter_not_ends_with;
+        impl ::cynic::schema::Field for twitter_not_ends_with {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "twitter_not_ends_with";
+        }
+        impl ::cynic::schema::HasInputField<twitter_not_ends_with, Option<super::super::String>>
+            for super::super::CompanyWhereInput
+        {
+        }
+        pub struct emailed;
+        impl ::cynic::schema::Field for emailed {
+            type Type = Option<super::super::Boolean>;
+            const NAME: &'static str = "emailed";
+        }
+        impl ::cynic::schema::HasInputField<emailed, Option<super::super::Boolean>>
+            for super::super::CompanyWhereInput
+        {
+        }
+        pub struct emailed_not;
+        impl ::cynic::schema::Field for emailed_not {
+            type Type = Option<super::super::Boolean>;
+            const NAME: &'static str = "emailed_not";
+        }
+        impl ::cynic::schema::HasInputField<emailed_not, Option<super::super::Boolean>>
+            for super::super::CompanyWhereInput
+        {
+        }
+        pub struct createdAt;
+        impl ::cynic::schema::Field for createdAt {
+            type Type = Option<super::super::DateTime>;
+            const NAME: &'static str = "createdAt";
+        }
+        impl ::cynic::schema::HasInputField<createdAt, Option<super::super::DateTime>>
+            for super::super::CompanyWhereInput
+        {
+        }
+        pub struct createdAt_not;
+        impl ::cynic::schema::Field for createdAt_not {
+            type Type = Option<super::super::DateTime>;
+            const NAME: &'static str = "createdAt_not";
+        }
+        impl ::cynic::schema::HasInputField<createdAt_not, Option<super::super::DateTime>>
+            for super::super::CompanyWhereInput
+        {
+        }
+        pub struct createdAt_in;
+        impl ::cynic::schema::Field for createdAt_in {
+            type Type = Option<Vec<super::super::DateTime>>;
+            const NAME: &'static str = "createdAt_in";
+        }
+        impl ::cynic::schema::HasInputField<createdAt_in, Option<Vec<super::super::DateTime>>>
+            for super::super::CompanyWhereInput
+        {
+        }
+        pub struct createdAt_not_in;
+        impl ::cynic::schema::Field for createdAt_not_in {
+            type Type = Option<Vec<super::super::DateTime>>;
+            const NAME: &'static str = "createdAt_not_in";
+        }
+        impl ::cynic::schema::HasInputField<createdAt_not_in, Option<Vec<super::super::DateTime>>>
+            for super::super::CompanyWhereInput
+        {
+        }
+        pub struct createdAt_lt;
+        impl ::cynic::schema::Field for createdAt_lt {
+            type Type = Option<super::super::DateTime>;
+            const NAME: &'static str = "createdAt_lt";
+        }
+        impl ::cynic::schema::HasInputField<createdAt_lt, Option<super::super::DateTime>>
+            for super::super::CompanyWhereInput
+        {
+        }
+        pub struct createdAt_lte;
+        impl ::cynic::schema::Field for createdAt_lte {
+            type Type = Option<super::super::DateTime>;
+            const NAME: &'static str = "createdAt_lte";
+        }
+        impl ::cynic::schema::HasInputField<createdAt_lte, Option<super::super::DateTime>>
+            for super::super::CompanyWhereInput
+        {
+        }
+        pub struct createdAt_gt;
+        impl ::cynic::schema::Field for createdAt_gt {
+            type Type = Option<super::super::DateTime>;
+            const NAME: &'static str = "createdAt_gt";
+        }
+        impl ::cynic::schema::HasInputField<createdAt_gt, Option<super::super::DateTime>>
+            for super::super::CompanyWhereInput
+        {
+        }
+        pub struct createdAt_gte;
+        impl ::cynic::schema::Field for createdAt_gte {
+            type Type = Option<super::super::DateTime>;
+            const NAME: &'static str = "createdAt_gte";
+        }
+        impl ::cynic::schema::HasInputField<createdAt_gte, Option<super::super::DateTime>>
+            for super::super::CompanyWhereInput
+        {
+        }
+        pub struct updatedAt;
+        impl ::cynic::schema::Field for updatedAt {
+            type Type = Option<super::super::DateTime>;
+            const NAME: &'static str = "updatedAt";
+        }
+        impl ::cynic::schema::HasInputField<updatedAt, Option<super::super::DateTime>>
+            for super::super::CompanyWhereInput
+        {
+        }
+        pub struct updatedAt_not;
+        impl ::cynic::schema::Field for updatedAt_not {
+            type Type = Option<super::super::DateTime>;
+            const NAME: &'static str = "updatedAt_not";
+        }
+        impl ::cynic::schema::HasInputField<updatedAt_not, Option<super::super::DateTime>>
+            for super::super::CompanyWhereInput
+        {
+        }
+        pub struct updatedAt_in;
+        impl ::cynic::schema::Field for updatedAt_in {
+            type Type = Option<Vec<super::super::DateTime>>;
+            const NAME: &'static str = "updatedAt_in";
+        }
+        impl ::cynic::schema::HasInputField<updatedAt_in, Option<Vec<super::super::DateTime>>>
+            for super::super::CompanyWhereInput
+        {
+        }
+        pub struct updatedAt_not_in;
+        impl ::cynic::schema::Field for updatedAt_not_in {
+            type Type = Option<Vec<super::super::DateTime>>;
+            const NAME: &'static str = "updatedAt_not_in";
+        }
+        impl ::cynic::schema::HasInputField<updatedAt_not_in, Option<Vec<super::super::DateTime>>>
+            for super::super::CompanyWhereInput
+        {
+        }
+        pub struct updatedAt_lt;
+        impl ::cynic::schema::Field for updatedAt_lt {
+            type Type = Option<super::super::DateTime>;
+            const NAME: &'static str = "updatedAt_lt";
+        }
+        impl ::cynic::schema::HasInputField<updatedAt_lt, Option<super::super::DateTime>>
+            for super::super::CompanyWhereInput
+        {
+        }
+        pub struct updatedAt_lte;
+        impl ::cynic::schema::Field for updatedAt_lte {
+            type Type = Option<super::super::DateTime>;
+            const NAME: &'static str = "updatedAt_lte";
+        }
+        impl ::cynic::schema::HasInputField<updatedAt_lte, Option<super::super::DateTime>>
+            for super::super::CompanyWhereInput
+        {
+        }
+        pub struct updatedAt_gt;
+        impl ::cynic::schema::Field for updatedAt_gt {
+            type Type = Option<super::super::DateTime>;
+            const NAME: &'static str = "updatedAt_gt";
+        }
+        impl ::cynic::schema::HasInputField<updatedAt_gt, Option<super::super::DateTime>>
+            for super::super::CompanyWhereInput
+        {
+        }
+        pub struct updatedAt_gte;
+        impl ::cynic::schema::Field for updatedAt_gte {
+            type Type = Option<super::super::DateTime>;
+            const NAME: &'static str = "updatedAt_gte";
+        }
+        impl ::cynic::schema::HasInputField<updatedAt_gte, Option<super::super::DateTime>>
+            for super::super::CompanyWhereInput
+        {
+        }
+        pub struct AND;
+        impl ::cynic::schema::Field for AND {
+            type Type = Option<Vec<super::super::CompanyWhereInput>>;
+            const NAME: &'static str = "AND";
+        }
+        impl ::cynic::schema::HasInputField<AND, Option<Vec<super::super::CompanyWhereInput>>>
+            for super::super::CompanyWhereInput
+        {
+        }
+        pub struct OR;
+        impl ::cynic::schema::Field for OR {
+            type Type = Option<Vec<super::super::CompanyWhereInput>>;
+            const NAME: &'static str = "OR";
+        }
+        impl ::cynic::schema::HasInputField<OR, Option<Vec<super::super::CompanyWhereInput>>>
+            for super::super::CompanyWhereInput
+        {
+        }
+        pub struct NOT;
+        impl ::cynic::schema::Field for NOT {
+            type Type = Option<Vec<super::super::CompanyWhereInput>>;
+            const NAME: &'static str = "NOT";
+        }
+        impl ::cynic::schema::HasInputField<NOT, Option<Vec<super::super::CompanyWhereInput>>>
+            for super::super::CompanyWhereInput
+        {
+        }
+    }
+    pub mod Country {
+        pub struct id;
+        impl ::cynic::schema::Field for id {
+            type Type = super::super::ID;
+            const NAME: &'static str = "id";
+        }
+        impl ::cynic::schema::HasField<id> for super::super::Country {
+            type Type = super::super::ID;
+        }
+        pub struct name;
+        impl ::cynic::schema::Field for name {
+            type Type = super::super::String;
+            const NAME: &'static str = "name";
+        }
+        impl ::cynic::schema::HasField<name> for super::super::Country {
+            type Type = super::super::String;
+        }
+        pub struct slug;
+        impl ::cynic::schema::Field for slug {
+            type Type = super::super::String;
+            const NAME: &'static str = "slug";
+        }
+        impl ::cynic::schema::HasField<slug> for super::super::Country {
+            type Type = super::super::String;
+        }
+        pub struct r#type;
+        impl ::cynic::schema::Field for r#type {
+            type Type = super::super::String;
+            const NAME: &'static str = "type";
+        }
+        impl ::cynic::schema::HasField<r#type> for super::super::Country {
+            type Type = super::super::String;
+        }
+        pub struct isoCode;
+        impl ::cynic::schema::Field for isoCode {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "isoCode";
+        }
+        impl ::cynic::schema::HasField<isoCode> for super::super::Country {
+            type Type = Option<super::super::String>;
+        }
+        pub struct cities;
+        impl ::cynic::schema::Field for cities {
+            type Type = Option<Vec<super::super::City>>;
+            const NAME: &'static str = "cities";
+        }
+        impl ::cynic::schema::HasField<cities> for super::super::Country {
+            type Type = Option<Vec<super::super::City>>;
+        }
+        pub mod cities_arguments {
+            pub struct r#where;
+            impl ::cynic::schema::HasArgument<r#where> for super::cities {
+                type ArgumentType = Option<super::super::super::CityWhereInput>;
+                const NAME: &'static str = "where";
+            }
+            pub struct orderBy;
+            impl ::cynic::schema::HasArgument<orderBy> for super::cities {
+                type ArgumentType = Option<super::super::super::CityOrderByInput>;
+                const NAME: &'static str = "orderBy";
+            }
+            pub struct skip;
+            impl ::cynic::schema::HasArgument<skip> for super::cities {
+                type ArgumentType = Option<super::super::super::Int>;
+                const NAME: &'static str = "skip";
+            }
+            pub struct after;
+            impl ::cynic::schema::HasArgument<after> for super::cities {
+                type ArgumentType = Option<super::super::super::String>;
+                const NAME: &'static str = "after";
+            }
+            pub struct before;
+            impl ::cynic::schema::HasArgument<before> for super::cities {
+                type ArgumentType = Option<super::super::super::String>;
+                const NAME: &'static str = "before";
+            }
+            pub struct first;
+            impl ::cynic::schema::HasArgument<first> for super::cities {
+                type ArgumentType = Option<super::super::super::Int>;
+                const NAME: &'static str = "first";
+            }
+            pub struct last;
+            impl ::cynic::schema::HasArgument<last> for super::cities {
+                type ArgumentType = Option<super::super::super::Int>;
+                const NAME: &'static str = "last";
+            }
+        }
+        pub struct jobs;
+        impl ::cynic::schema::Field for jobs {
+            type Type = Option<Vec<super::super::Job>>;
+            const NAME: &'static str = "jobs";
+        }
+        impl ::cynic::schema::HasField<jobs> for super::super::Country {
+            type Type = Option<Vec<super::super::Job>>;
+        }
+        pub mod jobs_arguments {
+            pub struct r#where;
+            impl ::cynic::schema::HasArgument<r#where> for super::jobs {
+                type ArgumentType = Option<super::super::super::JobWhereInput>;
+                const NAME: &'static str = "where";
+            }
+            pub struct orderBy;
+            impl ::cynic::schema::HasArgument<orderBy> for super::jobs {
+                type ArgumentType = Option<super::super::super::JobOrderByInput>;
+                const NAME: &'static str = "orderBy";
+            }
+            pub struct skip;
+            impl ::cynic::schema::HasArgument<skip> for super::jobs {
+                type ArgumentType = Option<super::super::super::Int>;
+                const NAME: &'static str = "skip";
+            }
+            pub struct after;
+            impl ::cynic::schema::HasArgument<after> for super::jobs {
+                type ArgumentType = Option<super::super::super::String>;
+                const NAME: &'static str = "after";
+            }
+            pub struct before;
+            impl ::cynic::schema::HasArgument<before> for super::jobs {
+                type ArgumentType = Option<super::super::super::String>;
+                const NAME: &'static str = "before";
+            }
+            pub struct first;
+            impl ::cynic::schema::HasArgument<first> for super::jobs {
+                type ArgumentType = Option<super::super::super::Int>;
+                const NAME: &'static str = "first";
+            }
+            pub struct last;
+            impl ::cynic::schema::HasArgument<last> for super::jobs {
+                type ArgumentType = Option<super::super::super::Int>;
+                const NAME: &'static str = "last";
+            }
+        }
+        pub struct createdAt;
+        impl ::cynic::schema::Field for createdAt {
+            type Type = super::super::DateTime;
+            const NAME: &'static str = "createdAt";
+        }
+        impl ::cynic::schema::HasField<createdAt> for super::super::Country {
+            type Type = super::super::DateTime;
+        }
+        pub struct updatedAt;
+        impl ::cynic::schema::Field for updatedAt {
+            type Type = super::super::DateTime;
+            const NAME: &'static str = "updatedAt";
+        }
+        impl ::cynic::schema::HasField<updatedAt> for super::super::Country {
+            type Type = super::super::DateTime;
+        }
+    }
+    pub mod CountryWhereInput {
+        pub struct id;
+        impl ::cynic::schema::Field for id {
+            type Type = Option<super::super::ID>;
+            const NAME: &'static str = "id";
+        }
+        impl ::cynic::schema::HasInputField<id, Option<super::super::ID>>
+            for super::super::CountryWhereInput
+        {
+        }
+        pub struct id_not;
+        impl ::cynic::schema::Field for id_not {
+            type Type = Option<super::super::ID>;
+            const NAME: &'static str = "id_not";
+        }
+        impl ::cynic::schema::HasInputField<id_not, Option<super::super::ID>>
+            for super::super::CountryWhereInput
+        {
+        }
+        pub struct id_in;
+        impl ::cynic::schema::Field for id_in {
+            type Type = Option<Vec<super::super::ID>>;
+            const NAME: &'static str = "id_in";
+        }
+        impl ::cynic::schema::HasInputField<id_in, Option<Vec<super::super::ID>>>
+            for super::super::CountryWhereInput
+        {
+        }
+        pub struct id_not_in;
+        impl ::cynic::schema::Field for id_not_in {
+            type Type = Option<Vec<super::super::ID>>;
+            const NAME: &'static str = "id_not_in";
+        }
+        impl ::cynic::schema::HasInputField<id_not_in, Option<Vec<super::super::ID>>>
+            for super::super::CountryWhereInput
+        {
+        }
+        pub struct id_lt;
+        impl ::cynic::schema::Field for id_lt {
+            type Type = Option<super::super::ID>;
+            const NAME: &'static str = "id_lt";
+        }
+        impl ::cynic::schema::HasInputField<id_lt, Option<super::super::ID>>
+            for super::super::CountryWhereInput
+        {
+        }
+        pub struct id_lte;
+        impl ::cynic::schema::Field for id_lte {
+            type Type = Option<super::super::ID>;
+            const NAME: &'static str = "id_lte";
+        }
+        impl ::cynic::schema::HasInputField<id_lte, Option<super::super::ID>>
+            for super::super::CountryWhereInput
+        {
+        }
+        pub struct id_gt;
+        impl ::cynic::schema::Field for id_gt {
+            type Type = Option<super::super::ID>;
+            const NAME: &'static str = "id_gt";
+        }
+        impl ::cynic::schema::HasInputField<id_gt, Option<super::super::ID>>
+            for super::super::CountryWhereInput
+        {
+        }
+        pub struct id_gte;
+        impl ::cynic::schema::Field for id_gte {
+            type Type = Option<super::super::ID>;
+            const NAME: &'static str = "id_gte";
+        }
+        impl ::cynic::schema::HasInputField<id_gte, Option<super::super::ID>>
+            for super::super::CountryWhereInput
+        {
+        }
+        pub struct id_contains;
+        impl ::cynic::schema::Field for id_contains {
+            type Type = Option<super::super::ID>;
+            const NAME: &'static str = "id_contains";
+        }
+        impl ::cynic::schema::HasInputField<id_contains, Option<super::super::ID>>
+            for super::super::CountryWhereInput
+        {
+        }
+        pub struct id_not_contains;
+        impl ::cynic::schema::Field for id_not_contains {
+            type Type = Option<super::super::ID>;
+            const NAME: &'static str = "id_not_contains";
+        }
+        impl ::cynic::schema::HasInputField<id_not_contains, Option<super::super::ID>>
+            for super::super::CountryWhereInput
+        {
+        }
+        pub struct id_starts_with;
+        impl ::cynic::schema::Field for id_starts_with {
+            type Type = Option<super::super::ID>;
+            const NAME: &'static str = "id_starts_with";
+        }
+        impl ::cynic::schema::HasInputField<id_starts_with, Option<super::super::ID>>
+            for super::super::CountryWhereInput
+        {
+        }
+        pub struct id_not_starts_with;
+        impl ::cynic::schema::Field for id_not_starts_with {
+            type Type = Option<super::super::ID>;
+            const NAME: &'static str = "id_not_starts_with";
+        }
+        impl ::cynic::schema::HasInputField<id_not_starts_with, Option<super::super::ID>>
+            for super::super::CountryWhereInput
+        {
+        }
+        pub struct id_ends_with;
+        impl ::cynic::schema::Field for id_ends_with {
+            type Type = Option<super::super::ID>;
+            const NAME: &'static str = "id_ends_with";
+        }
+        impl ::cynic::schema::HasInputField<id_ends_with, Option<super::super::ID>>
+            for super::super::CountryWhereInput
+        {
+        }
+        pub struct id_not_ends_with;
+        impl ::cynic::schema::Field for id_not_ends_with {
+            type Type = Option<super::super::ID>;
+            const NAME: &'static str = "id_not_ends_with";
+        }
+        impl ::cynic::schema::HasInputField<id_not_ends_with, Option<super::super::ID>>
+            for super::super::CountryWhereInput
+        {
+        }
+        pub struct name;
+        impl ::cynic::schema::Field for name {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "name";
+        }
+        impl ::cynic::schema::HasInputField<name, Option<super::super::String>>
+            for super::super::CountryWhereInput
+        {
+        }
+        pub struct name_not;
+        impl ::cynic::schema::Field for name_not {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "name_not";
+        }
+        impl ::cynic::schema::HasInputField<name_not, Option<super::super::String>>
+            for super::super::CountryWhereInput
+        {
+        }
+        pub struct name_in;
+        impl ::cynic::schema::Field for name_in {
+            type Type = Option<Vec<super::super::String>>;
+            const NAME: &'static str = "name_in";
+        }
+        impl ::cynic::schema::HasInputField<name_in, Option<Vec<super::super::String>>>
+            for super::super::CountryWhereInput
+        {
+        }
+        pub struct name_not_in;
+        impl ::cynic::schema::Field for name_not_in {
+            type Type = Option<Vec<super::super::String>>;
+            const NAME: &'static str = "name_not_in";
+        }
+        impl ::cynic::schema::HasInputField<name_not_in, Option<Vec<super::super::String>>>
+            for super::super::CountryWhereInput
+        {
+        }
+        pub struct name_lt;
+        impl ::cynic::schema::Field for name_lt {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "name_lt";
+        }
+        impl ::cynic::schema::HasInputField<name_lt, Option<super::super::String>>
+            for super::super::CountryWhereInput
+        {
+        }
+        pub struct name_lte;
+        impl ::cynic::schema::Field for name_lte {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "name_lte";
+        }
+        impl ::cynic::schema::HasInputField<name_lte, Option<super::super::String>>
+            for super::super::CountryWhereInput
+        {
+        }
+        pub struct name_gt;
+        impl ::cynic::schema::Field for name_gt {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "name_gt";
+        }
+        impl ::cynic::schema::HasInputField<name_gt, Option<super::super::String>>
+            for super::super::CountryWhereInput
+        {
+        }
+        pub struct name_gte;
+        impl ::cynic::schema::Field for name_gte {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "name_gte";
+        }
+        impl ::cynic::schema::HasInputField<name_gte, Option<super::super::String>>
+            for super::super::CountryWhereInput
+        {
+        }
+        pub struct name_contains;
+        impl ::cynic::schema::Field for name_contains {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "name_contains";
+        }
+        impl ::cynic::schema::HasInputField<name_contains, Option<super::super::String>>
+            for super::super::CountryWhereInput
+        {
+        }
+        pub struct name_not_contains;
+        impl ::cynic::schema::Field for name_not_contains {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "name_not_contains";
+        }
+        impl ::cynic::schema::HasInputField<name_not_contains, Option<super::super::String>>
+            for super::super::CountryWhereInput
+        {
+        }
+        pub struct name_starts_with;
+        impl ::cynic::schema::Field for name_starts_with {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "name_starts_with";
+        }
+        impl ::cynic::schema::HasInputField<name_starts_with, Option<super::super::String>>
+            for super::super::CountryWhereInput
+        {
+        }
+        pub struct name_not_starts_with;
+        impl ::cynic::schema::Field for name_not_starts_with {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "name_not_starts_with";
+        }
+        impl ::cynic::schema::HasInputField<name_not_starts_with, Option<super::super::String>>
+            for super::super::CountryWhereInput
+        {
+        }
+        pub struct name_ends_with;
+        impl ::cynic::schema::Field for name_ends_with {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "name_ends_with";
+        }
+        impl ::cynic::schema::HasInputField<name_ends_with, Option<super::super::String>>
+            for super::super::CountryWhereInput
+        {
+        }
+        pub struct name_not_ends_with;
+        impl ::cynic::schema::Field for name_not_ends_with {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "name_not_ends_with";
+        }
+        impl ::cynic::schema::HasInputField<name_not_ends_with, Option<super::super::String>>
+            for super::super::CountryWhereInput
+        {
+        }
+        pub struct slug;
+        impl ::cynic::schema::Field for slug {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "slug";
+        }
+        impl ::cynic::schema::HasInputField<slug, Option<super::super::String>>
+            for super::super::CountryWhereInput
+        {
+        }
+        pub struct slug_not;
+        impl ::cynic::schema::Field for slug_not {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "slug_not";
+        }
+        impl ::cynic::schema::HasInputField<slug_not, Option<super::super::String>>
+            for super::super::CountryWhereInput
+        {
+        }
+        pub struct slug_in;
+        impl ::cynic::schema::Field for slug_in {
+            type Type = Option<Vec<super::super::String>>;
+            const NAME: &'static str = "slug_in";
+        }
+        impl ::cynic::schema::HasInputField<slug_in, Option<Vec<super::super::String>>>
+            for super::super::CountryWhereInput
+        {
+        }
+        pub struct slug_not_in;
+        impl ::cynic::schema::Field for slug_not_in {
+            type Type = Option<Vec<super::super::String>>;
+            const NAME: &'static str = "slug_not_in";
+        }
+        impl ::cynic::schema::HasInputField<slug_not_in, Option<Vec<super::super::String>>>
+            for super::super::CountryWhereInput
+        {
+        }
+        pub struct slug_lt;
+        impl ::cynic::schema::Field for slug_lt {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "slug_lt";
+        }
+        impl ::cynic::schema::HasInputField<slug_lt, Option<super::super::String>>
+            for super::super::CountryWhereInput
+        {
+        }
+        pub struct slug_lte;
+        impl ::cynic::schema::Field for slug_lte {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "slug_lte";
+        }
+        impl ::cynic::schema::HasInputField<slug_lte, Option<super::super::String>>
+            for super::super::CountryWhereInput
+        {
+        }
+        pub struct slug_gt;
+        impl ::cynic::schema::Field for slug_gt {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "slug_gt";
+        }
+        impl ::cynic::schema::HasInputField<slug_gt, Option<super::super::String>>
+            for super::super::CountryWhereInput
+        {
+        }
+        pub struct slug_gte;
+        impl ::cynic::schema::Field for slug_gte {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "slug_gte";
+        }
+        impl ::cynic::schema::HasInputField<slug_gte, Option<super::super::String>>
+            for super::super::CountryWhereInput
+        {
+        }
+        pub struct slug_contains;
+        impl ::cynic::schema::Field for slug_contains {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "slug_contains";
+        }
+        impl ::cynic::schema::HasInputField<slug_contains, Option<super::super::String>>
+            for super::super::CountryWhereInput
+        {
+        }
+        pub struct slug_not_contains;
+        impl ::cynic::schema::Field for slug_not_contains {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "slug_not_contains";
+        }
+        impl ::cynic::schema::HasInputField<slug_not_contains, Option<super::super::String>>
+            for super::super::CountryWhereInput
+        {
+        }
+        pub struct slug_starts_with;
+        impl ::cynic::schema::Field for slug_starts_with {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "slug_starts_with";
+        }
+        impl ::cynic::schema::HasInputField<slug_starts_with, Option<super::super::String>>
+            for super::super::CountryWhereInput
+        {
+        }
+        pub struct slug_not_starts_with;
+        impl ::cynic::schema::Field for slug_not_starts_with {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "slug_not_starts_with";
+        }
+        impl ::cynic::schema::HasInputField<slug_not_starts_with, Option<super::super::String>>
+            for super::super::CountryWhereInput
+        {
+        }
+        pub struct slug_ends_with;
+        impl ::cynic::schema::Field for slug_ends_with {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "slug_ends_with";
+        }
+        impl ::cynic::schema::HasInputField<slug_ends_with, Option<super::super::String>>
+            for super::super::CountryWhereInput
+        {
+        }
+        pub struct slug_not_ends_with;
+        impl ::cynic::schema::Field for slug_not_ends_with {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "slug_not_ends_with";
+        }
+        impl ::cynic::schema::HasInputField<slug_not_ends_with, Option<super::super::String>>
+            for super::super::CountryWhereInput
+        {
+        }
+        pub struct r#type;
+        impl ::cynic::schema::Field for r#type {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "type";
+        }
+        impl ::cynic::schema::HasInputField<r#type, Option<super::super::String>>
+            for super::super::CountryWhereInput
+        {
+        }
+        pub struct type_not;
+        impl ::cynic::schema::Field for type_not {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "type_not";
+        }
+        impl ::cynic::schema::HasInputField<type_not, Option<super::super::String>>
+            for super::super::CountryWhereInput
+        {
+        }
+        pub struct type_in;
+        impl ::cynic::schema::Field for type_in {
+            type Type = Option<Vec<super::super::String>>;
+            const NAME: &'static str = "type_in";
+        }
+        impl ::cynic::schema::HasInputField<type_in, Option<Vec<super::super::String>>>
+            for super::super::CountryWhereInput
+        {
+        }
+        pub struct type_not_in;
+        impl ::cynic::schema::Field for type_not_in {
+            type Type = Option<Vec<super::super::String>>;
+            const NAME: &'static str = "type_not_in";
+        }
+        impl ::cynic::schema::HasInputField<type_not_in, Option<Vec<super::super::String>>>
+            for super::super::CountryWhereInput
+        {
+        }
+        pub struct type_lt;
+        impl ::cynic::schema::Field for type_lt {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "type_lt";
+        }
+        impl ::cynic::schema::HasInputField<type_lt, Option<super::super::String>>
+            for super::super::CountryWhereInput
+        {
+        }
+        pub struct type_lte;
+        impl ::cynic::schema::Field for type_lte {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "type_lte";
+        }
+        impl ::cynic::schema::HasInputField<type_lte, Option<super::super::String>>
+            for super::super::CountryWhereInput
+        {
+        }
+        pub struct type_gt;
+        impl ::cynic::schema::Field for type_gt {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "type_gt";
+        }
+        impl ::cynic::schema::HasInputField<type_gt, Option<super::super::String>>
+            for super::super::CountryWhereInput
+        {
+        }
+        pub struct type_gte;
+        impl ::cynic::schema::Field for type_gte {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "type_gte";
+        }
+        impl ::cynic::schema::HasInputField<type_gte, Option<super::super::String>>
+            for super::super::CountryWhereInput
+        {
+        }
+        pub struct type_contains;
+        impl ::cynic::schema::Field for type_contains {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "type_contains";
+        }
+        impl ::cynic::schema::HasInputField<type_contains, Option<super::super::String>>
+            for super::super::CountryWhereInput
+        {
+        }
+        pub struct type_not_contains;
+        impl ::cynic::schema::Field for type_not_contains {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "type_not_contains";
+        }
+        impl ::cynic::schema::HasInputField<type_not_contains, Option<super::super::String>>
+            for super::super::CountryWhereInput
+        {
+        }
+        pub struct type_starts_with;
+        impl ::cynic::schema::Field for type_starts_with {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "type_starts_with";
+        }
+        impl ::cynic::schema::HasInputField<type_starts_with, Option<super::super::String>>
+            for super::super::CountryWhereInput
+        {
+        }
+        pub struct type_not_starts_with;
+        impl ::cynic::schema::Field for type_not_starts_with {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "type_not_starts_with";
+        }
+        impl ::cynic::schema::HasInputField<type_not_starts_with, Option<super::super::String>>
+            for super::super::CountryWhereInput
+        {
+        }
+        pub struct type_ends_with;
+        impl ::cynic::schema::Field for type_ends_with {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "type_ends_with";
+        }
+        impl ::cynic::schema::HasInputField<type_ends_with, Option<super::super::String>>
+            for super::super::CountryWhereInput
+        {
+        }
+        pub struct type_not_ends_with;
+        impl ::cynic::schema::Field for type_not_ends_with {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "type_not_ends_with";
+        }
+        impl ::cynic::schema::HasInputField<type_not_ends_with, Option<super::super::String>>
+            for super::super::CountryWhereInput
+        {
+        }
+        pub struct isoCode;
+        impl ::cynic::schema::Field for isoCode {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "isoCode";
+        }
+        impl ::cynic::schema::HasInputField<isoCode, Option<super::super::String>>
+            for super::super::CountryWhereInput
+        {
+        }
+        pub struct isoCode_not;
+        impl ::cynic::schema::Field for isoCode_not {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "isoCode_not";
+        }
+        impl ::cynic::schema::HasInputField<isoCode_not, Option<super::super::String>>
+            for super::super::CountryWhereInput
+        {
+        }
+        pub struct isoCode_in;
+        impl ::cynic::schema::Field for isoCode_in {
+            type Type = Option<Vec<super::super::String>>;
+            const NAME: &'static str = "isoCode_in";
+        }
+        impl ::cynic::schema::HasInputField<isoCode_in, Option<Vec<super::super::String>>>
+            for super::super::CountryWhereInput
+        {
+        }
+        pub struct isoCode_not_in;
+        impl ::cynic::schema::Field for isoCode_not_in {
+            type Type = Option<Vec<super::super::String>>;
+            const NAME: &'static str = "isoCode_not_in";
+        }
+        impl ::cynic::schema::HasInputField<isoCode_not_in, Option<Vec<super::super::String>>>
+            for super::super::CountryWhereInput
+        {
+        }
+        pub struct isoCode_lt;
+        impl ::cynic::schema::Field for isoCode_lt {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "isoCode_lt";
+        }
+        impl ::cynic::schema::HasInputField<isoCode_lt, Option<super::super::String>>
+            for super::super::CountryWhereInput
+        {
+        }
+        pub struct isoCode_lte;
+        impl ::cynic::schema::Field for isoCode_lte {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "isoCode_lte";
+        }
+        impl ::cynic::schema::HasInputField<isoCode_lte, Option<super::super::String>>
+            for super::super::CountryWhereInput
+        {
+        }
+        pub struct isoCode_gt;
+        impl ::cynic::schema::Field for isoCode_gt {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "isoCode_gt";
+        }
+        impl ::cynic::schema::HasInputField<isoCode_gt, Option<super::super::String>>
+            for super::super::CountryWhereInput
+        {
+        }
+        pub struct isoCode_gte;
+        impl ::cynic::schema::Field for isoCode_gte {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "isoCode_gte";
+        }
+        impl ::cynic::schema::HasInputField<isoCode_gte, Option<super::super::String>>
+            for super::super::CountryWhereInput
+        {
+        }
+        pub struct isoCode_contains;
+        impl ::cynic::schema::Field for isoCode_contains {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "isoCode_contains";
+        }
+        impl ::cynic::schema::HasInputField<isoCode_contains, Option<super::super::String>>
+            for super::super::CountryWhereInput
+        {
+        }
+        pub struct isoCode_not_contains;
+        impl ::cynic::schema::Field for isoCode_not_contains {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "isoCode_not_contains";
+        }
+        impl ::cynic::schema::HasInputField<isoCode_not_contains, Option<super::super::String>>
+            for super::super::CountryWhereInput
+        {
+        }
+        pub struct isoCode_starts_with;
+        impl ::cynic::schema::Field for isoCode_starts_with {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "isoCode_starts_with";
+        }
+        impl ::cynic::schema::HasInputField<isoCode_starts_with, Option<super::super::String>>
+            for super::super::CountryWhereInput
+        {
+        }
+        pub struct isoCode_not_starts_with;
+        impl ::cynic::schema::Field for isoCode_not_starts_with {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "isoCode_not_starts_with";
+        }
+        impl ::cynic::schema::HasInputField<isoCode_not_starts_with, Option<super::super::String>>
+            for super::super::CountryWhereInput
+        {
+        }
+        pub struct isoCode_ends_with;
+        impl ::cynic::schema::Field for isoCode_ends_with {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "isoCode_ends_with";
+        }
+        impl ::cynic::schema::HasInputField<isoCode_ends_with, Option<super::super::String>>
+            for super::super::CountryWhereInput
+        {
+        }
+        pub struct isoCode_not_ends_with;
+        impl ::cynic::schema::Field for isoCode_not_ends_with {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "isoCode_not_ends_with";
+        }
+        impl ::cynic::schema::HasInputField<isoCode_not_ends_with, Option<super::super::String>>
+            for super::super::CountryWhereInput
+        {
+        }
+        pub struct cities_every;
+        impl ::cynic::schema::Field for cities_every {
+            type Type = Option<super::super::CityWhereInput>;
+            const NAME: &'static str = "cities_every";
+        }
+        impl ::cynic::schema::HasInputField<cities_every, Option<super::super::CityWhereInput>>
+            for super::super::CountryWhereInput
+        {
+        }
+        pub struct cities_some;
+        impl ::cynic::schema::Field for cities_some {
+            type Type = Option<super::super::CityWhereInput>;
+            const NAME: &'static str = "cities_some";
+        }
+        impl ::cynic::schema::HasInputField<cities_some, Option<super::super::CityWhereInput>>
+            for super::super::CountryWhereInput
+        {
+        }
+        pub struct cities_none;
+        impl ::cynic::schema::Field for cities_none {
+            type Type = Option<super::super::CityWhereInput>;
+            const NAME: &'static str = "cities_none";
+        }
+        impl ::cynic::schema::HasInputField<cities_none, Option<super::super::CityWhereInput>>
+            for super::super::CountryWhereInput
+        {
+        }
+        pub struct jobs_every;
+        impl ::cynic::schema::Field for jobs_every {
+            type Type = Option<super::super::JobWhereInput>;
+            const NAME: &'static str = "jobs_every";
+        }
+        impl ::cynic::schema::HasInputField<jobs_every, Option<super::super::JobWhereInput>>
+            for super::super::CountryWhereInput
+        {
+        }
+        pub struct jobs_some;
+        impl ::cynic::schema::Field for jobs_some {
+            type Type = Option<super::super::JobWhereInput>;
+            const NAME: &'static str = "jobs_some";
+        }
+        impl ::cynic::schema::HasInputField<jobs_some, Option<super::super::JobWhereInput>>
+            for super::super::CountryWhereInput
+        {
+        }
+        pub struct jobs_none;
+        impl ::cynic::schema::Field for jobs_none {
+            type Type = Option<super::super::JobWhereInput>;
+            const NAME: &'static str = "jobs_none";
+        }
+        impl ::cynic::schema::HasInputField<jobs_none, Option<super::super::JobWhereInput>>
+            for super::super::CountryWhereInput
+        {
+        }
+        pub struct createdAt;
+        impl ::cynic::schema::Field for createdAt {
+            type Type = Option<super::super::DateTime>;
+            const NAME: &'static str = "createdAt";
+        }
+        impl ::cynic::schema::HasInputField<createdAt, Option<super::super::DateTime>>
+            for super::super::CountryWhereInput
+        {
+        }
+        pub struct createdAt_not;
+        impl ::cynic::schema::Field for createdAt_not {
+            type Type = Option<super::super::DateTime>;
+            const NAME: &'static str = "createdAt_not";
+        }
+        impl ::cynic::schema::HasInputField<createdAt_not, Option<super::super::DateTime>>
+            for super::super::CountryWhereInput
+        {
+        }
+        pub struct createdAt_in;
+        impl ::cynic::schema::Field for createdAt_in {
+            type Type = Option<Vec<super::super::DateTime>>;
+            const NAME: &'static str = "createdAt_in";
+        }
+        impl ::cynic::schema::HasInputField<createdAt_in, Option<Vec<super::super::DateTime>>>
+            for super::super::CountryWhereInput
+        {
+        }
+        pub struct createdAt_not_in;
+        impl ::cynic::schema::Field for createdAt_not_in {
+            type Type = Option<Vec<super::super::DateTime>>;
+            const NAME: &'static str = "createdAt_not_in";
+        }
+        impl ::cynic::schema::HasInputField<createdAt_not_in, Option<Vec<super::super::DateTime>>>
+            for super::super::CountryWhereInput
+        {
+        }
+        pub struct createdAt_lt;
+        impl ::cynic::schema::Field for createdAt_lt {
+            type Type = Option<super::super::DateTime>;
+            const NAME: &'static str = "createdAt_lt";
+        }
+        impl ::cynic::schema::HasInputField<createdAt_lt, Option<super::super::DateTime>>
+            for super::super::CountryWhereInput
+        {
+        }
+        pub struct createdAt_lte;
+        impl ::cynic::schema::Field for createdAt_lte {
+            type Type = Option<super::super::DateTime>;
+            const NAME: &'static str = "createdAt_lte";
+        }
+        impl ::cynic::schema::HasInputField<createdAt_lte, Option<super::super::DateTime>>
+            for super::super::CountryWhereInput
+        {
+        }
+        pub struct createdAt_gt;
+        impl ::cynic::schema::Field for createdAt_gt {
+            type Type = Option<super::super::DateTime>;
+            const NAME: &'static str = "createdAt_gt";
+        }
+        impl ::cynic::schema::HasInputField<createdAt_gt, Option<super::super::DateTime>>
+            for super::super::CountryWhereInput
+        {
+        }
+        pub struct createdAt_gte;
+        impl ::cynic::schema::Field for createdAt_gte {
+            type Type = Option<super::super::DateTime>;
+            const NAME: &'static str = "createdAt_gte";
+        }
+        impl ::cynic::schema::HasInputField<createdAt_gte, Option<super::super::DateTime>>
+            for super::super::CountryWhereInput
+        {
+        }
+        pub struct updatedAt;
+        impl ::cynic::schema::Field for updatedAt {
+            type Type = Option<super::super::DateTime>;
+            const NAME: &'static str = "updatedAt";
+        }
+        impl ::cynic::schema::HasInputField<updatedAt, Option<super::super::DateTime>>
+            for super::super::CountryWhereInput
+        {
+        }
+        pub struct updatedAt_not;
+        impl ::cynic::schema::Field for updatedAt_not {
+            type Type = Option<super::super::DateTime>;
+            const NAME: &'static str = "updatedAt_not";
+        }
+        impl ::cynic::schema::HasInputField<updatedAt_not, Option<super::super::DateTime>>
+            for super::super::CountryWhereInput
+        {
+        }
+        pub struct updatedAt_in;
+        impl ::cynic::schema::Field for updatedAt_in {
+            type Type = Option<Vec<super::super::DateTime>>;
+            const NAME: &'static str = "updatedAt_in";
+        }
+        impl ::cynic::schema::HasInputField<updatedAt_in, Option<Vec<super::super::DateTime>>>
+            for super::super::CountryWhereInput
+        {
+        }
+        pub struct updatedAt_not_in;
+        impl ::cynic::schema::Field for updatedAt_not_in {
+            type Type = Option<Vec<super::super::DateTime>>;
+            const NAME: &'static str = "updatedAt_not_in";
+        }
+        impl ::cynic::schema::HasInputField<updatedAt_not_in, Option<Vec<super::super::DateTime>>>
+            for super::super::CountryWhereInput
+        {
+        }
+        pub struct updatedAt_lt;
+        impl ::cynic::schema::Field for updatedAt_lt {
+            type Type = Option<super::super::DateTime>;
+            const NAME: &'static str = "updatedAt_lt";
+        }
+        impl ::cynic::schema::HasInputField<updatedAt_lt, Option<super::super::DateTime>>
+            for super::super::CountryWhereInput
+        {
+        }
+        pub struct updatedAt_lte;
+        impl ::cynic::schema::Field for updatedAt_lte {
+            type Type = Option<super::super::DateTime>;
+            const NAME: &'static str = "updatedAt_lte";
+        }
+        impl ::cynic::schema::HasInputField<updatedAt_lte, Option<super::super::DateTime>>
+            for super::super::CountryWhereInput
+        {
+        }
+        pub struct updatedAt_gt;
+        impl ::cynic::schema::Field for updatedAt_gt {
+            type Type = Option<super::super::DateTime>;
+            const NAME: &'static str = "updatedAt_gt";
+        }
+        impl ::cynic::schema::HasInputField<updatedAt_gt, Option<super::super::DateTime>>
+            for super::super::CountryWhereInput
+        {
+        }
+        pub struct updatedAt_gte;
+        impl ::cynic::schema::Field for updatedAt_gte {
+            type Type = Option<super::super::DateTime>;
+            const NAME: &'static str = "updatedAt_gte";
+        }
+        impl ::cynic::schema::HasInputField<updatedAt_gte, Option<super::super::DateTime>>
+            for super::super::CountryWhereInput
+        {
+        }
+        pub struct AND;
+        impl ::cynic::schema::Field for AND {
+            type Type = Option<Vec<super::super::CountryWhereInput>>;
+            const NAME: &'static str = "AND";
+        }
+        impl ::cynic::schema::HasInputField<AND, Option<Vec<super::super::CountryWhereInput>>>
+            for super::super::CountryWhereInput
+        {
+        }
+        pub struct OR;
+        impl ::cynic::schema::Field for OR {
+            type Type = Option<Vec<super::super::CountryWhereInput>>;
+            const NAME: &'static str = "OR";
+        }
+        impl ::cynic::schema::HasInputField<OR, Option<Vec<super::super::CountryWhereInput>>>
+            for super::super::CountryWhereInput
+        {
+        }
+        pub struct NOT;
+        impl ::cynic::schema::Field for NOT {
+            type Type = Option<Vec<super::super::CountryWhereInput>>;
+            const NAME: &'static str = "NOT";
+        }
+        impl ::cynic::schema::HasInputField<NOT, Option<Vec<super::super::CountryWhereInput>>>
+            for super::super::CountryWhereInput
+        {
+        }
+    }
+    pub mod Job {
+        pub struct id;
+        impl ::cynic::schema::Field for id {
+            type Type = super::super::ID;
+            const NAME: &'static str = "id";
+        }
+        impl ::cynic::schema::HasField<id> for super::super::Job {
+            type Type = super::super::ID;
+        }
+        pub struct title;
+        impl ::cynic::schema::Field for title {
+            type Type = super::super::String;
+            const NAME: &'static str = "title";
+        }
+        impl ::cynic::schema::HasField<title> for super::super::Job {
+            type Type = super::super::String;
+        }
+        pub struct slug;
+        impl ::cynic::schema::Field for slug {
+            type Type = super::super::String;
+            const NAME: &'static str = "slug";
+        }
+        impl ::cynic::schema::HasField<slug> for super::super::Job {
+            type Type = super::super::String;
+        }
+        pub struct commitment;
+        impl ::cynic::schema::Field for commitment {
+            type Type = super::super::Commitment;
+            const NAME: &'static str = "commitment";
+        }
+        impl ::cynic::schema::HasField<commitment> for super::super::Job {
+            type Type = super::super::Commitment;
+        }
+        pub struct cities;
+        impl ::cynic::schema::Field for cities {
+            type Type = Option<Vec<super::super::City>>;
+            const NAME: &'static str = "cities";
+        }
+        impl ::cynic::schema::HasField<cities> for super::super::Job {
+            type Type = Option<Vec<super::super::City>>;
+        }
+        pub mod cities_arguments {
+            pub struct r#where;
+            impl ::cynic::schema::HasArgument<r#where> for super::cities {
+                type ArgumentType = Option<super::super::super::CityWhereInput>;
+                const NAME: &'static str = "where";
+            }
+            pub struct orderBy;
+            impl ::cynic::schema::HasArgument<orderBy> for super::cities {
+                type ArgumentType = Option<super::super::super::CityOrderByInput>;
+                const NAME: &'static str = "orderBy";
+            }
+            pub struct skip;
+            impl ::cynic::schema::HasArgument<skip> for super::cities {
+                type ArgumentType = Option<super::super::super::Int>;
+                const NAME: &'static str = "skip";
+            }
+            pub struct after;
+            impl ::cynic::schema::HasArgument<after> for super::cities {
+                type ArgumentType = Option<super::super::super::String>;
+                const NAME: &'static str = "after";
+            }
+            pub struct before;
+            impl ::cynic::schema::HasArgument<before> for super::cities {
+                type ArgumentType = Option<super::super::super::String>;
+                const NAME: &'static str = "before";
+            }
+            pub struct first;
+            impl ::cynic::schema::HasArgument<first> for super::cities {
+                type ArgumentType = Option<super::super::super::Int>;
+                const NAME: &'static str = "first";
+            }
+            pub struct last;
+            impl ::cynic::schema::HasArgument<last> for super::cities {
+                type ArgumentType = Option<super::super::super::Int>;
+                const NAME: &'static str = "last";
+            }
+        }
+        pub struct countries;
+        impl ::cynic::schema::Field for countries {
+            type Type = Option<Vec<super::super::Country>>;
+            const NAME: &'static str = "countries";
+        }
+        impl ::cynic::schema::HasField<countries> for super::super::Job {
+            type Type = Option<Vec<super::super::Country>>;
+        }
+        pub mod countries_arguments {
+            pub struct r#where;
+            impl ::cynic::schema::HasArgument<r#where> for super::countries {
+                type ArgumentType = Option<super::super::super::CountryWhereInput>;
+                const NAME: &'static str = "where";
+            }
+            pub struct orderBy;
+            impl ::cynic::schema::HasArgument<orderBy> for super::countries {
+                type ArgumentType = Option<super::super::super::CountryOrderByInput>;
+                const NAME: &'static str = "orderBy";
+            }
+            pub struct skip;
+            impl ::cynic::schema::HasArgument<skip> for super::countries {
+                type ArgumentType = Option<super::super::super::Int>;
+                const NAME: &'static str = "skip";
+            }
+            pub struct after;
+            impl ::cynic::schema::HasArgument<after> for super::countries {
+                type ArgumentType = Option<super::super::super::String>;
+                const NAME: &'static str = "after";
+            }
+            pub struct before;
+            impl ::cynic::schema::HasArgument<before> for super::countries {
+                type ArgumentType = Option<super::super::super::String>;
+                const NAME: &'static str = "before";
+            }
+            pub struct first;
+            impl ::cynic::schema::HasArgument<first> for super::countries {
+                type ArgumentType = Option<super::super::super::Int>;
+                const NAME: &'static str = "first";
+            }
+            pub struct last;
+            impl ::cynic::schema::HasArgument<last> for super::countries {
+                type ArgumentType = Option<super::super::super::Int>;
+                const NAME: &'static str = "last";
+            }
+        }
+        pub struct remotes;
+        impl ::cynic::schema::Field for remotes {
+            type Type = Option<Vec<super::super::Remote>>;
+            const NAME: &'static str = "remotes";
+        }
+        impl ::cynic::schema::HasField<remotes> for super::super::Job {
+            type Type = Option<Vec<super::super::Remote>>;
+        }
+        pub mod remotes_arguments {
+            pub struct r#where;
+            impl ::cynic::schema::HasArgument<r#where> for super::remotes {
+                type ArgumentType = Option<super::super::super::RemoteWhereInput>;
+                const NAME: &'static str = "where";
+            }
+            pub struct orderBy;
+            impl ::cynic::schema::HasArgument<orderBy> for super::remotes {
+                type ArgumentType = Option<super::super::super::RemoteOrderByInput>;
+                const NAME: &'static str = "orderBy";
+            }
+            pub struct skip;
+            impl ::cynic::schema::HasArgument<skip> for super::remotes {
+                type ArgumentType = Option<super::super::super::Int>;
+                const NAME: &'static str = "skip";
+            }
+            pub struct after;
+            impl ::cynic::schema::HasArgument<after> for super::remotes {
+                type ArgumentType = Option<super::super::super::String>;
+                const NAME: &'static str = "after";
+            }
+            pub struct before;
+            impl ::cynic::schema::HasArgument<before> for super::remotes {
+                type ArgumentType = Option<super::super::super::String>;
+                const NAME: &'static str = "before";
+            }
+            pub struct first;
+            impl ::cynic::schema::HasArgument<first> for super::remotes {
+                type ArgumentType = Option<super::super::super::Int>;
+                const NAME: &'static str = "first";
+            }
+            pub struct last;
+            impl ::cynic::schema::HasArgument<last> for super::remotes {
+                type ArgumentType = Option<super::super::super::Int>;
+                const NAME: &'static str = "last";
+            }
+        }
+        pub struct description;
+        impl ::cynic::schema::Field for description {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "description";
+        }
+        impl ::cynic::schema::HasField<description> for super::super::Job {
+            type Type = Option<super::super::String>;
+        }
+        pub struct applyUrl;
+        impl ::cynic::schema::Field for applyUrl {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "applyUrl";
+        }
+        impl ::cynic::schema::HasField<applyUrl> for super::super::Job {
+            type Type = Option<super::super::String>;
+        }
+        pub struct company;
+        impl ::cynic::schema::Field for company {
+            type Type = Option<super::super::Company>;
+            const NAME: &'static str = "company";
+        }
+        impl ::cynic::schema::HasField<company> for super::super::Job {
+            type Type = Option<super::super::Company>;
+        }
+        pub struct tags;
+        impl ::cynic::schema::Field for tags {
+            type Type = Option<Vec<super::super::Tag>>;
+            const NAME: &'static str = "tags";
+        }
+        impl ::cynic::schema::HasField<tags> for super::super::Job {
+            type Type = Option<Vec<super::super::Tag>>;
+        }
+        pub mod tags_arguments {
+            pub struct r#where;
+            impl ::cynic::schema::HasArgument<r#where> for super::tags {
+                type ArgumentType = Option<super::super::super::TagWhereInput>;
+                const NAME: &'static str = "where";
+            }
+            pub struct orderBy;
+            impl ::cynic::schema::HasArgument<orderBy> for super::tags {
+                type ArgumentType = Option<super::super::super::TagOrderByInput>;
+                const NAME: &'static str = "orderBy";
+            }
+            pub struct skip;
+            impl ::cynic::schema::HasArgument<skip> for super::tags {
+                type ArgumentType = Option<super::super::super::Int>;
+                const NAME: &'static str = "skip";
+            }
+            pub struct after;
+            impl ::cynic::schema::HasArgument<after> for super::tags {
+                type ArgumentType = Option<super::super::super::String>;
+                const NAME: &'static str = "after";
+            }
+            pub struct before;
+            impl ::cynic::schema::HasArgument<before> for super::tags {
+                type ArgumentType = Option<super::super::super::String>;
+                const NAME: &'static str = "before";
+            }
+            pub struct first;
+            impl ::cynic::schema::HasArgument<first> for super::tags {
+                type ArgumentType = Option<super::super::super::Int>;
+                const NAME: &'static str = "first";
+            }
+            pub struct last;
+            impl ::cynic::schema::HasArgument<last> for super::tags {
+                type ArgumentType = Option<super::super::super::Int>;
+                const NAME: &'static str = "last";
+            }
+        }
+        pub struct isPublished;
+        impl ::cynic::schema::Field for isPublished {
+            type Type = Option<super::super::Boolean>;
+            const NAME: &'static str = "isPublished";
+        }
+        impl ::cynic::schema::HasField<isPublished> for super::super::Job {
+            type Type = Option<super::super::Boolean>;
+        }
+        pub struct isFeatured;
+        impl ::cynic::schema::Field for isFeatured {
+            type Type = Option<super::super::Boolean>;
+            const NAME: &'static str = "isFeatured";
+        }
+        impl ::cynic::schema::HasField<isFeatured> for super::super::Job {
+            type Type = Option<super::super::Boolean>;
+        }
+        pub struct locationNames;
+        impl ::cynic::schema::Field for locationNames {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "locationNames";
+        }
+        impl ::cynic::schema::HasField<locationNames> for super::super::Job {
+            type Type = Option<super::super::String>;
+        }
+        pub struct userEmail;
+        impl ::cynic::schema::Field for userEmail {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "userEmail";
+        }
+        impl ::cynic::schema::HasField<userEmail> for super::super::Job {
+            type Type = Option<super::super::String>;
+        }
+        pub struct postedAt;
+        impl ::cynic::schema::Field for postedAt {
+            type Type = super::super::DateTime;
+            const NAME: &'static str = "postedAt";
+        }
+        impl ::cynic::schema::HasField<postedAt> for super::super::Job {
+            type Type = super::super::DateTime;
+        }
+        pub struct createdAt;
+        impl ::cynic::schema::Field for createdAt {
+            type Type = super::super::DateTime;
+            const NAME: &'static str = "createdAt";
+        }
+        impl ::cynic::schema::HasField<createdAt> for super::super::Job {
+            type Type = super::super::DateTime;
+        }
+        pub struct updatedAt;
+        impl ::cynic::schema::Field for updatedAt {
+            type Type = super::super::DateTime;
+            const NAME: &'static str = "updatedAt";
+        }
+        impl ::cynic::schema::HasField<updatedAt> for super::super::Job {
+            type Type = super::super::DateTime;
+        }
+    }
+    pub mod JobInput {
+        pub struct companySlug;
+        impl ::cynic::schema::Field for companySlug {
+            type Type = super::super::String;
+            const NAME: &'static str = "companySlug";
+        }
+        impl ::cynic::schema::HasInputField<companySlug, super::super::String> for super::super::JobInput {}
+        pub struct jobSlug;
+        impl ::cynic::schema::Field for jobSlug {
+            type Type = super::super::String;
+            const NAME: &'static str = "jobSlug";
+        }
+        impl ::cynic::schema::HasInputField<jobSlug, super::super::String> for super::super::JobInput {}
+    }
+    pub mod JobWhereInput {
+        pub struct id;
+        impl ::cynic::schema::Field for id {
+            type Type = Option<super::super::ID>;
+            const NAME: &'static str = "id";
+        }
+        impl ::cynic::schema::HasInputField<id, Option<super::super::ID>> for super::super::JobWhereInput {}
+        pub struct id_not;
+        impl ::cynic::schema::Field for id_not {
+            type Type = Option<super::super::ID>;
+            const NAME: &'static str = "id_not";
+        }
+        impl ::cynic::schema::HasInputField<id_not, Option<super::super::ID>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct id_in;
+        impl ::cynic::schema::Field for id_in {
+            type Type = Option<Vec<super::super::ID>>;
+            const NAME: &'static str = "id_in";
+        }
+        impl ::cynic::schema::HasInputField<id_in, Option<Vec<super::super::ID>>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct id_not_in;
+        impl ::cynic::schema::Field for id_not_in {
+            type Type = Option<Vec<super::super::ID>>;
+            const NAME: &'static str = "id_not_in";
+        }
+        impl ::cynic::schema::HasInputField<id_not_in, Option<Vec<super::super::ID>>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct id_lt;
+        impl ::cynic::schema::Field for id_lt {
+            type Type = Option<super::super::ID>;
+            const NAME: &'static str = "id_lt";
+        }
+        impl ::cynic::schema::HasInputField<id_lt, Option<super::super::ID>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct id_lte;
+        impl ::cynic::schema::Field for id_lte {
+            type Type = Option<super::super::ID>;
+            const NAME: &'static str = "id_lte";
+        }
+        impl ::cynic::schema::HasInputField<id_lte, Option<super::super::ID>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct id_gt;
+        impl ::cynic::schema::Field for id_gt {
+            type Type = Option<super::super::ID>;
+            const NAME: &'static str = "id_gt";
+        }
+        impl ::cynic::schema::HasInputField<id_gt, Option<super::super::ID>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct id_gte;
+        impl ::cynic::schema::Field for id_gte {
+            type Type = Option<super::super::ID>;
+            const NAME: &'static str = "id_gte";
+        }
+        impl ::cynic::schema::HasInputField<id_gte, Option<super::super::ID>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct id_contains;
+        impl ::cynic::schema::Field for id_contains {
+            type Type = Option<super::super::ID>;
+            const NAME: &'static str = "id_contains";
+        }
+        impl ::cynic::schema::HasInputField<id_contains, Option<super::super::ID>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct id_not_contains;
+        impl ::cynic::schema::Field for id_not_contains {
+            type Type = Option<super::super::ID>;
+            const NAME: &'static str = "id_not_contains";
+        }
+        impl ::cynic::schema::HasInputField<id_not_contains, Option<super::super::ID>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct id_starts_with;
+        impl ::cynic::schema::Field for id_starts_with {
+            type Type = Option<super::super::ID>;
+            const NAME: &'static str = "id_starts_with";
+        }
+        impl ::cynic::schema::HasInputField<id_starts_with, Option<super::super::ID>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct id_not_starts_with;
+        impl ::cynic::schema::Field for id_not_starts_with {
+            type Type = Option<super::super::ID>;
+            const NAME: &'static str = "id_not_starts_with";
+        }
+        impl ::cynic::schema::HasInputField<id_not_starts_with, Option<super::super::ID>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct id_ends_with;
+        impl ::cynic::schema::Field for id_ends_with {
+            type Type = Option<super::super::ID>;
+            const NAME: &'static str = "id_ends_with";
+        }
+        impl ::cynic::schema::HasInputField<id_ends_with, Option<super::super::ID>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct id_not_ends_with;
+        impl ::cynic::schema::Field for id_not_ends_with {
+            type Type = Option<super::super::ID>;
+            const NAME: &'static str = "id_not_ends_with";
+        }
+        impl ::cynic::schema::HasInputField<id_not_ends_with, Option<super::super::ID>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct title;
+        impl ::cynic::schema::Field for title {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "title";
+        }
+        impl ::cynic::schema::HasInputField<title, Option<super::super::String>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct title_not;
+        impl ::cynic::schema::Field for title_not {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "title_not";
+        }
+        impl ::cynic::schema::HasInputField<title_not, Option<super::super::String>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct title_in;
+        impl ::cynic::schema::Field for title_in {
+            type Type = Option<Vec<super::super::String>>;
+            const NAME: &'static str = "title_in";
+        }
+        impl ::cynic::schema::HasInputField<title_in, Option<Vec<super::super::String>>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct title_not_in;
+        impl ::cynic::schema::Field for title_not_in {
+            type Type = Option<Vec<super::super::String>>;
+            const NAME: &'static str = "title_not_in";
+        }
+        impl ::cynic::schema::HasInputField<title_not_in, Option<Vec<super::super::String>>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct title_lt;
+        impl ::cynic::schema::Field for title_lt {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "title_lt";
+        }
+        impl ::cynic::schema::HasInputField<title_lt, Option<super::super::String>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct title_lte;
+        impl ::cynic::schema::Field for title_lte {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "title_lte";
+        }
+        impl ::cynic::schema::HasInputField<title_lte, Option<super::super::String>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct title_gt;
+        impl ::cynic::schema::Field for title_gt {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "title_gt";
+        }
+        impl ::cynic::schema::HasInputField<title_gt, Option<super::super::String>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct title_gte;
+        impl ::cynic::schema::Field for title_gte {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "title_gte";
+        }
+        impl ::cynic::schema::HasInputField<title_gte, Option<super::super::String>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct title_contains;
+        impl ::cynic::schema::Field for title_contains {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "title_contains";
+        }
+        impl ::cynic::schema::HasInputField<title_contains, Option<super::super::String>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct title_not_contains;
+        impl ::cynic::schema::Field for title_not_contains {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "title_not_contains";
+        }
+        impl ::cynic::schema::HasInputField<title_not_contains, Option<super::super::String>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct title_starts_with;
+        impl ::cynic::schema::Field for title_starts_with {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "title_starts_with";
+        }
+        impl ::cynic::schema::HasInputField<title_starts_with, Option<super::super::String>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct title_not_starts_with;
+        impl ::cynic::schema::Field for title_not_starts_with {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "title_not_starts_with";
+        }
+        impl ::cynic::schema::HasInputField<title_not_starts_with, Option<super::super::String>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct title_ends_with;
+        impl ::cynic::schema::Field for title_ends_with {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "title_ends_with";
+        }
+        impl ::cynic::schema::HasInputField<title_ends_with, Option<super::super::String>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct title_not_ends_with;
+        impl ::cynic::schema::Field for title_not_ends_with {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "title_not_ends_with";
+        }
+        impl ::cynic::schema::HasInputField<title_not_ends_with, Option<super::super::String>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct slug;
+        impl ::cynic::schema::Field for slug {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "slug";
+        }
+        impl ::cynic::schema::HasInputField<slug, Option<super::super::String>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct slug_not;
+        impl ::cynic::schema::Field for slug_not {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "slug_not";
+        }
+        impl ::cynic::schema::HasInputField<slug_not, Option<super::super::String>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct slug_in;
+        impl ::cynic::schema::Field for slug_in {
+            type Type = Option<Vec<super::super::String>>;
+            const NAME: &'static str = "slug_in";
+        }
+        impl ::cynic::schema::HasInputField<slug_in, Option<Vec<super::super::String>>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct slug_not_in;
+        impl ::cynic::schema::Field for slug_not_in {
+            type Type = Option<Vec<super::super::String>>;
+            const NAME: &'static str = "slug_not_in";
+        }
+        impl ::cynic::schema::HasInputField<slug_not_in, Option<Vec<super::super::String>>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct slug_lt;
+        impl ::cynic::schema::Field for slug_lt {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "slug_lt";
+        }
+        impl ::cynic::schema::HasInputField<slug_lt, Option<super::super::String>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct slug_lte;
+        impl ::cynic::schema::Field for slug_lte {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "slug_lte";
+        }
+        impl ::cynic::schema::HasInputField<slug_lte, Option<super::super::String>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct slug_gt;
+        impl ::cynic::schema::Field for slug_gt {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "slug_gt";
+        }
+        impl ::cynic::schema::HasInputField<slug_gt, Option<super::super::String>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct slug_gte;
+        impl ::cynic::schema::Field for slug_gte {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "slug_gte";
+        }
+        impl ::cynic::schema::HasInputField<slug_gte, Option<super::super::String>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct slug_contains;
+        impl ::cynic::schema::Field for slug_contains {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "slug_contains";
+        }
+        impl ::cynic::schema::HasInputField<slug_contains, Option<super::super::String>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct slug_not_contains;
+        impl ::cynic::schema::Field for slug_not_contains {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "slug_not_contains";
+        }
+        impl ::cynic::schema::HasInputField<slug_not_contains, Option<super::super::String>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct slug_starts_with;
+        impl ::cynic::schema::Field for slug_starts_with {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "slug_starts_with";
+        }
+        impl ::cynic::schema::HasInputField<slug_starts_with, Option<super::super::String>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct slug_not_starts_with;
+        impl ::cynic::schema::Field for slug_not_starts_with {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "slug_not_starts_with";
+        }
+        impl ::cynic::schema::HasInputField<slug_not_starts_with, Option<super::super::String>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct slug_ends_with;
+        impl ::cynic::schema::Field for slug_ends_with {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "slug_ends_with";
+        }
+        impl ::cynic::schema::HasInputField<slug_ends_with, Option<super::super::String>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct slug_not_ends_with;
+        impl ::cynic::schema::Field for slug_not_ends_with {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "slug_not_ends_with";
+        }
+        impl ::cynic::schema::HasInputField<slug_not_ends_with, Option<super::super::String>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct commitment;
+        impl ::cynic::schema::Field for commitment {
+            type Type = Option<super::super::CommitmentWhereInput>;
+            const NAME: &'static str = "commitment";
+        }
+        impl ::cynic::schema::HasInputField<commitment, Option<super::super::CommitmentWhereInput>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct cities_every;
+        impl ::cynic::schema::Field for cities_every {
+            type Type = Option<super::super::CityWhereInput>;
+            const NAME: &'static str = "cities_every";
+        }
+        impl ::cynic::schema::HasInputField<cities_every, Option<super::super::CityWhereInput>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct cities_some;
+        impl ::cynic::schema::Field for cities_some {
+            type Type = Option<super::super::CityWhereInput>;
+            const NAME: &'static str = "cities_some";
+        }
+        impl ::cynic::schema::HasInputField<cities_some, Option<super::super::CityWhereInput>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct cities_none;
+        impl ::cynic::schema::Field for cities_none {
+            type Type = Option<super::super::CityWhereInput>;
+            const NAME: &'static str = "cities_none";
+        }
+        impl ::cynic::schema::HasInputField<cities_none, Option<super::super::CityWhereInput>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct countries_every;
+        impl ::cynic::schema::Field for countries_every {
+            type Type = Option<super::super::CountryWhereInput>;
+            const NAME: &'static str = "countries_every";
+        }
+        impl
+            ::cynic::schema::HasInputField<countries_every, Option<super::super::CountryWhereInput>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct countries_some;
+        impl ::cynic::schema::Field for countries_some {
+            type Type = Option<super::super::CountryWhereInput>;
+            const NAME: &'static str = "countries_some";
+        }
+        impl ::cynic::schema::HasInputField<countries_some, Option<super::super::CountryWhereInput>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct countries_none;
+        impl ::cynic::schema::Field for countries_none {
+            type Type = Option<super::super::CountryWhereInput>;
+            const NAME: &'static str = "countries_none";
+        }
+        impl ::cynic::schema::HasInputField<countries_none, Option<super::super::CountryWhereInput>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct remotes_every;
+        impl ::cynic::schema::Field for remotes_every {
+            type Type = Option<super::super::RemoteWhereInput>;
+            const NAME: &'static str = "remotes_every";
+        }
+        impl ::cynic::schema::HasInputField<remotes_every, Option<super::super::RemoteWhereInput>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct remotes_some;
+        impl ::cynic::schema::Field for remotes_some {
+            type Type = Option<super::super::RemoteWhereInput>;
+            const NAME: &'static str = "remotes_some";
+        }
+        impl ::cynic::schema::HasInputField<remotes_some, Option<super::super::RemoteWhereInput>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct remotes_none;
+        impl ::cynic::schema::Field for remotes_none {
+            type Type = Option<super::super::RemoteWhereInput>;
+            const NAME: &'static str = "remotes_none";
+        }
+        impl ::cynic::schema::HasInputField<remotes_none, Option<super::super::RemoteWhereInput>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct description;
+        impl ::cynic::schema::Field for description {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "description";
+        }
+        impl ::cynic::schema::HasInputField<description, Option<super::super::String>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct description_not;
+        impl ::cynic::schema::Field for description_not {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "description_not";
+        }
+        impl ::cynic::schema::HasInputField<description_not, Option<super::super::String>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct description_in;
+        impl ::cynic::schema::Field for description_in {
+            type Type = Option<Vec<super::super::String>>;
+            const NAME: &'static str = "description_in";
+        }
+        impl ::cynic::schema::HasInputField<description_in, Option<Vec<super::super::String>>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct description_not_in;
+        impl ::cynic::schema::Field for description_not_in {
+            type Type = Option<Vec<super::super::String>>;
+            const NAME: &'static str = "description_not_in";
+        }
+        impl ::cynic::schema::HasInputField<description_not_in, Option<Vec<super::super::String>>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct description_lt;
+        impl ::cynic::schema::Field for description_lt {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "description_lt";
+        }
+        impl ::cynic::schema::HasInputField<description_lt, Option<super::super::String>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct description_lte;
+        impl ::cynic::schema::Field for description_lte {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "description_lte";
+        }
+        impl ::cynic::schema::HasInputField<description_lte, Option<super::super::String>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct description_gt;
+        impl ::cynic::schema::Field for description_gt {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "description_gt";
+        }
+        impl ::cynic::schema::HasInputField<description_gt, Option<super::super::String>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct description_gte;
+        impl ::cynic::schema::Field for description_gte {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "description_gte";
+        }
+        impl ::cynic::schema::HasInputField<description_gte, Option<super::super::String>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct description_contains;
+        impl ::cynic::schema::Field for description_contains {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "description_contains";
+        }
+        impl ::cynic::schema::HasInputField<description_contains, Option<super::super::String>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct description_not_contains;
+        impl ::cynic::schema::Field for description_not_contains {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "description_not_contains";
+        }
+        impl ::cynic::schema::HasInputField<description_not_contains, Option<super::super::String>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct description_starts_with;
+        impl ::cynic::schema::Field for description_starts_with {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "description_starts_with";
+        }
+        impl ::cynic::schema::HasInputField<description_starts_with, Option<super::super::String>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct description_not_starts_with;
+        impl ::cynic::schema::Field for description_not_starts_with {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "description_not_starts_with";
+        }
+        impl
+            ::cynic::schema::HasInputField<
+                description_not_starts_with,
+                Option<super::super::String>,
+            > for super::super::JobWhereInput
+        {
+        }
+        pub struct description_ends_with;
+        impl ::cynic::schema::Field for description_ends_with {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "description_ends_with";
+        }
+        impl ::cynic::schema::HasInputField<description_ends_with, Option<super::super::String>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct description_not_ends_with;
+        impl ::cynic::schema::Field for description_not_ends_with {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "description_not_ends_with";
+        }
+        impl ::cynic::schema::HasInputField<description_not_ends_with, Option<super::super::String>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct applyUrl;
+        impl ::cynic::schema::Field for applyUrl {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "applyUrl";
+        }
+        impl ::cynic::schema::HasInputField<applyUrl, Option<super::super::String>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct applyUrl_not;
+        impl ::cynic::schema::Field for applyUrl_not {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "applyUrl_not";
+        }
+        impl ::cynic::schema::HasInputField<applyUrl_not, Option<super::super::String>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct applyUrl_in;
+        impl ::cynic::schema::Field for applyUrl_in {
+            type Type = Option<Vec<super::super::String>>;
+            const NAME: &'static str = "applyUrl_in";
+        }
+        impl ::cynic::schema::HasInputField<applyUrl_in, Option<Vec<super::super::String>>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct applyUrl_not_in;
+        impl ::cynic::schema::Field for applyUrl_not_in {
+            type Type = Option<Vec<super::super::String>>;
+            const NAME: &'static str = "applyUrl_not_in";
+        }
+        impl ::cynic::schema::HasInputField<applyUrl_not_in, Option<Vec<super::super::String>>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct applyUrl_lt;
+        impl ::cynic::schema::Field for applyUrl_lt {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "applyUrl_lt";
+        }
+        impl ::cynic::schema::HasInputField<applyUrl_lt, Option<super::super::String>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct applyUrl_lte;
+        impl ::cynic::schema::Field for applyUrl_lte {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "applyUrl_lte";
+        }
+        impl ::cynic::schema::HasInputField<applyUrl_lte, Option<super::super::String>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct applyUrl_gt;
+        impl ::cynic::schema::Field for applyUrl_gt {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "applyUrl_gt";
+        }
+        impl ::cynic::schema::HasInputField<applyUrl_gt, Option<super::super::String>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct applyUrl_gte;
+        impl ::cynic::schema::Field for applyUrl_gte {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "applyUrl_gte";
+        }
+        impl ::cynic::schema::HasInputField<applyUrl_gte, Option<super::super::String>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct applyUrl_contains;
+        impl ::cynic::schema::Field for applyUrl_contains {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "applyUrl_contains";
+        }
+        impl ::cynic::schema::HasInputField<applyUrl_contains, Option<super::super::String>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct applyUrl_not_contains;
+        impl ::cynic::schema::Field for applyUrl_not_contains {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "applyUrl_not_contains";
+        }
+        impl ::cynic::schema::HasInputField<applyUrl_not_contains, Option<super::super::String>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct applyUrl_starts_with;
+        impl ::cynic::schema::Field for applyUrl_starts_with {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "applyUrl_starts_with";
+        }
+        impl ::cynic::schema::HasInputField<applyUrl_starts_with, Option<super::super::String>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct applyUrl_not_starts_with;
+        impl ::cynic::schema::Field for applyUrl_not_starts_with {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "applyUrl_not_starts_with";
+        }
+        impl ::cynic::schema::HasInputField<applyUrl_not_starts_with, Option<super::super::String>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct applyUrl_ends_with;
+        impl ::cynic::schema::Field for applyUrl_ends_with {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "applyUrl_ends_with";
+        }
+        impl ::cynic::schema::HasInputField<applyUrl_ends_with, Option<super::super::String>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct applyUrl_not_ends_with;
+        impl ::cynic::schema::Field for applyUrl_not_ends_with {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "applyUrl_not_ends_with";
+        }
+        impl ::cynic::schema::HasInputField<applyUrl_not_ends_with, Option<super::super::String>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct company;
+        impl ::cynic::schema::Field for company {
+            type Type = Option<super::super::CompanyWhereInput>;
+            const NAME: &'static str = "company";
+        }
+        impl ::cynic::schema::HasInputField<company, Option<super::super::CompanyWhereInput>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct tags_every;
+        impl ::cynic::schema::Field for tags_every {
+            type Type = Option<super::super::TagWhereInput>;
+            const NAME: &'static str = "tags_every";
+        }
+        impl ::cynic::schema::HasInputField<tags_every, Option<super::super::TagWhereInput>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct tags_some;
+        impl ::cynic::schema::Field for tags_some {
+            type Type = Option<super::super::TagWhereInput>;
+            const NAME: &'static str = "tags_some";
+        }
+        impl ::cynic::schema::HasInputField<tags_some, Option<super::super::TagWhereInput>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct tags_none;
+        impl ::cynic::schema::Field for tags_none {
+            type Type = Option<super::super::TagWhereInput>;
+            const NAME: &'static str = "tags_none";
+        }
+        impl ::cynic::schema::HasInputField<tags_none, Option<super::super::TagWhereInput>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct isPublished;
+        impl ::cynic::schema::Field for isPublished {
+            type Type = Option<super::super::Boolean>;
+            const NAME: &'static str = "isPublished";
+        }
+        impl ::cynic::schema::HasInputField<isPublished, Option<super::super::Boolean>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct isPublished_not;
+        impl ::cynic::schema::Field for isPublished_not {
+            type Type = Option<super::super::Boolean>;
+            const NAME: &'static str = "isPublished_not";
+        }
+        impl ::cynic::schema::HasInputField<isPublished_not, Option<super::super::Boolean>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct isFeatured;
+        impl ::cynic::schema::Field for isFeatured {
+            type Type = Option<super::super::Boolean>;
+            const NAME: &'static str = "isFeatured";
+        }
+        impl ::cynic::schema::HasInputField<isFeatured, Option<super::super::Boolean>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct isFeatured_not;
+        impl ::cynic::schema::Field for isFeatured_not {
+            type Type = Option<super::super::Boolean>;
+            const NAME: &'static str = "isFeatured_not";
+        }
+        impl ::cynic::schema::HasInputField<isFeatured_not, Option<super::super::Boolean>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct locationNames;
+        impl ::cynic::schema::Field for locationNames {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "locationNames";
+        }
+        impl ::cynic::schema::HasInputField<locationNames, Option<super::super::String>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct locationNames_not;
+        impl ::cynic::schema::Field for locationNames_not {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "locationNames_not";
+        }
+        impl ::cynic::schema::HasInputField<locationNames_not, Option<super::super::String>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct locationNames_in;
+        impl ::cynic::schema::Field for locationNames_in {
+            type Type = Option<Vec<super::super::String>>;
+            const NAME: &'static str = "locationNames_in";
+        }
+        impl ::cynic::schema::HasInputField<locationNames_in, Option<Vec<super::super::String>>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct locationNames_not_in;
+        impl ::cynic::schema::Field for locationNames_not_in {
+            type Type = Option<Vec<super::super::String>>;
+            const NAME: &'static str = "locationNames_not_in";
+        }
+        impl ::cynic::schema::HasInputField<locationNames_not_in, Option<Vec<super::super::String>>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct locationNames_lt;
+        impl ::cynic::schema::Field for locationNames_lt {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "locationNames_lt";
+        }
+        impl ::cynic::schema::HasInputField<locationNames_lt, Option<super::super::String>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct locationNames_lte;
+        impl ::cynic::schema::Field for locationNames_lte {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "locationNames_lte";
+        }
+        impl ::cynic::schema::HasInputField<locationNames_lte, Option<super::super::String>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct locationNames_gt;
+        impl ::cynic::schema::Field for locationNames_gt {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "locationNames_gt";
+        }
+        impl ::cynic::schema::HasInputField<locationNames_gt, Option<super::super::String>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct locationNames_gte;
+        impl ::cynic::schema::Field for locationNames_gte {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "locationNames_gte";
+        }
+        impl ::cynic::schema::HasInputField<locationNames_gte, Option<super::super::String>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct locationNames_contains;
+        impl ::cynic::schema::Field for locationNames_contains {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "locationNames_contains";
+        }
+        impl ::cynic::schema::HasInputField<locationNames_contains, Option<super::super::String>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct locationNames_not_contains;
+        impl ::cynic::schema::Field for locationNames_not_contains {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "locationNames_not_contains";
+        }
+        impl
+            ::cynic::schema::HasInputField<locationNames_not_contains, Option<super::super::String>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct locationNames_starts_with;
+        impl ::cynic::schema::Field for locationNames_starts_with {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "locationNames_starts_with";
+        }
+        impl ::cynic::schema::HasInputField<locationNames_starts_with, Option<super::super::String>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct locationNames_not_starts_with;
+        impl ::cynic::schema::Field for locationNames_not_starts_with {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "locationNames_not_starts_with";
+        }
+        impl
+            ::cynic::schema::HasInputField<
+                locationNames_not_starts_with,
+                Option<super::super::String>,
+            > for super::super::JobWhereInput
+        {
+        }
+        pub struct locationNames_ends_with;
+        impl ::cynic::schema::Field for locationNames_ends_with {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "locationNames_ends_with";
+        }
+        impl ::cynic::schema::HasInputField<locationNames_ends_with, Option<super::super::String>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct locationNames_not_ends_with;
+        impl ::cynic::schema::Field for locationNames_not_ends_with {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "locationNames_not_ends_with";
+        }
+        impl
+            ::cynic::schema::HasInputField<
+                locationNames_not_ends_with,
+                Option<super::super::String>,
+            > for super::super::JobWhereInput
+        {
+        }
+        pub struct userEmail;
+        impl ::cynic::schema::Field for userEmail {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "userEmail";
+        }
+        impl ::cynic::schema::HasInputField<userEmail, Option<super::super::String>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct userEmail_not;
+        impl ::cynic::schema::Field for userEmail_not {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "userEmail_not";
+        }
+        impl ::cynic::schema::HasInputField<userEmail_not, Option<super::super::String>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct userEmail_in;
+        impl ::cynic::schema::Field for userEmail_in {
+            type Type = Option<Vec<super::super::String>>;
+            const NAME: &'static str = "userEmail_in";
+        }
+        impl ::cynic::schema::HasInputField<userEmail_in, Option<Vec<super::super::String>>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct userEmail_not_in;
+        impl ::cynic::schema::Field for userEmail_not_in {
+            type Type = Option<Vec<super::super::String>>;
+            const NAME: &'static str = "userEmail_not_in";
+        }
+        impl ::cynic::schema::HasInputField<userEmail_not_in, Option<Vec<super::super::String>>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct userEmail_lt;
+        impl ::cynic::schema::Field for userEmail_lt {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "userEmail_lt";
+        }
+        impl ::cynic::schema::HasInputField<userEmail_lt, Option<super::super::String>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct userEmail_lte;
+        impl ::cynic::schema::Field for userEmail_lte {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "userEmail_lte";
+        }
+        impl ::cynic::schema::HasInputField<userEmail_lte, Option<super::super::String>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct userEmail_gt;
+        impl ::cynic::schema::Field for userEmail_gt {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "userEmail_gt";
+        }
+        impl ::cynic::schema::HasInputField<userEmail_gt, Option<super::super::String>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct userEmail_gte;
+        impl ::cynic::schema::Field for userEmail_gte {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "userEmail_gte";
+        }
+        impl ::cynic::schema::HasInputField<userEmail_gte, Option<super::super::String>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct userEmail_contains;
+        impl ::cynic::schema::Field for userEmail_contains {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "userEmail_contains";
+        }
+        impl ::cynic::schema::HasInputField<userEmail_contains, Option<super::super::String>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct userEmail_not_contains;
+        impl ::cynic::schema::Field for userEmail_not_contains {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "userEmail_not_contains";
+        }
+        impl ::cynic::schema::HasInputField<userEmail_not_contains, Option<super::super::String>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct userEmail_starts_with;
+        impl ::cynic::schema::Field for userEmail_starts_with {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "userEmail_starts_with";
+        }
+        impl ::cynic::schema::HasInputField<userEmail_starts_with, Option<super::super::String>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct userEmail_not_starts_with;
+        impl ::cynic::schema::Field for userEmail_not_starts_with {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "userEmail_not_starts_with";
+        }
+        impl ::cynic::schema::HasInputField<userEmail_not_starts_with, Option<super::super::String>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct userEmail_ends_with;
+        impl ::cynic::schema::Field for userEmail_ends_with {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "userEmail_ends_with";
+        }
+        impl ::cynic::schema::HasInputField<userEmail_ends_with, Option<super::super::String>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct userEmail_not_ends_with;
+        impl ::cynic::schema::Field for userEmail_not_ends_with {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "userEmail_not_ends_with";
+        }
+        impl ::cynic::schema::HasInputField<userEmail_not_ends_with, Option<super::super::String>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct postedAt;
+        impl ::cynic::schema::Field for postedAt {
+            type Type = Option<super::super::DateTime>;
+            const NAME: &'static str = "postedAt";
+        }
+        impl ::cynic::schema::HasInputField<postedAt, Option<super::super::DateTime>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct postedAt_not;
+        impl ::cynic::schema::Field for postedAt_not {
+            type Type = Option<super::super::DateTime>;
+            const NAME: &'static str = "postedAt_not";
+        }
+        impl ::cynic::schema::HasInputField<postedAt_not, Option<super::super::DateTime>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct postedAt_in;
+        impl ::cynic::schema::Field for postedAt_in {
+            type Type = Option<Vec<super::super::DateTime>>;
+            const NAME: &'static str = "postedAt_in";
+        }
+        impl ::cynic::schema::HasInputField<postedAt_in, Option<Vec<super::super::DateTime>>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct postedAt_not_in;
+        impl ::cynic::schema::Field for postedAt_not_in {
+            type Type = Option<Vec<super::super::DateTime>>;
+            const NAME: &'static str = "postedAt_not_in";
+        }
+        impl ::cynic::schema::HasInputField<postedAt_not_in, Option<Vec<super::super::DateTime>>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct postedAt_lt;
+        impl ::cynic::schema::Field for postedAt_lt {
+            type Type = Option<super::super::DateTime>;
+            const NAME: &'static str = "postedAt_lt";
+        }
+        impl ::cynic::schema::HasInputField<postedAt_lt, Option<super::super::DateTime>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct postedAt_lte;
+        impl ::cynic::schema::Field for postedAt_lte {
+            type Type = Option<super::super::DateTime>;
+            const NAME: &'static str = "postedAt_lte";
+        }
+        impl ::cynic::schema::HasInputField<postedAt_lte, Option<super::super::DateTime>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct postedAt_gt;
+        impl ::cynic::schema::Field for postedAt_gt {
+            type Type = Option<super::super::DateTime>;
+            const NAME: &'static str = "postedAt_gt";
+        }
+        impl ::cynic::schema::HasInputField<postedAt_gt, Option<super::super::DateTime>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct postedAt_gte;
+        impl ::cynic::schema::Field for postedAt_gte {
+            type Type = Option<super::super::DateTime>;
+            const NAME: &'static str = "postedAt_gte";
+        }
+        impl ::cynic::schema::HasInputField<postedAt_gte, Option<super::super::DateTime>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct createdAt;
+        impl ::cynic::schema::Field for createdAt {
+            type Type = Option<super::super::DateTime>;
+            const NAME: &'static str = "createdAt";
+        }
+        impl ::cynic::schema::HasInputField<createdAt, Option<super::super::DateTime>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct createdAt_not;
+        impl ::cynic::schema::Field for createdAt_not {
+            type Type = Option<super::super::DateTime>;
+            const NAME: &'static str = "createdAt_not";
+        }
+        impl ::cynic::schema::HasInputField<createdAt_not, Option<super::super::DateTime>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct createdAt_in;
+        impl ::cynic::schema::Field for createdAt_in {
+            type Type = Option<Vec<super::super::DateTime>>;
+            const NAME: &'static str = "createdAt_in";
+        }
+        impl ::cynic::schema::HasInputField<createdAt_in, Option<Vec<super::super::DateTime>>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct createdAt_not_in;
+        impl ::cynic::schema::Field for createdAt_not_in {
+            type Type = Option<Vec<super::super::DateTime>>;
+            const NAME: &'static str = "createdAt_not_in";
+        }
+        impl ::cynic::schema::HasInputField<createdAt_not_in, Option<Vec<super::super::DateTime>>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct createdAt_lt;
+        impl ::cynic::schema::Field for createdAt_lt {
+            type Type = Option<super::super::DateTime>;
+            const NAME: &'static str = "createdAt_lt";
+        }
+        impl ::cynic::schema::HasInputField<createdAt_lt, Option<super::super::DateTime>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct createdAt_lte;
+        impl ::cynic::schema::Field for createdAt_lte {
+            type Type = Option<super::super::DateTime>;
+            const NAME: &'static str = "createdAt_lte";
+        }
+        impl ::cynic::schema::HasInputField<createdAt_lte, Option<super::super::DateTime>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct createdAt_gt;
+        impl ::cynic::schema::Field for createdAt_gt {
+            type Type = Option<super::super::DateTime>;
+            const NAME: &'static str = "createdAt_gt";
+        }
+        impl ::cynic::schema::HasInputField<createdAt_gt, Option<super::super::DateTime>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct createdAt_gte;
+        impl ::cynic::schema::Field for createdAt_gte {
+            type Type = Option<super::super::DateTime>;
+            const NAME: &'static str = "createdAt_gte";
+        }
+        impl ::cynic::schema::HasInputField<createdAt_gte, Option<super::super::DateTime>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct updatedAt;
+        impl ::cynic::schema::Field for updatedAt {
+            type Type = Option<super::super::DateTime>;
+            const NAME: &'static str = "updatedAt";
+        }
+        impl ::cynic::schema::HasInputField<updatedAt, Option<super::super::DateTime>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct updatedAt_not;
+        impl ::cynic::schema::Field for updatedAt_not {
+            type Type = Option<super::super::DateTime>;
+            const NAME: &'static str = "updatedAt_not";
+        }
+        impl ::cynic::schema::HasInputField<updatedAt_not, Option<super::super::DateTime>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct updatedAt_in;
+        impl ::cynic::schema::Field for updatedAt_in {
+            type Type = Option<Vec<super::super::DateTime>>;
+            const NAME: &'static str = "updatedAt_in";
+        }
+        impl ::cynic::schema::HasInputField<updatedAt_in, Option<Vec<super::super::DateTime>>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct updatedAt_not_in;
+        impl ::cynic::schema::Field for updatedAt_not_in {
+            type Type = Option<Vec<super::super::DateTime>>;
+            const NAME: &'static str = "updatedAt_not_in";
+        }
+        impl ::cynic::schema::HasInputField<updatedAt_not_in, Option<Vec<super::super::DateTime>>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct updatedAt_lt;
+        impl ::cynic::schema::Field for updatedAt_lt {
+            type Type = Option<super::super::DateTime>;
+            const NAME: &'static str = "updatedAt_lt";
+        }
+        impl ::cynic::schema::HasInputField<updatedAt_lt, Option<super::super::DateTime>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct updatedAt_lte;
+        impl ::cynic::schema::Field for updatedAt_lte {
+            type Type = Option<super::super::DateTime>;
+            const NAME: &'static str = "updatedAt_lte";
+        }
+        impl ::cynic::schema::HasInputField<updatedAt_lte, Option<super::super::DateTime>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct updatedAt_gt;
+        impl ::cynic::schema::Field for updatedAt_gt {
+            type Type = Option<super::super::DateTime>;
+            const NAME: &'static str = "updatedAt_gt";
+        }
+        impl ::cynic::schema::HasInputField<updatedAt_gt, Option<super::super::DateTime>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct updatedAt_gte;
+        impl ::cynic::schema::Field for updatedAt_gte {
+            type Type = Option<super::super::DateTime>;
+            const NAME: &'static str = "updatedAt_gte";
+        }
+        impl ::cynic::schema::HasInputField<updatedAt_gte, Option<super::super::DateTime>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct AND;
+        impl ::cynic::schema::Field for AND {
+            type Type = Option<Vec<super::super::JobWhereInput>>;
+            const NAME: &'static str = "AND";
+        }
+        impl ::cynic::schema::HasInputField<AND, Option<Vec<super::super::JobWhereInput>>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct OR;
+        impl ::cynic::schema::Field for OR {
+            type Type = Option<Vec<super::super::JobWhereInput>>;
+            const NAME: &'static str = "OR";
+        }
+        impl ::cynic::schema::HasInputField<OR, Option<Vec<super::super::JobWhereInput>>>
+            for super::super::JobWhereInput
+        {
+        }
+        pub struct NOT;
+        impl ::cynic::schema::Field for NOT {
+            type Type = Option<Vec<super::super::JobWhereInput>>;
+            const NAME: &'static str = "NOT";
+        }
+        impl ::cynic::schema::HasInputField<NOT, Option<Vec<super::super::JobWhereInput>>>
+            for super::super::JobWhereInput
+        {
+        }
+    }
+    pub mod JobsInput {
+        pub struct r#type;
+        impl ::cynic::schema::Field for r#type {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "type";
+        }
+        impl ::cynic::schema::HasInputField<r#type, Option<super::super::String>>
+            for super::super::JobsInput
+        {
+        }
+        pub struct slug;
+        impl ::cynic::schema::Field for slug {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "slug";
+        }
+        impl ::cynic::schema::HasInputField<slug, Option<super::super::String>>
+            for super::super::JobsInput
+        {
+        }
+    }
+    pub mod Location {
+        pub struct id;
+        impl ::cynic::schema::Field for id {
+            type Type = super::super::ID;
+            const NAME: &'static str = "id";
+        }
+        impl ::cynic::schema::HasField<id> for super::super::Location {
+            type Type = super::super::ID;
+        }
+        pub struct slug;
+        impl ::cynic::schema::Field for slug {
+            type Type = super::super::String;
+            const NAME: &'static str = "slug";
+        }
+        impl ::cynic::schema::HasField<slug> for super::super::Location {
+            type Type = super::super::String;
+        }
+        pub struct name;
+        impl ::cynic::schema::Field for name {
+            type Type = super::super::String;
+            const NAME: &'static str = "name";
+        }
+        impl ::cynic::schema::HasField<name> for super::super::Location {
+            type Type = super::super::String;
+        }
+        pub struct r#type;
+        impl ::cynic::schema::Field for r#type {
+            type Type = super::super::String;
+            const NAME: &'static str = "type";
+        }
+        impl ::cynic::schema::HasField<r#type> for super::super::Location {
+            type Type = super::super::String;
+        }
+    }
+    pub mod LocationInput {
+        pub struct slug;
+        impl ::cynic::schema::Field for slug {
+            type Type = super::super::String;
+            const NAME: &'static str = "slug";
+        }
+        impl ::cynic::schema::HasInputField<slug, super::super::String> for super::super::LocationInput {}
+    }
+    pub mod LocationsInput {
+        pub struct value;
+        impl ::cynic::schema::Field for value {
+            type Type = super::super::String;
+            const NAME: &'static str = "value";
+        }
+        impl ::cynic::schema::HasInputField<value, super::super::String> for super::super::LocationsInput {}
+    }
+    pub mod Mutation {
+        pub struct subscribe;
+        impl ::cynic::schema::Field for subscribe {
+            type Type = super::super::User;
+            const NAME: &'static str = "subscribe";
+        }
+        impl ::cynic::schema::HasField<subscribe> for super::super::Mutation {
+            type Type = super::super::User;
+        }
+        pub mod subscribe_arguments {
+            pub struct input;
+            impl ::cynic::schema::HasArgument<input> for super::subscribe {
+                type ArgumentType = super::super::super::SubscribeInput;
+                const NAME: &'static str = "input";
+            }
+        }
+        pub struct postJob;
+        impl ::cynic::schema::Field for postJob {
+            type Type = super::super::Job;
+            const NAME: &'static str = "postJob";
+        }
+        impl ::cynic::schema::HasField<postJob> for super::super::Mutation {
+            type Type = super::super::Job;
+        }
+        pub mod post_job_arguments {
+            pub struct input;
+            impl ::cynic::schema::HasArgument<input> for super::postJob {
+                type ArgumentType = super::super::super::PostJobInput;
+                const NAME: &'static str = "input";
+            }
+        }
+        pub struct updateJob;
+        impl ::cynic::schema::Field for updateJob {
+            type Type = super::super::Job;
+            const NAME: &'static str = "updateJob";
+        }
+        impl ::cynic::schema::HasField<updateJob> for super::super::Mutation {
+            type Type = super::super::Job;
+        }
+        pub mod update_job_arguments {
+            pub struct input;
+            impl ::cynic::schema::HasArgument<input> for super::updateJob {
+                type ArgumentType = super::super::super::UpdateJobInput;
+                const NAME: &'static str = "input";
+            }
+            pub struct adminSecret;
+            impl ::cynic::schema::HasArgument<adminSecret> for super::updateJob {
+                type ArgumentType = super::super::super::String;
+                const NAME: &'static str = "adminSecret";
+            }
+        }
+        pub struct updateCompany;
+        impl ::cynic::schema::Field for updateCompany {
+            type Type = super::super::Company;
+            const NAME: &'static str = "updateCompany";
+        }
+        impl ::cynic::schema::HasField<updateCompany> for super::super::Mutation {
+            type Type = super::super::Company;
+        }
+        pub mod update_company_arguments {
+            pub struct input;
+            impl ::cynic::schema::HasArgument<input> for super::updateCompany {
+                type ArgumentType = super::super::super::UpdateCompanyInput;
+                const NAME: &'static str = "input";
+            }
+            pub struct adminSecret;
+            impl ::cynic::schema::HasArgument<adminSecret> for super::updateCompany {
+                type ArgumentType = super::super::super::String;
+                const NAME: &'static str = "adminSecret";
+            }
+        }
+    }
+    pub mod PostJobInput {
+        pub struct title;
+        impl ::cynic::schema::Field for title {
+            type Type = super::super::String;
+            const NAME: &'static str = "title";
+        }
+        impl ::cynic::schema::HasInputField<title, super::super::String> for super::super::PostJobInput {}
+        pub struct commitmentId;
+        impl ::cynic::schema::Field for commitmentId {
+            type Type = super::super::ID;
+            const NAME: &'static str = "commitmentId";
+        }
+        impl ::cynic::schema::HasInputField<commitmentId, super::super::ID> for super::super::PostJobInput {}
+        pub struct companyName;
+        impl ::cynic::schema::Field for companyName {
+            type Type = super::super::String;
+            const NAME: &'static str = "companyName";
+        }
+        impl ::cynic::schema::HasInputField<companyName, super::super::String>
+            for super::super::PostJobInput
+        {
+        }
+        pub struct locationNames;
+        impl ::cynic::schema::Field for locationNames {
+            type Type = super::super::String;
+            const NAME: &'static str = "locationNames";
+        }
+        impl ::cynic::schema::HasInputField<locationNames, super::super::String>
+            for super::super::PostJobInput
+        {
+        }
+        pub struct userEmail;
+        impl ::cynic::schema::Field for userEmail {
+            type Type = super::super::String;
+            const NAME: &'static str = "userEmail";
+        }
+        impl ::cynic::schema::HasInputField<userEmail, super::super::String>
+            for super::super::PostJobInput
+        {
+        }
+        pub struct description;
+        impl ::cynic::schema::Field for description {
+            type Type = super::super::String;
+            const NAME: &'static str = "description";
+        }
+        impl ::cynic::schema::HasInputField<description, super::super::String>
+            for super::super::PostJobInput
+        {
+        }
+        pub struct applyUrl;
+        impl ::cynic::schema::Field for applyUrl {
+            type Type = super::super::String;
+            const NAME: &'static str = "applyUrl";
+        }
+        impl ::cynic::schema::HasInputField<applyUrl, super::super::String> for super::super::PostJobInput {}
+    }
+    pub mod Query {
+        pub struct jobs;
+        impl ::cynic::schema::Field for jobs {
+            type Type = Vec<super::super::Job>;
+            const NAME: &'static str = "jobs";
+        }
+        impl ::cynic::schema::HasField<jobs> for super::super::Query {
+            type Type = Vec<super::super::Job>;
+        }
+        pub mod jobs_arguments {
+            pub struct input;
+            impl ::cynic::schema::HasArgument<input> for super::jobs {
+                type ArgumentType = Option<super::super::super::JobsInput>;
+                const NAME: &'static str = "input";
+            }
+        }
+        pub struct job;
+        impl ::cynic::schema::Field for job {
+            type Type = super::super::Job;
+            const NAME: &'static str = "job";
+        }
+        impl ::cynic::schema::HasField<job> for super::super::Query {
+            type Type = super::super::Job;
+        }
+        pub mod job_arguments {
+            pub struct input;
+            impl ::cynic::schema::HasArgument<input> for super::job {
+                type ArgumentType = super::super::super::JobInput;
+                const NAME: &'static str = "input";
+            }
+        }
+        pub struct locations;
+        impl ::cynic::schema::Field for locations {
+            type Type = Vec<super::super::Location>;
+            const NAME: &'static str = "locations";
+        }
+        impl ::cynic::schema::HasField<locations> for super::super::Query {
+            type Type = Vec<super::super::Location>;
+        }
+        pub mod locations_arguments {
+            pub struct input;
+            impl ::cynic::schema::HasArgument<input> for super::locations {
+                type ArgumentType = super::super::super::LocationsInput;
+                const NAME: &'static str = "input";
+            }
+        }
+        pub struct city;
+        impl ::cynic::schema::Field for city {
+            type Type = super::super::City;
+            const NAME: &'static str = "city";
+        }
+        impl ::cynic::schema::HasField<city> for super::super::Query {
+            type Type = super::super::City;
+        }
+        pub mod city_arguments {
+            pub struct input;
+            impl ::cynic::schema::HasArgument<input> for super::city {
+                type ArgumentType = super::super::super::LocationInput;
+                const NAME: &'static str = "input";
+            }
+        }
+        pub struct country;
+        impl ::cynic::schema::Field for country {
+            type Type = super::super::Country;
+            const NAME: &'static str = "country";
+        }
+        impl ::cynic::schema::HasField<country> for super::super::Query {
+            type Type = super::super::Country;
+        }
+        pub mod country_arguments {
+            pub struct input;
+            impl ::cynic::schema::HasArgument<input> for super::country {
+                type ArgumentType = super::super::super::LocationInput;
+                const NAME: &'static str = "input";
+            }
+        }
+        pub struct remote;
+        impl ::cynic::schema::Field for remote {
+            type Type = super::super::Remote;
+            const NAME: &'static str = "remote";
+        }
+        impl ::cynic::schema::HasField<remote> for super::super::Query {
+            type Type = super::super::Remote;
+        }
+        pub mod remote_arguments {
+            pub struct input;
+            impl ::cynic::schema::HasArgument<input> for super::remote {
+                type ArgumentType = super::super::super::LocationInput;
+                const NAME: &'static str = "input";
+            }
+        }
+        pub struct commitments;
+        impl ::cynic::schema::Field for commitments {
+            type Type = Vec<super::super::Commitment>;
+            const NAME: &'static str = "commitments";
+        }
+        impl ::cynic::schema::HasField<commitments> for super::super::Query {
+            type Type = Vec<super::super::Commitment>;
+        }
+        pub struct cities;
+        impl ::cynic::schema::Field for cities {
+            type Type = Vec<super::super::City>;
+            const NAME: &'static str = "cities";
+        }
+        impl ::cynic::schema::HasField<cities> for super::super::Query {
+            type Type = Vec<super::super::City>;
+        }
+        pub struct countries;
+        impl ::cynic::schema::Field for countries {
+            type Type = Vec<super::super::Country>;
+            const NAME: &'static str = "countries";
+        }
+        impl ::cynic::schema::HasField<countries> for super::super::Query {
+            type Type = Vec<super::super::Country>;
+        }
+        pub struct remotes;
+        impl ::cynic::schema::Field for remotes {
+            type Type = Vec<super::super::Remote>;
+            const NAME: &'static str = "remotes";
+        }
+        impl ::cynic::schema::HasField<remotes> for super::super::Query {
+            type Type = Vec<super::super::Remote>;
+        }
+        pub struct companies;
+        impl ::cynic::schema::Field for companies {
+            type Type = Vec<super::super::Company>;
+            const NAME: &'static str = "companies";
+        }
+        impl ::cynic::schema::HasField<companies> for super::super::Query {
+            type Type = Vec<super::super::Company>;
+        }
+    }
+    pub mod Remote {
+        pub struct id;
+        impl ::cynic::schema::Field for id {
+            type Type = super::super::ID;
+            const NAME: &'static str = "id";
+        }
+        impl ::cynic::schema::HasField<id> for super::super::Remote {
+            type Type = super::super::ID;
+        }
+        pub struct name;
+        impl ::cynic::schema::Field for name {
+            type Type = super::super::String;
+            const NAME: &'static str = "name";
+        }
+        impl ::cynic::schema::HasField<name> for super::super::Remote {
+            type Type = super::super::String;
+        }
+        pub struct slug;
+        impl ::cynic::schema::Field for slug {
+            type Type = super::super::String;
+            const NAME: &'static str = "slug";
+        }
+        impl ::cynic::schema::HasField<slug> for super::super::Remote {
+            type Type = super::super::String;
+        }
+        pub struct r#type;
+        impl ::cynic::schema::Field for r#type {
+            type Type = super::super::String;
+            const NAME: &'static str = "type";
+        }
+        impl ::cynic::schema::HasField<r#type> for super::super::Remote {
+            type Type = super::super::String;
+        }
+        pub struct jobs;
+        impl ::cynic::schema::Field for jobs {
+            type Type = Option<Vec<super::super::Job>>;
+            const NAME: &'static str = "jobs";
+        }
+        impl ::cynic::schema::HasField<jobs> for super::super::Remote {
+            type Type = Option<Vec<super::super::Job>>;
+        }
+        pub mod jobs_arguments {
+            pub struct r#where;
+            impl ::cynic::schema::HasArgument<r#where> for super::jobs {
+                type ArgumentType = Option<super::super::super::JobWhereInput>;
+                const NAME: &'static str = "where";
+            }
+            pub struct orderBy;
+            impl ::cynic::schema::HasArgument<orderBy> for super::jobs {
+                type ArgumentType = Option<super::super::super::JobOrderByInput>;
+                const NAME: &'static str = "orderBy";
+            }
+            pub struct skip;
+            impl ::cynic::schema::HasArgument<skip> for super::jobs {
+                type ArgumentType = Option<super::super::super::Int>;
+                const NAME: &'static str = "skip";
+            }
+            pub struct after;
+            impl ::cynic::schema::HasArgument<after> for super::jobs {
+                type ArgumentType = Option<super::super::super::String>;
+                const NAME: &'static str = "after";
+            }
+            pub struct before;
+            impl ::cynic::schema::HasArgument<before> for super::jobs {
+                type ArgumentType = Option<super::super::super::String>;
+                const NAME: &'static str = "before";
+            }
+            pub struct first;
+            impl ::cynic::schema::HasArgument<first> for super::jobs {
+                type ArgumentType = Option<super::super::super::Int>;
+                const NAME: &'static str = "first";
+            }
+            pub struct last;
+            impl ::cynic::schema::HasArgument<last> for super::jobs {
+                type ArgumentType = Option<super::super::super::Int>;
+                const NAME: &'static str = "last";
+            }
+        }
+        pub struct createdAt;
+        impl ::cynic::schema::Field for createdAt {
+            type Type = super::super::DateTime;
+            const NAME: &'static str = "createdAt";
+        }
+        impl ::cynic::schema::HasField<createdAt> for super::super::Remote {
+            type Type = super::super::DateTime;
+        }
+        pub struct updatedAt;
+        impl ::cynic::schema::Field for updatedAt {
+            type Type = super::super::DateTime;
+            const NAME: &'static str = "updatedAt";
+        }
+        impl ::cynic::schema::HasField<updatedAt> for super::super::Remote {
+            type Type = super::super::DateTime;
+        }
+    }
+    pub mod RemoteWhereInput {
+        pub struct id;
+        impl ::cynic::schema::Field for id {
+            type Type = Option<super::super::ID>;
+            const NAME: &'static str = "id";
+        }
+        impl ::cynic::schema::HasInputField<id, Option<super::super::ID>>
+            for super::super::RemoteWhereInput
+        {
+        }
+        pub struct id_not;
+        impl ::cynic::schema::Field for id_not {
+            type Type = Option<super::super::ID>;
+            const NAME: &'static str = "id_not";
+        }
+        impl ::cynic::schema::HasInputField<id_not, Option<super::super::ID>>
+            for super::super::RemoteWhereInput
+        {
+        }
+        pub struct id_in;
+        impl ::cynic::schema::Field for id_in {
+            type Type = Option<Vec<super::super::ID>>;
+            const NAME: &'static str = "id_in";
+        }
+        impl ::cynic::schema::HasInputField<id_in, Option<Vec<super::super::ID>>>
+            for super::super::RemoteWhereInput
+        {
+        }
+        pub struct id_not_in;
+        impl ::cynic::schema::Field for id_not_in {
+            type Type = Option<Vec<super::super::ID>>;
+            const NAME: &'static str = "id_not_in";
+        }
+        impl ::cynic::schema::HasInputField<id_not_in, Option<Vec<super::super::ID>>>
+            for super::super::RemoteWhereInput
+        {
+        }
+        pub struct id_lt;
+        impl ::cynic::schema::Field for id_lt {
+            type Type = Option<super::super::ID>;
+            const NAME: &'static str = "id_lt";
+        }
+        impl ::cynic::schema::HasInputField<id_lt, Option<super::super::ID>>
+            for super::super::RemoteWhereInput
+        {
+        }
+        pub struct id_lte;
+        impl ::cynic::schema::Field for id_lte {
+            type Type = Option<super::super::ID>;
+            const NAME: &'static str = "id_lte";
+        }
+        impl ::cynic::schema::HasInputField<id_lte, Option<super::super::ID>>
+            for super::super::RemoteWhereInput
+        {
+        }
+        pub struct id_gt;
+        impl ::cynic::schema::Field for id_gt {
+            type Type = Option<super::super::ID>;
+            const NAME: &'static str = "id_gt";
+        }
+        impl ::cynic::schema::HasInputField<id_gt, Option<super::super::ID>>
+            for super::super::RemoteWhereInput
+        {
+        }
+        pub struct id_gte;
+        impl ::cynic::schema::Field for id_gte {
+            type Type = Option<super::super::ID>;
+            const NAME: &'static str = "id_gte";
+        }
+        impl ::cynic::schema::HasInputField<id_gte, Option<super::super::ID>>
+            for super::super::RemoteWhereInput
+        {
+        }
+        pub struct id_contains;
+        impl ::cynic::schema::Field for id_contains {
+            type Type = Option<super::super::ID>;
+            const NAME: &'static str = "id_contains";
+        }
+        impl ::cynic::schema::HasInputField<id_contains, Option<super::super::ID>>
+            for super::super::RemoteWhereInput
+        {
+        }
+        pub struct id_not_contains;
+        impl ::cynic::schema::Field for id_not_contains {
+            type Type = Option<super::super::ID>;
+            const NAME: &'static str = "id_not_contains";
+        }
+        impl ::cynic::schema::HasInputField<id_not_contains, Option<super::super::ID>>
+            for super::super::RemoteWhereInput
+        {
+        }
+        pub struct id_starts_with;
+        impl ::cynic::schema::Field for id_starts_with {
+            type Type = Option<super::super::ID>;
+            const NAME: &'static str = "id_starts_with";
+        }
+        impl ::cynic::schema::HasInputField<id_starts_with, Option<super::super::ID>>
+            for super::super::RemoteWhereInput
+        {
+        }
+        pub struct id_not_starts_with;
+        impl ::cynic::schema::Field for id_not_starts_with {
+            type Type = Option<super::super::ID>;
+            const NAME: &'static str = "id_not_starts_with";
+        }
+        impl ::cynic::schema::HasInputField<id_not_starts_with, Option<super::super::ID>>
+            for super::super::RemoteWhereInput
+        {
+        }
+        pub struct id_ends_with;
+        impl ::cynic::schema::Field for id_ends_with {
+            type Type = Option<super::super::ID>;
+            const NAME: &'static str = "id_ends_with";
+        }
+        impl ::cynic::schema::HasInputField<id_ends_with, Option<super::super::ID>>
+            for super::super::RemoteWhereInput
+        {
+        }
+        pub struct id_not_ends_with;
+        impl ::cynic::schema::Field for id_not_ends_with {
+            type Type = Option<super::super::ID>;
+            const NAME: &'static str = "id_not_ends_with";
+        }
+        impl ::cynic::schema::HasInputField<id_not_ends_with, Option<super::super::ID>>
+            for super::super::RemoteWhereInput
+        {
+        }
+        pub struct name;
+        impl ::cynic::schema::Field for name {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "name";
+        }
+        impl ::cynic::schema::HasInputField<name, Option<super::super::String>>
+            for super::super::RemoteWhereInput
+        {
+        }
+        pub struct name_not;
+        impl ::cynic::schema::Field for name_not {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "name_not";
+        }
+        impl ::cynic::schema::HasInputField<name_not, Option<super::super::String>>
+            for super::super::RemoteWhereInput
+        {
+        }
+        pub struct name_in;
+        impl ::cynic::schema::Field for name_in {
+            type Type = Option<Vec<super::super::String>>;
+            const NAME: &'static str = "name_in";
+        }
+        impl ::cynic::schema::HasInputField<name_in, Option<Vec<super::super::String>>>
+            for super::super::RemoteWhereInput
+        {
+        }
+        pub struct name_not_in;
+        impl ::cynic::schema::Field for name_not_in {
+            type Type = Option<Vec<super::super::String>>;
+            const NAME: &'static str = "name_not_in";
+        }
+        impl ::cynic::schema::HasInputField<name_not_in, Option<Vec<super::super::String>>>
+            for super::super::RemoteWhereInput
+        {
+        }
+        pub struct name_lt;
+        impl ::cynic::schema::Field for name_lt {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "name_lt";
+        }
+        impl ::cynic::schema::HasInputField<name_lt, Option<super::super::String>>
+            for super::super::RemoteWhereInput
+        {
+        }
+        pub struct name_lte;
+        impl ::cynic::schema::Field for name_lte {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "name_lte";
+        }
+        impl ::cynic::schema::HasInputField<name_lte, Option<super::super::String>>
+            for super::super::RemoteWhereInput
+        {
+        }
+        pub struct name_gt;
+        impl ::cynic::schema::Field for name_gt {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "name_gt";
+        }
+        impl ::cynic::schema::HasInputField<name_gt, Option<super::super::String>>
+            for super::super::RemoteWhereInput
+        {
+        }
+        pub struct name_gte;
+        impl ::cynic::schema::Field for name_gte {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "name_gte";
+        }
+        impl ::cynic::schema::HasInputField<name_gte, Option<super::super::String>>
+            for super::super::RemoteWhereInput
+        {
+        }
+        pub struct name_contains;
+        impl ::cynic::schema::Field for name_contains {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "name_contains";
+        }
+        impl ::cynic::schema::HasInputField<name_contains, Option<super::super::String>>
+            for super::super::RemoteWhereInput
+        {
+        }
+        pub struct name_not_contains;
+        impl ::cynic::schema::Field for name_not_contains {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "name_not_contains";
+        }
+        impl ::cynic::schema::HasInputField<name_not_contains, Option<super::super::String>>
+            for super::super::RemoteWhereInput
+        {
+        }
+        pub struct name_starts_with;
+        impl ::cynic::schema::Field for name_starts_with {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "name_starts_with";
+        }
+        impl ::cynic::schema::HasInputField<name_starts_with, Option<super::super::String>>
+            for super::super::RemoteWhereInput
+        {
+        }
+        pub struct name_not_starts_with;
+        impl ::cynic::schema::Field for name_not_starts_with {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "name_not_starts_with";
+        }
+        impl ::cynic::schema::HasInputField<name_not_starts_with, Option<super::super::String>>
+            for super::super::RemoteWhereInput
+        {
+        }
+        pub struct name_ends_with;
+        impl ::cynic::schema::Field for name_ends_with {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "name_ends_with";
+        }
+        impl ::cynic::schema::HasInputField<name_ends_with, Option<super::super::String>>
+            for super::super::RemoteWhereInput
+        {
+        }
+        pub struct name_not_ends_with;
+        impl ::cynic::schema::Field for name_not_ends_with {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "name_not_ends_with";
+        }
+        impl ::cynic::schema::HasInputField<name_not_ends_with, Option<super::super::String>>
+            for super::super::RemoteWhereInput
+        {
+        }
+        pub struct slug;
+        impl ::cynic::schema::Field for slug {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "slug";
+        }
+        impl ::cynic::schema::HasInputField<slug, Option<super::super::String>>
+            for super::super::RemoteWhereInput
+        {
+        }
+        pub struct slug_not;
+        impl ::cynic::schema::Field for slug_not {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "slug_not";
+        }
+        impl ::cynic::schema::HasInputField<slug_not, Option<super::super::String>>
+            for super::super::RemoteWhereInput
+        {
+        }
+        pub struct slug_in;
+        impl ::cynic::schema::Field for slug_in {
+            type Type = Option<Vec<super::super::String>>;
+            const NAME: &'static str = "slug_in";
+        }
+        impl ::cynic::schema::HasInputField<slug_in, Option<Vec<super::super::String>>>
+            for super::super::RemoteWhereInput
+        {
+        }
+        pub struct slug_not_in;
+        impl ::cynic::schema::Field for slug_not_in {
+            type Type = Option<Vec<super::super::String>>;
+            const NAME: &'static str = "slug_not_in";
+        }
+        impl ::cynic::schema::HasInputField<slug_not_in, Option<Vec<super::super::String>>>
+            for super::super::RemoteWhereInput
+        {
+        }
+        pub struct slug_lt;
+        impl ::cynic::schema::Field for slug_lt {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "slug_lt";
+        }
+        impl ::cynic::schema::HasInputField<slug_lt, Option<super::super::String>>
+            for super::super::RemoteWhereInput
+        {
+        }
+        pub struct slug_lte;
+        impl ::cynic::schema::Field for slug_lte {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "slug_lte";
+        }
+        impl ::cynic::schema::HasInputField<slug_lte, Option<super::super::String>>
+            for super::super::RemoteWhereInput
+        {
+        }
+        pub struct slug_gt;
+        impl ::cynic::schema::Field for slug_gt {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "slug_gt";
+        }
+        impl ::cynic::schema::HasInputField<slug_gt, Option<super::super::String>>
+            for super::super::RemoteWhereInput
+        {
+        }
+        pub struct slug_gte;
+        impl ::cynic::schema::Field for slug_gte {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "slug_gte";
+        }
+        impl ::cynic::schema::HasInputField<slug_gte, Option<super::super::String>>
+            for super::super::RemoteWhereInput
+        {
+        }
+        pub struct slug_contains;
+        impl ::cynic::schema::Field for slug_contains {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "slug_contains";
+        }
+        impl ::cynic::schema::HasInputField<slug_contains, Option<super::super::String>>
+            for super::super::RemoteWhereInput
+        {
+        }
+        pub struct slug_not_contains;
+        impl ::cynic::schema::Field for slug_not_contains {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "slug_not_contains";
+        }
+        impl ::cynic::schema::HasInputField<slug_not_contains, Option<super::super::String>>
+            for super::super::RemoteWhereInput
+        {
+        }
+        pub struct slug_starts_with;
+        impl ::cynic::schema::Field for slug_starts_with {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "slug_starts_with";
+        }
+        impl ::cynic::schema::HasInputField<slug_starts_with, Option<super::super::String>>
+            for super::super::RemoteWhereInput
+        {
+        }
+        pub struct slug_not_starts_with;
+        impl ::cynic::schema::Field for slug_not_starts_with {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "slug_not_starts_with";
+        }
+        impl ::cynic::schema::HasInputField<slug_not_starts_with, Option<super::super::String>>
+            for super::super::RemoteWhereInput
+        {
+        }
+        pub struct slug_ends_with;
+        impl ::cynic::schema::Field for slug_ends_with {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "slug_ends_with";
+        }
+        impl ::cynic::schema::HasInputField<slug_ends_with, Option<super::super::String>>
+            for super::super::RemoteWhereInput
+        {
+        }
+        pub struct slug_not_ends_with;
+        impl ::cynic::schema::Field for slug_not_ends_with {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "slug_not_ends_with";
+        }
+        impl ::cynic::schema::HasInputField<slug_not_ends_with, Option<super::super::String>>
+            for super::super::RemoteWhereInput
+        {
+        }
+        pub struct r#type;
+        impl ::cynic::schema::Field for r#type {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "type";
+        }
+        impl ::cynic::schema::HasInputField<r#type, Option<super::super::String>>
+            for super::super::RemoteWhereInput
+        {
+        }
+        pub struct type_not;
+        impl ::cynic::schema::Field for type_not {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "type_not";
+        }
+        impl ::cynic::schema::HasInputField<type_not, Option<super::super::String>>
+            for super::super::RemoteWhereInput
+        {
+        }
+        pub struct type_in;
+        impl ::cynic::schema::Field for type_in {
+            type Type = Option<Vec<super::super::String>>;
+            const NAME: &'static str = "type_in";
+        }
+        impl ::cynic::schema::HasInputField<type_in, Option<Vec<super::super::String>>>
+            for super::super::RemoteWhereInput
+        {
+        }
+        pub struct type_not_in;
+        impl ::cynic::schema::Field for type_not_in {
+            type Type = Option<Vec<super::super::String>>;
+            const NAME: &'static str = "type_not_in";
+        }
+        impl ::cynic::schema::HasInputField<type_not_in, Option<Vec<super::super::String>>>
+            for super::super::RemoteWhereInput
+        {
+        }
+        pub struct type_lt;
+        impl ::cynic::schema::Field for type_lt {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "type_lt";
+        }
+        impl ::cynic::schema::HasInputField<type_lt, Option<super::super::String>>
+            for super::super::RemoteWhereInput
+        {
+        }
+        pub struct type_lte;
+        impl ::cynic::schema::Field for type_lte {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "type_lte";
+        }
+        impl ::cynic::schema::HasInputField<type_lte, Option<super::super::String>>
+            for super::super::RemoteWhereInput
+        {
+        }
+        pub struct type_gt;
+        impl ::cynic::schema::Field for type_gt {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "type_gt";
+        }
+        impl ::cynic::schema::HasInputField<type_gt, Option<super::super::String>>
+            for super::super::RemoteWhereInput
+        {
+        }
+        pub struct type_gte;
+        impl ::cynic::schema::Field for type_gte {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "type_gte";
+        }
+        impl ::cynic::schema::HasInputField<type_gte, Option<super::super::String>>
+            for super::super::RemoteWhereInput
+        {
+        }
+        pub struct type_contains;
+        impl ::cynic::schema::Field for type_contains {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "type_contains";
+        }
+        impl ::cynic::schema::HasInputField<type_contains, Option<super::super::String>>
+            for super::super::RemoteWhereInput
+        {
+        }
+        pub struct type_not_contains;
+        impl ::cynic::schema::Field for type_not_contains {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "type_not_contains";
+        }
+        impl ::cynic::schema::HasInputField<type_not_contains, Option<super::super::String>>
+            for super::super::RemoteWhereInput
+        {
+        }
+        pub struct type_starts_with;
+        impl ::cynic::schema::Field for type_starts_with {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "type_starts_with";
+        }
+        impl ::cynic::schema::HasInputField<type_starts_with, Option<super::super::String>>
+            for super::super::RemoteWhereInput
+        {
+        }
+        pub struct type_not_starts_with;
+        impl ::cynic::schema::Field for type_not_starts_with {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "type_not_starts_with";
+        }
+        impl ::cynic::schema::HasInputField<type_not_starts_with, Option<super::super::String>>
+            for super::super::RemoteWhereInput
+        {
+        }
+        pub struct type_ends_with;
+        impl ::cynic::schema::Field for type_ends_with {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "type_ends_with";
+        }
+        impl ::cynic::schema::HasInputField<type_ends_with, Option<super::super::String>>
+            for super::super::RemoteWhereInput
+        {
+        }
+        pub struct type_not_ends_with;
+        impl ::cynic::schema::Field for type_not_ends_with {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "type_not_ends_with";
+        }
+        impl ::cynic::schema::HasInputField<type_not_ends_with, Option<super::super::String>>
+            for super::super::RemoteWhereInput
+        {
+        }
+        pub struct jobs_every;
+        impl ::cynic::schema::Field for jobs_every {
+            type Type = Option<super::super::JobWhereInput>;
+            const NAME: &'static str = "jobs_every";
+        }
+        impl ::cynic::schema::HasInputField<jobs_every, Option<super::super::JobWhereInput>>
+            for super::super::RemoteWhereInput
+        {
+        }
+        pub struct jobs_some;
+        impl ::cynic::schema::Field for jobs_some {
+            type Type = Option<super::super::JobWhereInput>;
+            const NAME: &'static str = "jobs_some";
+        }
+        impl ::cynic::schema::HasInputField<jobs_some, Option<super::super::JobWhereInput>>
+            for super::super::RemoteWhereInput
+        {
+        }
+        pub struct jobs_none;
+        impl ::cynic::schema::Field for jobs_none {
+            type Type = Option<super::super::JobWhereInput>;
+            const NAME: &'static str = "jobs_none";
+        }
+        impl ::cynic::schema::HasInputField<jobs_none, Option<super::super::JobWhereInput>>
+            for super::super::RemoteWhereInput
+        {
+        }
+        pub struct createdAt;
+        impl ::cynic::schema::Field for createdAt {
+            type Type = Option<super::super::DateTime>;
+            const NAME: &'static str = "createdAt";
+        }
+        impl ::cynic::schema::HasInputField<createdAt, Option<super::super::DateTime>>
+            for super::super::RemoteWhereInput
+        {
+        }
+        pub struct createdAt_not;
+        impl ::cynic::schema::Field for createdAt_not {
+            type Type = Option<super::super::DateTime>;
+            const NAME: &'static str = "createdAt_not";
+        }
+        impl ::cynic::schema::HasInputField<createdAt_not, Option<super::super::DateTime>>
+            for super::super::RemoteWhereInput
+        {
+        }
+        pub struct createdAt_in;
+        impl ::cynic::schema::Field for createdAt_in {
+            type Type = Option<Vec<super::super::DateTime>>;
+            const NAME: &'static str = "createdAt_in";
+        }
+        impl ::cynic::schema::HasInputField<createdAt_in, Option<Vec<super::super::DateTime>>>
+            for super::super::RemoteWhereInput
+        {
+        }
+        pub struct createdAt_not_in;
+        impl ::cynic::schema::Field for createdAt_not_in {
+            type Type = Option<Vec<super::super::DateTime>>;
+            const NAME: &'static str = "createdAt_not_in";
+        }
+        impl ::cynic::schema::HasInputField<createdAt_not_in, Option<Vec<super::super::DateTime>>>
+            for super::super::RemoteWhereInput
+        {
+        }
+        pub struct createdAt_lt;
+        impl ::cynic::schema::Field for createdAt_lt {
+            type Type = Option<super::super::DateTime>;
+            const NAME: &'static str = "createdAt_lt";
+        }
+        impl ::cynic::schema::HasInputField<createdAt_lt, Option<super::super::DateTime>>
+            for super::super::RemoteWhereInput
+        {
+        }
+        pub struct createdAt_lte;
+        impl ::cynic::schema::Field for createdAt_lte {
+            type Type = Option<super::super::DateTime>;
+            const NAME: &'static str = "createdAt_lte";
+        }
+        impl ::cynic::schema::HasInputField<createdAt_lte, Option<super::super::DateTime>>
+            for super::super::RemoteWhereInput
+        {
+        }
+        pub struct createdAt_gt;
+        impl ::cynic::schema::Field for createdAt_gt {
+            type Type = Option<super::super::DateTime>;
+            const NAME: &'static str = "createdAt_gt";
+        }
+        impl ::cynic::schema::HasInputField<createdAt_gt, Option<super::super::DateTime>>
+            for super::super::RemoteWhereInput
+        {
+        }
+        pub struct createdAt_gte;
+        impl ::cynic::schema::Field for createdAt_gte {
+            type Type = Option<super::super::DateTime>;
+            const NAME: &'static str = "createdAt_gte";
+        }
+        impl ::cynic::schema::HasInputField<createdAt_gte, Option<super::super::DateTime>>
+            for super::super::RemoteWhereInput
+        {
+        }
+        pub struct updatedAt;
+        impl ::cynic::schema::Field for updatedAt {
+            type Type = Option<super::super::DateTime>;
+            const NAME: &'static str = "updatedAt";
+        }
+        impl ::cynic::schema::HasInputField<updatedAt, Option<super::super::DateTime>>
+            for super::super::RemoteWhereInput
+        {
+        }
+        pub struct updatedAt_not;
+        impl ::cynic::schema::Field for updatedAt_not {
+            type Type = Option<super::super::DateTime>;
+            const NAME: &'static str = "updatedAt_not";
+        }
+        impl ::cynic::schema::HasInputField<updatedAt_not, Option<super::super::DateTime>>
+            for super::super::RemoteWhereInput
+        {
+        }
+        pub struct updatedAt_in;
+        impl ::cynic::schema::Field for updatedAt_in {
+            type Type = Option<Vec<super::super::DateTime>>;
+            const NAME: &'static str = "updatedAt_in";
+        }
+        impl ::cynic::schema::HasInputField<updatedAt_in, Option<Vec<super::super::DateTime>>>
+            for super::super::RemoteWhereInput
+        {
+        }
+        pub struct updatedAt_not_in;
+        impl ::cynic::schema::Field for updatedAt_not_in {
+            type Type = Option<Vec<super::super::DateTime>>;
+            const NAME: &'static str = "updatedAt_not_in";
+        }
+        impl ::cynic::schema::HasInputField<updatedAt_not_in, Option<Vec<super::super::DateTime>>>
+            for super::super::RemoteWhereInput
+        {
+        }
+        pub struct updatedAt_lt;
+        impl ::cynic::schema::Field for updatedAt_lt {
+            type Type = Option<super::super::DateTime>;
+            const NAME: &'static str = "updatedAt_lt";
+        }
+        impl ::cynic::schema::HasInputField<updatedAt_lt, Option<super::super::DateTime>>
+            for super::super::RemoteWhereInput
+        {
+        }
+        pub struct updatedAt_lte;
+        impl ::cynic::schema::Field for updatedAt_lte {
+            type Type = Option<super::super::DateTime>;
+            const NAME: &'static str = "updatedAt_lte";
+        }
+        impl ::cynic::schema::HasInputField<updatedAt_lte, Option<super::super::DateTime>>
+            for super::super::RemoteWhereInput
+        {
+        }
+        pub struct updatedAt_gt;
+        impl ::cynic::schema::Field for updatedAt_gt {
+            type Type = Option<super::super::DateTime>;
+            const NAME: &'static str = "updatedAt_gt";
+        }
+        impl ::cynic::schema::HasInputField<updatedAt_gt, Option<super::super::DateTime>>
+            for super::super::RemoteWhereInput
+        {
+        }
+        pub struct updatedAt_gte;
+        impl ::cynic::schema::Field for updatedAt_gte {
+            type Type = Option<super::super::DateTime>;
+            const NAME: &'static str = "updatedAt_gte";
+        }
+        impl ::cynic::schema::HasInputField<updatedAt_gte, Option<super::super::DateTime>>
+            for super::super::RemoteWhereInput
+        {
+        }
+        pub struct AND;
+        impl ::cynic::schema::Field for AND {
+            type Type = Option<Vec<super::super::RemoteWhereInput>>;
+            const NAME: &'static str = "AND";
+        }
+        impl ::cynic::schema::HasInputField<AND, Option<Vec<super::super::RemoteWhereInput>>>
+            for super::super::RemoteWhereInput
+        {
+        }
+        pub struct OR;
+        impl ::cynic::schema::Field for OR {
+            type Type = Option<Vec<super::super::RemoteWhereInput>>;
+            const NAME: &'static str = "OR";
+        }
+        impl ::cynic::schema::HasInputField<OR, Option<Vec<super::super::RemoteWhereInput>>>
+            for super::super::RemoteWhereInput
+        {
+        }
+        pub struct NOT;
+        impl ::cynic::schema::Field for NOT {
+            type Type = Option<Vec<super::super::RemoteWhereInput>>;
+            const NAME: &'static str = "NOT";
+        }
+        impl ::cynic::schema::HasInputField<NOT, Option<Vec<super::super::RemoteWhereInput>>>
+            for super::super::RemoteWhereInput
+        {
+        }
+    }
+    pub mod SubscribeInput {
+        pub struct name;
+        impl ::cynic::schema::Field for name {
+            type Type = super::super::String;
+            const NAME: &'static str = "name";
+        }
+        impl ::cynic::schema::HasInputField<name, super::super::String> for super::super::SubscribeInput {}
+        pub struct email;
+        impl ::cynic::schema::Field for email {
+            type Type = super::super::String;
+            const NAME: &'static str = "email";
+        }
+        impl ::cynic::schema::HasInputField<email, super::super::String> for super::super::SubscribeInput {}
+    }
+    pub mod Tag {
+        pub struct id;
+        impl ::cynic::schema::Field for id {
+            type Type = super::super::ID;
+            const NAME: &'static str = "id";
+        }
+        impl ::cynic::schema::HasField<id> for super::super::Tag {
+            type Type = super::super::ID;
+        }
+        pub struct name;
+        impl ::cynic::schema::Field for name {
+            type Type = super::super::String;
+            const NAME: &'static str = "name";
+        }
+        impl ::cynic::schema::HasField<name> for super::super::Tag {
+            type Type = super::super::String;
+        }
+        pub struct slug;
+        impl ::cynic::schema::Field for slug {
+            type Type = super::super::String;
+            const NAME: &'static str = "slug";
+        }
+        impl ::cynic::schema::HasField<slug> for super::super::Tag {
+            type Type = super::super::String;
+        }
+        pub struct jobs;
+        impl ::cynic::schema::Field for jobs {
+            type Type = Option<Vec<super::super::Job>>;
+            const NAME: &'static str = "jobs";
+        }
+        impl ::cynic::schema::HasField<jobs> for super::super::Tag {
+            type Type = Option<Vec<super::super::Job>>;
+        }
+        pub mod jobs_arguments {
+            pub struct r#where;
+            impl ::cynic::schema::HasArgument<r#where> for super::jobs {
+                type ArgumentType = Option<super::super::super::JobWhereInput>;
+                const NAME: &'static str = "where";
+            }
+            pub struct orderBy;
+            impl ::cynic::schema::HasArgument<orderBy> for super::jobs {
+                type ArgumentType = Option<super::super::super::JobOrderByInput>;
+                const NAME: &'static str = "orderBy";
+            }
+            pub struct skip;
+            impl ::cynic::schema::HasArgument<skip> for super::jobs {
+                type ArgumentType = Option<super::super::super::Int>;
+                const NAME: &'static str = "skip";
+            }
+            pub struct after;
+            impl ::cynic::schema::HasArgument<after> for super::jobs {
+                type ArgumentType = Option<super::super::super::String>;
+                const NAME: &'static str = "after";
+            }
+            pub struct before;
+            impl ::cynic::schema::HasArgument<before> for super::jobs {
+                type ArgumentType = Option<super::super::super::String>;
+                const NAME: &'static str = "before";
+            }
+            pub struct first;
+            impl ::cynic::schema::HasArgument<first> for super::jobs {
+                type ArgumentType = Option<super::super::super::Int>;
+                const NAME: &'static str = "first";
+            }
+            pub struct last;
+            impl ::cynic::schema::HasArgument<last> for super::jobs {
+                type ArgumentType = Option<super::super::super::Int>;
+                const NAME: &'static str = "last";
+            }
+        }
+        pub struct createdAt;
+        impl ::cynic::schema::Field for createdAt {
+            type Type = super::super::DateTime;
+            const NAME: &'static str = "createdAt";
+        }
+        impl ::cynic::schema::HasField<createdAt> for super::super::Tag {
+            type Type = super::super::DateTime;
+        }
+        pub struct updatedAt;
+        impl ::cynic::schema::Field for updatedAt {
+            type Type = super::super::DateTime;
+            const NAME: &'static str = "updatedAt";
+        }
+        impl ::cynic::schema::HasField<updatedAt> for super::super::Tag {
+            type Type = super::super::DateTime;
+        }
+    }
+    pub mod TagWhereInput {
+        pub struct id;
+        impl ::cynic::schema::Field for id {
+            type Type = Option<super::super::ID>;
+            const NAME: &'static str = "id";
+        }
+        impl ::cynic::schema::HasInputField<id, Option<super::super::ID>> for super::super::TagWhereInput {}
+        pub struct id_not;
+        impl ::cynic::schema::Field for id_not {
+            type Type = Option<super::super::ID>;
+            const NAME: &'static str = "id_not";
+        }
+        impl ::cynic::schema::HasInputField<id_not, Option<super::super::ID>>
+            for super::super::TagWhereInput
+        {
+        }
+        pub struct id_in;
+        impl ::cynic::schema::Field for id_in {
+            type Type = Option<Vec<super::super::ID>>;
+            const NAME: &'static str = "id_in";
+        }
+        impl ::cynic::schema::HasInputField<id_in, Option<Vec<super::super::ID>>>
+            for super::super::TagWhereInput
+        {
+        }
+        pub struct id_not_in;
+        impl ::cynic::schema::Field for id_not_in {
+            type Type = Option<Vec<super::super::ID>>;
+            const NAME: &'static str = "id_not_in";
+        }
+        impl ::cynic::schema::HasInputField<id_not_in, Option<Vec<super::super::ID>>>
+            for super::super::TagWhereInput
+        {
+        }
+        pub struct id_lt;
+        impl ::cynic::schema::Field for id_lt {
+            type Type = Option<super::super::ID>;
+            const NAME: &'static str = "id_lt";
+        }
+        impl ::cynic::schema::HasInputField<id_lt, Option<super::super::ID>>
+            for super::super::TagWhereInput
+        {
+        }
+        pub struct id_lte;
+        impl ::cynic::schema::Field for id_lte {
+            type Type = Option<super::super::ID>;
+            const NAME: &'static str = "id_lte";
+        }
+        impl ::cynic::schema::HasInputField<id_lte, Option<super::super::ID>>
+            for super::super::TagWhereInput
+        {
+        }
+        pub struct id_gt;
+        impl ::cynic::schema::Field for id_gt {
+            type Type = Option<super::super::ID>;
+            const NAME: &'static str = "id_gt";
+        }
+        impl ::cynic::schema::HasInputField<id_gt, Option<super::super::ID>>
+            for super::super::TagWhereInput
+        {
+        }
+        pub struct id_gte;
+        impl ::cynic::schema::Field for id_gte {
+            type Type = Option<super::super::ID>;
+            const NAME: &'static str = "id_gte";
+        }
+        impl ::cynic::schema::HasInputField<id_gte, Option<super::super::ID>>
+            for super::super::TagWhereInput
+        {
+        }
+        pub struct id_contains;
+        impl ::cynic::schema::Field for id_contains {
+            type Type = Option<super::super::ID>;
+            const NAME: &'static str = "id_contains";
+        }
+        impl ::cynic::schema::HasInputField<id_contains, Option<super::super::ID>>
+            for super::super::TagWhereInput
+        {
+        }
+        pub struct id_not_contains;
+        impl ::cynic::schema::Field for id_not_contains {
+            type Type = Option<super::super::ID>;
+            const NAME: &'static str = "id_not_contains";
+        }
+        impl ::cynic::schema::HasInputField<id_not_contains, Option<super::super::ID>>
+            for super::super::TagWhereInput
+        {
+        }
+        pub struct id_starts_with;
+        impl ::cynic::schema::Field for id_starts_with {
+            type Type = Option<super::super::ID>;
+            const NAME: &'static str = "id_starts_with";
+        }
+        impl ::cynic::schema::HasInputField<id_starts_with, Option<super::super::ID>>
+            for super::super::TagWhereInput
+        {
+        }
+        pub struct id_not_starts_with;
+        impl ::cynic::schema::Field for id_not_starts_with {
+            type Type = Option<super::super::ID>;
+            const NAME: &'static str = "id_not_starts_with";
+        }
+        impl ::cynic::schema::HasInputField<id_not_starts_with, Option<super::super::ID>>
+            for super::super::TagWhereInput
+        {
+        }
+        pub struct id_ends_with;
+        impl ::cynic::schema::Field for id_ends_with {
+            type Type = Option<super::super::ID>;
+            const NAME: &'static str = "id_ends_with";
+        }
+        impl ::cynic::schema::HasInputField<id_ends_with, Option<super::super::ID>>
+            for super::super::TagWhereInput
+        {
+        }
+        pub struct id_not_ends_with;
+        impl ::cynic::schema::Field for id_not_ends_with {
+            type Type = Option<super::super::ID>;
+            const NAME: &'static str = "id_not_ends_with";
+        }
+        impl ::cynic::schema::HasInputField<id_not_ends_with, Option<super::super::ID>>
+            for super::super::TagWhereInput
+        {
+        }
+        pub struct name;
+        impl ::cynic::schema::Field for name {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "name";
+        }
+        impl ::cynic::schema::HasInputField<name, Option<super::super::String>>
+            for super::super::TagWhereInput
+        {
+        }
+        pub struct name_not;
+        impl ::cynic::schema::Field for name_not {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "name_not";
+        }
+        impl ::cynic::schema::HasInputField<name_not, Option<super::super::String>>
+            for super::super::TagWhereInput
+        {
+        }
+        pub struct name_in;
+        impl ::cynic::schema::Field for name_in {
+            type Type = Option<Vec<super::super::String>>;
+            const NAME: &'static str = "name_in";
+        }
+        impl ::cynic::schema::HasInputField<name_in, Option<Vec<super::super::String>>>
+            for super::super::TagWhereInput
+        {
+        }
+        pub struct name_not_in;
+        impl ::cynic::schema::Field for name_not_in {
+            type Type = Option<Vec<super::super::String>>;
+            const NAME: &'static str = "name_not_in";
+        }
+        impl ::cynic::schema::HasInputField<name_not_in, Option<Vec<super::super::String>>>
+            for super::super::TagWhereInput
+        {
+        }
+        pub struct name_lt;
+        impl ::cynic::schema::Field for name_lt {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "name_lt";
+        }
+        impl ::cynic::schema::HasInputField<name_lt, Option<super::super::String>>
+            for super::super::TagWhereInput
+        {
+        }
+        pub struct name_lte;
+        impl ::cynic::schema::Field for name_lte {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "name_lte";
+        }
+        impl ::cynic::schema::HasInputField<name_lte, Option<super::super::String>>
+            for super::super::TagWhereInput
+        {
+        }
+        pub struct name_gt;
+        impl ::cynic::schema::Field for name_gt {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "name_gt";
+        }
+        impl ::cynic::schema::HasInputField<name_gt, Option<super::super::String>>
+            for super::super::TagWhereInput
+        {
+        }
+        pub struct name_gte;
+        impl ::cynic::schema::Field for name_gte {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "name_gte";
+        }
+        impl ::cynic::schema::HasInputField<name_gte, Option<super::super::String>>
+            for super::super::TagWhereInput
+        {
+        }
+        pub struct name_contains;
+        impl ::cynic::schema::Field for name_contains {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "name_contains";
+        }
+        impl ::cynic::schema::HasInputField<name_contains, Option<super::super::String>>
+            for super::super::TagWhereInput
+        {
+        }
+        pub struct name_not_contains;
+        impl ::cynic::schema::Field for name_not_contains {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "name_not_contains";
+        }
+        impl ::cynic::schema::HasInputField<name_not_contains, Option<super::super::String>>
+            for super::super::TagWhereInput
+        {
+        }
+        pub struct name_starts_with;
+        impl ::cynic::schema::Field for name_starts_with {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "name_starts_with";
+        }
+        impl ::cynic::schema::HasInputField<name_starts_with, Option<super::super::String>>
+            for super::super::TagWhereInput
+        {
+        }
+        pub struct name_not_starts_with;
+        impl ::cynic::schema::Field for name_not_starts_with {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "name_not_starts_with";
+        }
+        impl ::cynic::schema::HasInputField<name_not_starts_with, Option<super::super::String>>
+            for super::super::TagWhereInput
+        {
+        }
+        pub struct name_ends_with;
+        impl ::cynic::schema::Field for name_ends_with {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "name_ends_with";
+        }
+        impl ::cynic::schema::HasInputField<name_ends_with, Option<super::super::String>>
+            for super::super::TagWhereInput
+        {
+        }
+        pub struct name_not_ends_with;
+        impl ::cynic::schema::Field for name_not_ends_with {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "name_not_ends_with";
+        }
+        impl ::cynic::schema::HasInputField<name_not_ends_with, Option<super::super::String>>
+            for super::super::TagWhereInput
+        {
+        }
+        pub struct slug;
+        impl ::cynic::schema::Field for slug {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "slug";
+        }
+        impl ::cynic::schema::HasInputField<slug, Option<super::super::String>>
+            for super::super::TagWhereInput
+        {
+        }
+        pub struct slug_not;
+        impl ::cynic::schema::Field for slug_not {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "slug_not";
+        }
+        impl ::cynic::schema::HasInputField<slug_not, Option<super::super::String>>
+            for super::super::TagWhereInput
+        {
+        }
+        pub struct slug_in;
+        impl ::cynic::schema::Field for slug_in {
+            type Type = Option<Vec<super::super::String>>;
+            const NAME: &'static str = "slug_in";
+        }
+        impl ::cynic::schema::HasInputField<slug_in, Option<Vec<super::super::String>>>
+            for super::super::TagWhereInput
+        {
+        }
+        pub struct slug_not_in;
+        impl ::cynic::schema::Field for slug_not_in {
+            type Type = Option<Vec<super::super::String>>;
+            const NAME: &'static str = "slug_not_in";
+        }
+        impl ::cynic::schema::HasInputField<slug_not_in, Option<Vec<super::super::String>>>
+            for super::super::TagWhereInput
+        {
+        }
+        pub struct slug_lt;
+        impl ::cynic::schema::Field for slug_lt {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "slug_lt";
+        }
+        impl ::cynic::schema::HasInputField<slug_lt, Option<super::super::String>>
+            for super::super::TagWhereInput
+        {
+        }
+        pub struct slug_lte;
+        impl ::cynic::schema::Field for slug_lte {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "slug_lte";
+        }
+        impl ::cynic::schema::HasInputField<slug_lte, Option<super::super::String>>
+            for super::super::TagWhereInput
+        {
+        }
+        pub struct slug_gt;
+        impl ::cynic::schema::Field for slug_gt {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "slug_gt";
+        }
+        impl ::cynic::schema::HasInputField<slug_gt, Option<super::super::String>>
+            for super::super::TagWhereInput
+        {
+        }
+        pub struct slug_gte;
+        impl ::cynic::schema::Field for slug_gte {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "slug_gte";
+        }
+        impl ::cynic::schema::HasInputField<slug_gte, Option<super::super::String>>
+            for super::super::TagWhereInput
+        {
+        }
+        pub struct slug_contains;
+        impl ::cynic::schema::Field for slug_contains {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "slug_contains";
+        }
+        impl ::cynic::schema::HasInputField<slug_contains, Option<super::super::String>>
+            for super::super::TagWhereInput
+        {
+        }
+        pub struct slug_not_contains;
+        impl ::cynic::schema::Field for slug_not_contains {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "slug_not_contains";
+        }
+        impl ::cynic::schema::HasInputField<slug_not_contains, Option<super::super::String>>
+            for super::super::TagWhereInput
+        {
+        }
+        pub struct slug_starts_with;
+        impl ::cynic::schema::Field for slug_starts_with {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "slug_starts_with";
+        }
+        impl ::cynic::schema::HasInputField<slug_starts_with, Option<super::super::String>>
+            for super::super::TagWhereInput
+        {
+        }
+        pub struct slug_not_starts_with;
+        impl ::cynic::schema::Field for slug_not_starts_with {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "slug_not_starts_with";
+        }
+        impl ::cynic::schema::HasInputField<slug_not_starts_with, Option<super::super::String>>
+            for super::super::TagWhereInput
+        {
+        }
+        pub struct slug_ends_with;
+        impl ::cynic::schema::Field for slug_ends_with {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "slug_ends_with";
+        }
+        impl ::cynic::schema::HasInputField<slug_ends_with, Option<super::super::String>>
+            for super::super::TagWhereInput
+        {
+        }
+        pub struct slug_not_ends_with;
+        impl ::cynic::schema::Field for slug_not_ends_with {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "slug_not_ends_with";
+        }
+        impl ::cynic::schema::HasInputField<slug_not_ends_with, Option<super::super::String>>
+            for super::super::TagWhereInput
+        {
+        }
+        pub struct jobs_every;
+        impl ::cynic::schema::Field for jobs_every {
+            type Type = Option<super::super::JobWhereInput>;
+            const NAME: &'static str = "jobs_every";
+        }
+        impl ::cynic::schema::HasInputField<jobs_every, Option<super::super::JobWhereInput>>
+            for super::super::TagWhereInput
+        {
+        }
+        pub struct jobs_some;
+        impl ::cynic::schema::Field for jobs_some {
+            type Type = Option<super::super::JobWhereInput>;
+            const NAME: &'static str = "jobs_some";
+        }
+        impl ::cynic::schema::HasInputField<jobs_some, Option<super::super::JobWhereInput>>
+            for super::super::TagWhereInput
+        {
+        }
+        pub struct jobs_none;
+        impl ::cynic::schema::Field for jobs_none {
+            type Type = Option<super::super::JobWhereInput>;
+            const NAME: &'static str = "jobs_none";
+        }
+        impl ::cynic::schema::HasInputField<jobs_none, Option<super::super::JobWhereInput>>
+            for super::super::TagWhereInput
+        {
+        }
+        pub struct createdAt;
+        impl ::cynic::schema::Field for createdAt {
+            type Type = Option<super::super::DateTime>;
+            const NAME: &'static str = "createdAt";
+        }
+        impl ::cynic::schema::HasInputField<createdAt, Option<super::super::DateTime>>
+            for super::super::TagWhereInput
+        {
+        }
+        pub struct createdAt_not;
+        impl ::cynic::schema::Field for createdAt_not {
+            type Type = Option<super::super::DateTime>;
+            const NAME: &'static str = "createdAt_not";
+        }
+        impl ::cynic::schema::HasInputField<createdAt_not, Option<super::super::DateTime>>
+            for super::super::TagWhereInput
+        {
+        }
+        pub struct createdAt_in;
+        impl ::cynic::schema::Field for createdAt_in {
+            type Type = Option<Vec<super::super::DateTime>>;
+            const NAME: &'static str = "createdAt_in";
+        }
+        impl ::cynic::schema::HasInputField<createdAt_in, Option<Vec<super::super::DateTime>>>
+            for super::super::TagWhereInput
+        {
+        }
+        pub struct createdAt_not_in;
+        impl ::cynic::schema::Field for createdAt_not_in {
+            type Type = Option<Vec<super::super::DateTime>>;
+            const NAME: &'static str = "createdAt_not_in";
+        }
+        impl ::cynic::schema::HasInputField<createdAt_not_in, Option<Vec<super::super::DateTime>>>
+            for super::super::TagWhereInput
+        {
+        }
+        pub struct createdAt_lt;
+        impl ::cynic::schema::Field for createdAt_lt {
+            type Type = Option<super::super::DateTime>;
+            const NAME: &'static str = "createdAt_lt";
+        }
+        impl ::cynic::schema::HasInputField<createdAt_lt, Option<super::super::DateTime>>
+            for super::super::TagWhereInput
+        {
+        }
+        pub struct createdAt_lte;
+        impl ::cynic::schema::Field for createdAt_lte {
+            type Type = Option<super::super::DateTime>;
+            const NAME: &'static str = "createdAt_lte";
+        }
+        impl ::cynic::schema::HasInputField<createdAt_lte, Option<super::super::DateTime>>
+            for super::super::TagWhereInput
+        {
+        }
+        pub struct createdAt_gt;
+        impl ::cynic::schema::Field for createdAt_gt {
+            type Type = Option<super::super::DateTime>;
+            const NAME: &'static str = "createdAt_gt";
+        }
+        impl ::cynic::schema::HasInputField<createdAt_gt, Option<super::super::DateTime>>
+            for super::super::TagWhereInput
+        {
+        }
+        pub struct createdAt_gte;
+        impl ::cynic::schema::Field for createdAt_gte {
+            type Type = Option<super::super::DateTime>;
+            const NAME: &'static str = "createdAt_gte";
+        }
+        impl ::cynic::schema::HasInputField<createdAt_gte, Option<super::super::DateTime>>
+            for super::super::TagWhereInput
+        {
+        }
+        pub struct updatedAt;
+        impl ::cynic::schema::Field for updatedAt {
+            type Type = Option<super::super::DateTime>;
+            const NAME: &'static str = "updatedAt";
+        }
+        impl ::cynic::schema::HasInputField<updatedAt, Option<super::super::DateTime>>
+            for super::super::TagWhereInput
+        {
+        }
+        pub struct updatedAt_not;
+        impl ::cynic::schema::Field for updatedAt_not {
+            type Type = Option<super::super::DateTime>;
+            const NAME: &'static str = "updatedAt_not";
+        }
+        impl ::cynic::schema::HasInputField<updatedAt_not, Option<super::super::DateTime>>
+            for super::super::TagWhereInput
+        {
+        }
+        pub struct updatedAt_in;
+        impl ::cynic::schema::Field for updatedAt_in {
+            type Type = Option<Vec<super::super::DateTime>>;
+            const NAME: &'static str = "updatedAt_in";
+        }
+        impl ::cynic::schema::HasInputField<updatedAt_in, Option<Vec<super::super::DateTime>>>
+            for super::super::TagWhereInput
+        {
+        }
+        pub struct updatedAt_not_in;
+        impl ::cynic::schema::Field for updatedAt_not_in {
+            type Type = Option<Vec<super::super::DateTime>>;
+            const NAME: &'static str = "updatedAt_not_in";
+        }
+        impl ::cynic::schema::HasInputField<updatedAt_not_in, Option<Vec<super::super::DateTime>>>
+            for super::super::TagWhereInput
+        {
+        }
+        pub struct updatedAt_lt;
+        impl ::cynic::schema::Field for updatedAt_lt {
+            type Type = Option<super::super::DateTime>;
+            const NAME: &'static str = "updatedAt_lt";
+        }
+        impl ::cynic::schema::HasInputField<updatedAt_lt, Option<super::super::DateTime>>
+            for super::super::TagWhereInput
+        {
+        }
+        pub struct updatedAt_lte;
+        impl ::cynic::schema::Field for updatedAt_lte {
+            type Type = Option<super::super::DateTime>;
+            const NAME: &'static str = "updatedAt_lte";
+        }
+        impl ::cynic::schema::HasInputField<updatedAt_lte, Option<super::super::DateTime>>
+            for super::super::TagWhereInput
+        {
+        }
+        pub struct updatedAt_gt;
+        impl ::cynic::schema::Field for updatedAt_gt {
+            type Type = Option<super::super::DateTime>;
+            const NAME: &'static str = "updatedAt_gt";
+        }
+        impl ::cynic::schema::HasInputField<updatedAt_gt, Option<super::super::DateTime>>
+            for super::super::TagWhereInput
+        {
+        }
+        pub struct updatedAt_gte;
+        impl ::cynic::schema::Field for updatedAt_gte {
+            type Type = Option<super::super::DateTime>;
+            const NAME: &'static str = "updatedAt_gte";
+        }
+        impl ::cynic::schema::HasInputField<updatedAt_gte, Option<super::super::DateTime>>
+            for super::super::TagWhereInput
+        {
+        }
+        pub struct AND;
+        impl ::cynic::schema::Field for AND {
+            type Type = Option<Vec<super::super::TagWhereInput>>;
+            const NAME: &'static str = "AND";
+        }
+        impl ::cynic::schema::HasInputField<AND, Option<Vec<super::super::TagWhereInput>>>
+            for super::super::TagWhereInput
+        {
+        }
+        pub struct OR;
+        impl ::cynic::schema::Field for OR {
+            type Type = Option<Vec<super::super::TagWhereInput>>;
+            const NAME: &'static str = "OR";
+        }
+        impl ::cynic::schema::HasInputField<OR, Option<Vec<super::super::TagWhereInput>>>
+            for super::super::TagWhereInput
+        {
+        }
+        pub struct NOT;
+        impl ::cynic::schema::Field for NOT {
+            type Type = Option<Vec<super::super::TagWhereInput>>;
+            const NAME: &'static str = "NOT";
+        }
+        impl ::cynic::schema::HasInputField<NOT, Option<Vec<super::super::TagWhereInput>>>
+            for super::super::TagWhereInput
+        {
+        }
+    }
+    pub mod UpdateCompanyInput {
+        pub struct id;
+        impl ::cynic::schema::Field for id {
+            type Type = super::super::ID;
+            const NAME: &'static str = "id";
+        }
+        impl ::cynic::schema::HasInputField<id, super::super::ID> for super::super::UpdateCompanyInput {}
+        pub struct logoUrl;
+        impl ::cynic::schema::Field for logoUrl {
+            type Type = super::super::String;
+            const NAME: &'static str = "logoUrl";
+        }
+        impl ::cynic::schema::HasInputField<logoUrl, super::super::String>
+            for super::super::UpdateCompanyInput
+        {
+        }
+    }
+    pub mod UpdateJobInput {
+        pub struct id;
+        impl ::cynic::schema::Field for id {
+            type Type = super::super::ID;
+            const NAME: &'static str = "id";
+        }
+        impl ::cynic::schema::HasInputField<id, super::super::ID> for super::super::UpdateJobInput {}
+        pub struct description;
+        impl ::cynic::schema::Field for description {
+            type Type = super::super::String;
+            const NAME: &'static str = "description";
+        }
+        impl ::cynic::schema::HasInputField<description, super::super::String>
+            for super::super::UpdateJobInput
+        {
+        }
+    }
+    pub mod User {
+        pub struct id;
+        impl ::cynic::schema::Field for id {
+            type Type = super::super::ID;
+            const NAME: &'static str = "id";
+        }
+        impl ::cynic::schema::HasField<id> for super::super::User {
+            type Type = super::super::ID;
+        }
+        pub struct name;
+        impl ::cynic::schema::Field for name {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "name";
+        }
+        impl ::cynic::schema::HasField<name> for super::super::User {
+            type Type = Option<super::super::String>;
+        }
+        pub struct email;
+        impl ::cynic::schema::Field for email {
+            type Type = super::super::String;
+            const NAME: &'static str = "email";
+        }
+        impl ::cynic::schema::HasField<email> for super::super::User {
+            type Type = super::super::String;
+        }
+        pub struct subscribe;
+        impl ::cynic::schema::Field for subscribe {
+            type Type = super::super::Boolean;
+            const NAME: &'static str = "subscribe";
+        }
+        impl ::cynic::schema::HasField<subscribe> for super::super::User {
+            type Type = super::super::Boolean;
+        }
+        pub struct createdAt;
+        impl ::cynic::schema::Field for createdAt {
+            type Type = super::super::DateTime;
+            const NAME: &'static str = "createdAt";
+        }
+        impl ::cynic::schema::HasField<createdAt> for super::super::User {
+            type Type = super::super::DateTime;
+        }
+        pub struct updatedAt;
+        impl ::cynic::schema::Field for updatedAt {
+            type Type = super::super::DateTime;
+            const NAME: &'static str = "updatedAt";
+        }
+        impl ::cynic::schema::HasField<updatedAt> for super::super::User {
+            type Type = super::super::DateTime;
+        }
+    }
 }
 pub type Boolean = bool;
 pub type String = std::string::String;

--- a/cynic-codegen/tests/snapshots/use_schema__simple.graphql.snap
+++ b/cynic-codegen/tests/snapshots/use_schema__simple.graphql.snap
@@ -86,7 +86,7 @@ pub mod __fields {
         impl ::cynic::schema::HasField<fieldOne> for super::super::TestStruct {
             type Type = super::super::String;
         }
-        pub mod field_one_arguments {
+        pub mod _field_one_arguments {
             pub struct x;
             impl ::cynic::schema::HasArgument<x> for super::fieldOne {
                 type ArgumentType = Option<super::super::super::Int>;
@@ -106,7 +106,7 @@ pub mod __fields {
         impl ::cynic::schema::HasField<tastyCakes> for super::super::TestStruct {
             type Type = super::super::Dessert;
         }
-        pub mod tasty_cakes_arguments {
+        pub mod _tasty_cakes_arguments {
             pub struct first;
             impl ::cynic::schema::HasArgument<first> for super::tastyCakes {
                 type ArgumentType = super::super::super::Dessert;
@@ -126,7 +126,7 @@ pub mod __fields {
         impl ::cynic::schema::HasField<fieldWithInput> for super::super::TestStruct {
             type Type = super::super::Dessert;
         }
-        pub mod field_with_input_arguments {
+        pub mod _field_with_input_arguments {
             pub struct input;
             impl ::cynic::schema::HasArgument<input> for super::fieldWithInput {
                 type ArgumentType = super::super::super::AnInputType;

--- a/cynic-codegen/tests/snapshots/use_schema__simple.graphql.snap
+++ b/cynic-codegen/tests/snapshots/use_schema__simple.graphql.snap
@@ -5,17 +5,6 @@ expression: "format_code(format!(\"{}\", tokens))"
 impl ::cynic::schema::QueryRoot for Query {}
 pub struct AnInputType;
 impl ::cynic::schema::InputObjectMarker for AnInputType {}
-pub mod an_input_type_fields {
-    pub struct favouriteDessert;
-    impl ::cynic::schema::Field for favouriteDessert {
-        type Type = Option<super::Dessert>;
-        const NAME: &'static str = "favouriteDessert";
-    }
-    impl ::cynic::schema::HasInputField<favouriteDessert, Option<super::Dessert>>
-        for super::AnInputType
-    {
-    }
-}
 pub struct Dessert {}
 pub struct JSON {}
 impl ::cynic::schema::NamedType for JSON {
@@ -23,133 +12,8 @@ impl ::cynic::schema::NamedType for JSON {
 }
 pub struct MyUnionType {}
 pub struct Nested;
-pub mod nested_fields {
-    pub struct aString;
-    impl ::cynic::schema::Field for aString {
-        type Type = super::String;
-        const NAME: &'static str = "aString";
-    }
-    impl ::cynic::schema::HasField<aString> for super::Nested {
-        type Type = super::String;
-    }
-    pub struct optString;
-    impl ::cynic::schema::Field for optString {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "optString";
-    }
-    impl ::cynic::schema::HasField<optString> for super::Nested {
-        type Type = Option<super::String>;
-    }
-}
 pub struct Query;
-pub mod query_fields {
-    pub struct testStruct;
-    impl ::cynic::schema::Field for testStruct {
-        type Type = Option<super::TestStruct>;
-        const NAME: &'static str = "testStruct";
-    }
-    impl ::cynic::schema::HasField<testStruct> for super::Query {
-        type Type = Option<super::TestStruct>;
-    }
-    pub struct myUnion;
-    impl ::cynic::schema::Field for myUnion {
-        type Type = Option<super::MyUnionType>;
-        const NAME: &'static str = "myUnion";
-    }
-    impl ::cynic::schema::HasField<myUnion> for super::Query {
-        type Type = Option<super::MyUnionType>;
-    }
-}
 pub struct TestStruct;
-pub mod test_struct_fields {
-    pub struct fieldOne;
-    impl ::cynic::schema::Field for fieldOne {
-        type Type = super::String;
-        const NAME: &'static str = "fieldOne";
-    }
-    impl ::cynic::schema::HasField<fieldOne> for super::TestStruct {
-        type Type = super::String;
-    }
-    pub mod field_one_arguments {
-        pub struct x;
-        impl ::cynic::schema::HasArgument<x> for super::fieldOne {
-            type ArgumentType = Option<super::super::Int>;
-            const NAME: &'static str = "x";
-        }
-        pub struct y;
-        impl ::cynic::schema::HasArgument<y> for super::fieldOne {
-            type ArgumentType = Option<super::super::String>;
-            const NAME: &'static str = "y";
-        }
-    }
-    pub struct tastyCakes;
-    impl ::cynic::schema::Field for tastyCakes {
-        type Type = super::Dessert;
-        const NAME: &'static str = "tastyCakes";
-    }
-    impl ::cynic::schema::HasField<tastyCakes> for super::TestStruct {
-        type Type = super::Dessert;
-    }
-    pub mod tasty_cakes_arguments {
-        pub struct first;
-        impl ::cynic::schema::HasArgument<first> for super::tastyCakes {
-            type ArgumentType = super::super::Dessert;
-            const NAME: &'static str = "first";
-        }
-        pub struct second;
-        impl ::cynic::schema::HasArgument<second> for super::tastyCakes {
-            type ArgumentType = Option<super::super::Dessert>;
-            const NAME: &'static str = "second";
-        }
-    }
-    pub struct fieldWithInput;
-    impl ::cynic::schema::Field for fieldWithInput {
-        type Type = super::Dessert;
-        const NAME: &'static str = "fieldWithInput";
-    }
-    impl ::cynic::schema::HasField<fieldWithInput> for super::TestStruct {
-        type Type = super::Dessert;
-    }
-    pub mod field_with_input_arguments {
-        pub struct input;
-        impl ::cynic::schema::HasArgument<input> for super::fieldWithInput {
-            type ArgumentType = super::super::AnInputType;
-            const NAME: &'static str = "input";
-        }
-    }
-    pub struct nested;
-    impl ::cynic::schema::Field for nested {
-        type Type = super::Nested;
-        const NAME: &'static str = "nested";
-    }
-    impl ::cynic::schema::HasField<nested> for super::TestStruct {
-        type Type = super::Nested;
-    }
-    pub struct optNested;
-    impl ::cynic::schema::Field for optNested {
-        type Type = Option<super::Nested>;
-        const NAME: &'static str = "optNested";
-    }
-    impl ::cynic::schema::HasField<optNested> for super::TestStruct {
-        type Type = Option<super::Nested>;
-    }
-    pub struct dessert;
-    impl ::cynic::schema::Field for dessert {
-        type Type = Option<super::Dessert>;
-        const NAME: &'static str = "dessert";
-    }
-    impl ::cynic::schema::HasField<dessert> for super::TestStruct {
-        type Type = Option<super::Dessert>;
-    }
-    pub struct json;
-    impl ::cynic::schema::Field for json {
-        type Type = Option<super::JSON>;
-        const NAME: &'static str = "json";
-    }
-    impl ::cynic::schema::HasField<json> for super::TestStruct {
-        type Type = Option<super::JSON>;
-    }
-}
 impl ::cynic::schema::HasSubtype<Nested> for MyUnionType {}
 impl ::cynic::schema::HasSubtype<TestStruct> for MyUnionType {}
 impl ::cynic::schema::NamedType for MyUnionType {
@@ -163,6 +27,145 @@ impl ::cynic::schema::NamedType for Query {
 }
 impl ::cynic::schema::NamedType for TestStruct {
     const NAME: &'static str = "TestStruct";
+}
+#[allow(non_snake_case, non_camel_case_types)]
+pub mod __fields {
+    pub mod AnInputType {
+        pub struct favouriteDessert;
+        impl ::cynic::schema::Field for favouriteDessert {
+            type Type = Option<super::super::Dessert>;
+            const NAME: &'static str = "favouriteDessert";
+        }
+        impl ::cynic::schema::HasInputField<favouriteDessert, Option<super::super::Dessert>>
+            for super::super::AnInputType
+        {
+        }
+    }
+    pub mod Nested {
+        pub struct aString;
+        impl ::cynic::schema::Field for aString {
+            type Type = super::super::String;
+            const NAME: &'static str = "aString";
+        }
+        impl ::cynic::schema::HasField<aString> for super::super::Nested {
+            type Type = super::super::String;
+        }
+        pub struct optString;
+        impl ::cynic::schema::Field for optString {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "optString";
+        }
+        impl ::cynic::schema::HasField<optString> for super::super::Nested {
+            type Type = Option<super::super::String>;
+        }
+    }
+    pub mod Query {
+        pub struct testStruct;
+        impl ::cynic::schema::Field for testStruct {
+            type Type = Option<super::super::TestStruct>;
+            const NAME: &'static str = "testStruct";
+        }
+        impl ::cynic::schema::HasField<testStruct> for super::super::Query {
+            type Type = Option<super::super::TestStruct>;
+        }
+        pub struct myUnion;
+        impl ::cynic::schema::Field for myUnion {
+            type Type = Option<super::super::MyUnionType>;
+            const NAME: &'static str = "myUnion";
+        }
+        impl ::cynic::schema::HasField<myUnion> for super::super::Query {
+            type Type = Option<super::super::MyUnionType>;
+        }
+    }
+    pub mod TestStruct {
+        pub struct fieldOne;
+        impl ::cynic::schema::Field for fieldOne {
+            type Type = super::super::String;
+            const NAME: &'static str = "fieldOne";
+        }
+        impl ::cynic::schema::HasField<fieldOne> for super::super::TestStruct {
+            type Type = super::super::String;
+        }
+        pub mod field_one_arguments {
+            pub struct x;
+            impl ::cynic::schema::HasArgument<x> for super::fieldOne {
+                type ArgumentType = Option<super::super::super::Int>;
+                const NAME: &'static str = "x";
+            }
+            pub struct y;
+            impl ::cynic::schema::HasArgument<y> for super::fieldOne {
+                type ArgumentType = Option<super::super::super::String>;
+                const NAME: &'static str = "y";
+            }
+        }
+        pub struct tastyCakes;
+        impl ::cynic::schema::Field for tastyCakes {
+            type Type = super::super::Dessert;
+            const NAME: &'static str = "tastyCakes";
+        }
+        impl ::cynic::schema::HasField<tastyCakes> for super::super::TestStruct {
+            type Type = super::super::Dessert;
+        }
+        pub mod tasty_cakes_arguments {
+            pub struct first;
+            impl ::cynic::schema::HasArgument<first> for super::tastyCakes {
+                type ArgumentType = super::super::super::Dessert;
+                const NAME: &'static str = "first";
+            }
+            pub struct second;
+            impl ::cynic::schema::HasArgument<second> for super::tastyCakes {
+                type ArgumentType = Option<super::super::super::Dessert>;
+                const NAME: &'static str = "second";
+            }
+        }
+        pub struct fieldWithInput;
+        impl ::cynic::schema::Field for fieldWithInput {
+            type Type = super::super::Dessert;
+            const NAME: &'static str = "fieldWithInput";
+        }
+        impl ::cynic::schema::HasField<fieldWithInput> for super::super::TestStruct {
+            type Type = super::super::Dessert;
+        }
+        pub mod field_with_input_arguments {
+            pub struct input;
+            impl ::cynic::schema::HasArgument<input> for super::fieldWithInput {
+                type ArgumentType = super::super::super::AnInputType;
+                const NAME: &'static str = "input";
+            }
+        }
+        pub struct nested;
+        impl ::cynic::schema::Field for nested {
+            type Type = super::super::Nested;
+            const NAME: &'static str = "nested";
+        }
+        impl ::cynic::schema::HasField<nested> for super::super::TestStruct {
+            type Type = super::super::Nested;
+        }
+        pub struct optNested;
+        impl ::cynic::schema::Field for optNested {
+            type Type = Option<super::super::Nested>;
+            const NAME: &'static str = "optNested";
+        }
+        impl ::cynic::schema::HasField<optNested> for super::super::TestStruct {
+            type Type = Option<super::super::Nested>;
+        }
+        pub struct dessert;
+        impl ::cynic::schema::Field for dessert {
+            type Type = Option<super::super::Dessert>;
+            const NAME: &'static str = "dessert";
+        }
+        impl ::cynic::schema::HasField<dessert> for super::super::TestStruct {
+            type Type = Option<super::super::Dessert>;
+        }
+        pub struct json;
+        impl ::cynic::schema::Field for json {
+            type Type = Option<super::super::JSON>;
+            const NAME: &'static str = "json";
+        }
+        impl ::cynic::schema::HasField<json> for super::super::TestStruct {
+            type Type = Option<super::super::JSON>;
+        }
+    }
 }
 pub type Boolean = bool;
 pub type String = std::string::String;

--- a/cynic-codegen/tests/snapshots/use_schema__starwars.schema.graphql.snap
+++ b/cynic-codegen/tests/snapshots/use_schema__starwars.schema.graphql.snap
@@ -281,7 +281,7 @@ pub mod __fields {
         impl ::cynic::schema::HasField<speciesConnection> for super::super::Film {
             type Type = Option<super::super::FilmSpeciesConnection>;
         }
-        pub mod species_connection_arguments {
+        pub mod _species_connection_arguments {
             pub struct after;
             impl ::cynic::schema::HasArgument<after> for super::speciesConnection {
                 type ArgumentType = Option<super::super::super::String>;
@@ -311,7 +311,7 @@ pub mod __fields {
         impl ::cynic::schema::HasField<starshipConnection> for super::super::Film {
             type Type = Option<super::super::FilmStarshipsConnection>;
         }
-        pub mod starship_connection_arguments {
+        pub mod _starship_connection_arguments {
             pub struct after;
             impl ::cynic::schema::HasArgument<after> for super::starshipConnection {
                 type ArgumentType = Option<super::super::super::String>;
@@ -341,7 +341,7 @@ pub mod __fields {
         impl ::cynic::schema::HasField<vehicleConnection> for super::super::Film {
             type Type = Option<super::super::FilmVehiclesConnection>;
         }
-        pub mod vehicle_connection_arguments {
+        pub mod _vehicle_connection_arguments {
             pub struct after;
             impl ::cynic::schema::HasArgument<after> for super::vehicleConnection {
                 type ArgumentType = Option<super::super::super::String>;
@@ -371,7 +371,7 @@ pub mod __fields {
         impl ::cynic::schema::HasField<characterConnection> for super::super::Film {
             type Type = Option<super::super::FilmCharactersConnection>;
         }
-        pub mod character_connection_arguments {
+        pub mod _character_connection_arguments {
             pub struct after;
             impl ::cynic::schema::HasArgument<after> for super::characterConnection {
                 type ArgumentType = Option<super::super::super::String>;
@@ -401,7 +401,7 @@ pub mod __fields {
         impl ::cynic::schema::HasField<planetConnection> for super::super::Film {
             type Type = Option<super::super::FilmPlanetsConnection>;
         }
-        pub mod planet_connection_arguments {
+        pub mod _planet_connection_arguments {
             pub struct after;
             impl ::cynic::schema::HasArgument<after> for super::planetConnection {
                 type ArgumentType = Option<super::super::super::String>;
@@ -937,7 +937,7 @@ pub mod __fields {
         impl ::cynic::schema::HasField<filmConnection> for super::super::Person {
             type Type = Option<super::super::PersonFilmsConnection>;
         }
-        pub mod film_connection_arguments {
+        pub mod _film_connection_arguments {
             pub struct after;
             impl ::cynic::schema::HasArgument<after> for super::filmConnection {
                 type ArgumentType = Option<super::super::super::String>;
@@ -975,7 +975,7 @@ pub mod __fields {
         impl ::cynic::schema::HasField<starshipConnection> for super::super::Person {
             type Type = Option<super::super::PersonStarshipsConnection>;
         }
-        pub mod starship_connection_arguments {
+        pub mod _starship_connection_arguments {
             pub struct after;
             impl ::cynic::schema::HasArgument<after> for super::starshipConnection {
                 type ArgumentType = Option<super::super::super::String>;
@@ -1005,7 +1005,7 @@ pub mod __fields {
         impl ::cynic::schema::HasField<vehicleConnection> for super::super::Person {
             type Type = Option<super::super::PersonVehiclesConnection>;
         }
-        pub mod vehicle_connection_arguments {
+        pub mod _vehicle_connection_arguments {
             pub struct after;
             impl ::cynic::schema::HasArgument<after> for super::vehicleConnection {
                 type ArgumentType = Option<super::super::super::String>;
@@ -1289,7 +1289,7 @@ pub mod __fields {
         impl ::cynic::schema::HasField<residentConnection> for super::super::Planet {
             type Type = Option<super::super::PlanetResidentsConnection>;
         }
-        pub mod resident_connection_arguments {
+        pub mod _resident_connection_arguments {
             pub struct after;
             impl ::cynic::schema::HasArgument<after> for super::residentConnection {
                 type ArgumentType = Option<super::super::super::String>;
@@ -1319,7 +1319,7 @@ pub mod __fields {
         impl ::cynic::schema::HasField<filmConnection> for super::super::Planet {
             type Type = Option<super::super::PlanetFilmsConnection>;
         }
-        pub mod film_connection_arguments {
+        pub mod _film_connection_arguments {
             pub struct after;
             impl ::cynic::schema::HasArgument<after> for super::filmConnection {
                 type ArgumentType = Option<super::super::super::String>;
@@ -1531,7 +1531,7 @@ pub mod __fields {
         impl ::cynic::schema::HasField<allFilms> for super::super::Root {
             type Type = Option<super::super::FilmsConnection>;
         }
-        pub mod all_films_arguments {
+        pub mod _all_films_arguments {
             pub struct after;
             impl ::cynic::schema::HasArgument<after> for super::allFilms {
                 type ArgumentType = Option<super::super::super::String>;
@@ -1561,7 +1561,7 @@ pub mod __fields {
         impl ::cynic::schema::HasField<film> for super::super::Root {
             type Type = Option<super::super::Film>;
         }
-        pub mod film_arguments {
+        pub mod _film_arguments {
             pub struct id;
             impl ::cynic::schema::HasArgument<id> for super::film {
                 type ArgumentType = Option<super::super::super::ID>;
@@ -1581,7 +1581,7 @@ pub mod __fields {
         impl ::cynic::schema::HasField<allPeople> for super::super::Root {
             type Type = Option<super::super::PeopleConnection>;
         }
-        pub mod all_people_arguments {
+        pub mod _all_people_arguments {
             pub struct after;
             impl ::cynic::schema::HasArgument<after> for super::allPeople {
                 type ArgumentType = Option<super::super::super::String>;
@@ -1611,7 +1611,7 @@ pub mod __fields {
         impl ::cynic::schema::HasField<person> for super::super::Root {
             type Type = Option<super::super::Person>;
         }
-        pub mod person_arguments {
+        pub mod _person_arguments {
             pub struct id;
             impl ::cynic::schema::HasArgument<id> for super::person {
                 type ArgumentType = Option<super::super::super::ID>;
@@ -1631,7 +1631,7 @@ pub mod __fields {
         impl ::cynic::schema::HasField<allPlanets> for super::super::Root {
             type Type = Option<super::super::PlanetsConnection>;
         }
-        pub mod all_planets_arguments {
+        pub mod _all_planets_arguments {
             pub struct after;
             impl ::cynic::schema::HasArgument<after> for super::allPlanets {
                 type ArgumentType = Option<super::super::super::String>;
@@ -1661,7 +1661,7 @@ pub mod __fields {
         impl ::cynic::schema::HasField<planet> for super::super::Root {
             type Type = Option<super::super::Planet>;
         }
-        pub mod planet_arguments {
+        pub mod _planet_arguments {
             pub struct id;
             impl ::cynic::schema::HasArgument<id> for super::planet {
                 type ArgumentType = Option<super::super::super::ID>;
@@ -1681,7 +1681,7 @@ pub mod __fields {
         impl ::cynic::schema::HasField<allSpecies> for super::super::Root {
             type Type = Option<super::super::SpeciesConnection>;
         }
-        pub mod all_species_arguments {
+        pub mod _all_species_arguments {
             pub struct after;
             impl ::cynic::schema::HasArgument<after> for super::allSpecies {
                 type ArgumentType = Option<super::super::super::String>;
@@ -1711,7 +1711,7 @@ pub mod __fields {
         impl ::cynic::schema::HasField<species> for super::super::Root {
             type Type = Option<super::super::Species>;
         }
-        pub mod species_arguments {
+        pub mod _species_arguments {
             pub struct id;
             impl ::cynic::schema::HasArgument<id> for super::species {
                 type ArgumentType = Option<super::super::super::ID>;
@@ -1731,7 +1731,7 @@ pub mod __fields {
         impl ::cynic::schema::HasField<allStarships> for super::super::Root {
             type Type = Option<super::super::StarshipsConnection>;
         }
-        pub mod all_starships_arguments {
+        pub mod _all_starships_arguments {
             pub struct after;
             impl ::cynic::schema::HasArgument<after> for super::allStarships {
                 type ArgumentType = Option<super::super::super::String>;
@@ -1761,7 +1761,7 @@ pub mod __fields {
         impl ::cynic::schema::HasField<starship> for super::super::Root {
             type Type = Option<super::super::Starship>;
         }
-        pub mod starship_arguments {
+        pub mod _starship_arguments {
             pub struct id;
             impl ::cynic::schema::HasArgument<id> for super::starship {
                 type ArgumentType = Option<super::super::super::ID>;
@@ -1781,7 +1781,7 @@ pub mod __fields {
         impl ::cynic::schema::HasField<allVehicles> for super::super::Root {
             type Type = Option<super::super::VehiclesConnection>;
         }
-        pub mod all_vehicles_arguments {
+        pub mod _all_vehicles_arguments {
             pub struct after;
             impl ::cynic::schema::HasArgument<after> for super::allVehicles {
                 type ArgumentType = Option<super::super::super::String>;
@@ -1811,7 +1811,7 @@ pub mod __fields {
         impl ::cynic::schema::HasField<vehicle> for super::super::Root {
             type Type = Option<super::super::Vehicle>;
         }
-        pub mod vehicle_arguments {
+        pub mod _vehicle_arguments {
             pub struct id;
             impl ::cynic::schema::HasArgument<id> for super::vehicle {
                 type ArgumentType = Option<super::super::super::ID>;
@@ -1831,7 +1831,7 @@ pub mod __fields {
         impl ::cynic::schema::HasField<node> for super::super::Root {
             type Type = Option<super::super::Node>;
         }
-        pub mod node_arguments {
+        pub mod _node_arguments {
             pub struct id;
             impl ::cynic::schema::HasArgument<id> for super::node {
                 type ArgumentType = super::super::super::ID;
@@ -1928,7 +1928,7 @@ pub mod __fields {
         impl ::cynic::schema::HasField<personConnection> for super::super::Species {
             type Type = Option<super::super::SpeciesPeopleConnection>;
         }
-        pub mod person_connection_arguments {
+        pub mod _person_connection_arguments {
             pub struct after;
             impl ::cynic::schema::HasArgument<after> for super::personConnection {
                 type ArgumentType = Option<super::super::super::String>;
@@ -1958,7 +1958,7 @@ pub mod __fields {
         impl ::cynic::schema::HasField<filmConnection> for super::super::Species {
             type Type = Option<super::super::SpeciesFilmsConnection>;
         }
-        pub mod film_connection_arguments {
+        pub mod _film_connection_arguments {
             pub struct after;
             impl ::cynic::schema::HasArgument<after> for super::filmConnection {
                 type ArgumentType = Option<super::super::super::String>;
@@ -2274,7 +2274,7 @@ pub mod __fields {
         impl ::cynic::schema::HasField<pilotConnection> for super::super::Starship {
             type Type = Option<super::super::StarshipPilotsConnection>;
         }
-        pub mod pilot_connection_arguments {
+        pub mod _pilot_connection_arguments {
             pub struct after;
             impl ::cynic::schema::HasArgument<after> for super::pilotConnection {
                 type ArgumentType = Option<super::super::super::String>;
@@ -2304,7 +2304,7 @@ pub mod __fields {
         impl ::cynic::schema::HasField<filmConnection> for super::super::Starship {
             type Type = Option<super::super::StarshipFilmsConnection>;
         }
-        pub mod film_connection_arguments {
+        pub mod _film_connection_arguments {
             pub struct after;
             impl ::cynic::schema::HasArgument<after> for super::filmConnection {
                 type ArgumentType = Option<super::super::super::String>;
@@ -2604,7 +2604,7 @@ pub mod __fields {
         impl ::cynic::schema::HasField<pilotConnection> for super::super::Vehicle {
             type Type = Option<super::super::VehiclePilotsConnection>;
         }
-        pub mod pilot_connection_arguments {
+        pub mod _pilot_connection_arguments {
             pub struct after;
             impl ::cynic::schema::HasArgument<after> for super::pilotConnection {
                 type ArgumentType = Option<super::super::super::String>;
@@ -2634,7 +2634,7 @@ pub mod __fields {
         impl ::cynic::schema::HasField<filmConnection> for super::super::Vehicle {
             type Type = Option<super::super::VehicleFilmsConnection>;
         }
-        pub mod film_connection_arguments {
+        pub mod _film_connection_arguments {
             pub struct after;
             impl ::cynic::schema::HasArgument<after> for super::filmConnection {
                 type ArgumentType = Option<super::super::super::String>;

--- a/cynic-codegen/tests/snapshots/use_schema__starwars.schema.graphql.snap
+++ b/cynic-codegen/tests/snapshots/use_schema__starwars.schema.graphql.snap
@@ -1,2675 +1,61 @@
 ---
 source: cynic-codegen/tests/use-schema.rs
-assertion_line: 30
 expression: "format_code(format!(\"{}\", tokens))"
 ---
 impl ::cynic::schema::QueryRoot for Root {}
 pub struct Film;
-pub mod film_fields {
-    pub struct title;
-    impl ::cynic::schema::Field for title {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "title";
-    }
-    impl ::cynic::schema::HasField<title> for super::Film {
-        type Type = Option<super::String>;
-    }
-    pub struct episodeID;
-    impl ::cynic::schema::Field for episodeID {
-        type Type = Option<super::Int>;
-        const NAME: &'static str = "episodeID";
-    }
-    impl ::cynic::schema::HasField<episodeID> for super::Film {
-        type Type = Option<super::Int>;
-    }
-    pub struct openingCrawl;
-    impl ::cynic::schema::Field for openingCrawl {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "openingCrawl";
-    }
-    impl ::cynic::schema::HasField<openingCrawl> for super::Film {
-        type Type = Option<super::String>;
-    }
-    pub struct director;
-    impl ::cynic::schema::Field for director {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "director";
-    }
-    impl ::cynic::schema::HasField<director> for super::Film {
-        type Type = Option<super::String>;
-    }
-    pub struct producers;
-    impl ::cynic::schema::Field for producers {
-        type Type = Option<Vec<Option<super::String>>>;
-        const NAME: &'static str = "producers";
-    }
-    impl ::cynic::schema::HasField<producers> for super::Film {
-        type Type = Option<Vec<Option<super::String>>>;
-    }
-    pub struct releaseDate;
-    impl ::cynic::schema::Field for releaseDate {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "releaseDate";
-    }
-    impl ::cynic::schema::HasField<releaseDate> for super::Film {
-        type Type = Option<super::String>;
-    }
-    pub struct speciesConnection;
-    impl ::cynic::schema::Field for speciesConnection {
-        type Type = Option<super::FilmSpeciesConnection>;
-        const NAME: &'static str = "speciesConnection";
-    }
-    impl ::cynic::schema::HasField<speciesConnection> for super::Film {
-        type Type = Option<super::FilmSpeciesConnection>;
-    }
-    pub mod species_connection_arguments {
-        pub struct after;
-        impl ::cynic::schema::HasArgument<after> for super::speciesConnection {
-            type ArgumentType = Option<super::super::String>;
-            const NAME: &'static str = "after";
-        }
-        pub struct first;
-        impl ::cynic::schema::HasArgument<first> for super::speciesConnection {
-            type ArgumentType = Option<super::super::Int>;
-            const NAME: &'static str = "first";
-        }
-        pub struct before;
-        impl ::cynic::schema::HasArgument<before> for super::speciesConnection {
-            type ArgumentType = Option<super::super::String>;
-            const NAME: &'static str = "before";
-        }
-        pub struct last;
-        impl ::cynic::schema::HasArgument<last> for super::speciesConnection {
-            type ArgumentType = Option<super::super::Int>;
-            const NAME: &'static str = "last";
-        }
-    }
-    pub struct starshipConnection;
-    impl ::cynic::schema::Field for starshipConnection {
-        type Type = Option<super::FilmStarshipsConnection>;
-        const NAME: &'static str = "starshipConnection";
-    }
-    impl ::cynic::schema::HasField<starshipConnection> for super::Film {
-        type Type = Option<super::FilmStarshipsConnection>;
-    }
-    pub mod starship_connection_arguments {
-        pub struct after;
-        impl ::cynic::schema::HasArgument<after> for super::starshipConnection {
-            type ArgumentType = Option<super::super::String>;
-            const NAME: &'static str = "after";
-        }
-        pub struct first;
-        impl ::cynic::schema::HasArgument<first> for super::starshipConnection {
-            type ArgumentType = Option<super::super::Int>;
-            const NAME: &'static str = "first";
-        }
-        pub struct before;
-        impl ::cynic::schema::HasArgument<before> for super::starshipConnection {
-            type ArgumentType = Option<super::super::String>;
-            const NAME: &'static str = "before";
-        }
-        pub struct last;
-        impl ::cynic::schema::HasArgument<last> for super::starshipConnection {
-            type ArgumentType = Option<super::super::Int>;
-            const NAME: &'static str = "last";
-        }
-    }
-    pub struct vehicleConnection;
-    impl ::cynic::schema::Field for vehicleConnection {
-        type Type = Option<super::FilmVehiclesConnection>;
-        const NAME: &'static str = "vehicleConnection";
-    }
-    impl ::cynic::schema::HasField<vehicleConnection> for super::Film {
-        type Type = Option<super::FilmVehiclesConnection>;
-    }
-    pub mod vehicle_connection_arguments {
-        pub struct after;
-        impl ::cynic::schema::HasArgument<after> for super::vehicleConnection {
-            type ArgumentType = Option<super::super::String>;
-            const NAME: &'static str = "after";
-        }
-        pub struct first;
-        impl ::cynic::schema::HasArgument<first> for super::vehicleConnection {
-            type ArgumentType = Option<super::super::Int>;
-            const NAME: &'static str = "first";
-        }
-        pub struct before;
-        impl ::cynic::schema::HasArgument<before> for super::vehicleConnection {
-            type ArgumentType = Option<super::super::String>;
-            const NAME: &'static str = "before";
-        }
-        pub struct last;
-        impl ::cynic::schema::HasArgument<last> for super::vehicleConnection {
-            type ArgumentType = Option<super::super::Int>;
-            const NAME: &'static str = "last";
-        }
-    }
-    pub struct characterConnection;
-    impl ::cynic::schema::Field for characterConnection {
-        type Type = Option<super::FilmCharactersConnection>;
-        const NAME: &'static str = "characterConnection";
-    }
-    impl ::cynic::schema::HasField<characterConnection> for super::Film {
-        type Type = Option<super::FilmCharactersConnection>;
-    }
-    pub mod character_connection_arguments {
-        pub struct after;
-        impl ::cynic::schema::HasArgument<after> for super::characterConnection {
-            type ArgumentType = Option<super::super::String>;
-            const NAME: &'static str = "after";
-        }
-        pub struct first;
-        impl ::cynic::schema::HasArgument<first> for super::characterConnection {
-            type ArgumentType = Option<super::super::Int>;
-            const NAME: &'static str = "first";
-        }
-        pub struct before;
-        impl ::cynic::schema::HasArgument<before> for super::characterConnection {
-            type ArgumentType = Option<super::super::String>;
-            const NAME: &'static str = "before";
-        }
-        pub struct last;
-        impl ::cynic::schema::HasArgument<last> for super::characterConnection {
-            type ArgumentType = Option<super::super::Int>;
-            const NAME: &'static str = "last";
-        }
-    }
-    pub struct planetConnection;
-    impl ::cynic::schema::Field for planetConnection {
-        type Type = Option<super::FilmPlanetsConnection>;
-        const NAME: &'static str = "planetConnection";
-    }
-    impl ::cynic::schema::HasField<planetConnection> for super::Film {
-        type Type = Option<super::FilmPlanetsConnection>;
-    }
-    pub mod planet_connection_arguments {
-        pub struct after;
-        impl ::cynic::schema::HasArgument<after> for super::planetConnection {
-            type ArgumentType = Option<super::super::String>;
-            const NAME: &'static str = "after";
-        }
-        pub struct first;
-        impl ::cynic::schema::HasArgument<first> for super::planetConnection {
-            type ArgumentType = Option<super::super::Int>;
-            const NAME: &'static str = "first";
-        }
-        pub struct before;
-        impl ::cynic::schema::HasArgument<before> for super::planetConnection {
-            type ArgumentType = Option<super::super::String>;
-            const NAME: &'static str = "before";
-        }
-        pub struct last;
-        impl ::cynic::schema::HasArgument<last> for super::planetConnection {
-            type ArgumentType = Option<super::super::Int>;
-            const NAME: &'static str = "last";
-        }
-    }
-    pub struct created;
-    impl ::cynic::schema::Field for created {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "created";
-    }
-    impl ::cynic::schema::HasField<created> for super::Film {
-        type Type = Option<super::String>;
-    }
-    pub struct edited;
-    impl ::cynic::schema::Field for edited {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "edited";
-    }
-    impl ::cynic::schema::HasField<edited> for super::Film {
-        type Type = Option<super::String>;
-    }
-    pub struct id;
-    impl ::cynic::schema::Field for id {
-        type Type = super::ID;
-        const NAME: &'static str = "id";
-    }
-    impl ::cynic::schema::HasField<id> for super::Film {
-        type Type = super::ID;
-    }
-}
 pub struct FilmCharactersConnection;
-pub mod film_characters_connection_fields {
-    pub struct pageInfo;
-    impl ::cynic::schema::Field for pageInfo {
-        type Type = super::PageInfo;
-        const NAME: &'static str = "pageInfo";
-    }
-    impl ::cynic::schema::HasField<pageInfo> for super::FilmCharactersConnection {
-        type Type = super::PageInfo;
-    }
-    pub struct edges;
-    impl ::cynic::schema::Field for edges {
-        type Type = Option<Vec<Option<super::FilmCharactersEdge>>>;
-        const NAME: &'static str = "edges";
-    }
-    impl ::cynic::schema::HasField<edges> for super::FilmCharactersConnection {
-        type Type = Option<Vec<Option<super::FilmCharactersEdge>>>;
-    }
-    pub struct totalCount;
-    impl ::cynic::schema::Field for totalCount {
-        type Type = Option<super::Int>;
-        const NAME: &'static str = "totalCount";
-    }
-    impl ::cynic::schema::HasField<totalCount> for super::FilmCharactersConnection {
-        type Type = Option<super::Int>;
-    }
-    pub struct characters;
-    impl ::cynic::schema::Field for characters {
-        type Type = Option<Vec<Option<super::Person>>>;
-        const NAME: &'static str = "characters";
-    }
-    impl ::cynic::schema::HasField<characters> for super::FilmCharactersConnection {
-        type Type = Option<Vec<Option<super::Person>>>;
-    }
-}
 pub struct FilmCharactersEdge;
-pub mod film_characters_edge_fields {
-    pub struct node;
-    impl ::cynic::schema::Field for node {
-        type Type = Option<super::Person>;
-        const NAME: &'static str = "node";
-    }
-    impl ::cynic::schema::HasField<node> for super::FilmCharactersEdge {
-        type Type = Option<super::Person>;
-    }
-    pub struct cursor;
-    impl ::cynic::schema::Field for cursor {
-        type Type = super::String;
-        const NAME: &'static str = "cursor";
-    }
-    impl ::cynic::schema::HasField<cursor> for super::FilmCharactersEdge {
-        type Type = super::String;
-    }
-}
 pub struct FilmPlanetsConnection;
-pub mod film_planets_connection_fields {
-    pub struct pageInfo;
-    impl ::cynic::schema::Field for pageInfo {
-        type Type = super::PageInfo;
-        const NAME: &'static str = "pageInfo";
-    }
-    impl ::cynic::schema::HasField<pageInfo> for super::FilmPlanetsConnection {
-        type Type = super::PageInfo;
-    }
-    pub struct edges;
-    impl ::cynic::schema::Field for edges {
-        type Type = Option<Vec<Option<super::FilmPlanetsEdge>>>;
-        const NAME: &'static str = "edges";
-    }
-    impl ::cynic::schema::HasField<edges> for super::FilmPlanetsConnection {
-        type Type = Option<Vec<Option<super::FilmPlanetsEdge>>>;
-    }
-    pub struct totalCount;
-    impl ::cynic::schema::Field for totalCount {
-        type Type = Option<super::Int>;
-        const NAME: &'static str = "totalCount";
-    }
-    impl ::cynic::schema::HasField<totalCount> for super::FilmPlanetsConnection {
-        type Type = Option<super::Int>;
-    }
-    pub struct planets;
-    impl ::cynic::schema::Field for planets {
-        type Type = Option<Vec<Option<super::Planet>>>;
-        const NAME: &'static str = "planets";
-    }
-    impl ::cynic::schema::HasField<planets> for super::FilmPlanetsConnection {
-        type Type = Option<Vec<Option<super::Planet>>>;
-    }
-}
 pub struct FilmPlanetsEdge;
-pub mod film_planets_edge_fields {
-    pub struct node;
-    impl ::cynic::schema::Field for node {
-        type Type = Option<super::Planet>;
-        const NAME: &'static str = "node";
-    }
-    impl ::cynic::schema::HasField<node> for super::FilmPlanetsEdge {
-        type Type = Option<super::Planet>;
-    }
-    pub struct cursor;
-    impl ::cynic::schema::Field for cursor {
-        type Type = super::String;
-        const NAME: &'static str = "cursor";
-    }
-    impl ::cynic::schema::HasField<cursor> for super::FilmPlanetsEdge {
-        type Type = super::String;
-    }
-}
 pub struct FilmSpeciesConnection;
-pub mod film_species_connection_fields {
-    pub struct pageInfo;
-    impl ::cynic::schema::Field for pageInfo {
-        type Type = super::PageInfo;
-        const NAME: &'static str = "pageInfo";
-    }
-    impl ::cynic::schema::HasField<pageInfo> for super::FilmSpeciesConnection {
-        type Type = super::PageInfo;
-    }
-    pub struct edges;
-    impl ::cynic::schema::Field for edges {
-        type Type = Option<Vec<Option<super::FilmSpeciesEdge>>>;
-        const NAME: &'static str = "edges";
-    }
-    impl ::cynic::schema::HasField<edges> for super::FilmSpeciesConnection {
-        type Type = Option<Vec<Option<super::FilmSpeciesEdge>>>;
-    }
-    pub struct totalCount;
-    impl ::cynic::schema::Field for totalCount {
-        type Type = Option<super::Int>;
-        const NAME: &'static str = "totalCount";
-    }
-    impl ::cynic::schema::HasField<totalCount> for super::FilmSpeciesConnection {
-        type Type = Option<super::Int>;
-    }
-    pub struct species;
-    impl ::cynic::schema::Field for species {
-        type Type = Option<Vec<Option<super::Species>>>;
-        const NAME: &'static str = "species";
-    }
-    impl ::cynic::schema::HasField<species> for super::FilmSpeciesConnection {
-        type Type = Option<Vec<Option<super::Species>>>;
-    }
-}
 pub struct FilmSpeciesEdge;
-pub mod film_species_edge_fields {
-    pub struct node;
-    impl ::cynic::schema::Field for node {
-        type Type = Option<super::Species>;
-        const NAME: &'static str = "node";
-    }
-    impl ::cynic::schema::HasField<node> for super::FilmSpeciesEdge {
-        type Type = Option<super::Species>;
-    }
-    pub struct cursor;
-    impl ::cynic::schema::Field for cursor {
-        type Type = super::String;
-        const NAME: &'static str = "cursor";
-    }
-    impl ::cynic::schema::HasField<cursor> for super::FilmSpeciesEdge {
-        type Type = super::String;
-    }
-}
 pub struct FilmStarshipsConnection;
-pub mod film_starships_connection_fields {
-    pub struct pageInfo;
-    impl ::cynic::schema::Field for pageInfo {
-        type Type = super::PageInfo;
-        const NAME: &'static str = "pageInfo";
-    }
-    impl ::cynic::schema::HasField<pageInfo> for super::FilmStarshipsConnection {
-        type Type = super::PageInfo;
-    }
-    pub struct edges;
-    impl ::cynic::schema::Field for edges {
-        type Type = Option<Vec<Option<super::FilmStarshipsEdge>>>;
-        const NAME: &'static str = "edges";
-    }
-    impl ::cynic::schema::HasField<edges> for super::FilmStarshipsConnection {
-        type Type = Option<Vec<Option<super::FilmStarshipsEdge>>>;
-    }
-    pub struct totalCount;
-    impl ::cynic::schema::Field for totalCount {
-        type Type = Option<super::Int>;
-        const NAME: &'static str = "totalCount";
-    }
-    impl ::cynic::schema::HasField<totalCount> for super::FilmStarshipsConnection {
-        type Type = Option<super::Int>;
-    }
-    pub struct starships;
-    impl ::cynic::schema::Field for starships {
-        type Type = Option<Vec<Option<super::Starship>>>;
-        const NAME: &'static str = "starships";
-    }
-    impl ::cynic::schema::HasField<starships> for super::FilmStarshipsConnection {
-        type Type = Option<Vec<Option<super::Starship>>>;
-    }
-}
 pub struct FilmStarshipsEdge;
-pub mod film_starships_edge_fields {
-    pub struct node;
-    impl ::cynic::schema::Field for node {
-        type Type = Option<super::Starship>;
-        const NAME: &'static str = "node";
-    }
-    impl ::cynic::schema::HasField<node> for super::FilmStarshipsEdge {
-        type Type = Option<super::Starship>;
-    }
-    pub struct cursor;
-    impl ::cynic::schema::Field for cursor {
-        type Type = super::String;
-        const NAME: &'static str = "cursor";
-    }
-    impl ::cynic::schema::HasField<cursor> for super::FilmStarshipsEdge {
-        type Type = super::String;
-    }
-}
 pub struct FilmVehiclesConnection;
-pub mod film_vehicles_connection_fields {
-    pub struct pageInfo;
-    impl ::cynic::schema::Field for pageInfo {
-        type Type = super::PageInfo;
-        const NAME: &'static str = "pageInfo";
-    }
-    impl ::cynic::schema::HasField<pageInfo> for super::FilmVehiclesConnection {
-        type Type = super::PageInfo;
-    }
-    pub struct edges;
-    impl ::cynic::schema::Field for edges {
-        type Type = Option<Vec<Option<super::FilmVehiclesEdge>>>;
-        const NAME: &'static str = "edges";
-    }
-    impl ::cynic::schema::HasField<edges> for super::FilmVehiclesConnection {
-        type Type = Option<Vec<Option<super::FilmVehiclesEdge>>>;
-    }
-    pub struct totalCount;
-    impl ::cynic::schema::Field for totalCount {
-        type Type = Option<super::Int>;
-        const NAME: &'static str = "totalCount";
-    }
-    impl ::cynic::schema::HasField<totalCount> for super::FilmVehiclesConnection {
-        type Type = Option<super::Int>;
-    }
-    pub struct vehicles;
-    impl ::cynic::schema::Field for vehicles {
-        type Type = Option<Vec<Option<super::Vehicle>>>;
-        const NAME: &'static str = "vehicles";
-    }
-    impl ::cynic::schema::HasField<vehicles> for super::FilmVehiclesConnection {
-        type Type = Option<Vec<Option<super::Vehicle>>>;
-    }
-}
 pub struct FilmVehiclesEdge;
-pub mod film_vehicles_edge_fields {
-    pub struct node;
-    impl ::cynic::schema::Field for node {
-        type Type = Option<super::Vehicle>;
-        const NAME: &'static str = "node";
-    }
-    impl ::cynic::schema::HasField<node> for super::FilmVehiclesEdge {
-        type Type = Option<super::Vehicle>;
-    }
-    pub struct cursor;
-    impl ::cynic::schema::Field for cursor {
-        type Type = super::String;
-        const NAME: &'static str = "cursor";
-    }
-    impl ::cynic::schema::HasField<cursor> for super::FilmVehiclesEdge {
-        type Type = super::String;
-    }
-}
 pub struct FilmsConnection;
-pub mod films_connection_fields {
-    pub struct pageInfo;
-    impl ::cynic::schema::Field for pageInfo {
-        type Type = super::PageInfo;
-        const NAME: &'static str = "pageInfo";
-    }
-    impl ::cynic::schema::HasField<pageInfo> for super::FilmsConnection {
-        type Type = super::PageInfo;
-    }
-    pub struct edges;
-    impl ::cynic::schema::Field for edges {
-        type Type = Option<Vec<Option<super::FilmsEdge>>>;
-        const NAME: &'static str = "edges";
-    }
-    impl ::cynic::schema::HasField<edges> for super::FilmsConnection {
-        type Type = Option<Vec<Option<super::FilmsEdge>>>;
-    }
-    pub struct totalCount;
-    impl ::cynic::schema::Field for totalCount {
-        type Type = Option<super::Int>;
-        const NAME: &'static str = "totalCount";
-    }
-    impl ::cynic::schema::HasField<totalCount> for super::FilmsConnection {
-        type Type = Option<super::Int>;
-    }
-    pub struct films;
-    impl ::cynic::schema::Field for films {
-        type Type = Option<Vec<Option<super::Film>>>;
-        const NAME: &'static str = "films";
-    }
-    impl ::cynic::schema::HasField<films> for super::FilmsConnection {
-        type Type = Option<Vec<Option<super::Film>>>;
-    }
-}
 pub struct FilmsEdge;
-pub mod films_edge_fields {
-    pub struct node;
-    impl ::cynic::schema::Field for node {
-        type Type = Option<super::Film>;
-        const NAME: &'static str = "node";
-    }
-    impl ::cynic::schema::HasField<node> for super::FilmsEdge {
-        type Type = Option<super::Film>;
-    }
-    pub struct cursor;
-    impl ::cynic::schema::Field for cursor {
-        type Type = super::String;
-        const NAME: &'static str = "cursor";
-    }
-    impl ::cynic::schema::HasField<cursor> for super::FilmsEdge {
-        type Type = super::String;
-    }
-}
 pub struct Node;
-pub mod node_fields {
-    pub struct id;
-    impl ::cynic::schema::Field for id {
-        type Type = super::ID;
-        const NAME: &'static str = "id";
-    }
-    impl ::cynic::schema::HasField<id> for super::Node {
-        type Type = super::ID;
-    }
-}
 pub struct PageInfo;
-pub mod page_info_fields {
-    pub struct hasNextPage;
-    impl ::cynic::schema::Field for hasNextPage {
-        type Type = super::Boolean;
-        const NAME: &'static str = "hasNextPage";
-    }
-    impl ::cynic::schema::HasField<hasNextPage> for super::PageInfo {
-        type Type = super::Boolean;
-    }
-    pub struct hasPreviousPage;
-    impl ::cynic::schema::Field for hasPreviousPage {
-        type Type = super::Boolean;
-        const NAME: &'static str = "hasPreviousPage";
-    }
-    impl ::cynic::schema::HasField<hasPreviousPage> for super::PageInfo {
-        type Type = super::Boolean;
-    }
-    pub struct startCursor;
-    impl ::cynic::schema::Field for startCursor {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "startCursor";
-    }
-    impl ::cynic::schema::HasField<startCursor> for super::PageInfo {
-        type Type = Option<super::String>;
-    }
-    pub struct endCursor;
-    impl ::cynic::schema::Field for endCursor {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "endCursor";
-    }
-    impl ::cynic::schema::HasField<endCursor> for super::PageInfo {
-        type Type = Option<super::String>;
-    }
-}
 pub struct PeopleConnection;
-pub mod people_connection_fields {
-    pub struct pageInfo;
-    impl ::cynic::schema::Field for pageInfo {
-        type Type = super::PageInfo;
-        const NAME: &'static str = "pageInfo";
-    }
-    impl ::cynic::schema::HasField<pageInfo> for super::PeopleConnection {
-        type Type = super::PageInfo;
-    }
-    pub struct edges;
-    impl ::cynic::schema::Field for edges {
-        type Type = Option<Vec<Option<super::PeopleEdge>>>;
-        const NAME: &'static str = "edges";
-    }
-    impl ::cynic::schema::HasField<edges> for super::PeopleConnection {
-        type Type = Option<Vec<Option<super::PeopleEdge>>>;
-    }
-    pub struct totalCount;
-    impl ::cynic::schema::Field for totalCount {
-        type Type = Option<super::Int>;
-        const NAME: &'static str = "totalCount";
-    }
-    impl ::cynic::schema::HasField<totalCount> for super::PeopleConnection {
-        type Type = Option<super::Int>;
-    }
-    pub struct people;
-    impl ::cynic::schema::Field for people {
-        type Type = Option<Vec<Option<super::Person>>>;
-        const NAME: &'static str = "people";
-    }
-    impl ::cynic::schema::HasField<people> for super::PeopleConnection {
-        type Type = Option<Vec<Option<super::Person>>>;
-    }
-}
 pub struct PeopleEdge;
-pub mod people_edge_fields {
-    pub struct node;
-    impl ::cynic::schema::Field for node {
-        type Type = Option<super::Person>;
-        const NAME: &'static str = "node";
-    }
-    impl ::cynic::schema::HasField<node> for super::PeopleEdge {
-        type Type = Option<super::Person>;
-    }
-    pub struct cursor;
-    impl ::cynic::schema::Field for cursor {
-        type Type = super::String;
-        const NAME: &'static str = "cursor";
-    }
-    impl ::cynic::schema::HasField<cursor> for super::PeopleEdge {
-        type Type = super::String;
-    }
-}
 pub struct Person;
-pub mod person_fields {
-    pub struct name;
-    impl ::cynic::schema::Field for name {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "name";
-    }
-    impl ::cynic::schema::HasField<name> for super::Person {
-        type Type = Option<super::String>;
-    }
-    pub struct birthYear;
-    impl ::cynic::schema::Field for birthYear {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "birthYear";
-    }
-    impl ::cynic::schema::HasField<birthYear> for super::Person {
-        type Type = Option<super::String>;
-    }
-    pub struct eyeColor;
-    impl ::cynic::schema::Field for eyeColor {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "eyeColor";
-    }
-    impl ::cynic::schema::HasField<eyeColor> for super::Person {
-        type Type = Option<super::String>;
-    }
-    pub struct gender;
-    impl ::cynic::schema::Field for gender {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "gender";
-    }
-    impl ::cynic::schema::HasField<gender> for super::Person {
-        type Type = Option<super::String>;
-    }
-    pub struct hairColor;
-    impl ::cynic::schema::Field for hairColor {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "hairColor";
-    }
-    impl ::cynic::schema::HasField<hairColor> for super::Person {
-        type Type = Option<super::String>;
-    }
-    pub struct height;
-    impl ::cynic::schema::Field for height {
-        type Type = Option<super::Int>;
-        const NAME: &'static str = "height";
-    }
-    impl ::cynic::schema::HasField<height> for super::Person {
-        type Type = Option<super::Int>;
-    }
-    pub struct mass;
-    impl ::cynic::schema::Field for mass {
-        type Type = Option<super::Float>;
-        const NAME: &'static str = "mass";
-    }
-    impl ::cynic::schema::HasField<mass> for super::Person {
-        type Type = Option<super::Float>;
-    }
-    pub struct skinColor;
-    impl ::cynic::schema::Field for skinColor {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "skinColor";
-    }
-    impl ::cynic::schema::HasField<skinColor> for super::Person {
-        type Type = Option<super::String>;
-    }
-    pub struct homeworld;
-    impl ::cynic::schema::Field for homeworld {
-        type Type = Option<super::Planet>;
-        const NAME: &'static str = "homeworld";
-    }
-    impl ::cynic::schema::HasField<homeworld> for super::Person {
-        type Type = Option<super::Planet>;
-    }
-    pub struct filmConnection;
-    impl ::cynic::schema::Field for filmConnection {
-        type Type = Option<super::PersonFilmsConnection>;
-        const NAME: &'static str = "filmConnection";
-    }
-    impl ::cynic::schema::HasField<filmConnection> for super::Person {
-        type Type = Option<super::PersonFilmsConnection>;
-    }
-    pub mod film_connection_arguments {
-        pub struct after;
-        impl ::cynic::schema::HasArgument<after> for super::filmConnection {
-            type ArgumentType = Option<super::super::String>;
-            const NAME: &'static str = "after";
-        }
-        pub struct first;
-        impl ::cynic::schema::HasArgument<first> for super::filmConnection {
-            type ArgumentType = Option<super::super::Int>;
-            const NAME: &'static str = "first";
-        }
-        pub struct before;
-        impl ::cynic::schema::HasArgument<before> for super::filmConnection {
-            type ArgumentType = Option<super::super::String>;
-            const NAME: &'static str = "before";
-        }
-        pub struct last;
-        impl ::cynic::schema::HasArgument<last> for super::filmConnection {
-            type ArgumentType = Option<super::super::Int>;
-            const NAME: &'static str = "last";
-        }
-    }
-    pub struct species;
-    impl ::cynic::schema::Field for species {
-        type Type = Option<super::Species>;
-        const NAME: &'static str = "species";
-    }
-    impl ::cynic::schema::HasField<species> for super::Person {
-        type Type = Option<super::Species>;
-    }
-    pub struct starshipConnection;
-    impl ::cynic::schema::Field for starshipConnection {
-        type Type = Option<super::PersonStarshipsConnection>;
-        const NAME: &'static str = "starshipConnection";
-    }
-    impl ::cynic::schema::HasField<starshipConnection> for super::Person {
-        type Type = Option<super::PersonStarshipsConnection>;
-    }
-    pub mod starship_connection_arguments {
-        pub struct after;
-        impl ::cynic::schema::HasArgument<after> for super::starshipConnection {
-            type ArgumentType = Option<super::super::String>;
-            const NAME: &'static str = "after";
-        }
-        pub struct first;
-        impl ::cynic::schema::HasArgument<first> for super::starshipConnection {
-            type ArgumentType = Option<super::super::Int>;
-            const NAME: &'static str = "first";
-        }
-        pub struct before;
-        impl ::cynic::schema::HasArgument<before> for super::starshipConnection {
-            type ArgumentType = Option<super::super::String>;
-            const NAME: &'static str = "before";
-        }
-        pub struct last;
-        impl ::cynic::schema::HasArgument<last> for super::starshipConnection {
-            type ArgumentType = Option<super::super::Int>;
-            const NAME: &'static str = "last";
-        }
-    }
-    pub struct vehicleConnection;
-    impl ::cynic::schema::Field for vehicleConnection {
-        type Type = Option<super::PersonVehiclesConnection>;
-        const NAME: &'static str = "vehicleConnection";
-    }
-    impl ::cynic::schema::HasField<vehicleConnection> for super::Person {
-        type Type = Option<super::PersonVehiclesConnection>;
-    }
-    pub mod vehicle_connection_arguments {
-        pub struct after;
-        impl ::cynic::schema::HasArgument<after> for super::vehicleConnection {
-            type ArgumentType = Option<super::super::String>;
-            const NAME: &'static str = "after";
-        }
-        pub struct first;
-        impl ::cynic::schema::HasArgument<first> for super::vehicleConnection {
-            type ArgumentType = Option<super::super::Int>;
-            const NAME: &'static str = "first";
-        }
-        pub struct before;
-        impl ::cynic::schema::HasArgument<before> for super::vehicleConnection {
-            type ArgumentType = Option<super::super::String>;
-            const NAME: &'static str = "before";
-        }
-        pub struct last;
-        impl ::cynic::schema::HasArgument<last> for super::vehicleConnection {
-            type ArgumentType = Option<super::super::Int>;
-            const NAME: &'static str = "last";
-        }
-    }
-    pub struct created;
-    impl ::cynic::schema::Field for created {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "created";
-    }
-    impl ::cynic::schema::HasField<created> for super::Person {
-        type Type = Option<super::String>;
-    }
-    pub struct edited;
-    impl ::cynic::schema::Field for edited {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "edited";
-    }
-    impl ::cynic::schema::HasField<edited> for super::Person {
-        type Type = Option<super::String>;
-    }
-    pub struct id;
-    impl ::cynic::schema::Field for id {
-        type Type = super::ID;
-        const NAME: &'static str = "id";
-    }
-    impl ::cynic::schema::HasField<id> for super::Person {
-        type Type = super::ID;
-    }
-}
 pub struct PersonFilmsConnection;
-pub mod person_films_connection_fields {
-    pub struct pageInfo;
-    impl ::cynic::schema::Field for pageInfo {
-        type Type = super::PageInfo;
-        const NAME: &'static str = "pageInfo";
-    }
-    impl ::cynic::schema::HasField<pageInfo> for super::PersonFilmsConnection {
-        type Type = super::PageInfo;
-    }
-    pub struct edges;
-    impl ::cynic::schema::Field for edges {
-        type Type = Option<Vec<Option<super::PersonFilmsEdge>>>;
-        const NAME: &'static str = "edges";
-    }
-    impl ::cynic::schema::HasField<edges> for super::PersonFilmsConnection {
-        type Type = Option<Vec<Option<super::PersonFilmsEdge>>>;
-    }
-    pub struct totalCount;
-    impl ::cynic::schema::Field for totalCount {
-        type Type = Option<super::Int>;
-        const NAME: &'static str = "totalCount";
-    }
-    impl ::cynic::schema::HasField<totalCount> for super::PersonFilmsConnection {
-        type Type = Option<super::Int>;
-    }
-    pub struct films;
-    impl ::cynic::schema::Field for films {
-        type Type = Option<Vec<Option<super::Film>>>;
-        const NAME: &'static str = "films";
-    }
-    impl ::cynic::schema::HasField<films> for super::PersonFilmsConnection {
-        type Type = Option<Vec<Option<super::Film>>>;
-    }
-}
 pub struct PersonFilmsEdge;
-pub mod person_films_edge_fields {
-    pub struct node;
-    impl ::cynic::schema::Field for node {
-        type Type = Option<super::Film>;
-        const NAME: &'static str = "node";
-    }
-    impl ::cynic::schema::HasField<node> for super::PersonFilmsEdge {
-        type Type = Option<super::Film>;
-    }
-    pub struct cursor;
-    impl ::cynic::schema::Field for cursor {
-        type Type = super::String;
-        const NAME: &'static str = "cursor";
-    }
-    impl ::cynic::schema::HasField<cursor> for super::PersonFilmsEdge {
-        type Type = super::String;
-    }
-}
 pub struct PersonStarshipsConnection;
-pub mod person_starships_connection_fields {
-    pub struct pageInfo;
-    impl ::cynic::schema::Field for pageInfo {
-        type Type = super::PageInfo;
-        const NAME: &'static str = "pageInfo";
-    }
-    impl ::cynic::schema::HasField<pageInfo> for super::PersonStarshipsConnection {
-        type Type = super::PageInfo;
-    }
-    pub struct edges;
-    impl ::cynic::schema::Field for edges {
-        type Type = Option<Vec<Option<super::PersonStarshipsEdge>>>;
-        const NAME: &'static str = "edges";
-    }
-    impl ::cynic::schema::HasField<edges> for super::PersonStarshipsConnection {
-        type Type = Option<Vec<Option<super::PersonStarshipsEdge>>>;
-    }
-    pub struct totalCount;
-    impl ::cynic::schema::Field for totalCount {
-        type Type = Option<super::Int>;
-        const NAME: &'static str = "totalCount";
-    }
-    impl ::cynic::schema::HasField<totalCount> for super::PersonStarshipsConnection {
-        type Type = Option<super::Int>;
-    }
-    pub struct starships;
-    impl ::cynic::schema::Field for starships {
-        type Type = Option<Vec<Option<super::Starship>>>;
-        const NAME: &'static str = "starships";
-    }
-    impl ::cynic::schema::HasField<starships> for super::PersonStarshipsConnection {
-        type Type = Option<Vec<Option<super::Starship>>>;
-    }
-}
 pub struct PersonStarshipsEdge;
-pub mod person_starships_edge_fields {
-    pub struct node;
-    impl ::cynic::schema::Field for node {
-        type Type = Option<super::Starship>;
-        const NAME: &'static str = "node";
-    }
-    impl ::cynic::schema::HasField<node> for super::PersonStarshipsEdge {
-        type Type = Option<super::Starship>;
-    }
-    pub struct cursor;
-    impl ::cynic::schema::Field for cursor {
-        type Type = super::String;
-        const NAME: &'static str = "cursor";
-    }
-    impl ::cynic::schema::HasField<cursor> for super::PersonStarshipsEdge {
-        type Type = super::String;
-    }
-}
 pub struct PersonVehiclesConnection;
-pub mod person_vehicles_connection_fields {
-    pub struct pageInfo;
-    impl ::cynic::schema::Field for pageInfo {
-        type Type = super::PageInfo;
-        const NAME: &'static str = "pageInfo";
-    }
-    impl ::cynic::schema::HasField<pageInfo> for super::PersonVehiclesConnection {
-        type Type = super::PageInfo;
-    }
-    pub struct edges;
-    impl ::cynic::schema::Field for edges {
-        type Type = Option<Vec<Option<super::PersonVehiclesEdge>>>;
-        const NAME: &'static str = "edges";
-    }
-    impl ::cynic::schema::HasField<edges> for super::PersonVehiclesConnection {
-        type Type = Option<Vec<Option<super::PersonVehiclesEdge>>>;
-    }
-    pub struct totalCount;
-    impl ::cynic::schema::Field for totalCount {
-        type Type = Option<super::Int>;
-        const NAME: &'static str = "totalCount";
-    }
-    impl ::cynic::schema::HasField<totalCount> for super::PersonVehiclesConnection {
-        type Type = Option<super::Int>;
-    }
-    pub struct vehicles;
-    impl ::cynic::schema::Field for vehicles {
-        type Type = Option<Vec<Option<super::Vehicle>>>;
-        const NAME: &'static str = "vehicles";
-    }
-    impl ::cynic::schema::HasField<vehicles> for super::PersonVehiclesConnection {
-        type Type = Option<Vec<Option<super::Vehicle>>>;
-    }
-}
 pub struct PersonVehiclesEdge;
-pub mod person_vehicles_edge_fields {
-    pub struct node;
-    impl ::cynic::schema::Field for node {
-        type Type = Option<super::Vehicle>;
-        const NAME: &'static str = "node";
-    }
-    impl ::cynic::schema::HasField<node> for super::PersonVehiclesEdge {
-        type Type = Option<super::Vehicle>;
-    }
-    pub struct cursor;
-    impl ::cynic::schema::Field for cursor {
-        type Type = super::String;
-        const NAME: &'static str = "cursor";
-    }
-    impl ::cynic::schema::HasField<cursor> for super::PersonVehiclesEdge {
-        type Type = super::String;
-    }
-}
 pub struct Planet;
-pub mod planet_fields {
-    pub struct name;
-    impl ::cynic::schema::Field for name {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "name";
-    }
-    impl ::cynic::schema::HasField<name> for super::Planet {
-        type Type = Option<super::String>;
-    }
-    pub struct diameter;
-    impl ::cynic::schema::Field for diameter {
-        type Type = Option<super::Int>;
-        const NAME: &'static str = "diameter";
-    }
-    impl ::cynic::schema::HasField<diameter> for super::Planet {
-        type Type = Option<super::Int>;
-    }
-    pub struct rotationPeriod;
-    impl ::cynic::schema::Field for rotationPeriod {
-        type Type = Option<super::Int>;
-        const NAME: &'static str = "rotationPeriod";
-    }
-    impl ::cynic::schema::HasField<rotationPeriod> for super::Planet {
-        type Type = Option<super::Int>;
-    }
-    pub struct orbitalPeriod;
-    impl ::cynic::schema::Field for orbitalPeriod {
-        type Type = Option<super::Int>;
-        const NAME: &'static str = "orbitalPeriod";
-    }
-    impl ::cynic::schema::HasField<orbitalPeriod> for super::Planet {
-        type Type = Option<super::Int>;
-    }
-    pub struct gravity;
-    impl ::cynic::schema::Field for gravity {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "gravity";
-    }
-    impl ::cynic::schema::HasField<gravity> for super::Planet {
-        type Type = Option<super::String>;
-    }
-    pub struct population;
-    impl ::cynic::schema::Field for population {
-        type Type = Option<super::Float>;
-        const NAME: &'static str = "population";
-    }
-    impl ::cynic::schema::HasField<population> for super::Planet {
-        type Type = Option<super::Float>;
-    }
-    pub struct climates;
-    impl ::cynic::schema::Field for climates {
-        type Type = Option<Vec<Option<super::String>>>;
-        const NAME: &'static str = "climates";
-    }
-    impl ::cynic::schema::HasField<climates> for super::Planet {
-        type Type = Option<Vec<Option<super::String>>>;
-    }
-    pub struct terrains;
-    impl ::cynic::schema::Field for terrains {
-        type Type = Option<Vec<Option<super::String>>>;
-        const NAME: &'static str = "terrains";
-    }
-    impl ::cynic::schema::HasField<terrains> for super::Planet {
-        type Type = Option<Vec<Option<super::String>>>;
-    }
-    pub struct surfaceWater;
-    impl ::cynic::schema::Field for surfaceWater {
-        type Type = Option<super::Float>;
-        const NAME: &'static str = "surfaceWater";
-    }
-    impl ::cynic::schema::HasField<surfaceWater> for super::Planet {
-        type Type = Option<super::Float>;
-    }
-    pub struct residentConnection;
-    impl ::cynic::schema::Field for residentConnection {
-        type Type = Option<super::PlanetResidentsConnection>;
-        const NAME: &'static str = "residentConnection";
-    }
-    impl ::cynic::schema::HasField<residentConnection> for super::Planet {
-        type Type = Option<super::PlanetResidentsConnection>;
-    }
-    pub mod resident_connection_arguments {
-        pub struct after;
-        impl ::cynic::schema::HasArgument<after> for super::residentConnection {
-            type ArgumentType = Option<super::super::String>;
-            const NAME: &'static str = "after";
-        }
-        pub struct first;
-        impl ::cynic::schema::HasArgument<first> for super::residentConnection {
-            type ArgumentType = Option<super::super::Int>;
-            const NAME: &'static str = "first";
-        }
-        pub struct before;
-        impl ::cynic::schema::HasArgument<before> for super::residentConnection {
-            type ArgumentType = Option<super::super::String>;
-            const NAME: &'static str = "before";
-        }
-        pub struct last;
-        impl ::cynic::schema::HasArgument<last> for super::residentConnection {
-            type ArgumentType = Option<super::super::Int>;
-            const NAME: &'static str = "last";
-        }
-    }
-    pub struct filmConnection;
-    impl ::cynic::schema::Field for filmConnection {
-        type Type = Option<super::PlanetFilmsConnection>;
-        const NAME: &'static str = "filmConnection";
-    }
-    impl ::cynic::schema::HasField<filmConnection> for super::Planet {
-        type Type = Option<super::PlanetFilmsConnection>;
-    }
-    pub mod film_connection_arguments {
-        pub struct after;
-        impl ::cynic::schema::HasArgument<after> for super::filmConnection {
-            type ArgumentType = Option<super::super::String>;
-            const NAME: &'static str = "after";
-        }
-        pub struct first;
-        impl ::cynic::schema::HasArgument<first> for super::filmConnection {
-            type ArgumentType = Option<super::super::Int>;
-            const NAME: &'static str = "first";
-        }
-        pub struct before;
-        impl ::cynic::schema::HasArgument<before> for super::filmConnection {
-            type ArgumentType = Option<super::super::String>;
-            const NAME: &'static str = "before";
-        }
-        pub struct last;
-        impl ::cynic::schema::HasArgument<last> for super::filmConnection {
-            type ArgumentType = Option<super::super::Int>;
-            const NAME: &'static str = "last";
-        }
-    }
-    pub struct created;
-    impl ::cynic::schema::Field for created {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "created";
-    }
-    impl ::cynic::schema::HasField<created> for super::Planet {
-        type Type = Option<super::String>;
-    }
-    pub struct edited;
-    impl ::cynic::schema::Field for edited {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "edited";
-    }
-    impl ::cynic::schema::HasField<edited> for super::Planet {
-        type Type = Option<super::String>;
-    }
-    pub struct id;
-    impl ::cynic::schema::Field for id {
-        type Type = super::ID;
-        const NAME: &'static str = "id";
-    }
-    impl ::cynic::schema::HasField<id> for super::Planet {
-        type Type = super::ID;
-    }
-}
 pub struct PlanetFilmsConnection;
-pub mod planet_films_connection_fields {
-    pub struct pageInfo;
-    impl ::cynic::schema::Field for pageInfo {
-        type Type = super::PageInfo;
-        const NAME: &'static str = "pageInfo";
-    }
-    impl ::cynic::schema::HasField<pageInfo> for super::PlanetFilmsConnection {
-        type Type = super::PageInfo;
-    }
-    pub struct edges;
-    impl ::cynic::schema::Field for edges {
-        type Type = Option<Vec<Option<super::PlanetFilmsEdge>>>;
-        const NAME: &'static str = "edges";
-    }
-    impl ::cynic::schema::HasField<edges> for super::PlanetFilmsConnection {
-        type Type = Option<Vec<Option<super::PlanetFilmsEdge>>>;
-    }
-    pub struct totalCount;
-    impl ::cynic::schema::Field for totalCount {
-        type Type = Option<super::Int>;
-        const NAME: &'static str = "totalCount";
-    }
-    impl ::cynic::schema::HasField<totalCount> for super::PlanetFilmsConnection {
-        type Type = Option<super::Int>;
-    }
-    pub struct films;
-    impl ::cynic::schema::Field for films {
-        type Type = Option<Vec<Option<super::Film>>>;
-        const NAME: &'static str = "films";
-    }
-    impl ::cynic::schema::HasField<films> for super::PlanetFilmsConnection {
-        type Type = Option<Vec<Option<super::Film>>>;
-    }
-}
 pub struct PlanetFilmsEdge;
-pub mod planet_films_edge_fields {
-    pub struct node;
-    impl ::cynic::schema::Field for node {
-        type Type = Option<super::Film>;
-        const NAME: &'static str = "node";
-    }
-    impl ::cynic::schema::HasField<node> for super::PlanetFilmsEdge {
-        type Type = Option<super::Film>;
-    }
-    pub struct cursor;
-    impl ::cynic::schema::Field for cursor {
-        type Type = super::String;
-        const NAME: &'static str = "cursor";
-    }
-    impl ::cynic::schema::HasField<cursor> for super::PlanetFilmsEdge {
-        type Type = super::String;
-    }
-}
 pub struct PlanetResidentsConnection;
-pub mod planet_residents_connection_fields {
-    pub struct pageInfo;
-    impl ::cynic::schema::Field for pageInfo {
-        type Type = super::PageInfo;
-        const NAME: &'static str = "pageInfo";
-    }
-    impl ::cynic::schema::HasField<pageInfo> for super::PlanetResidentsConnection {
-        type Type = super::PageInfo;
-    }
-    pub struct edges;
-    impl ::cynic::schema::Field for edges {
-        type Type = Option<Vec<Option<super::PlanetResidentsEdge>>>;
-        const NAME: &'static str = "edges";
-    }
-    impl ::cynic::schema::HasField<edges> for super::PlanetResidentsConnection {
-        type Type = Option<Vec<Option<super::PlanetResidentsEdge>>>;
-    }
-    pub struct totalCount;
-    impl ::cynic::schema::Field for totalCount {
-        type Type = Option<super::Int>;
-        const NAME: &'static str = "totalCount";
-    }
-    impl ::cynic::schema::HasField<totalCount> for super::PlanetResidentsConnection {
-        type Type = Option<super::Int>;
-    }
-    pub struct residents;
-    impl ::cynic::schema::Field for residents {
-        type Type = Option<Vec<Option<super::Person>>>;
-        const NAME: &'static str = "residents";
-    }
-    impl ::cynic::schema::HasField<residents> for super::PlanetResidentsConnection {
-        type Type = Option<Vec<Option<super::Person>>>;
-    }
-}
 pub struct PlanetResidentsEdge;
-pub mod planet_residents_edge_fields {
-    pub struct node;
-    impl ::cynic::schema::Field for node {
-        type Type = Option<super::Person>;
-        const NAME: &'static str = "node";
-    }
-    impl ::cynic::schema::HasField<node> for super::PlanetResidentsEdge {
-        type Type = Option<super::Person>;
-    }
-    pub struct cursor;
-    impl ::cynic::schema::Field for cursor {
-        type Type = super::String;
-        const NAME: &'static str = "cursor";
-    }
-    impl ::cynic::schema::HasField<cursor> for super::PlanetResidentsEdge {
-        type Type = super::String;
-    }
-}
 pub struct PlanetsConnection;
-pub mod planets_connection_fields {
-    pub struct pageInfo;
-    impl ::cynic::schema::Field for pageInfo {
-        type Type = super::PageInfo;
-        const NAME: &'static str = "pageInfo";
-    }
-    impl ::cynic::schema::HasField<pageInfo> for super::PlanetsConnection {
-        type Type = super::PageInfo;
-    }
-    pub struct edges;
-    impl ::cynic::schema::Field for edges {
-        type Type = Option<Vec<Option<super::PlanetsEdge>>>;
-        const NAME: &'static str = "edges";
-    }
-    impl ::cynic::schema::HasField<edges> for super::PlanetsConnection {
-        type Type = Option<Vec<Option<super::PlanetsEdge>>>;
-    }
-    pub struct totalCount;
-    impl ::cynic::schema::Field for totalCount {
-        type Type = Option<super::Int>;
-        const NAME: &'static str = "totalCount";
-    }
-    impl ::cynic::schema::HasField<totalCount> for super::PlanetsConnection {
-        type Type = Option<super::Int>;
-    }
-    pub struct planets;
-    impl ::cynic::schema::Field for planets {
-        type Type = Option<Vec<Option<super::Planet>>>;
-        const NAME: &'static str = "planets";
-    }
-    impl ::cynic::schema::HasField<planets> for super::PlanetsConnection {
-        type Type = Option<Vec<Option<super::Planet>>>;
-    }
-}
 pub struct PlanetsEdge;
-pub mod planets_edge_fields {
-    pub struct node;
-    impl ::cynic::schema::Field for node {
-        type Type = Option<super::Planet>;
-        const NAME: &'static str = "node";
-    }
-    impl ::cynic::schema::HasField<node> for super::PlanetsEdge {
-        type Type = Option<super::Planet>;
-    }
-    pub struct cursor;
-    impl ::cynic::schema::Field for cursor {
-        type Type = super::String;
-        const NAME: &'static str = "cursor";
-    }
-    impl ::cynic::schema::HasField<cursor> for super::PlanetsEdge {
-        type Type = super::String;
-    }
-}
 pub struct Root;
-pub mod root_fields {
-    pub struct allFilms;
-    impl ::cynic::schema::Field for allFilms {
-        type Type = Option<super::FilmsConnection>;
-        const NAME: &'static str = "allFilms";
-    }
-    impl ::cynic::schema::HasField<allFilms> for super::Root {
-        type Type = Option<super::FilmsConnection>;
-    }
-    pub mod all_films_arguments {
-        pub struct after;
-        impl ::cynic::schema::HasArgument<after> for super::allFilms {
-            type ArgumentType = Option<super::super::String>;
-            const NAME: &'static str = "after";
-        }
-        pub struct first;
-        impl ::cynic::schema::HasArgument<first> for super::allFilms {
-            type ArgumentType = Option<super::super::Int>;
-            const NAME: &'static str = "first";
-        }
-        pub struct before;
-        impl ::cynic::schema::HasArgument<before> for super::allFilms {
-            type ArgumentType = Option<super::super::String>;
-            const NAME: &'static str = "before";
-        }
-        pub struct last;
-        impl ::cynic::schema::HasArgument<last> for super::allFilms {
-            type ArgumentType = Option<super::super::Int>;
-            const NAME: &'static str = "last";
-        }
-    }
-    pub struct film;
-    impl ::cynic::schema::Field for film {
-        type Type = Option<super::Film>;
-        const NAME: &'static str = "film";
-    }
-    impl ::cynic::schema::HasField<film> for super::Root {
-        type Type = Option<super::Film>;
-    }
-    pub mod film_arguments {
-        pub struct id;
-        impl ::cynic::schema::HasArgument<id> for super::film {
-            type ArgumentType = Option<super::super::ID>;
-            const NAME: &'static str = "id";
-        }
-        pub struct filmID;
-        impl ::cynic::schema::HasArgument<filmID> for super::film {
-            type ArgumentType = Option<super::super::ID>;
-            const NAME: &'static str = "filmID";
-        }
-    }
-    pub struct allPeople;
-    impl ::cynic::schema::Field for allPeople {
-        type Type = Option<super::PeopleConnection>;
-        const NAME: &'static str = "allPeople";
-    }
-    impl ::cynic::schema::HasField<allPeople> for super::Root {
-        type Type = Option<super::PeopleConnection>;
-    }
-    pub mod all_people_arguments {
-        pub struct after;
-        impl ::cynic::schema::HasArgument<after> for super::allPeople {
-            type ArgumentType = Option<super::super::String>;
-            const NAME: &'static str = "after";
-        }
-        pub struct first;
-        impl ::cynic::schema::HasArgument<first> for super::allPeople {
-            type ArgumentType = Option<super::super::Int>;
-            const NAME: &'static str = "first";
-        }
-        pub struct before;
-        impl ::cynic::schema::HasArgument<before> for super::allPeople {
-            type ArgumentType = Option<super::super::String>;
-            const NAME: &'static str = "before";
-        }
-        pub struct last;
-        impl ::cynic::schema::HasArgument<last> for super::allPeople {
-            type ArgumentType = Option<super::super::Int>;
-            const NAME: &'static str = "last";
-        }
-    }
-    pub struct person;
-    impl ::cynic::schema::Field for person {
-        type Type = Option<super::Person>;
-        const NAME: &'static str = "person";
-    }
-    impl ::cynic::schema::HasField<person> for super::Root {
-        type Type = Option<super::Person>;
-    }
-    pub mod person_arguments {
-        pub struct id;
-        impl ::cynic::schema::HasArgument<id> for super::person {
-            type ArgumentType = Option<super::super::ID>;
-            const NAME: &'static str = "id";
-        }
-        pub struct personID;
-        impl ::cynic::schema::HasArgument<personID> for super::person {
-            type ArgumentType = Option<super::super::ID>;
-            const NAME: &'static str = "personID";
-        }
-    }
-    pub struct allPlanets;
-    impl ::cynic::schema::Field for allPlanets {
-        type Type = Option<super::PlanetsConnection>;
-        const NAME: &'static str = "allPlanets";
-    }
-    impl ::cynic::schema::HasField<allPlanets> for super::Root {
-        type Type = Option<super::PlanetsConnection>;
-    }
-    pub mod all_planets_arguments {
-        pub struct after;
-        impl ::cynic::schema::HasArgument<after> for super::allPlanets {
-            type ArgumentType = Option<super::super::String>;
-            const NAME: &'static str = "after";
-        }
-        pub struct first;
-        impl ::cynic::schema::HasArgument<first> for super::allPlanets {
-            type ArgumentType = Option<super::super::Int>;
-            const NAME: &'static str = "first";
-        }
-        pub struct before;
-        impl ::cynic::schema::HasArgument<before> for super::allPlanets {
-            type ArgumentType = Option<super::super::String>;
-            const NAME: &'static str = "before";
-        }
-        pub struct last;
-        impl ::cynic::schema::HasArgument<last> for super::allPlanets {
-            type ArgumentType = Option<super::super::Int>;
-            const NAME: &'static str = "last";
-        }
-    }
-    pub struct planet;
-    impl ::cynic::schema::Field for planet {
-        type Type = Option<super::Planet>;
-        const NAME: &'static str = "planet";
-    }
-    impl ::cynic::schema::HasField<planet> for super::Root {
-        type Type = Option<super::Planet>;
-    }
-    pub mod planet_arguments {
-        pub struct id;
-        impl ::cynic::schema::HasArgument<id> for super::planet {
-            type ArgumentType = Option<super::super::ID>;
-            const NAME: &'static str = "id";
-        }
-        pub struct planetID;
-        impl ::cynic::schema::HasArgument<planetID> for super::planet {
-            type ArgumentType = Option<super::super::ID>;
-            const NAME: &'static str = "planetID";
-        }
-    }
-    pub struct allSpecies;
-    impl ::cynic::schema::Field for allSpecies {
-        type Type = Option<super::SpeciesConnection>;
-        const NAME: &'static str = "allSpecies";
-    }
-    impl ::cynic::schema::HasField<allSpecies> for super::Root {
-        type Type = Option<super::SpeciesConnection>;
-    }
-    pub mod all_species_arguments {
-        pub struct after;
-        impl ::cynic::schema::HasArgument<after> for super::allSpecies {
-            type ArgumentType = Option<super::super::String>;
-            const NAME: &'static str = "after";
-        }
-        pub struct first;
-        impl ::cynic::schema::HasArgument<first> for super::allSpecies {
-            type ArgumentType = Option<super::super::Int>;
-            const NAME: &'static str = "first";
-        }
-        pub struct before;
-        impl ::cynic::schema::HasArgument<before> for super::allSpecies {
-            type ArgumentType = Option<super::super::String>;
-            const NAME: &'static str = "before";
-        }
-        pub struct last;
-        impl ::cynic::schema::HasArgument<last> for super::allSpecies {
-            type ArgumentType = Option<super::super::Int>;
-            const NAME: &'static str = "last";
-        }
-    }
-    pub struct species;
-    impl ::cynic::schema::Field for species {
-        type Type = Option<super::Species>;
-        const NAME: &'static str = "species";
-    }
-    impl ::cynic::schema::HasField<species> for super::Root {
-        type Type = Option<super::Species>;
-    }
-    pub mod species_arguments {
-        pub struct id;
-        impl ::cynic::schema::HasArgument<id> for super::species {
-            type ArgumentType = Option<super::super::ID>;
-            const NAME: &'static str = "id";
-        }
-        pub struct speciesID;
-        impl ::cynic::schema::HasArgument<speciesID> for super::species {
-            type ArgumentType = Option<super::super::ID>;
-            const NAME: &'static str = "speciesID";
-        }
-    }
-    pub struct allStarships;
-    impl ::cynic::schema::Field for allStarships {
-        type Type = Option<super::StarshipsConnection>;
-        const NAME: &'static str = "allStarships";
-    }
-    impl ::cynic::schema::HasField<allStarships> for super::Root {
-        type Type = Option<super::StarshipsConnection>;
-    }
-    pub mod all_starships_arguments {
-        pub struct after;
-        impl ::cynic::schema::HasArgument<after> for super::allStarships {
-            type ArgumentType = Option<super::super::String>;
-            const NAME: &'static str = "after";
-        }
-        pub struct first;
-        impl ::cynic::schema::HasArgument<first> for super::allStarships {
-            type ArgumentType = Option<super::super::Int>;
-            const NAME: &'static str = "first";
-        }
-        pub struct before;
-        impl ::cynic::schema::HasArgument<before> for super::allStarships {
-            type ArgumentType = Option<super::super::String>;
-            const NAME: &'static str = "before";
-        }
-        pub struct last;
-        impl ::cynic::schema::HasArgument<last> for super::allStarships {
-            type ArgumentType = Option<super::super::Int>;
-            const NAME: &'static str = "last";
-        }
-    }
-    pub struct starship;
-    impl ::cynic::schema::Field for starship {
-        type Type = Option<super::Starship>;
-        const NAME: &'static str = "starship";
-    }
-    impl ::cynic::schema::HasField<starship> for super::Root {
-        type Type = Option<super::Starship>;
-    }
-    pub mod starship_arguments {
-        pub struct id;
-        impl ::cynic::schema::HasArgument<id> for super::starship {
-            type ArgumentType = Option<super::super::ID>;
-            const NAME: &'static str = "id";
-        }
-        pub struct starshipID;
-        impl ::cynic::schema::HasArgument<starshipID> for super::starship {
-            type ArgumentType = Option<super::super::ID>;
-            const NAME: &'static str = "starshipID";
-        }
-    }
-    pub struct allVehicles;
-    impl ::cynic::schema::Field for allVehicles {
-        type Type = Option<super::VehiclesConnection>;
-        const NAME: &'static str = "allVehicles";
-    }
-    impl ::cynic::schema::HasField<allVehicles> for super::Root {
-        type Type = Option<super::VehiclesConnection>;
-    }
-    pub mod all_vehicles_arguments {
-        pub struct after;
-        impl ::cynic::schema::HasArgument<after> for super::allVehicles {
-            type ArgumentType = Option<super::super::String>;
-            const NAME: &'static str = "after";
-        }
-        pub struct first;
-        impl ::cynic::schema::HasArgument<first> for super::allVehicles {
-            type ArgumentType = Option<super::super::Int>;
-            const NAME: &'static str = "first";
-        }
-        pub struct before;
-        impl ::cynic::schema::HasArgument<before> for super::allVehicles {
-            type ArgumentType = Option<super::super::String>;
-            const NAME: &'static str = "before";
-        }
-        pub struct last;
-        impl ::cynic::schema::HasArgument<last> for super::allVehicles {
-            type ArgumentType = Option<super::super::Int>;
-            const NAME: &'static str = "last";
-        }
-    }
-    pub struct vehicle;
-    impl ::cynic::schema::Field for vehicle {
-        type Type = Option<super::Vehicle>;
-        const NAME: &'static str = "vehicle";
-    }
-    impl ::cynic::schema::HasField<vehicle> for super::Root {
-        type Type = Option<super::Vehicle>;
-    }
-    pub mod vehicle_arguments {
-        pub struct id;
-        impl ::cynic::schema::HasArgument<id> for super::vehicle {
-            type ArgumentType = Option<super::super::ID>;
-            const NAME: &'static str = "id";
-        }
-        pub struct vehicleID;
-        impl ::cynic::schema::HasArgument<vehicleID> for super::vehicle {
-            type ArgumentType = Option<super::super::ID>;
-            const NAME: &'static str = "vehicleID";
-        }
-    }
-    pub struct node;
-    impl ::cynic::schema::Field for node {
-        type Type = Option<super::Node>;
-        const NAME: &'static str = "node";
-    }
-    impl ::cynic::schema::HasField<node> for super::Root {
-        type Type = Option<super::Node>;
-    }
-    pub mod node_arguments {
-        pub struct id;
-        impl ::cynic::schema::HasArgument<id> for super::node {
-            type ArgumentType = super::super::ID;
-            const NAME: &'static str = "id";
-        }
-    }
-}
 pub struct Species;
-pub mod species_fields {
-    pub struct name;
-    impl ::cynic::schema::Field for name {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "name";
-    }
-    impl ::cynic::schema::HasField<name> for super::Species {
-        type Type = Option<super::String>;
-    }
-    pub struct classification;
-    impl ::cynic::schema::Field for classification {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "classification";
-    }
-    impl ::cynic::schema::HasField<classification> for super::Species {
-        type Type = Option<super::String>;
-    }
-    pub struct designation;
-    impl ::cynic::schema::Field for designation {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "designation";
-    }
-    impl ::cynic::schema::HasField<designation> for super::Species {
-        type Type = Option<super::String>;
-    }
-    pub struct averageHeight;
-    impl ::cynic::schema::Field for averageHeight {
-        type Type = Option<super::Float>;
-        const NAME: &'static str = "averageHeight";
-    }
-    impl ::cynic::schema::HasField<averageHeight> for super::Species {
-        type Type = Option<super::Float>;
-    }
-    pub struct averageLifespan;
-    impl ::cynic::schema::Field for averageLifespan {
-        type Type = Option<super::Int>;
-        const NAME: &'static str = "averageLifespan";
-    }
-    impl ::cynic::schema::HasField<averageLifespan> for super::Species {
-        type Type = Option<super::Int>;
-    }
-    pub struct eyeColors;
-    impl ::cynic::schema::Field for eyeColors {
-        type Type = Option<Vec<Option<super::String>>>;
-        const NAME: &'static str = "eyeColors";
-    }
-    impl ::cynic::schema::HasField<eyeColors> for super::Species {
-        type Type = Option<Vec<Option<super::String>>>;
-    }
-    pub struct hairColors;
-    impl ::cynic::schema::Field for hairColors {
-        type Type = Option<Vec<Option<super::String>>>;
-        const NAME: &'static str = "hairColors";
-    }
-    impl ::cynic::schema::HasField<hairColors> for super::Species {
-        type Type = Option<Vec<Option<super::String>>>;
-    }
-    pub struct skinColors;
-    impl ::cynic::schema::Field for skinColors {
-        type Type = Option<Vec<Option<super::String>>>;
-        const NAME: &'static str = "skinColors";
-    }
-    impl ::cynic::schema::HasField<skinColors> for super::Species {
-        type Type = Option<Vec<Option<super::String>>>;
-    }
-    pub struct language;
-    impl ::cynic::schema::Field for language {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "language";
-    }
-    impl ::cynic::schema::HasField<language> for super::Species {
-        type Type = Option<super::String>;
-    }
-    pub struct homeworld;
-    impl ::cynic::schema::Field for homeworld {
-        type Type = Option<super::Planet>;
-        const NAME: &'static str = "homeworld";
-    }
-    impl ::cynic::schema::HasField<homeworld> for super::Species {
-        type Type = Option<super::Planet>;
-    }
-    pub struct personConnection;
-    impl ::cynic::schema::Field for personConnection {
-        type Type = Option<super::SpeciesPeopleConnection>;
-        const NAME: &'static str = "personConnection";
-    }
-    impl ::cynic::schema::HasField<personConnection> for super::Species {
-        type Type = Option<super::SpeciesPeopleConnection>;
-    }
-    pub mod person_connection_arguments {
-        pub struct after;
-        impl ::cynic::schema::HasArgument<after> for super::personConnection {
-            type ArgumentType = Option<super::super::String>;
-            const NAME: &'static str = "after";
-        }
-        pub struct first;
-        impl ::cynic::schema::HasArgument<first> for super::personConnection {
-            type ArgumentType = Option<super::super::Int>;
-            const NAME: &'static str = "first";
-        }
-        pub struct before;
-        impl ::cynic::schema::HasArgument<before> for super::personConnection {
-            type ArgumentType = Option<super::super::String>;
-            const NAME: &'static str = "before";
-        }
-        pub struct last;
-        impl ::cynic::schema::HasArgument<last> for super::personConnection {
-            type ArgumentType = Option<super::super::Int>;
-            const NAME: &'static str = "last";
-        }
-    }
-    pub struct filmConnection;
-    impl ::cynic::schema::Field for filmConnection {
-        type Type = Option<super::SpeciesFilmsConnection>;
-        const NAME: &'static str = "filmConnection";
-    }
-    impl ::cynic::schema::HasField<filmConnection> for super::Species {
-        type Type = Option<super::SpeciesFilmsConnection>;
-    }
-    pub mod film_connection_arguments {
-        pub struct after;
-        impl ::cynic::schema::HasArgument<after> for super::filmConnection {
-            type ArgumentType = Option<super::super::String>;
-            const NAME: &'static str = "after";
-        }
-        pub struct first;
-        impl ::cynic::schema::HasArgument<first> for super::filmConnection {
-            type ArgumentType = Option<super::super::Int>;
-            const NAME: &'static str = "first";
-        }
-        pub struct before;
-        impl ::cynic::schema::HasArgument<before> for super::filmConnection {
-            type ArgumentType = Option<super::super::String>;
-            const NAME: &'static str = "before";
-        }
-        pub struct last;
-        impl ::cynic::schema::HasArgument<last> for super::filmConnection {
-            type ArgumentType = Option<super::super::Int>;
-            const NAME: &'static str = "last";
-        }
-    }
-    pub struct created;
-    impl ::cynic::schema::Field for created {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "created";
-    }
-    impl ::cynic::schema::HasField<created> for super::Species {
-        type Type = Option<super::String>;
-    }
-    pub struct edited;
-    impl ::cynic::schema::Field for edited {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "edited";
-    }
-    impl ::cynic::schema::HasField<edited> for super::Species {
-        type Type = Option<super::String>;
-    }
-    pub struct id;
-    impl ::cynic::schema::Field for id {
-        type Type = super::ID;
-        const NAME: &'static str = "id";
-    }
-    impl ::cynic::schema::HasField<id> for super::Species {
-        type Type = super::ID;
-    }
-}
 pub struct SpeciesConnection;
-pub mod species_connection_fields {
-    pub struct pageInfo;
-    impl ::cynic::schema::Field for pageInfo {
-        type Type = super::PageInfo;
-        const NAME: &'static str = "pageInfo";
-    }
-    impl ::cynic::schema::HasField<pageInfo> for super::SpeciesConnection {
-        type Type = super::PageInfo;
-    }
-    pub struct edges;
-    impl ::cynic::schema::Field for edges {
-        type Type = Option<Vec<Option<super::SpeciesEdge>>>;
-        const NAME: &'static str = "edges";
-    }
-    impl ::cynic::schema::HasField<edges> for super::SpeciesConnection {
-        type Type = Option<Vec<Option<super::SpeciesEdge>>>;
-    }
-    pub struct totalCount;
-    impl ::cynic::schema::Field for totalCount {
-        type Type = Option<super::Int>;
-        const NAME: &'static str = "totalCount";
-    }
-    impl ::cynic::schema::HasField<totalCount> for super::SpeciesConnection {
-        type Type = Option<super::Int>;
-    }
-    pub struct species;
-    impl ::cynic::schema::Field for species {
-        type Type = Option<Vec<Option<super::Species>>>;
-        const NAME: &'static str = "species";
-    }
-    impl ::cynic::schema::HasField<species> for super::SpeciesConnection {
-        type Type = Option<Vec<Option<super::Species>>>;
-    }
-}
 pub struct SpeciesEdge;
-pub mod species_edge_fields {
-    pub struct node;
-    impl ::cynic::schema::Field for node {
-        type Type = Option<super::Species>;
-        const NAME: &'static str = "node";
-    }
-    impl ::cynic::schema::HasField<node> for super::SpeciesEdge {
-        type Type = Option<super::Species>;
-    }
-    pub struct cursor;
-    impl ::cynic::schema::Field for cursor {
-        type Type = super::String;
-        const NAME: &'static str = "cursor";
-    }
-    impl ::cynic::schema::HasField<cursor> for super::SpeciesEdge {
-        type Type = super::String;
-    }
-}
 pub struct SpeciesFilmsConnection;
-pub mod species_films_connection_fields {
-    pub struct pageInfo;
-    impl ::cynic::schema::Field for pageInfo {
-        type Type = super::PageInfo;
-        const NAME: &'static str = "pageInfo";
-    }
-    impl ::cynic::schema::HasField<pageInfo> for super::SpeciesFilmsConnection {
-        type Type = super::PageInfo;
-    }
-    pub struct edges;
-    impl ::cynic::schema::Field for edges {
-        type Type = Option<Vec<Option<super::SpeciesFilmsEdge>>>;
-        const NAME: &'static str = "edges";
-    }
-    impl ::cynic::schema::HasField<edges> for super::SpeciesFilmsConnection {
-        type Type = Option<Vec<Option<super::SpeciesFilmsEdge>>>;
-    }
-    pub struct totalCount;
-    impl ::cynic::schema::Field for totalCount {
-        type Type = Option<super::Int>;
-        const NAME: &'static str = "totalCount";
-    }
-    impl ::cynic::schema::HasField<totalCount> for super::SpeciesFilmsConnection {
-        type Type = Option<super::Int>;
-    }
-    pub struct films;
-    impl ::cynic::schema::Field for films {
-        type Type = Option<Vec<Option<super::Film>>>;
-        const NAME: &'static str = "films";
-    }
-    impl ::cynic::schema::HasField<films> for super::SpeciesFilmsConnection {
-        type Type = Option<Vec<Option<super::Film>>>;
-    }
-}
 pub struct SpeciesFilmsEdge;
-pub mod species_films_edge_fields {
-    pub struct node;
-    impl ::cynic::schema::Field for node {
-        type Type = Option<super::Film>;
-        const NAME: &'static str = "node";
-    }
-    impl ::cynic::schema::HasField<node> for super::SpeciesFilmsEdge {
-        type Type = Option<super::Film>;
-    }
-    pub struct cursor;
-    impl ::cynic::schema::Field for cursor {
-        type Type = super::String;
-        const NAME: &'static str = "cursor";
-    }
-    impl ::cynic::schema::HasField<cursor> for super::SpeciesFilmsEdge {
-        type Type = super::String;
-    }
-}
 pub struct SpeciesPeopleConnection;
-pub mod species_people_connection_fields {
-    pub struct pageInfo;
-    impl ::cynic::schema::Field for pageInfo {
-        type Type = super::PageInfo;
-        const NAME: &'static str = "pageInfo";
-    }
-    impl ::cynic::schema::HasField<pageInfo> for super::SpeciesPeopleConnection {
-        type Type = super::PageInfo;
-    }
-    pub struct edges;
-    impl ::cynic::schema::Field for edges {
-        type Type = Option<Vec<Option<super::SpeciesPeopleEdge>>>;
-        const NAME: &'static str = "edges";
-    }
-    impl ::cynic::schema::HasField<edges> for super::SpeciesPeopleConnection {
-        type Type = Option<Vec<Option<super::SpeciesPeopleEdge>>>;
-    }
-    pub struct totalCount;
-    impl ::cynic::schema::Field for totalCount {
-        type Type = Option<super::Int>;
-        const NAME: &'static str = "totalCount";
-    }
-    impl ::cynic::schema::HasField<totalCount> for super::SpeciesPeopleConnection {
-        type Type = Option<super::Int>;
-    }
-    pub struct people;
-    impl ::cynic::schema::Field for people {
-        type Type = Option<Vec<Option<super::Person>>>;
-        const NAME: &'static str = "people";
-    }
-    impl ::cynic::schema::HasField<people> for super::SpeciesPeopleConnection {
-        type Type = Option<Vec<Option<super::Person>>>;
-    }
-}
 pub struct SpeciesPeopleEdge;
-pub mod species_people_edge_fields {
-    pub struct node;
-    impl ::cynic::schema::Field for node {
-        type Type = Option<super::Person>;
-        const NAME: &'static str = "node";
-    }
-    impl ::cynic::schema::HasField<node> for super::SpeciesPeopleEdge {
-        type Type = Option<super::Person>;
-    }
-    pub struct cursor;
-    impl ::cynic::schema::Field for cursor {
-        type Type = super::String;
-        const NAME: &'static str = "cursor";
-    }
-    impl ::cynic::schema::HasField<cursor> for super::SpeciesPeopleEdge {
-        type Type = super::String;
-    }
-}
 pub struct Starship;
-pub mod starship_fields {
-    pub struct name;
-    impl ::cynic::schema::Field for name {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "name";
-    }
-    impl ::cynic::schema::HasField<name> for super::Starship {
-        type Type = Option<super::String>;
-    }
-    pub struct model;
-    impl ::cynic::schema::Field for model {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "model";
-    }
-    impl ::cynic::schema::HasField<model> for super::Starship {
-        type Type = Option<super::String>;
-    }
-    pub struct starshipClass;
-    impl ::cynic::schema::Field for starshipClass {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "starshipClass";
-    }
-    impl ::cynic::schema::HasField<starshipClass> for super::Starship {
-        type Type = Option<super::String>;
-    }
-    pub struct manufacturers;
-    impl ::cynic::schema::Field for manufacturers {
-        type Type = Option<Vec<Option<super::String>>>;
-        const NAME: &'static str = "manufacturers";
-    }
-    impl ::cynic::schema::HasField<manufacturers> for super::Starship {
-        type Type = Option<Vec<Option<super::String>>>;
-    }
-    pub struct costInCredits;
-    impl ::cynic::schema::Field for costInCredits {
-        type Type = Option<super::Float>;
-        const NAME: &'static str = "costInCredits";
-    }
-    impl ::cynic::schema::HasField<costInCredits> for super::Starship {
-        type Type = Option<super::Float>;
-    }
-    pub struct length;
-    impl ::cynic::schema::Field for length {
-        type Type = Option<super::Float>;
-        const NAME: &'static str = "length";
-    }
-    impl ::cynic::schema::HasField<length> for super::Starship {
-        type Type = Option<super::Float>;
-    }
-    pub struct crew;
-    impl ::cynic::schema::Field for crew {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "crew";
-    }
-    impl ::cynic::schema::HasField<crew> for super::Starship {
-        type Type = Option<super::String>;
-    }
-    pub struct passengers;
-    impl ::cynic::schema::Field for passengers {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "passengers";
-    }
-    impl ::cynic::schema::HasField<passengers> for super::Starship {
-        type Type = Option<super::String>;
-    }
-    pub struct maxAtmospheringSpeed;
-    impl ::cynic::schema::Field for maxAtmospheringSpeed {
-        type Type = Option<super::Int>;
-        const NAME: &'static str = "maxAtmospheringSpeed";
-    }
-    impl ::cynic::schema::HasField<maxAtmospheringSpeed> for super::Starship {
-        type Type = Option<super::Int>;
-    }
-    pub struct hyperdriveRating;
-    impl ::cynic::schema::Field for hyperdriveRating {
-        type Type = Option<super::Float>;
-        const NAME: &'static str = "hyperdriveRating";
-    }
-    impl ::cynic::schema::HasField<hyperdriveRating> for super::Starship {
-        type Type = Option<super::Float>;
-    }
-    pub struct MGLT;
-    impl ::cynic::schema::Field for MGLT {
-        type Type = Option<super::Int>;
-        const NAME: &'static str = "MGLT";
-    }
-    impl ::cynic::schema::HasField<MGLT> for super::Starship {
-        type Type = Option<super::Int>;
-    }
-    pub struct cargoCapacity;
-    impl ::cynic::schema::Field for cargoCapacity {
-        type Type = Option<super::Float>;
-        const NAME: &'static str = "cargoCapacity";
-    }
-    impl ::cynic::schema::HasField<cargoCapacity> for super::Starship {
-        type Type = Option<super::Float>;
-    }
-    pub struct consumables;
-    impl ::cynic::schema::Field for consumables {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "consumables";
-    }
-    impl ::cynic::schema::HasField<consumables> for super::Starship {
-        type Type = Option<super::String>;
-    }
-    pub struct pilotConnection;
-    impl ::cynic::schema::Field for pilotConnection {
-        type Type = Option<super::StarshipPilotsConnection>;
-        const NAME: &'static str = "pilotConnection";
-    }
-    impl ::cynic::schema::HasField<pilotConnection> for super::Starship {
-        type Type = Option<super::StarshipPilotsConnection>;
-    }
-    pub mod pilot_connection_arguments {
-        pub struct after;
-        impl ::cynic::schema::HasArgument<after> for super::pilotConnection {
-            type ArgumentType = Option<super::super::String>;
-            const NAME: &'static str = "after";
-        }
-        pub struct first;
-        impl ::cynic::schema::HasArgument<first> for super::pilotConnection {
-            type ArgumentType = Option<super::super::Int>;
-            const NAME: &'static str = "first";
-        }
-        pub struct before;
-        impl ::cynic::schema::HasArgument<before> for super::pilotConnection {
-            type ArgumentType = Option<super::super::String>;
-            const NAME: &'static str = "before";
-        }
-        pub struct last;
-        impl ::cynic::schema::HasArgument<last> for super::pilotConnection {
-            type ArgumentType = Option<super::super::Int>;
-            const NAME: &'static str = "last";
-        }
-    }
-    pub struct filmConnection;
-    impl ::cynic::schema::Field for filmConnection {
-        type Type = Option<super::StarshipFilmsConnection>;
-        const NAME: &'static str = "filmConnection";
-    }
-    impl ::cynic::schema::HasField<filmConnection> for super::Starship {
-        type Type = Option<super::StarshipFilmsConnection>;
-    }
-    pub mod film_connection_arguments {
-        pub struct after;
-        impl ::cynic::schema::HasArgument<after> for super::filmConnection {
-            type ArgumentType = Option<super::super::String>;
-            const NAME: &'static str = "after";
-        }
-        pub struct first;
-        impl ::cynic::schema::HasArgument<first> for super::filmConnection {
-            type ArgumentType = Option<super::super::Int>;
-            const NAME: &'static str = "first";
-        }
-        pub struct before;
-        impl ::cynic::schema::HasArgument<before> for super::filmConnection {
-            type ArgumentType = Option<super::super::String>;
-            const NAME: &'static str = "before";
-        }
-        pub struct last;
-        impl ::cynic::schema::HasArgument<last> for super::filmConnection {
-            type ArgumentType = Option<super::super::Int>;
-            const NAME: &'static str = "last";
-        }
-    }
-    pub struct created;
-    impl ::cynic::schema::Field for created {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "created";
-    }
-    impl ::cynic::schema::HasField<created> for super::Starship {
-        type Type = Option<super::String>;
-    }
-    pub struct edited;
-    impl ::cynic::schema::Field for edited {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "edited";
-    }
-    impl ::cynic::schema::HasField<edited> for super::Starship {
-        type Type = Option<super::String>;
-    }
-    pub struct id;
-    impl ::cynic::schema::Field for id {
-        type Type = super::ID;
-        const NAME: &'static str = "id";
-    }
-    impl ::cynic::schema::HasField<id> for super::Starship {
-        type Type = super::ID;
-    }
-}
 pub struct StarshipFilmsConnection;
-pub mod starship_films_connection_fields {
-    pub struct pageInfo;
-    impl ::cynic::schema::Field for pageInfo {
-        type Type = super::PageInfo;
-        const NAME: &'static str = "pageInfo";
-    }
-    impl ::cynic::schema::HasField<pageInfo> for super::StarshipFilmsConnection {
-        type Type = super::PageInfo;
-    }
-    pub struct edges;
-    impl ::cynic::schema::Field for edges {
-        type Type = Option<Vec<Option<super::StarshipFilmsEdge>>>;
-        const NAME: &'static str = "edges";
-    }
-    impl ::cynic::schema::HasField<edges> for super::StarshipFilmsConnection {
-        type Type = Option<Vec<Option<super::StarshipFilmsEdge>>>;
-    }
-    pub struct totalCount;
-    impl ::cynic::schema::Field for totalCount {
-        type Type = Option<super::Int>;
-        const NAME: &'static str = "totalCount";
-    }
-    impl ::cynic::schema::HasField<totalCount> for super::StarshipFilmsConnection {
-        type Type = Option<super::Int>;
-    }
-    pub struct films;
-    impl ::cynic::schema::Field for films {
-        type Type = Option<Vec<Option<super::Film>>>;
-        const NAME: &'static str = "films";
-    }
-    impl ::cynic::schema::HasField<films> for super::StarshipFilmsConnection {
-        type Type = Option<Vec<Option<super::Film>>>;
-    }
-}
 pub struct StarshipFilmsEdge;
-pub mod starship_films_edge_fields {
-    pub struct node;
-    impl ::cynic::schema::Field for node {
-        type Type = Option<super::Film>;
-        const NAME: &'static str = "node";
-    }
-    impl ::cynic::schema::HasField<node> for super::StarshipFilmsEdge {
-        type Type = Option<super::Film>;
-    }
-    pub struct cursor;
-    impl ::cynic::schema::Field for cursor {
-        type Type = super::String;
-        const NAME: &'static str = "cursor";
-    }
-    impl ::cynic::schema::HasField<cursor> for super::StarshipFilmsEdge {
-        type Type = super::String;
-    }
-}
 pub struct StarshipPilotsConnection;
-pub mod starship_pilots_connection_fields {
-    pub struct pageInfo;
-    impl ::cynic::schema::Field for pageInfo {
-        type Type = super::PageInfo;
-        const NAME: &'static str = "pageInfo";
-    }
-    impl ::cynic::schema::HasField<pageInfo> for super::StarshipPilotsConnection {
-        type Type = super::PageInfo;
-    }
-    pub struct edges;
-    impl ::cynic::schema::Field for edges {
-        type Type = Option<Vec<Option<super::StarshipPilotsEdge>>>;
-        const NAME: &'static str = "edges";
-    }
-    impl ::cynic::schema::HasField<edges> for super::StarshipPilotsConnection {
-        type Type = Option<Vec<Option<super::StarshipPilotsEdge>>>;
-    }
-    pub struct totalCount;
-    impl ::cynic::schema::Field for totalCount {
-        type Type = Option<super::Int>;
-        const NAME: &'static str = "totalCount";
-    }
-    impl ::cynic::schema::HasField<totalCount> for super::StarshipPilotsConnection {
-        type Type = Option<super::Int>;
-    }
-    pub struct pilots;
-    impl ::cynic::schema::Field for pilots {
-        type Type = Option<Vec<Option<super::Person>>>;
-        const NAME: &'static str = "pilots";
-    }
-    impl ::cynic::schema::HasField<pilots> for super::StarshipPilotsConnection {
-        type Type = Option<Vec<Option<super::Person>>>;
-    }
-}
 pub struct StarshipPilotsEdge;
-pub mod starship_pilots_edge_fields {
-    pub struct node;
-    impl ::cynic::schema::Field for node {
-        type Type = Option<super::Person>;
-        const NAME: &'static str = "node";
-    }
-    impl ::cynic::schema::HasField<node> for super::StarshipPilotsEdge {
-        type Type = Option<super::Person>;
-    }
-    pub struct cursor;
-    impl ::cynic::schema::Field for cursor {
-        type Type = super::String;
-        const NAME: &'static str = "cursor";
-    }
-    impl ::cynic::schema::HasField<cursor> for super::StarshipPilotsEdge {
-        type Type = super::String;
-    }
-}
 pub struct StarshipsConnection;
-pub mod starships_connection_fields {
-    pub struct pageInfo;
-    impl ::cynic::schema::Field for pageInfo {
-        type Type = super::PageInfo;
-        const NAME: &'static str = "pageInfo";
-    }
-    impl ::cynic::schema::HasField<pageInfo> for super::StarshipsConnection {
-        type Type = super::PageInfo;
-    }
-    pub struct edges;
-    impl ::cynic::schema::Field for edges {
-        type Type = Option<Vec<Option<super::StarshipsEdge>>>;
-        const NAME: &'static str = "edges";
-    }
-    impl ::cynic::schema::HasField<edges> for super::StarshipsConnection {
-        type Type = Option<Vec<Option<super::StarshipsEdge>>>;
-    }
-    pub struct totalCount;
-    impl ::cynic::schema::Field for totalCount {
-        type Type = Option<super::Int>;
-        const NAME: &'static str = "totalCount";
-    }
-    impl ::cynic::schema::HasField<totalCount> for super::StarshipsConnection {
-        type Type = Option<super::Int>;
-    }
-    pub struct starships;
-    impl ::cynic::schema::Field for starships {
-        type Type = Option<Vec<Option<super::Starship>>>;
-        const NAME: &'static str = "starships";
-    }
-    impl ::cynic::schema::HasField<starships> for super::StarshipsConnection {
-        type Type = Option<Vec<Option<super::Starship>>>;
-    }
-}
 pub struct StarshipsEdge;
-pub mod starships_edge_fields {
-    pub struct node;
-    impl ::cynic::schema::Field for node {
-        type Type = Option<super::Starship>;
-        const NAME: &'static str = "node";
-    }
-    impl ::cynic::schema::HasField<node> for super::StarshipsEdge {
-        type Type = Option<super::Starship>;
-    }
-    pub struct cursor;
-    impl ::cynic::schema::Field for cursor {
-        type Type = super::String;
-        const NAME: &'static str = "cursor";
-    }
-    impl ::cynic::schema::HasField<cursor> for super::StarshipsEdge {
-        type Type = super::String;
-    }
-}
 pub struct Vehicle;
-pub mod vehicle_fields {
-    pub struct name;
-    impl ::cynic::schema::Field for name {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "name";
-    }
-    impl ::cynic::schema::HasField<name> for super::Vehicle {
-        type Type = Option<super::String>;
-    }
-    pub struct model;
-    impl ::cynic::schema::Field for model {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "model";
-    }
-    impl ::cynic::schema::HasField<model> for super::Vehicle {
-        type Type = Option<super::String>;
-    }
-    pub struct vehicleClass;
-    impl ::cynic::schema::Field for vehicleClass {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "vehicleClass";
-    }
-    impl ::cynic::schema::HasField<vehicleClass> for super::Vehicle {
-        type Type = Option<super::String>;
-    }
-    pub struct manufacturers;
-    impl ::cynic::schema::Field for manufacturers {
-        type Type = Option<Vec<Option<super::String>>>;
-        const NAME: &'static str = "manufacturers";
-    }
-    impl ::cynic::schema::HasField<manufacturers> for super::Vehicle {
-        type Type = Option<Vec<Option<super::String>>>;
-    }
-    pub struct costInCredits;
-    impl ::cynic::schema::Field for costInCredits {
-        type Type = Option<super::Float>;
-        const NAME: &'static str = "costInCredits";
-    }
-    impl ::cynic::schema::HasField<costInCredits> for super::Vehicle {
-        type Type = Option<super::Float>;
-    }
-    pub struct length;
-    impl ::cynic::schema::Field for length {
-        type Type = Option<super::Float>;
-        const NAME: &'static str = "length";
-    }
-    impl ::cynic::schema::HasField<length> for super::Vehicle {
-        type Type = Option<super::Float>;
-    }
-    pub struct crew;
-    impl ::cynic::schema::Field for crew {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "crew";
-    }
-    impl ::cynic::schema::HasField<crew> for super::Vehicle {
-        type Type = Option<super::String>;
-    }
-    pub struct passengers;
-    impl ::cynic::schema::Field for passengers {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "passengers";
-    }
-    impl ::cynic::schema::HasField<passengers> for super::Vehicle {
-        type Type = Option<super::String>;
-    }
-    pub struct maxAtmospheringSpeed;
-    impl ::cynic::schema::Field for maxAtmospheringSpeed {
-        type Type = Option<super::Int>;
-        const NAME: &'static str = "maxAtmospheringSpeed";
-    }
-    impl ::cynic::schema::HasField<maxAtmospheringSpeed> for super::Vehicle {
-        type Type = Option<super::Int>;
-    }
-    pub struct cargoCapacity;
-    impl ::cynic::schema::Field for cargoCapacity {
-        type Type = Option<super::Float>;
-        const NAME: &'static str = "cargoCapacity";
-    }
-    impl ::cynic::schema::HasField<cargoCapacity> for super::Vehicle {
-        type Type = Option<super::Float>;
-    }
-    pub struct consumables;
-    impl ::cynic::schema::Field for consumables {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "consumables";
-    }
-    impl ::cynic::schema::HasField<consumables> for super::Vehicle {
-        type Type = Option<super::String>;
-    }
-    pub struct pilotConnection;
-    impl ::cynic::schema::Field for pilotConnection {
-        type Type = Option<super::VehiclePilotsConnection>;
-        const NAME: &'static str = "pilotConnection";
-    }
-    impl ::cynic::schema::HasField<pilotConnection> for super::Vehicle {
-        type Type = Option<super::VehiclePilotsConnection>;
-    }
-    pub mod pilot_connection_arguments {
-        pub struct after;
-        impl ::cynic::schema::HasArgument<after> for super::pilotConnection {
-            type ArgumentType = Option<super::super::String>;
-            const NAME: &'static str = "after";
-        }
-        pub struct first;
-        impl ::cynic::schema::HasArgument<first> for super::pilotConnection {
-            type ArgumentType = Option<super::super::Int>;
-            const NAME: &'static str = "first";
-        }
-        pub struct before;
-        impl ::cynic::schema::HasArgument<before> for super::pilotConnection {
-            type ArgumentType = Option<super::super::String>;
-            const NAME: &'static str = "before";
-        }
-        pub struct last;
-        impl ::cynic::schema::HasArgument<last> for super::pilotConnection {
-            type ArgumentType = Option<super::super::Int>;
-            const NAME: &'static str = "last";
-        }
-    }
-    pub struct filmConnection;
-    impl ::cynic::schema::Field for filmConnection {
-        type Type = Option<super::VehicleFilmsConnection>;
-        const NAME: &'static str = "filmConnection";
-    }
-    impl ::cynic::schema::HasField<filmConnection> for super::Vehicle {
-        type Type = Option<super::VehicleFilmsConnection>;
-    }
-    pub mod film_connection_arguments {
-        pub struct after;
-        impl ::cynic::schema::HasArgument<after> for super::filmConnection {
-            type ArgumentType = Option<super::super::String>;
-            const NAME: &'static str = "after";
-        }
-        pub struct first;
-        impl ::cynic::schema::HasArgument<first> for super::filmConnection {
-            type ArgumentType = Option<super::super::Int>;
-            const NAME: &'static str = "first";
-        }
-        pub struct before;
-        impl ::cynic::schema::HasArgument<before> for super::filmConnection {
-            type ArgumentType = Option<super::super::String>;
-            const NAME: &'static str = "before";
-        }
-        pub struct last;
-        impl ::cynic::schema::HasArgument<last> for super::filmConnection {
-            type ArgumentType = Option<super::super::Int>;
-            const NAME: &'static str = "last";
-        }
-    }
-    pub struct created;
-    impl ::cynic::schema::Field for created {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "created";
-    }
-    impl ::cynic::schema::HasField<created> for super::Vehicle {
-        type Type = Option<super::String>;
-    }
-    pub struct edited;
-    impl ::cynic::schema::Field for edited {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "edited";
-    }
-    impl ::cynic::schema::HasField<edited> for super::Vehicle {
-        type Type = Option<super::String>;
-    }
-    pub struct id;
-    impl ::cynic::schema::Field for id {
-        type Type = super::ID;
-        const NAME: &'static str = "id";
-    }
-    impl ::cynic::schema::HasField<id> for super::Vehicle {
-        type Type = super::ID;
-    }
-}
 pub struct VehicleFilmsConnection;
-pub mod vehicle_films_connection_fields {
-    pub struct pageInfo;
-    impl ::cynic::schema::Field for pageInfo {
-        type Type = super::PageInfo;
-        const NAME: &'static str = "pageInfo";
-    }
-    impl ::cynic::schema::HasField<pageInfo> for super::VehicleFilmsConnection {
-        type Type = super::PageInfo;
-    }
-    pub struct edges;
-    impl ::cynic::schema::Field for edges {
-        type Type = Option<Vec<Option<super::VehicleFilmsEdge>>>;
-        const NAME: &'static str = "edges";
-    }
-    impl ::cynic::schema::HasField<edges> for super::VehicleFilmsConnection {
-        type Type = Option<Vec<Option<super::VehicleFilmsEdge>>>;
-    }
-    pub struct totalCount;
-    impl ::cynic::schema::Field for totalCount {
-        type Type = Option<super::Int>;
-        const NAME: &'static str = "totalCount";
-    }
-    impl ::cynic::schema::HasField<totalCount> for super::VehicleFilmsConnection {
-        type Type = Option<super::Int>;
-    }
-    pub struct films;
-    impl ::cynic::schema::Field for films {
-        type Type = Option<Vec<Option<super::Film>>>;
-        const NAME: &'static str = "films";
-    }
-    impl ::cynic::schema::HasField<films> for super::VehicleFilmsConnection {
-        type Type = Option<Vec<Option<super::Film>>>;
-    }
-}
 pub struct VehicleFilmsEdge;
-pub mod vehicle_films_edge_fields {
-    pub struct node;
-    impl ::cynic::schema::Field for node {
-        type Type = Option<super::Film>;
-        const NAME: &'static str = "node";
-    }
-    impl ::cynic::schema::HasField<node> for super::VehicleFilmsEdge {
-        type Type = Option<super::Film>;
-    }
-    pub struct cursor;
-    impl ::cynic::schema::Field for cursor {
-        type Type = super::String;
-        const NAME: &'static str = "cursor";
-    }
-    impl ::cynic::schema::HasField<cursor> for super::VehicleFilmsEdge {
-        type Type = super::String;
-    }
-}
 pub struct VehiclePilotsConnection;
-pub mod vehicle_pilots_connection_fields {
-    pub struct pageInfo;
-    impl ::cynic::schema::Field for pageInfo {
-        type Type = super::PageInfo;
-        const NAME: &'static str = "pageInfo";
-    }
-    impl ::cynic::schema::HasField<pageInfo> for super::VehiclePilotsConnection {
-        type Type = super::PageInfo;
-    }
-    pub struct edges;
-    impl ::cynic::schema::Field for edges {
-        type Type = Option<Vec<Option<super::VehiclePilotsEdge>>>;
-        const NAME: &'static str = "edges";
-    }
-    impl ::cynic::schema::HasField<edges> for super::VehiclePilotsConnection {
-        type Type = Option<Vec<Option<super::VehiclePilotsEdge>>>;
-    }
-    pub struct totalCount;
-    impl ::cynic::schema::Field for totalCount {
-        type Type = Option<super::Int>;
-        const NAME: &'static str = "totalCount";
-    }
-    impl ::cynic::schema::HasField<totalCount> for super::VehiclePilotsConnection {
-        type Type = Option<super::Int>;
-    }
-    pub struct pilots;
-    impl ::cynic::schema::Field for pilots {
-        type Type = Option<Vec<Option<super::Person>>>;
-        const NAME: &'static str = "pilots";
-    }
-    impl ::cynic::schema::HasField<pilots> for super::VehiclePilotsConnection {
-        type Type = Option<Vec<Option<super::Person>>>;
-    }
-}
 pub struct VehiclePilotsEdge;
-pub mod vehicle_pilots_edge_fields {
-    pub struct node;
-    impl ::cynic::schema::Field for node {
-        type Type = Option<super::Person>;
-        const NAME: &'static str = "node";
-    }
-    impl ::cynic::schema::HasField<node> for super::VehiclePilotsEdge {
-        type Type = Option<super::Person>;
-    }
-    pub struct cursor;
-    impl ::cynic::schema::Field for cursor {
-        type Type = super::String;
-        const NAME: &'static str = "cursor";
-    }
-    impl ::cynic::schema::HasField<cursor> for super::VehiclePilotsEdge {
-        type Type = super::String;
-    }
-}
 pub struct VehiclesConnection;
-pub mod vehicles_connection_fields {
-    pub struct pageInfo;
-    impl ::cynic::schema::Field for pageInfo {
-        type Type = super::PageInfo;
-        const NAME: &'static str = "pageInfo";
-    }
-    impl ::cynic::schema::HasField<pageInfo> for super::VehiclesConnection {
-        type Type = super::PageInfo;
-    }
-    pub struct edges;
-    impl ::cynic::schema::Field for edges {
-        type Type = Option<Vec<Option<super::VehiclesEdge>>>;
-        const NAME: &'static str = "edges";
-    }
-    impl ::cynic::schema::HasField<edges> for super::VehiclesConnection {
-        type Type = Option<Vec<Option<super::VehiclesEdge>>>;
-    }
-    pub struct totalCount;
-    impl ::cynic::schema::Field for totalCount {
-        type Type = Option<super::Int>;
-        const NAME: &'static str = "totalCount";
-    }
-    impl ::cynic::schema::HasField<totalCount> for super::VehiclesConnection {
-        type Type = Option<super::Int>;
-    }
-    pub struct vehicles;
-    impl ::cynic::schema::Field for vehicles {
-        type Type = Option<Vec<Option<super::Vehicle>>>;
-        const NAME: &'static str = "vehicles";
-    }
-    impl ::cynic::schema::HasField<vehicles> for super::VehiclesConnection {
-        type Type = Option<Vec<Option<super::Vehicle>>>;
-    }
-}
 pub struct VehiclesEdge;
-pub mod vehicles_edge_fields {
-    pub struct node;
-    impl ::cynic::schema::Field for node {
-        type Type = Option<super::Vehicle>;
-        const NAME: &'static str = "node";
-    }
-    impl ::cynic::schema::HasField<node> for super::VehiclesEdge {
-        type Type = Option<super::Vehicle>;
-    }
-    pub struct cursor;
-    impl ::cynic::schema::Field for cursor {
-        type Type = super::String;
-        const NAME: &'static str = "cursor";
-    }
-    impl ::cynic::schema::HasField<cursor> for super::VehiclesEdge {
-        type Type = super::String;
-    }
-}
 impl ::cynic::schema::HasSubtype<Film> for Node {}
 impl ::cynic::schema::HasSubtype<Node> for Node {}
 impl ::cynic::schema::HasSubtype<Person> for Node {}
@@ -2835,6 +221,2622 @@ impl ::cynic::schema::NamedType for VehiclesConnection {
 }
 impl ::cynic::schema::NamedType for VehiclesEdge {
     const NAME: &'static str = "VehiclesEdge";
+}
+#[allow(non_snake_case, non_camel_case_types)]
+pub mod __fields {
+    pub mod Film {
+        pub struct title;
+        impl ::cynic::schema::Field for title {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "title";
+        }
+        impl ::cynic::schema::HasField<title> for super::super::Film {
+            type Type = Option<super::super::String>;
+        }
+        pub struct episodeID;
+        impl ::cynic::schema::Field for episodeID {
+            type Type = Option<super::super::Int>;
+            const NAME: &'static str = "episodeID";
+        }
+        impl ::cynic::schema::HasField<episodeID> for super::super::Film {
+            type Type = Option<super::super::Int>;
+        }
+        pub struct openingCrawl;
+        impl ::cynic::schema::Field for openingCrawl {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "openingCrawl";
+        }
+        impl ::cynic::schema::HasField<openingCrawl> for super::super::Film {
+            type Type = Option<super::super::String>;
+        }
+        pub struct director;
+        impl ::cynic::schema::Field for director {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "director";
+        }
+        impl ::cynic::schema::HasField<director> for super::super::Film {
+            type Type = Option<super::super::String>;
+        }
+        pub struct producers;
+        impl ::cynic::schema::Field for producers {
+            type Type = Option<Vec<Option<super::super::String>>>;
+            const NAME: &'static str = "producers";
+        }
+        impl ::cynic::schema::HasField<producers> for super::super::Film {
+            type Type = Option<Vec<Option<super::super::String>>>;
+        }
+        pub struct releaseDate;
+        impl ::cynic::schema::Field for releaseDate {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "releaseDate";
+        }
+        impl ::cynic::schema::HasField<releaseDate> for super::super::Film {
+            type Type = Option<super::super::String>;
+        }
+        pub struct speciesConnection;
+        impl ::cynic::schema::Field for speciesConnection {
+            type Type = Option<super::super::FilmSpeciesConnection>;
+            const NAME: &'static str = "speciesConnection";
+        }
+        impl ::cynic::schema::HasField<speciesConnection> for super::super::Film {
+            type Type = Option<super::super::FilmSpeciesConnection>;
+        }
+        pub mod species_connection_arguments {
+            pub struct after;
+            impl ::cynic::schema::HasArgument<after> for super::speciesConnection {
+                type ArgumentType = Option<super::super::super::String>;
+                const NAME: &'static str = "after";
+            }
+            pub struct first;
+            impl ::cynic::schema::HasArgument<first> for super::speciesConnection {
+                type ArgumentType = Option<super::super::super::Int>;
+                const NAME: &'static str = "first";
+            }
+            pub struct before;
+            impl ::cynic::schema::HasArgument<before> for super::speciesConnection {
+                type ArgumentType = Option<super::super::super::String>;
+                const NAME: &'static str = "before";
+            }
+            pub struct last;
+            impl ::cynic::schema::HasArgument<last> for super::speciesConnection {
+                type ArgumentType = Option<super::super::super::Int>;
+                const NAME: &'static str = "last";
+            }
+        }
+        pub struct starshipConnection;
+        impl ::cynic::schema::Field for starshipConnection {
+            type Type = Option<super::super::FilmStarshipsConnection>;
+            const NAME: &'static str = "starshipConnection";
+        }
+        impl ::cynic::schema::HasField<starshipConnection> for super::super::Film {
+            type Type = Option<super::super::FilmStarshipsConnection>;
+        }
+        pub mod starship_connection_arguments {
+            pub struct after;
+            impl ::cynic::schema::HasArgument<after> for super::starshipConnection {
+                type ArgumentType = Option<super::super::super::String>;
+                const NAME: &'static str = "after";
+            }
+            pub struct first;
+            impl ::cynic::schema::HasArgument<first> for super::starshipConnection {
+                type ArgumentType = Option<super::super::super::Int>;
+                const NAME: &'static str = "first";
+            }
+            pub struct before;
+            impl ::cynic::schema::HasArgument<before> for super::starshipConnection {
+                type ArgumentType = Option<super::super::super::String>;
+                const NAME: &'static str = "before";
+            }
+            pub struct last;
+            impl ::cynic::schema::HasArgument<last> for super::starshipConnection {
+                type ArgumentType = Option<super::super::super::Int>;
+                const NAME: &'static str = "last";
+            }
+        }
+        pub struct vehicleConnection;
+        impl ::cynic::schema::Field for vehicleConnection {
+            type Type = Option<super::super::FilmVehiclesConnection>;
+            const NAME: &'static str = "vehicleConnection";
+        }
+        impl ::cynic::schema::HasField<vehicleConnection> for super::super::Film {
+            type Type = Option<super::super::FilmVehiclesConnection>;
+        }
+        pub mod vehicle_connection_arguments {
+            pub struct after;
+            impl ::cynic::schema::HasArgument<after> for super::vehicleConnection {
+                type ArgumentType = Option<super::super::super::String>;
+                const NAME: &'static str = "after";
+            }
+            pub struct first;
+            impl ::cynic::schema::HasArgument<first> for super::vehicleConnection {
+                type ArgumentType = Option<super::super::super::Int>;
+                const NAME: &'static str = "first";
+            }
+            pub struct before;
+            impl ::cynic::schema::HasArgument<before> for super::vehicleConnection {
+                type ArgumentType = Option<super::super::super::String>;
+                const NAME: &'static str = "before";
+            }
+            pub struct last;
+            impl ::cynic::schema::HasArgument<last> for super::vehicleConnection {
+                type ArgumentType = Option<super::super::super::Int>;
+                const NAME: &'static str = "last";
+            }
+        }
+        pub struct characterConnection;
+        impl ::cynic::schema::Field for characterConnection {
+            type Type = Option<super::super::FilmCharactersConnection>;
+            const NAME: &'static str = "characterConnection";
+        }
+        impl ::cynic::schema::HasField<characterConnection> for super::super::Film {
+            type Type = Option<super::super::FilmCharactersConnection>;
+        }
+        pub mod character_connection_arguments {
+            pub struct after;
+            impl ::cynic::schema::HasArgument<after> for super::characterConnection {
+                type ArgumentType = Option<super::super::super::String>;
+                const NAME: &'static str = "after";
+            }
+            pub struct first;
+            impl ::cynic::schema::HasArgument<first> for super::characterConnection {
+                type ArgumentType = Option<super::super::super::Int>;
+                const NAME: &'static str = "first";
+            }
+            pub struct before;
+            impl ::cynic::schema::HasArgument<before> for super::characterConnection {
+                type ArgumentType = Option<super::super::super::String>;
+                const NAME: &'static str = "before";
+            }
+            pub struct last;
+            impl ::cynic::schema::HasArgument<last> for super::characterConnection {
+                type ArgumentType = Option<super::super::super::Int>;
+                const NAME: &'static str = "last";
+            }
+        }
+        pub struct planetConnection;
+        impl ::cynic::schema::Field for planetConnection {
+            type Type = Option<super::super::FilmPlanetsConnection>;
+            const NAME: &'static str = "planetConnection";
+        }
+        impl ::cynic::schema::HasField<planetConnection> for super::super::Film {
+            type Type = Option<super::super::FilmPlanetsConnection>;
+        }
+        pub mod planet_connection_arguments {
+            pub struct after;
+            impl ::cynic::schema::HasArgument<after> for super::planetConnection {
+                type ArgumentType = Option<super::super::super::String>;
+                const NAME: &'static str = "after";
+            }
+            pub struct first;
+            impl ::cynic::schema::HasArgument<first> for super::planetConnection {
+                type ArgumentType = Option<super::super::super::Int>;
+                const NAME: &'static str = "first";
+            }
+            pub struct before;
+            impl ::cynic::schema::HasArgument<before> for super::planetConnection {
+                type ArgumentType = Option<super::super::super::String>;
+                const NAME: &'static str = "before";
+            }
+            pub struct last;
+            impl ::cynic::schema::HasArgument<last> for super::planetConnection {
+                type ArgumentType = Option<super::super::super::Int>;
+                const NAME: &'static str = "last";
+            }
+        }
+        pub struct created;
+        impl ::cynic::schema::Field for created {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "created";
+        }
+        impl ::cynic::schema::HasField<created> for super::super::Film {
+            type Type = Option<super::super::String>;
+        }
+        pub struct edited;
+        impl ::cynic::schema::Field for edited {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "edited";
+        }
+        impl ::cynic::schema::HasField<edited> for super::super::Film {
+            type Type = Option<super::super::String>;
+        }
+        pub struct id;
+        impl ::cynic::schema::Field for id {
+            type Type = super::super::ID;
+            const NAME: &'static str = "id";
+        }
+        impl ::cynic::schema::HasField<id> for super::super::Film {
+            type Type = super::super::ID;
+        }
+    }
+    pub mod FilmCharactersConnection {
+        pub struct pageInfo;
+        impl ::cynic::schema::Field for pageInfo {
+            type Type = super::super::PageInfo;
+            const NAME: &'static str = "pageInfo";
+        }
+        impl ::cynic::schema::HasField<pageInfo> for super::super::FilmCharactersConnection {
+            type Type = super::super::PageInfo;
+        }
+        pub struct edges;
+        impl ::cynic::schema::Field for edges {
+            type Type = Option<Vec<Option<super::super::FilmCharactersEdge>>>;
+            const NAME: &'static str = "edges";
+        }
+        impl ::cynic::schema::HasField<edges> for super::super::FilmCharactersConnection {
+            type Type = Option<Vec<Option<super::super::FilmCharactersEdge>>>;
+        }
+        pub struct totalCount;
+        impl ::cynic::schema::Field for totalCount {
+            type Type = Option<super::super::Int>;
+            const NAME: &'static str = "totalCount";
+        }
+        impl ::cynic::schema::HasField<totalCount> for super::super::FilmCharactersConnection {
+            type Type = Option<super::super::Int>;
+        }
+        pub struct characters;
+        impl ::cynic::schema::Field for characters {
+            type Type = Option<Vec<Option<super::super::Person>>>;
+            const NAME: &'static str = "characters";
+        }
+        impl ::cynic::schema::HasField<characters> for super::super::FilmCharactersConnection {
+            type Type = Option<Vec<Option<super::super::Person>>>;
+        }
+    }
+    pub mod FilmCharactersEdge {
+        pub struct node;
+        impl ::cynic::schema::Field for node {
+            type Type = Option<super::super::Person>;
+            const NAME: &'static str = "node";
+        }
+        impl ::cynic::schema::HasField<node> for super::super::FilmCharactersEdge {
+            type Type = Option<super::super::Person>;
+        }
+        pub struct cursor;
+        impl ::cynic::schema::Field for cursor {
+            type Type = super::super::String;
+            const NAME: &'static str = "cursor";
+        }
+        impl ::cynic::schema::HasField<cursor> for super::super::FilmCharactersEdge {
+            type Type = super::super::String;
+        }
+    }
+    pub mod FilmPlanetsConnection {
+        pub struct pageInfo;
+        impl ::cynic::schema::Field for pageInfo {
+            type Type = super::super::PageInfo;
+            const NAME: &'static str = "pageInfo";
+        }
+        impl ::cynic::schema::HasField<pageInfo> for super::super::FilmPlanetsConnection {
+            type Type = super::super::PageInfo;
+        }
+        pub struct edges;
+        impl ::cynic::schema::Field for edges {
+            type Type = Option<Vec<Option<super::super::FilmPlanetsEdge>>>;
+            const NAME: &'static str = "edges";
+        }
+        impl ::cynic::schema::HasField<edges> for super::super::FilmPlanetsConnection {
+            type Type = Option<Vec<Option<super::super::FilmPlanetsEdge>>>;
+        }
+        pub struct totalCount;
+        impl ::cynic::schema::Field for totalCount {
+            type Type = Option<super::super::Int>;
+            const NAME: &'static str = "totalCount";
+        }
+        impl ::cynic::schema::HasField<totalCount> for super::super::FilmPlanetsConnection {
+            type Type = Option<super::super::Int>;
+        }
+        pub struct planets;
+        impl ::cynic::schema::Field for planets {
+            type Type = Option<Vec<Option<super::super::Planet>>>;
+            const NAME: &'static str = "planets";
+        }
+        impl ::cynic::schema::HasField<planets> for super::super::FilmPlanetsConnection {
+            type Type = Option<Vec<Option<super::super::Planet>>>;
+        }
+    }
+    pub mod FilmPlanetsEdge {
+        pub struct node;
+        impl ::cynic::schema::Field for node {
+            type Type = Option<super::super::Planet>;
+            const NAME: &'static str = "node";
+        }
+        impl ::cynic::schema::HasField<node> for super::super::FilmPlanetsEdge {
+            type Type = Option<super::super::Planet>;
+        }
+        pub struct cursor;
+        impl ::cynic::schema::Field for cursor {
+            type Type = super::super::String;
+            const NAME: &'static str = "cursor";
+        }
+        impl ::cynic::schema::HasField<cursor> for super::super::FilmPlanetsEdge {
+            type Type = super::super::String;
+        }
+    }
+    pub mod FilmSpeciesConnection {
+        pub struct pageInfo;
+        impl ::cynic::schema::Field for pageInfo {
+            type Type = super::super::PageInfo;
+            const NAME: &'static str = "pageInfo";
+        }
+        impl ::cynic::schema::HasField<pageInfo> for super::super::FilmSpeciesConnection {
+            type Type = super::super::PageInfo;
+        }
+        pub struct edges;
+        impl ::cynic::schema::Field for edges {
+            type Type = Option<Vec<Option<super::super::FilmSpeciesEdge>>>;
+            const NAME: &'static str = "edges";
+        }
+        impl ::cynic::schema::HasField<edges> for super::super::FilmSpeciesConnection {
+            type Type = Option<Vec<Option<super::super::FilmSpeciesEdge>>>;
+        }
+        pub struct totalCount;
+        impl ::cynic::schema::Field for totalCount {
+            type Type = Option<super::super::Int>;
+            const NAME: &'static str = "totalCount";
+        }
+        impl ::cynic::schema::HasField<totalCount> for super::super::FilmSpeciesConnection {
+            type Type = Option<super::super::Int>;
+        }
+        pub struct species;
+        impl ::cynic::schema::Field for species {
+            type Type = Option<Vec<Option<super::super::Species>>>;
+            const NAME: &'static str = "species";
+        }
+        impl ::cynic::schema::HasField<species> for super::super::FilmSpeciesConnection {
+            type Type = Option<Vec<Option<super::super::Species>>>;
+        }
+    }
+    pub mod FilmSpeciesEdge {
+        pub struct node;
+        impl ::cynic::schema::Field for node {
+            type Type = Option<super::super::Species>;
+            const NAME: &'static str = "node";
+        }
+        impl ::cynic::schema::HasField<node> for super::super::FilmSpeciesEdge {
+            type Type = Option<super::super::Species>;
+        }
+        pub struct cursor;
+        impl ::cynic::schema::Field for cursor {
+            type Type = super::super::String;
+            const NAME: &'static str = "cursor";
+        }
+        impl ::cynic::schema::HasField<cursor> for super::super::FilmSpeciesEdge {
+            type Type = super::super::String;
+        }
+    }
+    pub mod FilmStarshipsConnection {
+        pub struct pageInfo;
+        impl ::cynic::schema::Field for pageInfo {
+            type Type = super::super::PageInfo;
+            const NAME: &'static str = "pageInfo";
+        }
+        impl ::cynic::schema::HasField<pageInfo> for super::super::FilmStarshipsConnection {
+            type Type = super::super::PageInfo;
+        }
+        pub struct edges;
+        impl ::cynic::schema::Field for edges {
+            type Type = Option<Vec<Option<super::super::FilmStarshipsEdge>>>;
+            const NAME: &'static str = "edges";
+        }
+        impl ::cynic::schema::HasField<edges> for super::super::FilmStarshipsConnection {
+            type Type = Option<Vec<Option<super::super::FilmStarshipsEdge>>>;
+        }
+        pub struct totalCount;
+        impl ::cynic::schema::Field for totalCount {
+            type Type = Option<super::super::Int>;
+            const NAME: &'static str = "totalCount";
+        }
+        impl ::cynic::schema::HasField<totalCount> for super::super::FilmStarshipsConnection {
+            type Type = Option<super::super::Int>;
+        }
+        pub struct starships;
+        impl ::cynic::schema::Field for starships {
+            type Type = Option<Vec<Option<super::super::Starship>>>;
+            const NAME: &'static str = "starships";
+        }
+        impl ::cynic::schema::HasField<starships> for super::super::FilmStarshipsConnection {
+            type Type = Option<Vec<Option<super::super::Starship>>>;
+        }
+    }
+    pub mod FilmStarshipsEdge {
+        pub struct node;
+        impl ::cynic::schema::Field for node {
+            type Type = Option<super::super::Starship>;
+            const NAME: &'static str = "node";
+        }
+        impl ::cynic::schema::HasField<node> for super::super::FilmStarshipsEdge {
+            type Type = Option<super::super::Starship>;
+        }
+        pub struct cursor;
+        impl ::cynic::schema::Field for cursor {
+            type Type = super::super::String;
+            const NAME: &'static str = "cursor";
+        }
+        impl ::cynic::schema::HasField<cursor> for super::super::FilmStarshipsEdge {
+            type Type = super::super::String;
+        }
+    }
+    pub mod FilmVehiclesConnection {
+        pub struct pageInfo;
+        impl ::cynic::schema::Field for pageInfo {
+            type Type = super::super::PageInfo;
+            const NAME: &'static str = "pageInfo";
+        }
+        impl ::cynic::schema::HasField<pageInfo> for super::super::FilmVehiclesConnection {
+            type Type = super::super::PageInfo;
+        }
+        pub struct edges;
+        impl ::cynic::schema::Field for edges {
+            type Type = Option<Vec<Option<super::super::FilmVehiclesEdge>>>;
+            const NAME: &'static str = "edges";
+        }
+        impl ::cynic::schema::HasField<edges> for super::super::FilmVehiclesConnection {
+            type Type = Option<Vec<Option<super::super::FilmVehiclesEdge>>>;
+        }
+        pub struct totalCount;
+        impl ::cynic::schema::Field for totalCount {
+            type Type = Option<super::super::Int>;
+            const NAME: &'static str = "totalCount";
+        }
+        impl ::cynic::schema::HasField<totalCount> for super::super::FilmVehiclesConnection {
+            type Type = Option<super::super::Int>;
+        }
+        pub struct vehicles;
+        impl ::cynic::schema::Field for vehicles {
+            type Type = Option<Vec<Option<super::super::Vehicle>>>;
+            const NAME: &'static str = "vehicles";
+        }
+        impl ::cynic::schema::HasField<vehicles> for super::super::FilmVehiclesConnection {
+            type Type = Option<Vec<Option<super::super::Vehicle>>>;
+        }
+    }
+    pub mod FilmVehiclesEdge {
+        pub struct node;
+        impl ::cynic::schema::Field for node {
+            type Type = Option<super::super::Vehicle>;
+            const NAME: &'static str = "node";
+        }
+        impl ::cynic::schema::HasField<node> for super::super::FilmVehiclesEdge {
+            type Type = Option<super::super::Vehicle>;
+        }
+        pub struct cursor;
+        impl ::cynic::schema::Field for cursor {
+            type Type = super::super::String;
+            const NAME: &'static str = "cursor";
+        }
+        impl ::cynic::schema::HasField<cursor> for super::super::FilmVehiclesEdge {
+            type Type = super::super::String;
+        }
+    }
+    pub mod FilmsConnection {
+        pub struct pageInfo;
+        impl ::cynic::schema::Field for pageInfo {
+            type Type = super::super::PageInfo;
+            const NAME: &'static str = "pageInfo";
+        }
+        impl ::cynic::schema::HasField<pageInfo> for super::super::FilmsConnection {
+            type Type = super::super::PageInfo;
+        }
+        pub struct edges;
+        impl ::cynic::schema::Field for edges {
+            type Type = Option<Vec<Option<super::super::FilmsEdge>>>;
+            const NAME: &'static str = "edges";
+        }
+        impl ::cynic::schema::HasField<edges> for super::super::FilmsConnection {
+            type Type = Option<Vec<Option<super::super::FilmsEdge>>>;
+        }
+        pub struct totalCount;
+        impl ::cynic::schema::Field for totalCount {
+            type Type = Option<super::super::Int>;
+            const NAME: &'static str = "totalCount";
+        }
+        impl ::cynic::schema::HasField<totalCount> for super::super::FilmsConnection {
+            type Type = Option<super::super::Int>;
+        }
+        pub struct films;
+        impl ::cynic::schema::Field for films {
+            type Type = Option<Vec<Option<super::super::Film>>>;
+            const NAME: &'static str = "films";
+        }
+        impl ::cynic::schema::HasField<films> for super::super::FilmsConnection {
+            type Type = Option<Vec<Option<super::super::Film>>>;
+        }
+    }
+    pub mod FilmsEdge {
+        pub struct node;
+        impl ::cynic::schema::Field for node {
+            type Type = Option<super::super::Film>;
+            const NAME: &'static str = "node";
+        }
+        impl ::cynic::schema::HasField<node> for super::super::FilmsEdge {
+            type Type = Option<super::super::Film>;
+        }
+        pub struct cursor;
+        impl ::cynic::schema::Field for cursor {
+            type Type = super::super::String;
+            const NAME: &'static str = "cursor";
+        }
+        impl ::cynic::schema::HasField<cursor> for super::super::FilmsEdge {
+            type Type = super::super::String;
+        }
+    }
+    pub mod Node {
+        pub struct id;
+        impl ::cynic::schema::Field for id {
+            type Type = super::super::ID;
+            const NAME: &'static str = "id";
+        }
+        impl ::cynic::schema::HasField<id> for super::super::Node {
+            type Type = super::super::ID;
+        }
+    }
+    pub mod PageInfo {
+        pub struct hasNextPage;
+        impl ::cynic::schema::Field for hasNextPage {
+            type Type = super::super::Boolean;
+            const NAME: &'static str = "hasNextPage";
+        }
+        impl ::cynic::schema::HasField<hasNextPage> for super::super::PageInfo {
+            type Type = super::super::Boolean;
+        }
+        pub struct hasPreviousPage;
+        impl ::cynic::schema::Field for hasPreviousPage {
+            type Type = super::super::Boolean;
+            const NAME: &'static str = "hasPreviousPage";
+        }
+        impl ::cynic::schema::HasField<hasPreviousPage> for super::super::PageInfo {
+            type Type = super::super::Boolean;
+        }
+        pub struct startCursor;
+        impl ::cynic::schema::Field for startCursor {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "startCursor";
+        }
+        impl ::cynic::schema::HasField<startCursor> for super::super::PageInfo {
+            type Type = Option<super::super::String>;
+        }
+        pub struct endCursor;
+        impl ::cynic::schema::Field for endCursor {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "endCursor";
+        }
+        impl ::cynic::schema::HasField<endCursor> for super::super::PageInfo {
+            type Type = Option<super::super::String>;
+        }
+    }
+    pub mod PeopleConnection {
+        pub struct pageInfo;
+        impl ::cynic::schema::Field for pageInfo {
+            type Type = super::super::PageInfo;
+            const NAME: &'static str = "pageInfo";
+        }
+        impl ::cynic::schema::HasField<pageInfo> for super::super::PeopleConnection {
+            type Type = super::super::PageInfo;
+        }
+        pub struct edges;
+        impl ::cynic::schema::Field for edges {
+            type Type = Option<Vec<Option<super::super::PeopleEdge>>>;
+            const NAME: &'static str = "edges";
+        }
+        impl ::cynic::schema::HasField<edges> for super::super::PeopleConnection {
+            type Type = Option<Vec<Option<super::super::PeopleEdge>>>;
+        }
+        pub struct totalCount;
+        impl ::cynic::schema::Field for totalCount {
+            type Type = Option<super::super::Int>;
+            const NAME: &'static str = "totalCount";
+        }
+        impl ::cynic::schema::HasField<totalCount> for super::super::PeopleConnection {
+            type Type = Option<super::super::Int>;
+        }
+        pub struct people;
+        impl ::cynic::schema::Field for people {
+            type Type = Option<Vec<Option<super::super::Person>>>;
+            const NAME: &'static str = "people";
+        }
+        impl ::cynic::schema::HasField<people> for super::super::PeopleConnection {
+            type Type = Option<Vec<Option<super::super::Person>>>;
+        }
+    }
+    pub mod PeopleEdge {
+        pub struct node;
+        impl ::cynic::schema::Field for node {
+            type Type = Option<super::super::Person>;
+            const NAME: &'static str = "node";
+        }
+        impl ::cynic::schema::HasField<node> for super::super::PeopleEdge {
+            type Type = Option<super::super::Person>;
+        }
+        pub struct cursor;
+        impl ::cynic::schema::Field for cursor {
+            type Type = super::super::String;
+            const NAME: &'static str = "cursor";
+        }
+        impl ::cynic::schema::HasField<cursor> for super::super::PeopleEdge {
+            type Type = super::super::String;
+        }
+    }
+    pub mod Person {
+        pub struct name;
+        impl ::cynic::schema::Field for name {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "name";
+        }
+        impl ::cynic::schema::HasField<name> for super::super::Person {
+            type Type = Option<super::super::String>;
+        }
+        pub struct birthYear;
+        impl ::cynic::schema::Field for birthYear {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "birthYear";
+        }
+        impl ::cynic::schema::HasField<birthYear> for super::super::Person {
+            type Type = Option<super::super::String>;
+        }
+        pub struct eyeColor;
+        impl ::cynic::schema::Field for eyeColor {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "eyeColor";
+        }
+        impl ::cynic::schema::HasField<eyeColor> for super::super::Person {
+            type Type = Option<super::super::String>;
+        }
+        pub struct gender;
+        impl ::cynic::schema::Field for gender {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "gender";
+        }
+        impl ::cynic::schema::HasField<gender> for super::super::Person {
+            type Type = Option<super::super::String>;
+        }
+        pub struct hairColor;
+        impl ::cynic::schema::Field for hairColor {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "hairColor";
+        }
+        impl ::cynic::schema::HasField<hairColor> for super::super::Person {
+            type Type = Option<super::super::String>;
+        }
+        pub struct height;
+        impl ::cynic::schema::Field for height {
+            type Type = Option<super::super::Int>;
+            const NAME: &'static str = "height";
+        }
+        impl ::cynic::schema::HasField<height> for super::super::Person {
+            type Type = Option<super::super::Int>;
+        }
+        pub struct mass;
+        impl ::cynic::schema::Field for mass {
+            type Type = Option<super::super::Float>;
+            const NAME: &'static str = "mass";
+        }
+        impl ::cynic::schema::HasField<mass> for super::super::Person {
+            type Type = Option<super::super::Float>;
+        }
+        pub struct skinColor;
+        impl ::cynic::schema::Field for skinColor {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "skinColor";
+        }
+        impl ::cynic::schema::HasField<skinColor> for super::super::Person {
+            type Type = Option<super::super::String>;
+        }
+        pub struct homeworld;
+        impl ::cynic::schema::Field for homeworld {
+            type Type = Option<super::super::Planet>;
+            const NAME: &'static str = "homeworld";
+        }
+        impl ::cynic::schema::HasField<homeworld> for super::super::Person {
+            type Type = Option<super::super::Planet>;
+        }
+        pub struct filmConnection;
+        impl ::cynic::schema::Field for filmConnection {
+            type Type = Option<super::super::PersonFilmsConnection>;
+            const NAME: &'static str = "filmConnection";
+        }
+        impl ::cynic::schema::HasField<filmConnection> for super::super::Person {
+            type Type = Option<super::super::PersonFilmsConnection>;
+        }
+        pub mod film_connection_arguments {
+            pub struct after;
+            impl ::cynic::schema::HasArgument<after> for super::filmConnection {
+                type ArgumentType = Option<super::super::super::String>;
+                const NAME: &'static str = "after";
+            }
+            pub struct first;
+            impl ::cynic::schema::HasArgument<first> for super::filmConnection {
+                type ArgumentType = Option<super::super::super::Int>;
+                const NAME: &'static str = "first";
+            }
+            pub struct before;
+            impl ::cynic::schema::HasArgument<before> for super::filmConnection {
+                type ArgumentType = Option<super::super::super::String>;
+                const NAME: &'static str = "before";
+            }
+            pub struct last;
+            impl ::cynic::schema::HasArgument<last> for super::filmConnection {
+                type ArgumentType = Option<super::super::super::Int>;
+                const NAME: &'static str = "last";
+            }
+        }
+        pub struct species;
+        impl ::cynic::schema::Field for species {
+            type Type = Option<super::super::Species>;
+            const NAME: &'static str = "species";
+        }
+        impl ::cynic::schema::HasField<species> for super::super::Person {
+            type Type = Option<super::super::Species>;
+        }
+        pub struct starshipConnection;
+        impl ::cynic::schema::Field for starshipConnection {
+            type Type = Option<super::super::PersonStarshipsConnection>;
+            const NAME: &'static str = "starshipConnection";
+        }
+        impl ::cynic::schema::HasField<starshipConnection> for super::super::Person {
+            type Type = Option<super::super::PersonStarshipsConnection>;
+        }
+        pub mod starship_connection_arguments {
+            pub struct after;
+            impl ::cynic::schema::HasArgument<after> for super::starshipConnection {
+                type ArgumentType = Option<super::super::super::String>;
+                const NAME: &'static str = "after";
+            }
+            pub struct first;
+            impl ::cynic::schema::HasArgument<first> for super::starshipConnection {
+                type ArgumentType = Option<super::super::super::Int>;
+                const NAME: &'static str = "first";
+            }
+            pub struct before;
+            impl ::cynic::schema::HasArgument<before> for super::starshipConnection {
+                type ArgumentType = Option<super::super::super::String>;
+                const NAME: &'static str = "before";
+            }
+            pub struct last;
+            impl ::cynic::schema::HasArgument<last> for super::starshipConnection {
+                type ArgumentType = Option<super::super::super::Int>;
+                const NAME: &'static str = "last";
+            }
+        }
+        pub struct vehicleConnection;
+        impl ::cynic::schema::Field for vehicleConnection {
+            type Type = Option<super::super::PersonVehiclesConnection>;
+            const NAME: &'static str = "vehicleConnection";
+        }
+        impl ::cynic::schema::HasField<vehicleConnection> for super::super::Person {
+            type Type = Option<super::super::PersonVehiclesConnection>;
+        }
+        pub mod vehicle_connection_arguments {
+            pub struct after;
+            impl ::cynic::schema::HasArgument<after> for super::vehicleConnection {
+                type ArgumentType = Option<super::super::super::String>;
+                const NAME: &'static str = "after";
+            }
+            pub struct first;
+            impl ::cynic::schema::HasArgument<first> for super::vehicleConnection {
+                type ArgumentType = Option<super::super::super::Int>;
+                const NAME: &'static str = "first";
+            }
+            pub struct before;
+            impl ::cynic::schema::HasArgument<before> for super::vehicleConnection {
+                type ArgumentType = Option<super::super::super::String>;
+                const NAME: &'static str = "before";
+            }
+            pub struct last;
+            impl ::cynic::schema::HasArgument<last> for super::vehicleConnection {
+                type ArgumentType = Option<super::super::super::Int>;
+                const NAME: &'static str = "last";
+            }
+        }
+        pub struct created;
+        impl ::cynic::schema::Field for created {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "created";
+        }
+        impl ::cynic::schema::HasField<created> for super::super::Person {
+            type Type = Option<super::super::String>;
+        }
+        pub struct edited;
+        impl ::cynic::schema::Field for edited {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "edited";
+        }
+        impl ::cynic::schema::HasField<edited> for super::super::Person {
+            type Type = Option<super::super::String>;
+        }
+        pub struct id;
+        impl ::cynic::schema::Field for id {
+            type Type = super::super::ID;
+            const NAME: &'static str = "id";
+        }
+        impl ::cynic::schema::HasField<id> for super::super::Person {
+            type Type = super::super::ID;
+        }
+    }
+    pub mod PersonFilmsConnection {
+        pub struct pageInfo;
+        impl ::cynic::schema::Field for pageInfo {
+            type Type = super::super::PageInfo;
+            const NAME: &'static str = "pageInfo";
+        }
+        impl ::cynic::schema::HasField<pageInfo> for super::super::PersonFilmsConnection {
+            type Type = super::super::PageInfo;
+        }
+        pub struct edges;
+        impl ::cynic::schema::Field for edges {
+            type Type = Option<Vec<Option<super::super::PersonFilmsEdge>>>;
+            const NAME: &'static str = "edges";
+        }
+        impl ::cynic::schema::HasField<edges> for super::super::PersonFilmsConnection {
+            type Type = Option<Vec<Option<super::super::PersonFilmsEdge>>>;
+        }
+        pub struct totalCount;
+        impl ::cynic::schema::Field for totalCount {
+            type Type = Option<super::super::Int>;
+            const NAME: &'static str = "totalCount";
+        }
+        impl ::cynic::schema::HasField<totalCount> for super::super::PersonFilmsConnection {
+            type Type = Option<super::super::Int>;
+        }
+        pub struct films;
+        impl ::cynic::schema::Field for films {
+            type Type = Option<Vec<Option<super::super::Film>>>;
+            const NAME: &'static str = "films";
+        }
+        impl ::cynic::schema::HasField<films> for super::super::PersonFilmsConnection {
+            type Type = Option<Vec<Option<super::super::Film>>>;
+        }
+    }
+    pub mod PersonFilmsEdge {
+        pub struct node;
+        impl ::cynic::schema::Field for node {
+            type Type = Option<super::super::Film>;
+            const NAME: &'static str = "node";
+        }
+        impl ::cynic::schema::HasField<node> for super::super::PersonFilmsEdge {
+            type Type = Option<super::super::Film>;
+        }
+        pub struct cursor;
+        impl ::cynic::schema::Field for cursor {
+            type Type = super::super::String;
+            const NAME: &'static str = "cursor";
+        }
+        impl ::cynic::schema::HasField<cursor> for super::super::PersonFilmsEdge {
+            type Type = super::super::String;
+        }
+    }
+    pub mod PersonStarshipsConnection {
+        pub struct pageInfo;
+        impl ::cynic::schema::Field for pageInfo {
+            type Type = super::super::PageInfo;
+            const NAME: &'static str = "pageInfo";
+        }
+        impl ::cynic::schema::HasField<pageInfo> for super::super::PersonStarshipsConnection {
+            type Type = super::super::PageInfo;
+        }
+        pub struct edges;
+        impl ::cynic::schema::Field for edges {
+            type Type = Option<Vec<Option<super::super::PersonStarshipsEdge>>>;
+            const NAME: &'static str = "edges";
+        }
+        impl ::cynic::schema::HasField<edges> for super::super::PersonStarshipsConnection {
+            type Type = Option<Vec<Option<super::super::PersonStarshipsEdge>>>;
+        }
+        pub struct totalCount;
+        impl ::cynic::schema::Field for totalCount {
+            type Type = Option<super::super::Int>;
+            const NAME: &'static str = "totalCount";
+        }
+        impl ::cynic::schema::HasField<totalCount> for super::super::PersonStarshipsConnection {
+            type Type = Option<super::super::Int>;
+        }
+        pub struct starships;
+        impl ::cynic::schema::Field for starships {
+            type Type = Option<Vec<Option<super::super::Starship>>>;
+            const NAME: &'static str = "starships";
+        }
+        impl ::cynic::schema::HasField<starships> for super::super::PersonStarshipsConnection {
+            type Type = Option<Vec<Option<super::super::Starship>>>;
+        }
+    }
+    pub mod PersonStarshipsEdge {
+        pub struct node;
+        impl ::cynic::schema::Field for node {
+            type Type = Option<super::super::Starship>;
+            const NAME: &'static str = "node";
+        }
+        impl ::cynic::schema::HasField<node> for super::super::PersonStarshipsEdge {
+            type Type = Option<super::super::Starship>;
+        }
+        pub struct cursor;
+        impl ::cynic::schema::Field for cursor {
+            type Type = super::super::String;
+            const NAME: &'static str = "cursor";
+        }
+        impl ::cynic::schema::HasField<cursor> for super::super::PersonStarshipsEdge {
+            type Type = super::super::String;
+        }
+    }
+    pub mod PersonVehiclesConnection {
+        pub struct pageInfo;
+        impl ::cynic::schema::Field for pageInfo {
+            type Type = super::super::PageInfo;
+            const NAME: &'static str = "pageInfo";
+        }
+        impl ::cynic::schema::HasField<pageInfo> for super::super::PersonVehiclesConnection {
+            type Type = super::super::PageInfo;
+        }
+        pub struct edges;
+        impl ::cynic::schema::Field for edges {
+            type Type = Option<Vec<Option<super::super::PersonVehiclesEdge>>>;
+            const NAME: &'static str = "edges";
+        }
+        impl ::cynic::schema::HasField<edges> for super::super::PersonVehiclesConnection {
+            type Type = Option<Vec<Option<super::super::PersonVehiclesEdge>>>;
+        }
+        pub struct totalCount;
+        impl ::cynic::schema::Field for totalCount {
+            type Type = Option<super::super::Int>;
+            const NAME: &'static str = "totalCount";
+        }
+        impl ::cynic::schema::HasField<totalCount> for super::super::PersonVehiclesConnection {
+            type Type = Option<super::super::Int>;
+        }
+        pub struct vehicles;
+        impl ::cynic::schema::Field for vehicles {
+            type Type = Option<Vec<Option<super::super::Vehicle>>>;
+            const NAME: &'static str = "vehicles";
+        }
+        impl ::cynic::schema::HasField<vehicles> for super::super::PersonVehiclesConnection {
+            type Type = Option<Vec<Option<super::super::Vehicle>>>;
+        }
+    }
+    pub mod PersonVehiclesEdge {
+        pub struct node;
+        impl ::cynic::schema::Field for node {
+            type Type = Option<super::super::Vehicle>;
+            const NAME: &'static str = "node";
+        }
+        impl ::cynic::schema::HasField<node> for super::super::PersonVehiclesEdge {
+            type Type = Option<super::super::Vehicle>;
+        }
+        pub struct cursor;
+        impl ::cynic::schema::Field for cursor {
+            type Type = super::super::String;
+            const NAME: &'static str = "cursor";
+        }
+        impl ::cynic::schema::HasField<cursor> for super::super::PersonVehiclesEdge {
+            type Type = super::super::String;
+        }
+    }
+    pub mod Planet {
+        pub struct name;
+        impl ::cynic::schema::Field for name {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "name";
+        }
+        impl ::cynic::schema::HasField<name> for super::super::Planet {
+            type Type = Option<super::super::String>;
+        }
+        pub struct diameter;
+        impl ::cynic::schema::Field for diameter {
+            type Type = Option<super::super::Int>;
+            const NAME: &'static str = "diameter";
+        }
+        impl ::cynic::schema::HasField<diameter> for super::super::Planet {
+            type Type = Option<super::super::Int>;
+        }
+        pub struct rotationPeriod;
+        impl ::cynic::schema::Field for rotationPeriod {
+            type Type = Option<super::super::Int>;
+            const NAME: &'static str = "rotationPeriod";
+        }
+        impl ::cynic::schema::HasField<rotationPeriod> for super::super::Planet {
+            type Type = Option<super::super::Int>;
+        }
+        pub struct orbitalPeriod;
+        impl ::cynic::schema::Field for orbitalPeriod {
+            type Type = Option<super::super::Int>;
+            const NAME: &'static str = "orbitalPeriod";
+        }
+        impl ::cynic::schema::HasField<orbitalPeriod> for super::super::Planet {
+            type Type = Option<super::super::Int>;
+        }
+        pub struct gravity;
+        impl ::cynic::schema::Field for gravity {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "gravity";
+        }
+        impl ::cynic::schema::HasField<gravity> for super::super::Planet {
+            type Type = Option<super::super::String>;
+        }
+        pub struct population;
+        impl ::cynic::schema::Field for population {
+            type Type = Option<super::super::Float>;
+            const NAME: &'static str = "population";
+        }
+        impl ::cynic::schema::HasField<population> for super::super::Planet {
+            type Type = Option<super::super::Float>;
+        }
+        pub struct climates;
+        impl ::cynic::schema::Field for climates {
+            type Type = Option<Vec<Option<super::super::String>>>;
+            const NAME: &'static str = "climates";
+        }
+        impl ::cynic::schema::HasField<climates> for super::super::Planet {
+            type Type = Option<Vec<Option<super::super::String>>>;
+        }
+        pub struct terrains;
+        impl ::cynic::schema::Field for terrains {
+            type Type = Option<Vec<Option<super::super::String>>>;
+            const NAME: &'static str = "terrains";
+        }
+        impl ::cynic::schema::HasField<terrains> for super::super::Planet {
+            type Type = Option<Vec<Option<super::super::String>>>;
+        }
+        pub struct surfaceWater;
+        impl ::cynic::schema::Field for surfaceWater {
+            type Type = Option<super::super::Float>;
+            const NAME: &'static str = "surfaceWater";
+        }
+        impl ::cynic::schema::HasField<surfaceWater> for super::super::Planet {
+            type Type = Option<super::super::Float>;
+        }
+        pub struct residentConnection;
+        impl ::cynic::schema::Field for residentConnection {
+            type Type = Option<super::super::PlanetResidentsConnection>;
+            const NAME: &'static str = "residentConnection";
+        }
+        impl ::cynic::schema::HasField<residentConnection> for super::super::Planet {
+            type Type = Option<super::super::PlanetResidentsConnection>;
+        }
+        pub mod resident_connection_arguments {
+            pub struct after;
+            impl ::cynic::schema::HasArgument<after> for super::residentConnection {
+                type ArgumentType = Option<super::super::super::String>;
+                const NAME: &'static str = "after";
+            }
+            pub struct first;
+            impl ::cynic::schema::HasArgument<first> for super::residentConnection {
+                type ArgumentType = Option<super::super::super::Int>;
+                const NAME: &'static str = "first";
+            }
+            pub struct before;
+            impl ::cynic::schema::HasArgument<before> for super::residentConnection {
+                type ArgumentType = Option<super::super::super::String>;
+                const NAME: &'static str = "before";
+            }
+            pub struct last;
+            impl ::cynic::schema::HasArgument<last> for super::residentConnection {
+                type ArgumentType = Option<super::super::super::Int>;
+                const NAME: &'static str = "last";
+            }
+        }
+        pub struct filmConnection;
+        impl ::cynic::schema::Field for filmConnection {
+            type Type = Option<super::super::PlanetFilmsConnection>;
+            const NAME: &'static str = "filmConnection";
+        }
+        impl ::cynic::schema::HasField<filmConnection> for super::super::Planet {
+            type Type = Option<super::super::PlanetFilmsConnection>;
+        }
+        pub mod film_connection_arguments {
+            pub struct after;
+            impl ::cynic::schema::HasArgument<after> for super::filmConnection {
+                type ArgumentType = Option<super::super::super::String>;
+                const NAME: &'static str = "after";
+            }
+            pub struct first;
+            impl ::cynic::schema::HasArgument<first> for super::filmConnection {
+                type ArgumentType = Option<super::super::super::Int>;
+                const NAME: &'static str = "first";
+            }
+            pub struct before;
+            impl ::cynic::schema::HasArgument<before> for super::filmConnection {
+                type ArgumentType = Option<super::super::super::String>;
+                const NAME: &'static str = "before";
+            }
+            pub struct last;
+            impl ::cynic::schema::HasArgument<last> for super::filmConnection {
+                type ArgumentType = Option<super::super::super::Int>;
+                const NAME: &'static str = "last";
+            }
+        }
+        pub struct created;
+        impl ::cynic::schema::Field for created {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "created";
+        }
+        impl ::cynic::schema::HasField<created> for super::super::Planet {
+            type Type = Option<super::super::String>;
+        }
+        pub struct edited;
+        impl ::cynic::schema::Field for edited {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "edited";
+        }
+        impl ::cynic::schema::HasField<edited> for super::super::Planet {
+            type Type = Option<super::super::String>;
+        }
+        pub struct id;
+        impl ::cynic::schema::Field for id {
+            type Type = super::super::ID;
+            const NAME: &'static str = "id";
+        }
+        impl ::cynic::schema::HasField<id> for super::super::Planet {
+            type Type = super::super::ID;
+        }
+    }
+    pub mod PlanetFilmsConnection {
+        pub struct pageInfo;
+        impl ::cynic::schema::Field for pageInfo {
+            type Type = super::super::PageInfo;
+            const NAME: &'static str = "pageInfo";
+        }
+        impl ::cynic::schema::HasField<pageInfo> for super::super::PlanetFilmsConnection {
+            type Type = super::super::PageInfo;
+        }
+        pub struct edges;
+        impl ::cynic::schema::Field for edges {
+            type Type = Option<Vec<Option<super::super::PlanetFilmsEdge>>>;
+            const NAME: &'static str = "edges";
+        }
+        impl ::cynic::schema::HasField<edges> for super::super::PlanetFilmsConnection {
+            type Type = Option<Vec<Option<super::super::PlanetFilmsEdge>>>;
+        }
+        pub struct totalCount;
+        impl ::cynic::schema::Field for totalCount {
+            type Type = Option<super::super::Int>;
+            const NAME: &'static str = "totalCount";
+        }
+        impl ::cynic::schema::HasField<totalCount> for super::super::PlanetFilmsConnection {
+            type Type = Option<super::super::Int>;
+        }
+        pub struct films;
+        impl ::cynic::schema::Field for films {
+            type Type = Option<Vec<Option<super::super::Film>>>;
+            const NAME: &'static str = "films";
+        }
+        impl ::cynic::schema::HasField<films> for super::super::PlanetFilmsConnection {
+            type Type = Option<Vec<Option<super::super::Film>>>;
+        }
+    }
+    pub mod PlanetFilmsEdge {
+        pub struct node;
+        impl ::cynic::schema::Field for node {
+            type Type = Option<super::super::Film>;
+            const NAME: &'static str = "node";
+        }
+        impl ::cynic::schema::HasField<node> for super::super::PlanetFilmsEdge {
+            type Type = Option<super::super::Film>;
+        }
+        pub struct cursor;
+        impl ::cynic::schema::Field for cursor {
+            type Type = super::super::String;
+            const NAME: &'static str = "cursor";
+        }
+        impl ::cynic::schema::HasField<cursor> for super::super::PlanetFilmsEdge {
+            type Type = super::super::String;
+        }
+    }
+    pub mod PlanetResidentsConnection {
+        pub struct pageInfo;
+        impl ::cynic::schema::Field for pageInfo {
+            type Type = super::super::PageInfo;
+            const NAME: &'static str = "pageInfo";
+        }
+        impl ::cynic::schema::HasField<pageInfo> for super::super::PlanetResidentsConnection {
+            type Type = super::super::PageInfo;
+        }
+        pub struct edges;
+        impl ::cynic::schema::Field for edges {
+            type Type = Option<Vec<Option<super::super::PlanetResidentsEdge>>>;
+            const NAME: &'static str = "edges";
+        }
+        impl ::cynic::schema::HasField<edges> for super::super::PlanetResidentsConnection {
+            type Type = Option<Vec<Option<super::super::PlanetResidentsEdge>>>;
+        }
+        pub struct totalCount;
+        impl ::cynic::schema::Field for totalCount {
+            type Type = Option<super::super::Int>;
+            const NAME: &'static str = "totalCount";
+        }
+        impl ::cynic::schema::HasField<totalCount> for super::super::PlanetResidentsConnection {
+            type Type = Option<super::super::Int>;
+        }
+        pub struct residents;
+        impl ::cynic::schema::Field for residents {
+            type Type = Option<Vec<Option<super::super::Person>>>;
+            const NAME: &'static str = "residents";
+        }
+        impl ::cynic::schema::HasField<residents> for super::super::PlanetResidentsConnection {
+            type Type = Option<Vec<Option<super::super::Person>>>;
+        }
+    }
+    pub mod PlanetResidentsEdge {
+        pub struct node;
+        impl ::cynic::schema::Field for node {
+            type Type = Option<super::super::Person>;
+            const NAME: &'static str = "node";
+        }
+        impl ::cynic::schema::HasField<node> for super::super::PlanetResidentsEdge {
+            type Type = Option<super::super::Person>;
+        }
+        pub struct cursor;
+        impl ::cynic::schema::Field for cursor {
+            type Type = super::super::String;
+            const NAME: &'static str = "cursor";
+        }
+        impl ::cynic::schema::HasField<cursor> for super::super::PlanetResidentsEdge {
+            type Type = super::super::String;
+        }
+    }
+    pub mod PlanetsConnection {
+        pub struct pageInfo;
+        impl ::cynic::schema::Field for pageInfo {
+            type Type = super::super::PageInfo;
+            const NAME: &'static str = "pageInfo";
+        }
+        impl ::cynic::schema::HasField<pageInfo> for super::super::PlanetsConnection {
+            type Type = super::super::PageInfo;
+        }
+        pub struct edges;
+        impl ::cynic::schema::Field for edges {
+            type Type = Option<Vec<Option<super::super::PlanetsEdge>>>;
+            const NAME: &'static str = "edges";
+        }
+        impl ::cynic::schema::HasField<edges> for super::super::PlanetsConnection {
+            type Type = Option<Vec<Option<super::super::PlanetsEdge>>>;
+        }
+        pub struct totalCount;
+        impl ::cynic::schema::Field for totalCount {
+            type Type = Option<super::super::Int>;
+            const NAME: &'static str = "totalCount";
+        }
+        impl ::cynic::schema::HasField<totalCount> for super::super::PlanetsConnection {
+            type Type = Option<super::super::Int>;
+        }
+        pub struct planets;
+        impl ::cynic::schema::Field for planets {
+            type Type = Option<Vec<Option<super::super::Planet>>>;
+            const NAME: &'static str = "planets";
+        }
+        impl ::cynic::schema::HasField<planets> for super::super::PlanetsConnection {
+            type Type = Option<Vec<Option<super::super::Planet>>>;
+        }
+    }
+    pub mod PlanetsEdge {
+        pub struct node;
+        impl ::cynic::schema::Field for node {
+            type Type = Option<super::super::Planet>;
+            const NAME: &'static str = "node";
+        }
+        impl ::cynic::schema::HasField<node> for super::super::PlanetsEdge {
+            type Type = Option<super::super::Planet>;
+        }
+        pub struct cursor;
+        impl ::cynic::schema::Field for cursor {
+            type Type = super::super::String;
+            const NAME: &'static str = "cursor";
+        }
+        impl ::cynic::schema::HasField<cursor> for super::super::PlanetsEdge {
+            type Type = super::super::String;
+        }
+    }
+    pub mod Root {
+        pub struct allFilms;
+        impl ::cynic::schema::Field for allFilms {
+            type Type = Option<super::super::FilmsConnection>;
+            const NAME: &'static str = "allFilms";
+        }
+        impl ::cynic::schema::HasField<allFilms> for super::super::Root {
+            type Type = Option<super::super::FilmsConnection>;
+        }
+        pub mod all_films_arguments {
+            pub struct after;
+            impl ::cynic::schema::HasArgument<after> for super::allFilms {
+                type ArgumentType = Option<super::super::super::String>;
+                const NAME: &'static str = "after";
+            }
+            pub struct first;
+            impl ::cynic::schema::HasArgument<first> for super::allFilms {
+                type ArgumentType = Option<super::super::super::Int>;
+                const NAME: &'static str = "first";
+            }
+            pub struct before;
+            impl ::cynic::schema::HasArgument<before> for super::allFilms {
+                type ArgumentType = Option<super::super::super::String>;
+                const NAME: &'static str = "before";
+            }
+            pub struct last;
+            impl ::cynic::schema::HasArgument<last> for super::allFilms {
+                type ArgumentType = Option<super::super::super::Int>;
+                const NAME: &'static str = "last";
+            }
+        }
+        pub struct film;
+        impl ::cynic::schema::Field for film {
+            type Type = Option<super::super::Film>;
+            const NAME: &'static str = "film";
+        }
+        impl ::cynic::schema::HasField<film> for super::super::Root {
+            type Type = Option<super::super::Film>;
+        }
+        pub mod film_arguments {
+            pub struct id;
+            impl ::cynic::schema::HasArgument<id> for super::film {
+                type ArgumentType = Option<super::super::super::ID>;
+                const NAME: &'static str = "id";
+            }
+            pub struct filmID;
+            impl ::cynic::schema::HasArgument<filmID> for super::film {
+                type ArgumentType = Option<super::super::super::ID>;
+                const NAME: &'static str = "filmID";
+            }
+        }
+        pub struct allPeople;
+        impl ::cynic::schema::Field for allPeople {
+            type Type = Option<super::super::PeopleConnection>;
+            const NAME: &'static str = "allPeople";
+        }
+        impl ::cynic::schema::HasField<allPeople> for super::super::Root {
+            type Type = Option<super::super::PeopleConnection>;
+        }
+        pub mod all_people_arguments {
+            pub struct after;
+            impl ::cynic::schema::HasArgument<after> for super::allPeople {
+                type ArgumentType = Option<super::super::super::String>;
+                const NAME: &'static str = "after";
+            }
+            pub struct first;
+            impl ::cynic::schema::HasArgument<first> for super::allPeople {
+                type ArgumentType = Option<super::super::super::Int>;
+                const NAME: &'static str = "first";
+            }
+            pub struct before;
+            impl ::cynic::schema::HasArgument<before> for super::allPeople {
+                type ArgumentType = Option<super::super::super::String>;
+                const NAME: &'static str = "before";
+            }
+            pub struct last;
+            impl ::cynic::schema::HasArgument<last> for super::allPeople {
+                type ArgumentType = Option<super::super::super::Int>;
+                const NAME: &'static str = "last";
+            }
+        }
+        pub struct person;
+        impl ::cynic::schema::Field for person {
+            type Type = Option<super::super::Person>;
+            const NAME: &'static str = "person";
+        }
+        impl ::cynic::schema::HasField<person> for super::super::Root {
+            type Type = Option<super::super::Person>;
+        }
+        pub mod person_arguments {
+            pub struct id;
+            impl ::cynic::schema::HasArgument<id> for super::person {
+                type ArgumentType = Option<super::super::super::ID>;
+                const NAME: &'static str = "id";
+            }
+            pub struct personID;
+            impl ::cynic::schema::HasArgument<personID> for super::person {
+                type ArgumentType = Option<super::super::super::ID>;
+                const NAME: &'static str = "personID";
+            }
+        }
+        pub struct allPlanets;
+        impl ::cynic::schema::Field for allPlanets {
+            type Type = Option<super::super::PlanetsConnection>;
+            const NAME: &'static str = "allPlanets";
+        }
+        impl ::cynic::schema::HasField<allPlanets> for super::super::Root {
+            type Type = Option<super::super::PlanetsConnection>;
+        }
+        pub mod all_planets_arguments {
+            pub struct after;
+            impl ::cynic::schema::HasArgument<after> for super::allPlanets {
+                type ArgumentType = Option<super::super::super::String>;
+                const NAME: &'static str = "after";
+            }
+            pub struct first;
+            impl ::cynic::schema::HasArgument<first> for super::allPlanets {
+                type ArgumentType = Option<super::super::super::Int>;
+                const NAME: &'static str = "first";
+            }
+            pub struct before;
+            impl ::cynic::schema::HasArgument<before> for super::allPlanets {
+                type ArgumentType = Option<super::super::super::String>;
+                const NAME: &'static str = "before";
+            }
+            pub struct last;
+            impl ::cynic::schema::HasArgument<last> for super::allPlanets {
+                type ArgumentType = Option<super::super::super::Int>;
+                const NAME: &'static str = "last";
+            }
+        }
+        pub struct planet;
+        impl ::cynic::schema::Field for planet {
+            type Type = Option<super::super::Planet>;
+            const NAME: &'static str = "planet";
+        }
+        impl ::cynic::schema::HasField<planet> for super::super::Root {
+            type Type = Option<super::super::Planet>;
+        }
+        pub mod planet_arguments {
+            pub struct id;
+            impl ::cynic::schema::HasArgument<id> for super::planet {
+                type ArgumentType = Option<super::super::super::ID>;
+                const NAME: &'static str = "id";
+            }
+            pub struct planetID;
+            impl ::cynic::schema::HasArgument<planetID> for super::planet {
+                type ArgumentType = Option<super::super::super::ID>;
+                const NAME: &'static str = "planetID";
+            }
+        }
+        pub struct allSpecies;
+        impl ::cynic::schema::Field for allSpecies {
+            type Type = Option<super::super::SpeciesConnection>;
+            const NAME: &'static str = "allSpecies";
+        }
+        impl ::cynic::schema::HasField<allSpecies> for super::super::Root {
+            type Type = Option<super::super::SpeciesConnection>;
+        }
+        pub mod all_species_arguments {
+            pub struct after;
+            impl ::cynic::schema::HasArgument<after> for super::allSpecies {
+                type ArgumentType = Option<super::super::super::String>;
+                const NAME: &'static str = "after";
+            }
+            pub struct first;
+            impl ::cynic::schema::HasArgument<first> for super::allSpecies {
+                type ArgumentType = Option<super::super::super::Int>;
+                const NAME: &'static str = "first";
+            }
+            pub struct before;
+            impl ::cynic::schema::HasArgument<before> for super::allSpecies {
+                type ArgumentType = Option<super::super::super::String>;
+                const NAME: &'static str = "before";
+            }
+            pub struct last;
+            impl ::cynic::schema::HasArgument<last> for super::allSpecies {
+                type ArgumentType = Option<super::super::super::Int>;
+                const NAME: &'static str = "last";
+            }
+        }
+        pub struct species;
+        impl ::cynic::schema::Field for species {
+            type Type = Option<super::super::Species>;
+            const NAME: &'static str = "species";
+        }
+        impl ::cynic::schema::HasField<species> for super::super::Root {
+            type Type = Option<super::super::Species>;
+        }
+        pub mod species_arguments {
+            pub struct id;
+            impl ::cynic::schema::HasArgument<id> for super::species {
+                type ArgumentType = Option<super::super::super::ID>;
+                const NAME: &'static str = "id";
+            }
+            pub struct speciesID;
+            impl ::cynic::schema::HasArgument<speciesID> for super::species {
+                type ArgumentType = Option<super::super::super::ID>;
+                const NAME: &'static str = "speciesID";
+            }
+        }
+        pub struct allStarships;
+        impl ::cynic::schema::Field for allStarships {
+            type Type = Option<super::super::StarshipsConnection>;
+            const NAME: &'static str = "allStarships";
+        }
+        impl ::cynic::schema::HasField<allStarships> for super::super::Root {
+            type Type = Option<super::super::StarshipsConnection>;
+        }
+        pub mod all_starships_arguments {
+            pub struct after;
+            impl ::cynic::schema::HasArgument<after> for super::allStarships {
+                type ArgumentType = Option<super::super::super::String>;
+                const NAME: &'static str = "after";
+            }
+            pub struct first;
+            impl ::cynic::schema::HasArgument<first> for super::allStarships {
+                type ArgumentType = Option<super::super::super::Int>;
+                const NAME: &'static str = "first";
+            }
+            pub struct before;
+            impl ::cynic::schema::HasArgument<before> for super::allStarships {
+                type ArgumentType = Option<super::super::super::String>;
+                const NAME: &'static str = "before";
+            }
+            pub struct last;
+            impl ::cynic::schema::HasArgument<last> for super::allStarships {
+                type ArgumentType = Option<super::super::super::Int>;
+                const NAME: &'static str = "last";
+            }
+        }
+        pub struct starship;
+        impl ::cynic::schema::Field for starship {
+            type Type = Option<super::super::Starship>;
+            const NAME: &'static str = "starship";
+        }
+        impl ::cynic::schema::HasField<starship> for super::super::Root {
+            type Type = Option<super::super::Starship>;
+        }
+        pub mod starship_arguments {
+            pub struct id;
+            impl ::cynic::schema::HasArgument<id> for super::starship {
+                type ArgumentType = Option<super::super::super::ID>;
+                const NAME: &'static str = "id";
+            }
+            pub struct starshipID;
+            impl ::cynic::schema::HasArgument<starshipID> for super::starship {
+                type ArgumentType = Option<super::super::super::ID>;
+                const NAME: &'static str = "starshipID";
+            }
+        }
+        pub struct allVehicles;
+        impl ::cynic::schema::Field for allVehicles {
+            type Type = Option<super::super::VehiclesConnection>;
+            const NAME: &'static str = "allVehicles";
+        }
+        impl ::cynic::schema::HasField<allVehicles> for super::super::Root {
+            type Type = Option<super::super::VehiclesConnection>;
+        }
+        pub mod all_vehicles_arguments {
+            pub struct after;
+            impl ::cynic::schema::HasArgument<after> for super::allVehicles {
+                type ArgumentType = Option<super::super::super::String>;
+                const NAME: &'static str = "after";
+            }
+            pub struct first;
+            impl ::cynic::schema::HasArgument<first> for super::allVehicles {
+                type ArgumentType = Option<super::super::super::Int>;
+                const NAME: &'static str = "first";
+            }
+            pub struct before;
+            impl ::cynic::schema::HasArgument<before> for super::allVehicles {
+                type ArgumentType = Option<super::super::super::String>;
+                const NAME: &'static str = "before";
+            }
+            pub struct last;
+            impl ::cynic::schema::HasArgument<last> for super::allVehicles {
+                type ArgumentType = Option<super::super::super::Int>;
+                const NAME: &'static str = "last";
+            }
+        }
+        pub struct vehicle;
+        impl ::cynic::schema::Field for vehicle {
+            type Type = Option<super::super::Vehicle>;
+            const NAME: &'static str = "vehicle";
+        }
+        impl ::cynic::schema::HasField<vehicle> for super::super::Root {
+            type Type = Option<super::super::Vehicle>;
+        }
+        pub mod vehicle_arguments {
+            pub struct id;
+            impl ::cynic::schema::HasArgument<id> for super::vehicle {
+                type ArgumentType = Option<super::super::super::ID>;
+                const NAME: &'static str = "id";
+            }
+            pub struct vehicleID;
+            impl ::cynic::schema::HasArgument<vehicleID> for super::vehicle {
+                type ArgumentType = Option<super::super::super::ID>;
+                const NAME: &'static str = "vehicleID";
+            }
+        }
+        pub struct node;
+        impl ::cynic::schema::Field for node {
+            type Type = Option<super::super::Node>;
+            const NAME: &'static str = "node";
+        }
+        impl ::cynic::schema::HasField<node> for super::super::Root {
+            type Type = Option<super::super::Node>;
+        }
+        pub mod node_arguments {
+            pub struct id;
+            impl ::cynic::schema::HasArgument<id> for super::node {
+                type ArgumentType = super::super::super::ID;
+                const NAME: &'static str = "id";
+            }
+        }
+    }
+    pub mod Species {
+        pub struct name;
+        impl ::cynic::schema::Field for name {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "name";
+        }
+        impl ::cynic::schema::HasField<name> for super::super::Species {
+            type Type = Option<super::super::String>;
+        }
+        pub struct classification;
+        impl ::cynic::schema::Field for classification {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "classification";
+        }
+        impl ::cynic::schema::HasField<classification> for super::super::Species {
+            type Type = Option<super::super::String>;
+        }
+        pub struct designation;
+        impl ::cynic::schema::Field for designation {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "designation";
+        }
+        impl ::cynic::schema::HasField<designation> for super::super::Species {
+            type Type = Option<super::super::String>;
+        }
+        pub struct averageHeight;
+        impl ::cynic::schema::Field for averageHeight {
+            type Type = Option<super::super::Float>;
+            const NAME: &'static str = "averageHeight";
+        }
+        impl ::cynic::schema::HasField<averageHeight> for super::super::Species {
+            type Type = Option<super::super::Float>;
+        }
+        pub struct averageLifespan;
+        impl ::cynic::schema::Field for averageLifespan {
+            type Type = Option<super::super::Int>;
+            const NAME: &'static str = "averageLifespan";
+        }
+        impl ::cynic::schema::HasField<averageLifespan> for super::super::Species {
+            type Type = Option<super::super::Int>;
+        }
+        pub struct eyeColors;
+        impl ::cynic::schema::Field for eyeColors {
+            type Type = Option<Vec<Option<super::super::String>>>;
+            const NAME: &'static str = "eyeColors";
+        }
+        impl ::cynic::schema::HasField<eyeColors> for super::super::Species {
+            type Type = Option<Vec<Option<super::super::String>>>;
+        }
+        pub struct hairColors;
+        impl ::cynic::schema::Field for hairColors {
+            type Type = Option<Vec<Option<super::super::String>>>;
+            const NAME: &'static str = "hairColors";
+        }
+        impl ::cynic::schema::HasField<hairColors> for super::super::Species {
+            type Type = Option<Vec<Option<super::super::String>>>;
+        }
+        pub struct skinColors;
+        impl ::cynic::schema::Field for skinColors {
+            type Type = Option<Vec<Option<super::super::String>>>;
+            const NAME: &'static str = "skinColors";
+        }
+        impl ::cynic::schema::HasField<skinColors> for super::super::Species {
+            type Type = Option<Vec<Option<super::super::String>>>;
+        }
+        pub struct language;
+        impl ::cynic::schema::Field for language {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "language";
+        }
+        impl ::cynic::schema::HasField<language> for super::super::Species {
+            type Type = Option<super::super::String>;
+        }
+        pub struct homeworld;
+        impl ::cynic::schema::Field for homeworld {
+            type Type = Option<super::super::Planet>;
+            const NAME: &'static str = "homeworld";
+        }
+        impl ::cynic::schema::HasField<homeworld> for super::super::Species {
+            type Type = Option<super::super::Planet>;
+        }
+        pub struct personConnection;
+        impl ::cynic::schema::Field for personConnection {
+            type Type = Option<super::super::SpeciesPeopleConnection>;
+            const NAME: &'static str = "personConnection";
+        }
+        impl ::cynic::schema::HasField<personConnection> for super::super::Species {
+            type Type = Option<super::super::SpeciesPeopleConnection>;
+        }
+        pub mod person_connection_arguments {
+            pub struct after;
+            impl ::cynic::schema::HasArgument<after> for super::personConnection {
+                type ArgumentType = Option<super::super::super::String>;
+                const NAME: &'static str = "after";
+            }
+            pub struct first;
+            impl ::cynic::schema::HasArgument<first> for super::personConnection {
+                type ArgumentType = Option<super::super::super::Int>;
+                const NAME: &'static str = "first";
+            }
+            pub struct before;
+            impl ::cynic::schema::HasArgument<before> for super::personConnection {
+                type ArgumentType = Option<super::super::super::String>;
+                const NAME: &'static str = "before";
+            }
+            pub struct last;
+            impl ::cynic::schema::HasArgument<last> for super::personConnection {
+                type ArgumentType = Option<super::super::super::Int>;
+                const NAME: &'static str = "last";
+            }
+        }
+        pub struct filmConnection;
+        impl ::cynic::schema::Field for filmConnection {
+            type Type = Option<super::super::SpeciesFilmsConnection>;
+            const NAME: &'static str = "filmConnection";
+        }
+        impl ::cynic::schema::HasField<filmConnection> for super::super::Species {
+            type Type = Option<super::super::SpeciesFilmsConnection>;
+        }
+        pub mod film_connection_arguments {
+            pub struct after;
+            impl ::cynic::schema::HasArgument<after> for super::filmConnection {
+                type ArgumentType = Option<super::super::super::String>;
+                const NAME: &'static str = "after";
+            }
+            pub struct first;
+            impl ::cynic::schema::HasArgument<first> for super::filmConnection {
+                type ArgumentType = Option<super::super::super::Int>;
+                const NAME: &'static str = "first";
+            }
+            pub struct before;
+            impl ::cynic::schema::HasArgument<before> for super::filmConnection {
+                type ArgumentType = Option<super::super::super::String>;
+                const NAME: &'static str = "before";
+            }
+            pub struct last;
+            impl ::cynic::schema::HasArgument<last> for super::filmConnection {
+                type ArgumentType = Option<super::super::super::Int>;
+                const NAME: &'static str = "last";
+            }
+        }
+        pub struct created;
+        impl ::cynic::schema::Field for created {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "created";
+        }
+        impl ::cynic::schema::HasField<created> for super::super::Species {
+            type Type = Option<super::super::String>;
+        }
+        pub struct edited;
+        impl ::cynic::schema::Field for edited {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "edited";
+        }
+        impl ::cynic::schema::HasField<edited> for super::super::Species {
+            type Type = Option<super::super::String>;
+        }
+        pub struct id;
+        impl ::cynic::schema::Field for id {
+            type Type = super::super::ID;
+            const NAME: &'static str = "id";
+        }
+        impl ::cynic::schema::HasField<id> for super::super::Species {
+            type Type = super::super::ID;
+        }
+    }
+    pub mod SpeciesConnection {
+        pub struct pageInfo;
+        impl ::cynic::schema::Field for pageInfo {
+            type Type = super::super::PageInfo;
+            const NAME: &'static str = "pageInfo";
+        }
+        impl ::cynic::schema::HasField<pageInfo> for super::super::SpeciesConnection {
+            type Type = super::super::PageInfo;
+        }
+        pub struct edges;
+        impl ::cynic::schema::Field for edges {
+            type Type = Option<Vec<Option<super::super::SpeciesEdge>>>;
+            const NAME: &'static str = "edges";
+        }
+        impl ::cynic::schema::HasField<edges> for super::super::SpeciesConnection {
+            type Type = Option<Vec<Option<super::super::SpeciesEdge>>>;
+        }
+        pub struct totalCount;
+        impl ::cynic::schema::Field for totalCount {
+            type Type = Option<super::super::Int>;
+            const NAME: &'static str = "totalCount";
+        }
+        impl ::cynic::schema::HasField<totalCount> for super::super::SpeciesConnection {
+            type Type = Option<super::super::Int>;
+        }
+        pub struct species;
+        impl ::cynic::schema::Field for species {
+            type Type = Option<Vec<Option<super::super::Species>>>;
+            const NAME: &'static str = "species";
+        }
+        impl ::cynic::schema::HasField<species> for super::super::SpeciesConnection {
+            type Type = Option<Vec<Option<super::super::Species>>>;
+        }
+    }
+    pub mod SpeciesEdge {
+        pub struct node;
+        impl ::cynic::schema::Field for node {
+            type Type = Option<super::super::Species>;
+            const NAME: &'static str = "node";
+        }
+        impl ::cynic::schema::HasField<node> for super::super::SpeciesEdge {
+            type Type = Option<super::super::Species>;
+        }
+        pub struct cursor;
+        impl ::cynic::schema::Field for cursor {
+            type Type = super::super::String;
+            const NAME: &'static str = "cursor";
+        }
+        impl ::cynic::schema::HasField<cursor> for super::super::SpeciesEdge {
+            type Type = super::super::String;
+        }
+    }
+    pub mod SpeciesFilmsConnection {
+        pub struct pageInfo;
+        impl ::cynic::schema::Field for pageInfo {
+            type Type = super::super::PageInfo;
+            const NAME: &'static str = "pageInfo";
+        }
+        impl ::cynic::schema::HasField<pageInfo> for super::super::SpeciesFilmsConnection {
+            type Type = super::super::PageInfo;
+        }
+        pub struct edges;
+        impl ::cynic::schema::Field for edges {
+            type Type = Option<Vec<Option<super::super::SpeciesFilmsEdge>>>;
+            const NAME: &'static str = "edges";
+        }
+        impl ::cynic::schema::HasField<edges> for super::super::SpeciesFilmsConnection {
+            type Type = Option<Vec<Option<super::super::SpeciesFilmsEdge>>>;
+        }
+        pub struct totalCount;
+        impl ::cynic::schema::Field for totalCount {
+            type Type = Option<super::super::Int>;
+            const NAME: &'static str = "totalCount";
+        }
+        impl ::cynic::schema::HasField<totalCount> for super::super::SpeciesFilmsConnection {
+            type Type = Option<super::super::Int>;
+        }
+        pub struct films;
+        impl ::cynic::schema::Field for films {
+            type Type = Option<Vec<Option<super::super::Film>>>;
+            const NAME: &'static str = "films";
+        }
+        impl ::cynic::schema::HasField<films> for super::super::SpeciesFilmsConnection {
+            type Type = Option<Vec<Option<super::super::Film>>>;
+        }
+    }
+    pub mod SpeciesFilmsEdge {
+        pub struct node;
+        impl ::cynic::schema::Field for node {
+            type Type = Option<super::super::Film>;
+            const NAME: &'static str = "node";
+        }
+        impl ::cynic::schema::HasField<node> for super::super::SpeciesFilmsEdge {
+            type Type = Option<super::super::Film>;
+        }
+        pub struct cursor;
+        impl ::cynic::schema::Field for cursor {
+            type Type = super::super::String;
+            const NAME: &'static str = "cursor";
+        }
+        impl ::cynic::schema::HasField<cursor> for super::super::SpeciesFilmsEdge {
+            type Type = super::super::String;
+        }
+    }
+    pub mod SpeciesPeopleConnection {
+        pub struct pageInfo;
+        impl ::cynic::schema::Field for pageInfo {
+            type Type = super::super::PageInfo;
+            const NAME: &'static str = "pageInfo";
+        }
+        impl ::cynic::schema::HasField<pageInfo> for super::super::SpeciesPeopleConnection {
+            type Type = super::super::PageInfo;
+        }
+        pub struct edges;
+        impl ::cynic::schema::Field for edges {
+            type Type = Option<Vec<Option<super::super::SpeciesPeopleEdge>>>;
+            const NAME: &'static str = "edges";
+        }
+        impl ::cynic::schema::HasField<edges> for super::super::SpeciesPeopleConnection {
+            type Type = Option<Vec<Option<super::super::SpeciesPeopleEdge>>>;
+        }
+        pub struct totalCount;
+        impl ::cynic::schema::Field for totalCount {
+            type Type = Option<super::super::Int>;
+            const NAME: &'static str = "totalCount";
+        }
+        impl ::cynic::schema::HasField<totalCount> for super::super::SpeciesPeopleConnection {
+            type Type = Option<super::super::Int>;
+        }
+        pub struct people;
+        impl ::cynic::schema::Field for people {
+            type Type = Option<Vec<Option<super::super::Person>>>;
+            const NAME: &'static str = "people";
+        }
+        impl ::cynic::schema::HasField<people> for super::super::SpeciesPeopleConnection {
+            type Type = Option<Vec<Option<super::super::Person>>>;
+        }
+    }
+    pub mod SpeciesPeopleEdge {
+        pub struct node;
+        impl ::cynic::schema::Field for node {
+            type Type = Option<super::super::Person>;
+            const NAME: &'static str = "node";
+        }
+        impl ::cynic::schema::HasField<node> for super::super::SpeciesPeopleEdge {
+            type Type = Option<super::super::Person>;
+        }
+        pub struct cursor;
+        impl ::cynic::schema::Field for cursor {
+            type Type = super::super::String;
+            const NAME: &'static str = "cursor";
+        }
+        impl ::cynic::schema::HasField<cursor> for super::super::SpeciesPeopleEdge {
+            type Type = super::super::String;
+        }
+    }
+    pub mod Starship {
+        pub struct name;
+        impl ::cynic::schema::Field for name {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "name";
+        }
+        impl ::cynic::schema::HasField<name> for super::super::Starship {
+            type Type = Option<super::super::String>;
+        }
+        pub struct model;
+        impl ::cynic::schema::Field for model {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "model";
+        }
+        impl ::cynic::schema::HasField<model> for super::super::Starship {
+            type Type = Option<super::super::String>;
+        }
+        pub struct starshipClass;
+        impl ::cynic::schema::Field for starshipClass {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "starshipClass";
+        }
+        impl ::cynic::schema::HasField<starshipClass> for super::super::Starship {
+            type Type = Option<super::super::String>;
+        }
+        pub struct manufacturers;
+        impl ::cynic::schema::Field for manufacturers {
+            type Type = Option<Vec<Option<super::super::String>>>;
+            const NAME: &'static str = "manufacturers";
+        }
+        impl ::cynic::schema::HasField<manufacturers> for super::super::Starship {
+            type Type = Option<Vec<Option<super::super::String>>>;
+        }
+        pub struct costInCredits;
+        impl ::cynic::schema::Field for costInCredits {
+            type Type = Option<super::super::Float>;
+            const NAME: &'static str = "costInCredits";
+        }
+        impl ::cynic::schema::HasField<costInCredits> for super::super::Starship {
+            type Type = Option<super::super::Float>;
+        }
+        pub struct length;
+        impl ::cynic::schema::Field for length {
+            type Type = Option<super::super::Float>;
+            const NAME: &'static str = "length";
+        }
+        impl ::cynic::schema::HasField<length> for super::super::Starship {
+            type Type = Option<super::super::Float>;
+        }
+        pub struct crew;
+        impl ::cynic::schema::Field for crew {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "crew";
+        }
+        impl ::cynic::schema::HasField<crew> for super::super::Starship {
+            type Type = Option<super::super::String>;
+        }
+        pub struct passengers;
+        impl ::cynic::schema::Field for passengers {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "passengers";
+        }
+        impl ::cynic::schema::HasField<passengers> for super::super::Starship {
+            type Type = Option<super::super::String>;
+        }
+        pub struct maxAtmospheringSpeed;
+        impl ::cynic::schema::Field for maxAtmospheringSpeed {
+            type Type = Option<super::super::Int>;
+            const NAME: &'static str = "maxAtmospheringSpeed";
+        }
+        impl ::cynic::schema::HasField<maxAtmospheringSpeed> for super::super::Starship {
+            type Type = Option<super::super::Int>;
+        }
+        pub struct hyperdriveRating;
+        impl ::cynic::schema::Field for hyperdriveRating {
+            type Type = Option<super::super::Float>;
+            const NAME: &'static str = "hyperdriveRating";
+        }
+        impl ::cynic::schema::HasField<hyperdriveRating> for super::super::Starship {
+            type Type = Option<super::super::Float>;
+        }
+        pub struct MGLT;
+        impl ::cynic::schema::Field for MGLT {
+            type Type = Option<super::super::Int>;
+            const NAME: &'static str = "MGLT";
+        }
+        impl ::cynic::schema::HasField<MGLT> for super::super::Starship {
+            type Type = Option<super::super::Int>;
+        }
+        pub struct cargoCapacity;
+        impl ::cynic::schema::Field for cargoCapacity {
+            type Type = Option<super::super::Float>;
+            const NAME: &'static str = "cargoCapacity";
+        }
+        impl ::cynic::schema::HasField<cargoCapacity> for super::super::Starship {
+            type Type = Option<super::super::Float>;
+        }
+        pub struct consumables;
+        impl ::cynic::schema::Field for consumables {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "consumables";
+        }
+        impl ::cynic::schema::HasField<consumables> for super::super::Starship {
+            type Type = Option<super::super::String>;
+        }
+        pub struct pilotConnection;
+        impl ::cynic::schema::Field for pilotConnection {
+            type Type = Option<super::super::StarshipPilotsConnection>;
+            const NAME: &'static str = "pilotConnection";
+        }
+        impl ::cynic::schema::HasField<pilotConnection> for super::super::Starship {
+            type Type = Option<super::super::StarshipPilotsConnection>;
+        }
+        pub mod pilot_connection_arguments {
+            pub struct after;
+            impl ::cynic::schema::HasArgument<after> for super::pilotConnection {
+                type ArgumentType = Option<super::super::super::String>;
+                const NAME: &'static str = "after";
+            }
+            pub struct first;
+            impl ::cynic::schema::HasArgument<first> for super::pilotConnection {
+                type ArgumentType = Option<super::super::super::Int>;
+                const NAME: &'static str = "first";
+            }
+            pub struct before;
+            impl ::cynic::schema::HasArgument<before> for super::pilotConnection {
+                type ArgumentType = Option<super::super::super::String>;
+                const NAME: &'static str = "before";
+            }
+            pub struct last;
+            impl ::cynic::schema::HasArgument<last> for super::pilotConnection {
+                type ArgumentType = Option<super::super::super::Int>;
+                const NAME: &'static str = "last";
+            }
+        }
+        pub struct filmConnection;
+        impl ::cynic::schema::Field for filmConnection {
+            type Type = Option<super::super::StarshipFilmsConnection>;
+            const NAME: &'static str = "filmConnection";
+        }
+        impl ::cynic::schema::HasField<filmConnection> for super::super::Starship {
+            type Type = Option<super::super::StarshipFilmsConnection>;
+        }
+        pub mod film_connection_arguments {
+            pub struct after;
+            impl ::cynic::schema::HasArgument<after> for super::filmConnection {
+                type ArgumentType = Option<super::super::super::String>;
+                const NAME: &'static str = "after";
+            }
+            pub struct first;
+            impl ::cynic::schema::HasArgument<first> for super::filmConnection {
+                type ArgumentType = Option<super::super::super::Int>;
+                const NAME: &'static str = "first";
+            }
+            pub struct before;
+            impl ::cynic::schema::HasArgument<before> for super::filmConnection {
+                type ArgumentType = Option<super::super::super::String>;
+                const NAME: &'static str = "before";
+            }
+            pub struct last;
+            impl ::cynic::schema::HasArgument<last> for super::filmConnection {
+                type ArgumentType = Option<super::super::super::Int>;
+                const NAME: &'static str = "last";
+            }
+        }
+        pub struct created;
+        impl ::cynic::schema::Field for created {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "created";
+        }
+        impl ::cynic::schema::HasField<created> for super::super::Starship {
+            type Type = Option<super::super::String>;
+        }
+        pub struct edited;
+        impl ::cynic::schema::Field for edited {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "edited";
+        }
+        impl ::cynic::schema::HasField<edited> for super::super::Starship {
+            type Type = Option<super::super::String>;
+        }
+        pub struct id;
+        impl ::cynic::schema::Field for id {
+            type Type = super::super::ID;
+            const NAME: &'static str = "id";
+        }
+        impl ::cynic::schema::HasField<id> for super::super::Starship {
+            type Type = super::super::ID;
+        }
+    }
+    pub mod StarshipFilmsConnection {
+        pub struct pageInfo;
+        impl ::cynic::schema::Field for pageInfo {
+            type Type = super::super::PageInfo;
+            const NAME: &'static str = "pageInfo";
+        }
+        impl ::cynic::schema::HasField<pageInfo> for super::super::StarshipFilmsConnection {
+            type Type = super::super::PageInfo;
+        }
+        pub struct edges;
+        impl ::cynic::schema::Field for edges {
+            type Type = Option<Vec<Option<super::super::StarshipFilmsEdge>>>;
+            const NAME: &'static str = "edges";
+        }
+        impl ::cynic::schema::HasField<edges> for super::super::StarshipFilmsConnection {
+            type Type = Option<Vec<Option<super::super::StarshipFilmsEdge>>>;
+        }
+        pub struct totalCount;
+        impl ::cynic::schema::Field for totalCount {
+            type Type = Option<super::super::Int>;
+            const NAME: &'static str = "totalCount";
+        }
+        impl ::cynic::schema::HasField<totalCount> for super::super::StarshipFilmsConnection {
+            type Type = Option<super::super::Int>;
+        }
+        pub struct films;
+        impl ::cynic::schema::Field for films {
+            type Type = Option<Vec<Option<super::super::Film>>>;
+            const NAME: &'static str = "films";
+        }
+        impl ::cynic::schema::HasField<films> for super::super::StarshipFilmsConnection {
+            type Type = Option<Vec<Option<super::super::Film>>>;
+        }
+    }
+    pub mod StarshipFilmsEdge {
+        pub struct node;
+        impl ::cynic::schema::Field for node {
+            type Type = Option<super::super::Film>;
+            const NAME: &'static str = "node";
+        }
+        impl ::cynic::schema::HasField<node> for super::super::StarshipFilmsEdge {
+            type Type = Option<super::super::Film>;
+        }
+        pub struct cursor;
+        impl ::cynic::schema::Field for cursor {
+            type Type = super::super::String;
+            const NAME: &'static str = "cursor";
+        }
+        impl ::cynic::schema::HasField<cursor> for super::super::StarshipFilmsEdge {
+            type Type = super::super::String;
+        }
+    }
+    pub mod StarshipPilotsConnection {
+        pub struct pageInfo;
+        impl ::cynic::schema::Field for pageInfo {
+            type Type = super::super::PageInfo;
+            const NAME: &'static str = "pageInfo";
+        }
+        impl ::cynic::schema::HasField<pageInfo> for super::super::StarshipPilotsConnection {
+            type Type = super::super::PageInfo;
+        }
+        pub struct edges;
+        impl ::cynic::schema::Field for edges {
+            type Type = Option<Vec<Option<super::super::StarshipPilotsEdge>>>;
+            const NAME: &'static str = "edges";
+        }
+        impl ::cynic::schema::HasField<edges> for super::super::StarshipPilotsConnection {
+            type Type = Option<Vec<Option<super::super::StarshipPilotsEdge>>>;
+        }
+        pub struct totalCount;
+        impl ::cynic::schema::Field for totalCount {
+            type Type = Option<super::super::Int>;
+            const NAME: &'static str = "totalCount";
+        }
+        impl ::cynic::schema::HasField<totalCount> for super::super::StarshipPilotsConnection {
+            type Type = Option<super::super::Int>;
+        }
+        pub struct pilots;
+        impl ::cynic::schema::Field for pilots {
+            type Type = Option<Vec<Option<super::super::Person>>>;
+            const NAME: &'static str = "pilots";
+        }
+        impl ::cynic::schema::HasField<pilots> for super::super::StarshipPilotsConnection {
+            type Type = Option<Vec<Option<super::super::Person>>>;
+        }
+    }
+    pub mod StarshipPilotsEdge {
+        pub struct node;
+        impl ::cynic::schema::Field for node {
+            type Type = Option<super::super::Person>;
+            const NAME: &'static str = "node";
+        }
+        impl ::cynic::schema::HasField<node> for super::super::StarshipPilotsEdge {
+            type Type = Option<super::super::Person>;
+        }
+        pub struct cursor;
+        impl ::cynic::schema::Field for cursor {
+            type Type = super::super::String;
+            const NAME: &'static str = "cursor";
+        }
+        impl ::cynic::schema::HasField<cursor> for super::super::StarshipPilotsEdge {
+            type Type = super::super::String;
+        }
+    }
+    pub mod StarshipsConnection {
+        pub struct pageInfo;
+        impl ::cynic::schema::Field for pageInfo {
+            type Type = super::super::PageInfo;
+            const NAME: &'static str = "pageInfo";
+        }
+        impl ::cynic::schema::HasField<pageInfo> for super::super::StarshipsConnection {
+            type Type = super::super::PageInfo;
+        }
+        pub struct edges;
+        impl ::cynic::schema::Field for edges {
+            type Type = Option<Vec<Option<super::super::StarshipsEdge>>>;
+            const NAME: &'static str = "edges";
+        }
+        impl ::cynic::schema::HasField<edges> for super::super::StarshipsConnection {
+            type Type = Option<Vec<Option<super::super::StarshipsEdge>>>;
+        }
+        pub struct totalCount;
+        impl ::cynic::schema::Field for totalCount {
+            type Type = Option<super::super::Int>;
+            const NAME: &'static str = "totalCount";
+        }
+        impl ::cynic::schema::HasField<totalCount> for super::super::StarshipsConnection {
+            type Type = Option<super::super::Int>;
+        }
+        pub struct starships;
+        impl ::cynic::schema::Field for starships {
+            type Type = Option<Vec<Option<super::super::Starship>>>;
+            const NAME: &'static str = "starships";
+        }
+        impl ::cynic::schema::HasField<starships> for super::super::StarshipsConnection {
+            type Type = Option<Vec<Option<super::super::Starship>>>;
+        }
+    }
+    pub mod StarshipsEdge {
+        pub struct node;
+        impl ::cynic::schema::Field for node {
+            type Type = Option<super::super::Starship>;
+            const NAME: &'static str = "node";
+        }
+        impl ::cynic::schema::HasField<node> for super::super::StarshipsEdge {
+            type Type = Option<super::super::Starship>;
+        }
+        pub struct cursor;
+        impl ::cynic::schema::Field for cursor {
+            type Type = super::super::String;
+            const NAME: &'static str = "cursor";
+        }
+        impl ::cynic::schema::HasField<cursor> for super::super::StarshipsEdge {
+            type Type = super::super::String;
+        }
+    }
+    pub mod Vehicle {
+        pub struct name;
+        impl ::cynic::schema::Field for name {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "name";
+        }
+        impl ::cynic::schema::HasField<name> for super::super::Vehicle {
+            type Type = Option<super::super::String>;
+        }
+        pub struct model;
+        impl ::cynic::schema::Field for model {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "model";
+        }
+        impl ::cynic::schema::HasField<model> for super::super::Vehicle {
+            type Type = Option<super::super::String>;
+        }
+        pub struct vehicleClass;
+        impl ::cynic::schema::Field for vehicleClass {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "vehicleClass";
+        }
+        impl ::cynic::schema::HasField<vehicleClass> for super::super::Vehicle {
+            type Type = Option<super::super::String>;
+        }
+        pub struct manufacturers;
+        impl ::cynic::schema::Field for manufacturers {
+            type Type = Option<Vec<Option<super::super::String>>>;
+            const NAME: &'static str = "manufacturers";
+        }
+        impl ::cynic::schema::HasField<manufacturers> for super::super::Vehicle {
+            type Type = Option<Vec<Option<super::super::String>>>;
+        }
+        pub struct costInCredits;
+        impl ::cynic::schema::Field for costInCredits {
+            type Type = Option<super::super::Float>;
+            const NAME: &'static str = "costInCredits";
+        }
+        impl ::cynic::schema::HasField<costInCredits> for super::super::Vehicle {
+            type Type = Option<super::super::Float>;
+        }
+        pub struct length;
+        impl ::cynic::schema::Field for length {
+            type Type = Option<super::super::Float>;
+            const NAME: &'static str = "length";
+        }
+        impl ::cynic::schema::HasField<length> for super::super::Vehicle {
+            type Type = Option<super::super::Float>;
+        }
+        pub struct crew;
+        impl ::cynic::schema::Field for crew {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "crew";
+        }
+        impl ::cynic::schema::HasField<crew> for super::super::Vehicle {
+            type Type = Option<super::super::String>;
+        }
+        pub struct passengers;
+        impl ::cynic::schema::Field for passengers {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "passengers";
+        }
+        impl ::cynic::schema::HasField<passengers> for super::super::Vehicle {
+            type Type = Option<super::super::String>;
+        }
+        pub struct maxAtmospheringSpeed;
+        impl ::cynic::schema::Field for maxAtmospheringSpeed {
+            type Type = Option<super::super::Int>;
+            const NAME: &'static str = "maxAtmospheringSpeed";
+        }
+        impl ::cynic::schema::HasField<maxAtmospheringSpeed> for super::super::Vehicle {
+            type Type = Option<super::super::Int>;
+        }
+        pub struct cargoCapacity;
+        impl ::cynic::schema::Field for cargoCapacity {
+            type Type = Option<super::super::Float>;
+            const NAME: &'static str = "cargoCapacity";
+        }
+        impl ::cynic::schema::HasField<cargoCapacity> for super::super::Vehicle {
+            type Type = Option<super::super::Float>;
+        }
+        pub struct consumables;
+        impl ::cynic::schema::Field for consumables {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "consumables";
+        }
+        impl ::cynic::schema::HasField<consumables> for super::super::Vehicle {
+            type Type = Option<super::super::String>;
+        }
+        pub struct pilotConnection;
+        impl ::cynic::schema::Field for pilotConnection {
+            type Type = Option<super::super::VehiclePilotsConnection>;
+            const NAME: &'static str = "pilotConnection";
+        }
+        impl ::cynic::schema::HasField<pilotConnection> for super::super::Vehicle {
+            type Type = Option<super::super::VehiclePilotsConnection>;
+        }
+        pub mod pilot_connection_arguments {
+            pub struct after;
+            impl ::cynic::schema::HasArgument<after> for super::pilotConnection {
+                type ArgumentType = Option<super::super::super::String>;
+                const NAME: &'static str = "after";
+            }
+            pub struct first;
+            impl ::cynic::schema::HasArgument<first> for super::pilotConnection {
+                type ArgumentType = Option<super::super::super::Int>;
+                const NAME: &'static str = "first";
+            }
+            pub struct before;
+            impl ::cynic::schema::HasArgument<before> for super::pilotConnection {
+                type ArgumentType = Option<super::super::super::String>;
+                const NAME: &'static str = "before";
+            }
+            pub struct last;
+            impl ::cynic::schema::HasArgument<last> for super::pilotConnection {
+                type ArgumentType = Option<super::super::super::Int>;
+                const NAME: &'static str = "last";
+            }
+        }
+        pub struct filmConnection;
+        impl ::cynic::schema::Field for filmConnection {
+            type Type = Option<super::super::VehicleFilmsConnection>;
+            const NAME: &'static str = "filmConnection";
+        }
+        impl ::cynic::schema::HasField<filmConnection> for super::super::Vehicle {
+            type Type = Option<super::super::VehicleFilmsConnection>;
+        }
+        pub mod film_connection_arguments {
+            pub struct after;
+            impl ::cynic::schema::HasArgument<after> for super::filmConnection {
+                type ArgumentType = Option<super::super::super::String>;
+                const NAME: &'static str = "after";
+            }
+            pub struct first;
+            impl ::cynic::schema::HasArgument<first> for super::filmConnection {
+                type ArgumentType = Option<super::super::super::Int>;
+                const NAME: &'static str = "first";
+            }
+            pub struct before;
+            impl ::cynic::schema::HasArgument<before> for super::filmConnection {
+                type ArgumentType = Option<super::super::super::String>;
+                const NAME: &'static str = "before";
+            }
+            pub struct last;
+            impl ::cynic::schema::HasArgument<last> for super::filmConnection {
+                type ArgumentType = Option<super::super::super::Int>;
+                const NAME: &'static str = "last";
+            }
+        }
+        pub struct created;
+        impl ::cynic::schema::Field for created {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "created";
+        }
+        impl ::cynic::schema::HasField<created> for super::super::Vehicle {
+            type Type = Option<super::super::String>;
+        }
+        pub struct edited;
+        impl ::cynic::schema::Field for edited {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "edited";
+        }
+        impl ::cynic::schema::HasField<edited> for super::super::Vehicle {
+            type Type = Option<super::super::String>;
+        }
+        pub struct id;
+        impl ::cynic::schema::Field for id {
+            type Type = super::super::ID;
+            const NAME: &'static str = "id";
+        }
+        impl ::cynic::schema::HasField<id> for super::super::Vehicle {
+            type Type = super::super::ID;
+        }
+    }
+    pub mod VehicleFilmsConnection {
+        pub struct pageInfo;
+        impl ::cynic::schema::Field for pageInfo {
+            type Type = super::super::PageInfo;
+            const NAME: &'static str = "pageInfo";
+        }
+        impl ::cynic::schema::HasField<pageInfo> for super::super::VehicleFilmsConnection {
+            type Type = super::super::PageInfo;
+        }
+        pub struct edges;
+        impl ::cynic::schema::Field for edges {
+            type Type = Option<Vec<Option<super::super::VehicleFilmsEdge>>>;
+            const NAME: &'static str = "edges";
+        }
+        impl ::cynic::schema::HasField<edges> for super::super::VehicleFilmsConnection {
+            type Type = Option<Vec<Option<super::super::VehicleFilmsEdge>>>;
+        }
+        pub struct totalCount;
+        impl ::cynic::schema::Field for totalCount {
+            type Type = Option<super::super::Int>;
+            const NAME: &'static str = "totalCount";
+        }
+        impl ::cynic::schema::HasField<totalCount> for super::super::VehicleFilmsConnection {
+            type Type = Option<super::super::Int>;
+        }
+        pub struct films;
+        impl ::cynic::schema::Field for films {
+            type Type = Option<Vec<Option<super::super::Film>>>;
+            const NAME: &'static str = "films";
+        }
+        impl ::cynic::schema::HasField<films> for super::super::VehicleFilmsConnection {
+            type Type = Option<Vec<Option<super::super::Film>>>;
+        }
+    }
+    pub mod VehicleFilmsEdge {
+        pub struct node;
+        impl ::cynic::schema::Field for node {
+            type Type = Option<super::super::Film>;
+            const NAME: &'static str = "node";
+        }
+        impl ::cynic::schema::HasField<node> for super::super::VehicleFilmsEdge {
+            type Type = Option<super::super::Film>;
+        }
+        pub struct cursor;
+        impl ::cynic::schema::Field for cursor {
+            type Type = super::super::String;
+            const NAME: &'static str = "cursor";
+        }
+        impl ::cynic::schema::HasField<cursor> for super::super::VehicleFilmsEdge {
+            type Type = super::super::String;
+        }
+    }
+    pub mod VehiclePilotsConnection {
+        pub struct pageInfo;
+        impl ::cynic::schema::Field for pageInfo {
+            type Type = super::super::PageInfo;
+            const NAME: &'static str = "pageInfo";
+        }
+        impl ::cynic::schema::HasField<pageInfo> for super::super::VehiclePilotsConnection {
+            type Type = super::super::PageInfo;
+        }
+        pub struct edges;
+        impl ::cynic::schema::Field for edges {
+            type Type = Option<Vec<Option<super::super::VehiclePilotsEdge>>>;
+            const NAME: &'static str = "edges";
+        }
+        impl ::cynic::schema::HasField<edges> for super::super::VehiclePilotsConnection {
+            type Type = Option<Vec<Option<super::super::VehiclePilotsEdge>>>;
+        }
+        pub struct totalCount;
+        impl ::cynic::schema::Field for totalCount {
+            type Type = Option<super::super::Int>;
+            const NAME: &'static str = "totalCount";
+        }
+        impl ::cynic::schema::HasField<totalCount> for super::super::VehiclePilotsConnection {
+            type Type = Option<super::super::Int>;
+        }
+        pub struct pilots;
+        impl ::cynic::schema::Field for pilots {
+            type Type = Option<Vec<Option<super::super::Person>>>;
+            const NAME: &'static str = "pilots";
+        }
+        impl ::cynic::schema::HasField<pilots> for super::super::VehiclePilotsConnection {
+            type Type = Option<Vec<Option<super::super::Person>>>;
+        }
+    }
+    pub mod VehiclePilotsEdge {
+        pub struct node;
+        impl ::cynic::schema::Field for node {
+            type Type = Option<super::super::Person>;
+            const NAME: &'static str = "node";
+        }
+        impl ::cynic::schema::HasField<node> for super::super::VehiclePilotsEdge {
+            type Type = Option<super::super::Person>;
+        }
+        pub struct cursor;
+        impl ::cynic::schema::Field for cursor {
+            type Type = super::super::String;
+            const NAME: &'static str = "cursor";
+        }
+        impl ::cynic::schema::HasField<cursor> for super::super::VehiclePilotsEdge {
+            type Type = super::super::String;
+        }
+    }
+    pub mod VehiclesConnection {
+        pub struct pageInfo;
+        impl ::cynic::schema::Field for pageInfo {
+            type Type = super::super::PageInfo;
+            const NAME: &'static str = "pageInfo";
+        }
+        impl ::cynic::schema::HasField<pageInfo> for super::super::VehiclesConnection {
+            type Type = super::super::PageInfo;
+        }
+        pub struct edges;
+        impl ::cynic::schema::Field for edges {
+            type Type = Option<Vec<Option<super::super::VehiclesEdge>>>;
+            const NAME: &'static str = "edges";
+        }
+        impl ::cynic::schema::HasField<edges> for super::super::VehiclesConnection {
+            type Type = Option<Vec<Option<super::super::VehiclesEdge>>>;
+        }
+        pub struct totalCount;
+        impl ::cynic::schema::Field for totalCount {
+            type Type = Option<super::super::Int>;
+            const NAME: &'static str = "totalCount";
+        }
+        impl ::cynic::schema::HasField<totalCount> for super::super::VehiclesConnection {
+            type Type = Option<super::super::Int>;
+        }
+        pub struct vehicles;
+        impl ::cynic::schema::Field for vehicles {
+            type Type = Option<Vec<Option<super::super::Vehicle>>>;
+            const NAME: &'static str = "vehicles";
+        }
+        impl ::cynic::schema::HasField<vehicles> for super::super::VehiclesConnection {
+            type Type = Option<Vec<Option<super::super::Vehicle>>>;
+        }
+    }
+    pub mod VehiclesEdge {
+        pub struct node;
+        impl ::cynic::schema::Field for node {
+            type Type = Option<super::super::Vehicle>;
+            const NAME: &'static str = "node";
+        }
+        impl ::cynic::schema::HasField<node> for super::super::VehiclesEdge {
+            type Type = Option<super::super::Vehicle>;
+        }
+        pub struct cursor;
+        impl ::cynic::schema::Field for cursor {
+            type Type = super::super::String;
+            const NAME: &'static str = "cursor";
+        }
+        impl ::cynic::schema::HasField<cursor> for super::super::VehiclesEdge {
+            type Type = super::super::String;
+        }
+    }
 }
 pub type Boolean = bool;
 pub type String = std::string::String;

--- a/cynic-codegen/tests/snapshots/use_schema__test_cases.graphql.snap
+++ b/cynic-codegen/tests/snapshots/use_schema__test_cases.graphql.snap
@@ -4,156 +4,13 @@ expression: "format_code(format!(\"{}\", tokens))"
 ---
 impl ::cynic::schema::QueryRoot for Foo {}
 pub struct Bar;
-pub mod bar_fields {
-    pub struct id;
-    impl ::cynic::schema::Field for id {
-        type Type = super::UUID;
-        const NAME: &'static str = "id";
-    }
-    impl ::cynic::schema::HasField<id> for super::Bar {
-        type Type = super::UUID;
-    }
-    pub struct name;
-    impl ::cynic::schema::Field for name {
-        type Type = Option<super::String>;
-        const NAME: &'static str = "name";
-    }
-    impl ::cynic::schema::HasField<name> for super::Bar {
-        type Type = Option<super::String>;
-    }
-}
 pub struct Foo;
-pub mod foo_fields {
-    pub struct _Underscore;
-    impl ::cynic::schema::Field for _Underscore {
-        type Type = Option<super::Boolean>;
-        const NAME: &'static str = "_";
-    }
-    impl ::cynic::schema::HasField<_Underscore> for super::Foo {
-        type Type = Option<super::Boolean>;
-    }
-    pub struct self_;
-    impl ::cynic::schema::Field for self_ {
-        type Type = Option<super::Boolean>;
-        const NAME: &'static str = "self";
-    }
-    impl ::cynic::schema::HasField<self_> for super::Foo {
-        type Type = Option<super::Boolean>;
-    }
-    pub struct super_;
-    impl ::cynic::schema::Field for super_ {
-        type Type = Option<super::Boolean>;
-        const NAME: &'static str = "super";
-    }
-    impl ::cynic::schema::HasField<super_> for super::Foo {
-        type Type = Option<super::Boolean>;
-    }
-    pub struct crate_;
-    impl ::cynic::schema::Field for crate_ {
-        type Type = Option<super::Boolean>;
-        const NAME: &'static str = "crate";
-    }
-    impl ::cynic::schema::HasField<crate_> for super::Foo {
-        type Type = Option<super::Boolean>;
-    }
-    pub struct r#async;
-    impl ::cynic::schema::Field for r#async {
-        type Type = Option<super::Boolean>;
-        const NAME: &'static str = "async";
-    }
-    impl ::cynic::schema::HasField<r#async> for super::Foo {
-        type Type = Option<super::Boolean>;
-    }
-    pub struct bar;
-    impl ::cynic::schema::Field for bar {
-        type Type = Option<super::Bar>;
-        const NAME: &'static str = "bar";
-    }
-    impl ::cynic::schema::HasField<bar> for super::Foo {
-        type Type = Option<super::Bar>;
-    }
-    pub mod bar_arguments {
-        pub struct id;
-        impl ::cynic::schema::HasArgument<id> for super::bar {
-            type ArgumentType = super::super::UUID;
-            const NAME: &'static str = "id";
-        }
-    }
-    pub struct fieldWithKeywordArg;
-    impl ::cynic::schema::Field for fieldWithKeywordArg {
-        type Type = Vec<super::Int>;
-        const NAME: &'static str = "fieldWithKeywordArg";
-    }
-    impl ::cynic::schema::HasField<fieldWithKeywordArg> for super::Foo {
-        type Type = Vec<super::Int>;
-    }
-    pub mod field_with_keyword_arg_arguments {
-        pub struct r#where;
-        impl ::cynic::schema::HasArgument<r#where> for super::fieldWithKeywordArg {
-            type ArgumentType = Option<super::super::Int>;
-            const NAME: &'static str = "where";
-        }
-    }
-    pub struct recursiveInputField;
-    impl ::cynic::schema::Field for recursiveInputField {
-        type Type = Option<super::Boolean>;
-        const NAME: &'static str = "recursiveInputField";
-    }
-    impl ::cynic::schema::HasField<recursiveInputField> for super::Foo {
-        type Type = Option<super::Boolean>;
-    }
-    pub mod recursive_input_field_arguments {
-        pub struct recursive;
-        impl ::cynic::schema::HasArgument<recursive> for super::recursiveInputField {
-            type ArgumentType = Option<super::super::SelfRecursiveInput>;
-            const NAME: &'static str = "recursive";
-        }
-        pub struct recursive2;
-        impl ::cynic::schema::HasArgument<recursive2> for super::recursiveInputField {
-            type ArgumentType = Option<super::super::RecursiveInputParent>;
-            const NAME: &'static str = "recursive2";
-        }
-    }
-}
 pub struct RecursiveInputChild;
 impl ::cynic::schema::InputObjectMarker for RecursiveInputChild {}
-pub mod recursive_input_child_fields {
-    pub struct recurse;
-    impl ::cynic::schema::Field for recurse {
-        type Type = Option<super::RecursiveInputParent>;
-        const NAME: &'static str = "recurse";
-    }
-    impl ::cynic::schema::HasInputField<recurse, Option<super::RecursiveInputParent>>
-        for super::RecursiveInputChild
-    {
-    }
-}
 pub struct RecursiveInputParent;
 impl ::cynic::schema::InputObjectMarker for RecursiveInputParent {}
-pub mod recursive_input_parent_fields {
-    pub struct recurse;
-    impl ::cynic::schema::Field for recurse {
-        type Type = Option<super::RecursiveInputChild>;
-        const NAME: &'static str = "recurse";
-    }
-    impl ::cynic::schema::HasInputField<recurse, Option<super::RecursiveInputChild>>
-        for super::RecursiveInputParent
-    {
-    }
-}
 pub struct SelfRecursiveInput;
 impl ::cynic::schema::InputObjectMarker for SelfRecursiveInput {}
-pub mod self_recursive_input_fields {
-    pub struct recurse;
-    impl ::cynic::schema::Field for recurse {
-        type Type = Option<super::SelfRecursiveInput>;
-        const NAME: &'static str = "recurse";
-    }
-    impl ::cynic::schema::HasInputField<recurse, Option<super::SelfRecursiveInput>>
-        for super::SelfRecursiveInput
-    {
-    }
-}
 pub struct States {}
 pub struct UUID {}
 impl ::cynic::schema::NamedType for UUID {
@@ -164,6 +21,152 @@ impl ::cynic::schema::NamedType for Bar {
 }
 impl ::cynic::schema::NamedType for Foo {
     const NAME: &'static str = "Foo";
+}
+#[allow(non_snake_case, non_camel_case_types)]
+pub mod __fields {
+    pub mod Bar {
+        pub struct id;
+        impl ::cynic::schema::Field for id {
+            type Type = super::super::UUID;
+            const NAME: &'static str = "id";
+        }
+        impl ::cynic::schema::HasField<id> for super::super::Bar {
+            type Type = super::super::UUID;
+        }
+        pub struct name;
+        impl ::cynic::schema::Field for name {
+            type Type = Option<super::super::String>;
+            const NAME: &'static str = "name";
+        }
+        impl ::cynic::schema::HasField<name> for super::super::Bar {
+            type Type = Option<super::super::String>;
+        }
+    }
+    pub mod Foo {
+        pub struct _Underscore;
+        impl ::cynic::schema::Field for _Underscore {
+            type Type = Option<super::super::Boolean>;
+            const NAME: &'static str = "_";
+        }
+        impl ::cynic::schema::HasField<_Underscore> for super::super::Foo {
+            type Type = Option<super::super::Boolean>;
+        }
+        pub struct self_;
+        impl ::cynic::schema::Field for self_ {
+            type Type = Option<super::super::Boolean>;
+            const NAME: &'static str = "self";
+        }
+        impl ::cynic::schema::HasField<self_> for super::super::Foo {
+            type Type = Option<super::super::Boolean>;
+        }
+        pub struct super_;
+        impl ::cynic::schema::Field for super_ {
+            type Type = Option<super::super::Boolean>;
+            const NAME: &'static str = "super";
+        }
+        impl ::cynic::schema::HasField<super_> for super::super::Foo {
+            type Type = Option<super::super::Boolean>;
+        }
+        pub struct crate_;
+        impl ::cynic::schema::Field for crate_ {
+            type Type = Option<super::super::Boolean>;
+            const NAME: &'static str = "crate";
+        }
+        impl ::cynic::schema::HasField<crate_> for super::super::Foo {
+            type Type = Option<super::super::Boolean>;
+        }
+        pub struct r#async;
+        impl ::cynic::schema::Field for r#async {
+            type Type = Option<super::super::Boolean>;
+            const NAME: &'static str = "async";
+        }
+        impl ::cynic::schema::HasField<r#async> for super::super::Foo {
+            type Type = Option<super::super::Boolean>;
+        }
+        pub struct bar;
+        impl ::cynic::schema::Field for bar {
+            type Type = Option<super::super::Bar>;
+            const NAME: &'static str = "bar";
+        }
+        impl ::cynic::schema::HasField<bar> for super::super::Foo {
+            type Type = Option<super::super::Bar>;
+        }
+        pub mod bar_arguments {
+            pub struct id;
+            impl ::cynic::schema::HasArgument<id> for super::bar {
+                type ArgumentType = super::super::super::UUID;
+                const NAME: &'static str = "id";
+            }
+        }
+        pub struct fieldWithKeywordArg;
+        impl ::cynic::schema::Field for fieldWithKeywordArg {
+            type Type = Vec<super::super::Int>;
+            const NAME: &'static str = "fieldWithKeywordArg";
+        }
+        impl ::cynic::schema::HasField<fieldWithKeywordArg> for super::super::Foo {
+            type Type = Vec<super::super::Int>;
+        }
+        pub mod field_with_keyword_arg_arguments {
+            pub struct r#where;
+            impl ::cynic::schema::HasArgument<r#where> for super::fieldWithKeywordArg {
+                type ArgumentType = Option<super::super::super::Int>;
+                const NAME: &'static str = "where";
+            }
+        }
+        pub struct recursiveInputField;
+        impl ::cynic::schema::Field for recursiveInputField {
+            type Type = Option<super::super::Boolean>;
+            const NAME: &'static str = "recursiveInputField";
+        }
+        impl ::cynic::schema::HasField<recursiveInputField> for super::super::Foo {
+            type Type = Option<super::super::Boolean>;
+        }
+        pub mod recursive_input_field_arguments {
+            pub struct recursive;
+            impl ::cynic::schema::HasArgument<recursive> for super::recursiveInputField {
+                type ArgumentType = Option<super::super::super::SelfRecursiveInput>;
+                const NAME: &'static str = "recursive";
+            }
+            pub struct recursive2;
+            impl ::cynic::schema::HasArgument<recursive2> for super::recursiveInputField {
+                type ArgumentType = Option<super::super::super::RecursiveInputParent>;
+                const NAME: &'static str = "recursive2";
+            }
+        }
+    }
+    pub mod RecursiveInputChild {
+        pub struct recurse;
+        impl ::cynic::schema::Field for recurse {
+            type Type = Option<super::super::RecursiveInputParent>;
+            const NAME: &'static str = "recurse";
+        }
+        impl ::cynic::schema::HasInputField<recurse, Option<super::super::RecursiveInputParent>>
+            for super::super::RecursiveInputChild
+        {
+        }
+    }
+    pub mod RecursiveInputParent {
+        pub struct recurse;
+        impl ::cynic::schema::Field for recurse {
+            type Type = Option<super::super::RecursiveInputChild>;
+            const NAME: &'static str = "recurse";
+        }
+        impl ::cynic::schema::HasInputField<recurse, Option<super::super::RecursiveInputChild>>
+            for super::super::RecursiveInputParent
+        {
+        }
+    }
+    pub mod SelfRecursiveInput {
+        pub struct recurse;
+        impl ::cynic::schema::Field for recurse {
+            type Type = Option<super::super::SelfRecursiveInput>;
+            const NAME: &'static str = "recurse";
+        }
+        impl ::cynic::schema::HasInputField<recurse, Option<super::super::SelfRecursiveInput>>
+            for super::super::SelfRecursiveInput
+        {
+        }
+    }
 }
 pub type Boolean = bool;
 pub type String = std::string::String;

--- a/cynic-codegen/tests/snapshots/use_schema__test_cases.graphql.snap
+++ b/cynic-codegen/tests/snapshots/use_schema__test_cases.graphql.snap
@@ -91,7 +91,7 @@ pub mod __fields {
         impl ::cynic::schema::HasField<bar> for super::super::Foo {
             type Type = Option<super::super::Bar>;
         }
-        pub mod bar_arguments {
+        pub mod _bar_arguments {
             pub struct id;
             impl ::cynic::schema::HasArgument<id> for super::bar {
                 type ArgumentType = super::super::super::UUID;
@@ -106,7 +106,7 @@ pub mod __fields {
         impl ::cynic::schema::HasField<fieldWithKeywordArg> for super::super::Foo {
             type Type = Vec<super::super::Int>;
         }
-        pub mod field_with_keyword_arg_arguments {
+        pub mod _field_with_keyword_arg_arguments {
             pub struct r#where;
             impl ::cynic::schema::HasArgument<r#where> for super::fieldWithKeywordArg {
                 type ArgumentType = Option<super::super::super::Int>;
@@ -121,7 +121,7 @@ pub mod __fields {
         impl ::cynic::schema::HasField<recursiveInputField> for super::super::Foo {
             type Type = Option<super::super::Boolean>;
         }
-        pub mod recursive_input_field_arguments {
+        pub mod _recursive_input_field_arguments {
             pub struct recursive;
             impl ::cynic::schema::HasArgument<recursive> for super::recursiveInputField {
                 type ArgumentType = Option<super::super::super::SelfRecursiveInput>;


### PR DESCRIPTION
#### Why are we making this change?

The output of `use_schema` puts out structs for each type and a module of
fields in that type.  Previously these were all output in the same location: so
a type `foo` would end up with a module `foo_fields` that contains it's fields.
However if there was also a `foo_fields` type in the schema this would clash.

#### What effects does this change have?

Refactored the field modules so they live under a `__fields` module.  I suppose
this will also break if someone has a `__fields` type.  But _hopefully_ they
don't and I guess I'll re-think if they do.
