### PR TITLE
[Merged by Bors] - Expose `StreamingOperation`

### DIFF
--- a/cynic/src/builders.rs
+++ b/cynic/src/builders.rs
@@ -1,6 +1,4 @@
-use crate::operation::StreamingOperation;
-
-use super::{Operation, QueryFragment};
+use super::{Operation, QueryFragment, StreamingOperation};
 
 /// Provides a `build` function on `QueryFragment`s that represent a query
 pub trait QueryBuilder<'de>: Sized {

--- a/cynic/src/lib.rs
+++ b/cynic/src/lib.rs
@@ -185,7 +185,7 @@ pub mod __private;
 pub use self::core::{Enum, InlineFragments, InputObject, QueryFragment};
 pub use builders::{MutationBuilder, QueryBuilder, SubscriptionBuilder};
 pub use id::Id;
-pub use operation::Operation;
+pub use operation::{Operation, StreamingOperation};
 pub use result::{GraphQlError, GraphQlResponse};
 pub use variables::QueryVariables;
 


### PR DESCRIPTION
#### Why are we making this change?

In version `1.*` of the cynic library it was exposed.
