### PR TITLE
[Merged by Bors] - Remove Send bound from ReqwestExt futures on wasm

### DIFF
--- a/cynic/src/http.rs
+++ b/cynic/src/http.rs
@@ -135,7 +135,11 @@ mod reqwest_ext {
 
     use crate::{GraphQlResponse, Operation};
 
+    #[cfg(not(target_arch = "wasm32"))]
     type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
+
+    #[cfg(target_arch = "wasm32")]
+    type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + 'a>>;
 
     /// An extension trait for reqwest::RequestBuilder.
     ///


### PR DESCRIPTION
When compiled for wasm, reqwest futures are not send as they contain a websys type that is not Send.  Cynic uses a `BoxFuture` type that expects a Send future, so doesn't compile when compiled for wasm with http-reqwest enabled.

This commit updates the code to not expect a `Send` future under these conditions which allows the code to compile.

Fixes #596