### PR TITLE
[Merged by Bors] - Use cargo-nextest on CI

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,6 @@
+[profile.ci]
+# Print out output for failing tests as soon as they fail, and also at the end
+# of the run (for easy scrollability).
+failure-output = "immediate-final"
+# Do not cancel the test run on the first failure.
+fail-fast = false

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Build tests
         shell: bash
         run: |
-          cargo nextest run --no-run --workspace --all-features
+          cargo nextest run --workspace --all-features --no-run 
 
       - name: Run tests
         shell: bash
@@ -57,9 +57,19 @@ jobs:
       - name: Build example tests
         shell: bash
         run: |
-          cargo nextest run --no-run --workspace --examples
+          cargo nextest run --workspace --examples --no-run 
 
       - name: Run example tests
         shell: bash
         run: |
           cargo nextest run --workspace --examples
+
+      - name: Build doctests
+        shell: bash
+        run: |
+          cargo test --doc --workspace --no-run
+
+      - name: Run doctests
+        shell: bash
+        run: |
+          cargo test --doc --workspace

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -38,26 +38,27 @@ jobs:
           command: build
           args: --workspace
 
+      - name: Install nextest
+        shell: bash
+        run: |
+          curl -LsSf https://get.nexte.st/0.9/linux | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
+
       - name: Build tests
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --workspace --no-run --all-features
+        shell: bash
+        run: |
+          cargo nextest run --no-run --workspace --all-features
 
       - name: Run tests
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --workspace --all-features
+        shell: bash
+        run: |
+          cargo nextest run --workspace --all-features
 
       - name: Build example tests
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --workspace --no-run --examples
+        shell: bash
+        run: |
+          cargo nextest run --no-run --workspace --examples
 
       - name: Run example tests
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --workspace --examples
+        shell: bash
+        run: |
+          cargo nextest run --workspace --examples

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -64,12 +64,7 @@ jobs:
         run: |
           cargo nextest run --workspace --examples
 
-      - name: Build doctests
-        shell: bash
-        run: |
-          cargo test --doc --workspace --no-run
-
-      - name: Run doctests
+      - name: Build & run doctests
         shell: bash
         run: |
           cargo test --doc --workspace

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,6 +11,7 @@ env:
   # TODO: Would be nice to disable warnings here too, but there are too many of them.
   RUSTFLAGS: "-W rust-2021-compatibility"
   RUST_BACKTRACE: short
+  NEXTEST_PROFILE: ci
   CI: 1
 
 jobs:


### PR DESCRIPTION
#### Why are we making this change?

Cynics tests are _slow_.  Cargo nextest is quite a nice test runner that can speed things up a bit.

#### What effects does this change have?

Updates cynic to use cargo nextest on CI.
