### PR TITLE
Fix typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,10 +69,10 @@ This release contains a lot of breaking changes.
 - `Operation` has changed:
   - It no longer has a lifetime.
   - It is now generic over the arguments type.
-- The `http` extension traits have had their signatures changed to accomodate
+- The `http` extension traits have had their signatures changed to accommodate
   the new signature of `Operation`. Their use should still be the same.
 - An `Enum` can no longer be shared between schemas. If you were doing this,
-  you should define two `Enum`s and provide conversion functions beteween the
+  you should define two `Enum`s and provide conversion functions between the
   two of them.
 - `InlineFragments` now always require a fallback and no longer perform
   exhaustiveness checking.
@@ -391,7 +391,7 @@ much work for users to update. An example of an upgrade can be found
 ### Breaking Changes
 
 - `QueryFragment::fragment` now accepts a `FragmentContext` rather than
-  arguments. This change was neccesary to support recursive queries.
+  arguments. This change was necessary to support recursive queries.
 - It is no longer recommended to use `QueryFragment::fragment` directly -
   instead an Operation should be constructed with `QueryBuilder::build` or
   `MutationBuilder::build`. Note that these return an `Operation` so you no
@@ -444,7 +444,7 @@ much work for users to update. An example of an upgrade can be found
   - Supports multiple queries, sharing structs between all the generated queries
     as appropriate.
   - Generates unique names for each struct it creates, even when faced with
-    different structs targetting the same type.
+    different structs targeting the same type.
   - Generates partial InputObjects when faced with literals with missing fields
     (previously it would generate all fields even when unused)
   - Correctly generates different argument structs if a single type with
@@ -529,7 +529,7 @@ much work for users to update. An example of an upgrade can be found
 
 ### Removed Features
 
-- Removed the `optimised_query_modules` feature from codegen, as it invovled
+- Removed the `optimised_query_modules` feature from codegen, as it involved
   more code than it was worth to keep it around. Functionally this should make
   no difference, though it may change performance characteristics of compiling
   cynic code. Didn't seem to make a significant difference when I was using it
@@ -634,7 +634,7 @@ much work for users to update. An example of an upgrade can be found
 
 ### Breaking Changes
 
-- `schema_path` parameters are now relative to `CARGO_MANFIEST_DIR` rather than
+- `schema_path` parameters are now relative to `CARGO_MANIFIEST_DIR` rather than
   the current working directory. This fixes an issue with cargo workspace
   projects where doc-tests would be relative to the sub-crate but cargo builds
   were relative to the workspace root. For projects not using workspaces this
@@ -730,7 +730,7 @@ much work for users to update. An example of an upgrade can be found
 ### Changed
 
 - Split the procedural macros out into their own cynic-proc-macros crate.
-  cynic-codegen now exists as a re-usable library for programatically
+  cynic-codegen now exists as a re-usable library for programmatically
   doing the codegen.
 - The IntoArguments trait is now named FromArguments and has had it's
   parameters switched up.

--- a/cynic-book/src/building-queries/index.md
+++ b/cynic-book/src/building-queries/index.md
@@ -2,7 +2,7 @@
 
 The previous section of the book showed how to use the various derive macros
 cynic provides to build out GraphQL queries. If you've got a more complex use
-case, these might not always provide the functonality you're looking for.
+case, these might not always provide the functionality you're looking for.
 Cynic provides lower level functionality for building queries without these
 derives, and that's what we'll go into in this chapter.
 

--- a/cynic-book/src/derives/inline-fragments.md
+++ b/cynic-book/src/derives/inline-fragments.md
@@ -33,7 +33,7 @@ implement `QueryFragment` for the respective GraphQL types.
 Cynic requires a fallback variant on each `InlineFragments` that will be
 matched when the server returns a type other than the ones you provide.  This
 allows your code to continue compiling & running in the face of additions to
-the server, similar to the usual GraphQL backwards compatability guarantees.
+the server, similar to the usual GraphQL backwards compatibility guarantees.
 
 ```rust
 #[derive(cynic::InlineFragments)]
@@ -117,7 +117,7 @@ enum itself:
 Each variant can also have it's own attributes:
 
 - `fallback` can be applied on a single variant to indicate that it
-  should be used whenver cynic encounters a `__typename` that doesn't
+  should be used whenever cynic encounters a `__typename` that doesn't
   match one of the other variants. For interfaces this can contain a
   `QueryFragment` type. For union types it must be applied on a unit
   variant.

--- a/cynic-book/src/derives/input-objects.md
+++ b/cynic-book/src/derives/input-objects.md
@@ -23,7 +23,7 @@ attribute or the rename attribute on individual fields.
 If there are any fields in the struct that are not on the GraphQL input type
 the derive will emit errors. Any required fields that are on the GraphQL input
 type but not the rust struct will also error. Optional fields may be omitted
-without error. This maintains the same backwards compatability guarantees as
+without error. This maintains the same backwards compatibility guarantees as
 most GraphQL clients: adding a required field is a breaking change, but adding
 an optional field is not.
 

--- a/cynic-book/src/derives/query-fragments.md
+++ b/cynic-book/src/derives/query-fragments.md
@@ -188,7 +188,7 @@ See [query variables][1] for more details.
 The example above showed how to pass variables to the top level of a query. If
 you want to pass variables to a nested QueryFragment then all it's parent
 `QueryFragment`s must specify the same `variables` in their `cynic`
-attribute. This is neccesary so that the `QueryVariables` struct gets passed
+attribute. This is necessary so that the `QueryVariables` struct gets passed
 down to that level of a query.
 
 If no nested `QueryFragments` require arguments, you can omit the

--- a/cynic-book/src/derives/recursive-queries.md
+++ b/cynic-book/src/derives/recursive-queries.md
@@ -4,7 +4,7 @@ GraphQL allows for types to recurse and allows queries of those recursive types
 to a particular depth. Cynic supports this in it's `QueryFragment` derive when
 users provide the `recurse` attribute on the field that recurses.
 
-If we wanted to recurisvely fetch characters that were in a star wars film and
+If we wanted to recursively fetch characters that were in a star wars film and
 the other films that they were in (and so on) we could do:
 
 ```rust

--- a/cynic-codegen/src/fragment_derive/arguments/tests.rs
+++ b/cynic-codegen/src/fragment_derive/arguments/tests.rs
@@ -14,7 +14,7 @@ use super::{analyse::analyse, parsing::CynicArguments};
 #[case::list_wrapping("list_wrapping", "filteredBooks", parse_quote! { filters: { authors: "Ann Leckie" } })]
 #[case::an_enum("an_enum", "filteredBooks", parse_quote! { filters: { state: "PUBLISHED" } })]
 #[case::variable_in_object("variable_in_object", "filteredBooks", parse_quote! { filters: { state: $aVariable } })]
-#[case::top_level_variable("top_level_variable", "filteredBooks", parse_quote! { filters: $aVaraible })]
+#[case::top_level_variable("top_level_variable", "filteredBooks", parse_quote! { filters: $aVariable })]
 #[case::top_level_variables("top_level_variables", "filteredBooks", parse_quote! { filters: $aVaraible, optionalFilters: $anotherVar })]
 #[case::boolean_scalar("boolean_scalar", "someNullableScalarParams", parse_quote! { aBool: true })]
 #[case::missing_parameter("missing_parameter", "filteredBooks", parse_quote! {})]

--- a/cynic-codegen/src/scalar_derive/mod.rs
+++ b/cynic-codegen/src/scalar_derive/mod.rs
@@ -25,7 +25,7 @@ pub fn scalar_derive_impl(input: ScalarDeriveInput) -> Result<TokenStream, syn::
     let schema_module = input.schema_module();
 
     // We're assuming that Darling has already validated this as a newtype enum,
-    // so we can get away with panicing here.
+    // so we can get away with panicking here.
     let field = input
         .data
         .take_struct()

--- a/cynic-codegen/src/schema/type_index.rs
+++ b/cynic-codegen/src/schema/type_index.rs
@@ -70,7 +70,7 @@ impl<'a> TypeIndex<'a> {
     }
 
     pub(super) fn private_lookup(&self, name: &str) -> Option<Type<'a>> {
-        // Note: This function should absolutely only be called after the heirarchy has
+        // Note: This function should absolutely only be called after the hierarchy has
         // been validated.  The current module privacy settings enforce this, but don't make this
         // private or call it without being careful.
         let type_def = self
@@ -320,7 +320,7 @@ where
             TypeRef::Named(name, index, _) => {
                 // Note: we assume that TypeRef is only constructed after validation,
                 // which makes this unwrap ok.
-                // Probably want to enforce this via module heirarchy.
+                // Probably want to enforce this via module hierarchy.
                 index.private_lookup(name).unwrap().try_into().unwrap()
             }
             TypeRef::List(inner) => inner.inner_type(),

--- a/cynic-codegen/src/types/validation.rs
+++ b/cynic-codegen/src/types/validation.rs
@@ -25,7 +25,7 @@ pub fn check_types_are_compatible<'a>(
         CheckMode::OutputTypes => output_type_check(gql_type, &rust_type, false)?,
         CheckMode::Recursing => recursing_check(gql_type, &rust_type)?,
         CheckMode::Spreading => {
-            panic!("check_types_are_compatible shouldnt be called with CheckMode::Spreading")
+            panic!("check_types_are_compatible shouldn't be called with CheckMode::Spreading")
         }
     }
 
@@ -52,7 +52,7 @@ pub fn check_spread_type(rust_type: &syn::Type) -> Result<(), syn::Error> {
                 Ok(())
             }
             RustType::Box { inner, .. } => {
-                // Box is a transparent container for the purposes of checking compatability
+                // Box is a transparent container for the purposes of checking compatibility
                 // so just recurse
                 inner_fn(inner.as_ref())
             }
@@ -98,7 +98,7 @@ fn output_type_check<'a>(
 ) -> Result<(), TypeValidationError> {
     match (&gql_type, rust_type) {
         (_, RustType::Box { inner, .. }) => {
-            // Box is a transparent container for the purposes of checking compatability
+            // Box is a transparent container for the purposes of checking compatibility
             // so just recurse
             output_type_check(gql_type, inner.as_ref(), flattening)
         }
@@ -154,7 +154,7 @@ fn input_type_check<'a>(
 ) -> Result<(), TypeValidationError> {
     match (&gql_type, rust_type) {
         (gql_type, RustType::Box { inner, .. }) => {
-            // Box is a transparent container for the purposes of checking compatability
+            // Box is a transparent container for the purposes of checking compatibility
             // so just recurse
             input_type_check(gql_type, has_default, inner.as_ref())
         }

--- a/cynic-querygen/src/bin/querygen.rs
+++ b/cynic-querygen/src/bin/querygen.rs
@@ -32,7 +32,7 @@ fn main() {
               display_name
               currency
               description
-              Fulfilment {
+              Fulfillment {
                 delivery
                 collection
                 eat_in

--- a/cynic-querygen/src/lib.rs
+++ b/cynic-querygen/src/lib.rs
@@ -56,7 +56,7 @@ pub enum Error {
     #[error("expected an interface")]
     ExpectedInterfaceType,
 
-    #[error("expected a homogenous list of input values")]
+    #[error("expected a homogeneous list of input values")]
     ExpectedHomogenousList,
 
     #[error("expected field to be a list")]

--- a/cynic-querygen/src/query_parsing/variables.rs
+++ b/cynic-querygen/src/query_parsing/variables.rs
@@ -90,7 +90,7 @@ impl<'query, 'schema> SelectionArguments<'query, 'schema> {
                     let nested_struct = nested.as_variable_struct(parent_map, output_mapping);
 
                     if parent_map.get(&nested).map(|hs| hs.len()).unwrap_or(0) <= 1 {
-                        // This particular childs arguments are only used by it,
+                        // This particular children arguments are only used by it,
                         // so we can safely lift them up into our argument struct
                         output_mapping.selection_structs.remove(&nested_struct.id);
                         output_mapping.remappings.insert(nested_struct.id, our_id);

--- a/cynic-querygen/src/schema/mod.rs
+++ b/cynic-querygen/src/schema/mod.rs
@@ -78,7 +78,7 @@ pub enum OutputType<'schema> {
 pub struct InterfaceType<'schema>(pub InterfaceDetails<'schema>);
 
 impl<'schema> Type<'schema> {
-    fn from_type_defintion(
+    fn from_type_definition(
         type_def: &parser::TypeDefinition<'schema>,
         type_index: &Rc<TypeIndex<'schema>>,
     ) -> Type<'schema> {

--- a/cynic-querygen/src/schema/type_index.rs
+++ b/cynic-querygen/src/schema/type_index.rs
@@ -96,7 +96,7 @@ impl<'schema> TypeIndex<'schema> {
             .get(name)
             .ok_or_else(|| Error::UnknownType(name.to_string()))?;
 
-        Ok(Type::from_type_defintion(type_def, self))
+        Ok(Type::from_type_definition(type_def, self))
     }
 
     pub fn type_for_path<'path>(

--- a/cynic/src/core.rs
+++ b/cynic/src/core.rs
@@ -96,7 +96,7 @@ impl<'de> QueryFragment<'de> for String {
 /// A QueryFragment that contains a set of inline fragments
 ///
 /// This should be derived on an enum with newtype variants where each
-/// inner type is a `QueryFragment` for an apppropriate type.
+/// inner type is a `QueryFragment` for an appropriate type.
 pub trait InlineFragments<'de>: QueryFragment<'de> {
     /// Attempts to deserialize a variant with the given typename.
     fn deserialize_variant<D>(typename: &str, deserializer: D) -> Result<Self, D::Error>

--- a/cynic/src/http.rs
+++ b/cynic/src/http.rs
@@ -123,7 +123,7 @@ pub enum CynicReqwestError {
     #[error("Error making HTTP request: {0}")]
     ReqwestError(#[from] reqwest::Error),
 
-    /// An error resposne from the server with the given status code and body.
+    /// An error response from the server with the given status code and body.
     #[error("Server returned {0}: {1}")]
     ErrorResponse(reqwest::StatusCode, String),
 }

--- a/cynic/src/lib.rs
+++ b/cynic/src/lib.rs
@@ -25,7 +25,7 @@
 //!
 //! 1. Some structs to represent the Input types the underlying schema.
 //!    You may need to use these to build mutations or as parameters to queries.
-//! 2. Definitons of all the Enums in the provided schema.  You'll need these if
+//! 2. Definitions of all the Enums in the provided schema.  You'll need these if
 //!    you want to use any enum types.
 //! 3. Type safe selection set functions.  These can be used to build up a query
 //!    manually, though it's usually easier to use the `QueryFragment` derive
@@ -130,7 +130,7 @@
 //!     schema_path = "../schemas/starwars.schema.graphql",
 //!     graphql_type = "Root",
 //!     // By adding the `variables` parameter to our `QueryFragment` we've made a variable
-//!     // named `args` avaiable for use in the `arguments` attribute.
+//!     // named `args` available for use in the `arguments` attribute.
 //!     variables = "FilmArguments"
 //! )]
 //! struct FilmDirectorQueryWithArgs {
@@ -159,9 +159,9 @@
 //!
 //! It's worth noting that each of these features pulls in extra
 //! dependencies, which may impact your build size.  Particularly
-//! if you're targetting WASM.  In particular the `url` crate has
+//! if you're targeting WASM.  In particular the `url` crate has
 //! [known issues](https://github.com/servo/rust-url/issues/557) when
-//! targetting web assembly.
+//! targeting web assembly.
 
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![warn(missing_docs)]

--- a/cynic/src/queries/builders.rs
+++ b/cynic/src/queries/builders.rs
@@ -385,8 +385,8 @@ impl<'a> InputLiteralContainer<'a> {
 
 /// Enforces type equality on a Variable struct.
 ///
-/// Each `crate::QueryVariables` implementaiton should also implement this for `()` for
-/// compatability with QueryFragments that don't need variables.
+/// Each `crate::QueryVariables` implementation should also implement this for `()` for
+/// compatibility with QueryFragments that don't need variables.
 pub trait VariableMatch<T> {}
 
 impl<T> VariableMatch<()> for T where T: crate::QueryVariables {}

--- a/cynic/src/result.rs
+++ b/cynic/src/result.rs
@@ -1,7 +1,7 @@
 /// The response to a GraphQl operation
 #[derive(Debug, serde::Deserialize)]
 pub struct GraphQlResponse<T, ErrorExtensions = serde::de::IgnoredAny> {
-    /// The operation data (if the operation was succesful)
+    /// The operation data (if the operation was successful)
     pub data: Option<T>,
 
     /// Any errors that occurred as part of this operation

--- a/cynic/tests/compatability.rs
+++ b/cynic/tests/compatability.rs
@@ -1,9 +1,9 @@
-//! Some tests of cynics implementation of backwards/forwards compatability
+//! Some tests of cynics implementation of backwards/forwards compatibility
 
 use cynic::{InputObject, QueryFragment};
 
 #[test]
-fn query_fields_may_be_unnecesarily_option() {
+fn query_fields_may_be_unnecessarily_option() {
     // Fields in a query can be wrapped in `Option` when the underlying field
     // is required
 
@@ -45,7 +45,7 @@ fn input_fields_may_be_required_when_nullable() {
 
 #[test]
 fn input_fields_may_be_singular_when_should_be_list() {
-    // Input fields can be singlular when the underlying type is a list.
+    // Input fields can be singular when the underlying type is a list.
 
     #[allow(dead_code)]
     #[derive(InputObject)]

--- a/schemas/github.graphql
+++ b/schemas/github.graphql
@@ -2948,7 +2948,7 @@ type Commit implements GitObject & Node & Subscribable & UniformResourceLocatabl
   committedDate: DateTime!
 
   """
-  Check if commited via GitHub web UI.
+  Check if committed via GitHub web UI.
   """
   committedViaWeb: Boolean!
 
@@ -5275,7 +5275,7 @@ input CreateTeamDiscussionInput {
   clientMutationId: String
 
   """
-  If true, restricts the visiblity of this discussion to team members and
+  If true, restricts the visibility of this discussion to team members and
   organization admins. If false or not specified, allows any organization member
   to view this discussion.
   """
@@ -10702,7 +10702,7 @@ enum GitSignatureState {
   NO_USER
 
   """
-  Valid siganture, though certificate revocation check failed
+  Valid signature, though certificate revocation check failed
   """
   OCSP_ERROR
 
@@ -17570,7 +17570,7 @@ type OrgRestoreMemberAuditEntry implements AuditEntry & Node & OrganizationAudit
   restoredCustomEmailRoutingsCount: Int
 
   """
-  The number of issue assignemnts for the restored member.
+  The number of issue assignments for the restored member.
   """
   restoredIssueAssignmentsCount: Int
 
@@ -19110,7 +19110,7 @@ type OrganizationIdentityProvider implements Node {
   id: ID!
 
   """
-  The x509 certificate used by the Identity Provder to sign assertions and responses.
+  The x509 certificate used by the Identity Provider to sign assertions and responses.
   """
   idpCertificate: X509Certificate
 
@@ -20248,7 +20248,7 @@ type PinnedIssueEdge @preview(toggledBy: "elektra-preview") {
 }
 
 """
-An ISO-8601 encoded UTC date string with millisecond precison.
+An ISO-8601 encoded UTC date string with millisecond precision.
 """
 scalar PreciseDateTime
 
@@ -30037,7 +30037,7 @@ type RepositoryVulnerabilityAlert implements Node & RepositoryNode {
   dismissReason: String
 
   """
-  When was the alert dimissed?
+  When was the alert dismissed?
   """
   dismissedAt: DateTime
 
@@ -30058,7 +30058,7 @@ type RepositoryVulnerabilityAlert implements Node & RepositoryNode {
   securityAdvisory: SecurityAdvisory
 
   """
-  The associated security vulnerablity
+  The associated security vulnerability
   """
   securityVulnerability: SecurityVulnerability
 
@@ -31311,7 +31311,7 @@ type SmimeSignature implements GitSignature {
 }
 
 """
-Entites that can sponsor others via GitHub Sponsors
+Entities that can sponsor others via GitHub Sponsors
 """
 union Sponsor = Organization | User
 
@@ -36807,7 +36807,7 @@ input UpdateTeamReviewAssignmentInput @preview(toggledBy: "stone-crop-preview") 
   excludedTeamMemberIds: [ID!] @possibleTypes(concreteTypes: ["User"])
 
   """
-  The Node ID of the team to update review assginments of
+  The Node ID of the team to update review assignments of
   """
   id: ID! @possibleTypes(concreteTypes: ["Team"])
 

--- a/schemas/starwars.schema.graphql
+++ b/schemas/starwars.schema.graphql
@@ -515,7 +515,7 @@ type Planet implements Node {
   terrains: [String]
 
   """
-  The percentage of the planet surface that is naturally occuring water or bodies
+  The percentage of the planet surface that is naturally occurring water or bodies
   of water.
   """
   surfaceWater: Float

--- a/tests/compile-benchmarks/github-query/src/github.schema.graphql
+++ b/tests/compile-benchmarks/github-query/src/github.schema.graphql
@@ -2948,7 +2948,7 @@ type Commit implements GitObject & Node & Subscribable & UniformResourceLocatabl
   committedDate: DateTime!
 
   """
-  Check if commited via GitHub web UI.
+  Check if committed via GitHub web UI.
   """
   committedViaWeb: Boolean!
 
@@ -5275,7 +5275,7 @@ input CreateTeamDiscussionInput {
   clientMutationId: String
 
   """
-  If true, restricts the visiblity of this discussion to team members and
+  If true, restricts the visibility of this discussion to team members and
   organization admins. If false or not specified, allows any organization member
   to view this discussion.
   """
@@ -10702,7 +10702,7 @@ enum GitSignatureState {
   NO_USER
 
   """
-  Valid siganture, though certificate revocation check failed
+  Valid signature, though certificate revocation check failed
   """
   OCSP_ERROR
 
@@ -17570,7 +17570,7 @@ type OrgRestoreMemberAuditEntry implements AuditEntry & Node & OrganizationAudit
   restoredCustomEmailRoutingsCount: Int
 
   """
-  The number of issue assignemnts for the restored member.
+  The number of issue assignments for the restored member.
   """
   restoredIssueAssignmentsCount: Int
 
@@ -19110,7 +19110,7 @@ type OrganizationIdentityProvider implements Node {
   id: ID!
 
   """
-  The x509 certificate used by the Identity Provder to sign assertions and responses.
+  The x509 certificate used by the Identity Provider to sign assertions and responses.
   """
   idpCertificate: X509Certificate
 
@@ -20248,7 +20248,7 @@ type PinnedIssueEdge @preview(toggledBy: "elektra-preview") {
 }
 
 """
-An ISO-8601 encoded UTC date string with millisecond precison.
+An ISO-8601 encoded UTC date string with millisecond precision.
 """
 scalar PreciseDateTime
 
@@ -30037,7 +30037,7 @@ type RepositoryVulnerabilityAlert implements Node & RepositoryNode {
   dismissReason: String
 
   """
-  When was the alert dimissed?
+  When was the alert dismissed?
   """
   dismissedAt: DateTime
 
@@ -30058,7 +30058,7 @@ type RepositoryVulnerabilityAlert implements Node & RepositoryNode {
   securityAdvisory: SecurityAdvisory
 
   """
-  The associated security vulnerablity
+  The associated security vulnerability
   """
   securityVulnerability: SecurityVulnerability
 
@@ -31311,7 +31311,7 @@ type SmimeSignature implements GitSignature {
 }
 
 """
-Entites that can sponsor others via GitHub Sponsors
+Entities that can sponsor others via GitHub Sponsors
 """
 union Sponsor = Organization | User
 
@@ -36807,7 +36807,7 @@ input UpdateTeamReviewAssignmentInput @preview(toggledBy: "stone-crop-preview") 
   excludedTeamMemberIds: [ID!] @possibleTypes(concreteTypes: ["User"])
 
   """
-  The Node ID of the team to update review assginments of
+  The Node ID of the team to update review assignments of
   """
   id: ID! @possibleTypes(concreteTypes: ["Team"])
 


### PR DESCRIPTION
#### Why are we making this change?

Fix typos.

Found via `codespell -L pullrequests,pullrequest,crate,ser,anid,fieid` and `typos --format brief`

<!-- Provide details of the context of and justification for this change -->

#### What effects does this change have?

Documentation changes.