### PR TITLE
[Merged by Bors] - Add support for querying __typename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ## Unreleased - xxxx-xx-xx
 
+### Bug Fixes
+
+- The generator and derive macros are now aware of the implicit `__typename`
+  that every object & interface type gets.
+- Fixed support for support fields with one or more leading underscores in the
+  derives. This would have been possible before but only by using a rename
+  attribute.
+
 ## v2.2.2 - 2022-12-28
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1112,9 +1112,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.9.1"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hermit-abi"
@@ -1277,9 +1277,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.6.2"
+version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824845a0bf897a9042383849b02c1bc219c2383772efcd5c6f9766fa4b81aef3"
+checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
 dependencies = [
  "autocfg",
  "hashbrown",

--- a/cynic-codegen/src/idents/old_ident.rs
+++ b/cynic-codegen/src/idents/old_ident.rs
@@ -74,10 +74,20 @@ pub fn to_pascal_case(s: &str) -> String {
     let mut first_char = true;
     let mut prev_is_upper = false;
     let mut prev_is_underscore = false;
-    for c in s.chars() {
+    let mut chars = s.chars().peekable();
+    loop {
+        let c = chars.next();
+        if c.is_none() {
+            break;
+        }
+        let c = c.unwrap();
         if first_char {
             if c == '_' {
-                prev_is_underscore = true;
+                // keep leading underscores
+                buf.push('_');
+                while let Some('_') = chars.peek() {
+                    buf.push(chars.next().unwrap());
+                }
             } else if c.is_uppercase() {
                 prev_is_upper = true;
                 buf.push(c);
@@ -153,9 +163,10 @@ mod tests {
         assert_eq!(to_camel_case("aString"), "aString");
         assert_eq!(to_camel_case("MyString"), "myString");
         assert_eq!(to_camel_case("my_string"), "myString");
-        assert_eq!(to_camel_case("_another_one"), "anotherOne");
+        assert_eq!(to_camel_case("_another_one"), "_anotherOne");
         assert_eq!(to_camel_case("RepeatedUPPERCASE"), "repeatedUppercase");
         assert_eq!(to_camel_case("UUID"), "uuid");
+        assert_eq!(to_camel_case("__typename"), "__typename");
     }
 
     #[test]
@@ -163,9 +174,10 @@ mod tests {
         assert_eq!(to_pascal_case("aString"), "AString");
         assert_eq!(to_pascal_case("MyString"), "MyString");
         assert_eq!(to_pascal_case("my_string"), "MyString");
-        assert_eq!(to_pascal_case("_another_one"), "AnotherOne");
+        assert_eq!(to_pascal_case("_another_one"), "_anotherOne");
         assert_eq!(to_pascal_case("RepeatedUPPERCASE"), "RepeatedUppercase");
         assert_eq!(to_pascal_case("UUID"), "Uuid");
+        assert_eq!(to_pascal_case("__typename"), "__typename");
     }
 
     #[test]

--- a/cynic-codegen/tests/snapshots/use_schema__books.graphql.snap
+++ b/cynic-codegen/tests/snapshots/use_schema__books.graphql.snap
@@ -53,6 +53,14 @@ pub mod __fields {
         impl ::cynic::schema::HasField<author> for super::super::Book {
             type Type = super::super::String;
         }
+        pub struct __typename;
+        impl ::cynic::schema::Field for __typename {
+            type Type = super::super::String;
+            const NAME: &'static str = "__typename";
+        }
+        impl ::cynic::schema::HasField<__typename> for super::super::Book {
+            type Type = super::super::String;
+        }
     }
     pub mod BookChanged {
         pub struct mutationType;
@@ -78,6 +86,14 @@ pub mod __fields {
         }
         impl ::cynic::schema::HasField<book> for super::super::BookChanged {
             type Type = Option<super::super::Book>;
+        }
+        pub struct __typename;
+        impl ::cynic::schema::Field for __typename {
+            type Type = super::super::String;
+            const NAME: &'static str = "__typename";
+        }
+        impl ::cynic::schema::HasField<__typename> for super::super::BookChanged {
+            type Type = super::super::String;
         }
     }
     pub mod MutationRoot {
@@ -116,6 +132,14 @@ pub mod __fields {
                 const NAME: &'static str = "id";
             }
         }
+        pub struct __typename;
+        impl ::cynic::schema::Field for __typename {
+            type Type = super::super::String;
+            const NAME: &'static str = "__typename";
+        }
+        impl ::cynic::schema::HasField<__typename> for super::super::MutationRoot {
+            type Type = super::super::String;
+        }
     }
     pub mod QueryRoot {
         pub struct books;
@@ -125,6 +149,14 @@ pub mod __fields {
         }
         impl ::cynic::schema::HasField<books> for super::super::QueryRoot {
             type Type = Vec<super::super::Book>;
+        }
+        pub struct __typename;
+        impl ::cynic::schema::Field for __typename {
+            type Type = super::super::String;
+            const NAME: &'static str = "__typename";
+        }
+        impl ::cynic::schema::HasField<__typename> for super::super::QueryRoot {
+            type Type = super::super::String;
         }
     }
     pub mod SubscriptionRoot {
@@ -157,6 +189,14 @@ pub mod __fields {
                 type ArgumentType = Option<super::super::super::MutationType>;
                 const NAME: &'static str = "mutationType";
             }
+        }
+        pub struct __typename;
+        impl ::cynic::schema::Field for __typename {
+            type Type = super::super::String;
+            const NAME: &'static str = "__typename";
+        }
+        impl ::cynic::schema::HasField<__typename> for super::super::SubscriptionRoot {
+            type Type = super::super::String;
         }
     }
 }

--- a/cynic-codegen/tests/snapshots/use_schema__graphql.jobs.graphql.snap
+++ b/cynic-codegen/tests/snapshots/use_schema__graphql.jobs.graphql.snap
@@ -191,6 +191,14 @@ pub mod __fields {
         impl ::cynic::schema::HasField<updatedAt> for super::super::City {
             type Type = super::super::DateTime;
         }
+        pub struct __typename;
+        impl ::cynic::schema::Field for __typename {
+            type Type = super::super::String;
+            const NAME: &'static str = "__typename";
+        }
+        impl ::cynic::schema::HasField<__typename> for super::super::City {
+            type Type = super::super::String;
+        }
     }
     pub mod CityWhereInput {
         pub struct id;
@@ -988,6 +996,14 @@ pub mod __fields {
         impl ::cynic::schema::HasField<updatedAt> for super::super::Commitment {
             type Type = super::super::DateTime;
         }
+        pub struct __typename;
+        impl ::cynic::schema::Field for __typename {
+            type Type = super::super::String;
+            const NAME: &'static str = "__typename";
+        }
+        impl ::cynic::schema::HasField<__typename> for super::super::Commitment {
+            type Type = super::super::String;
+        }
     }
     pub mod CommitmentWhereInput {
         pub struct id;
@@ -1684,6 +1700,14 @@ pub mod __fields {
         }
         impl ::cynic::schema::HasField<updatedAt> for super::super::Company {
             type Type = super::super::DateTime;
+        }
+        pub struct __typename;
+        impl ::cynic::schema::Field for __typename {
+            type Type = super::super::String;
+            const NAME: &'static str = "__typename";
+        }
+        impl ::cynic::schema::HasField<__typename> for super::super::Company {
+            type Type = super::super::String;
         }
     }
     pub mod CompanyWhereInput {
@@ -2807,6 +2831,14 @@ pub mod __fields {
         }
         impl ::cynic::schema::HasField<updatedAt> for super::super::Country {
             type Type = super::super::DateTime;
+        }
+        pub struct __typename;
+        impl ::cynic::schema::Field for __typename {
+            type Type = super::super::String;
+            const NAME: &'static str = "__typename";
+        }
+        impl ::cynic::schema::HasField<__typename> for super::super::Country {
+            type Type = super::super::String;
         }
     }
     pub mod CountryWhereInput {
@@ -3958,6 +3990,14 @@ pub mod __fields {
         }
         impl ::cynic::schema::HasField<updatedAt> for super::super::Job {
             type Type = super::super::DateTime;
+        }
+        pub struct __typename;
+        impl ::cynic::schema::Field for __typename {
+            type Type = super::super::String;
+            const NAME: &'static str = "__typename";
+        }
+        impl ::cynic::schema::HasField<__typename> for super::super::Job {
+            type Type = super::super::String;
         }
     }
     pub mod JobInput {
@@ -5324,6 +5364,14 @@ pub mod __fields {
         impl ::cynic::schema::HasField<r#type> for super::super::Location {
             type Type = super::super::String;
         }
+        pub struct __typename;
+        impl ::cynic::schema::Field for __typename {
+            type Type = super::super::String;
+            const NAME: &'static str = "__typename";
+        }
+        impl ::cynic::schema::HasField<__typename> for super::super::Location {
+            type Type = super::super::String;
+        }
     }
     pub mod LocationInput {
         pub struct slug;
@@ -5411,6 +5459,14 @@ pub mod __fields {
                 type ArgumentType = super::super::super::String;
                 const NAME: &'static str = "adminSecret";
             }
+        }
+        pub struct __typename;
+        impl ::cynic::schema::Field for __typename {
+            type Type = super::super::String;
+            const NAME: &'static str = "__typename";
+        }
+        impl ::cynic::schema::HasField<__typename> for super::super::Mutation {
+            type Type = super::super::String;
         }
     }
     pub mod PostJobInput {
@@ -5600,6 +5656,14 @@ pub mod __fields {
         impl ::cynic::schema::HasField<companies> for super::super::Query {
             type Type = Vec<super::super::Company>;
         }
+        pub struct __typename;
+        impl ::cynic::schema::Field for __typename {
+            type Type = super::super::String;
+            const NAME: &'static str = "__typename";
+        }
+        impl ::cynic::schema::HasField<__typename> for super::super::Query {
+            type Type = super::super::String;
+        }
     }
     pub mod Remote {
         pub struct id;
@@ -5694,6 +5758,14 @@ pub mod __fields {
         }
         impl ::cynic::schema::HasField<updatedAt> for super::super::Remote {
             type Type = super::super::DateTime;
+        }
+        pub struct __typename;
+        impl ::cynic::schema::Field for __typename {
+            type Type = super::super::String;
+            const NAME: &'static str = "__typename";
+        }
+        impl ::cynic::schema::HasField<__typename> for super::super::Remote {
+            type Type = super::super::String;
         }
     }
     pub mod RemoteWhereInput {
@@ -6500,6 +6572,14 @@ pub mod __fields {
         impl ::cynic::schema::HasField<updatedAt> for super::super::Tag {
             type Type = super::super::DateTime;
         }
+        pub struct __typename;
+        impl ::cynic::schema::Field for __typename {
+            type Type = super::super::String;
+            const NAME: &'static str = "__typename";
+        }
+        impl ::cynic::schema::HasField<__typename> for super::super::Tag {
+            type Type = super::super::String;
+        }
     }
     pub mod TagWhereInput {
         pub struct id;
@@ -7158,6 +7238,14 @@ pub mod __fields {
         }
         impl ::cynic::schema::HasField<updatedAt> for super::super::User {
             type Type = super::super::DateTime;
+        }
+        pub struct __typename;
+        impl ::cynic::schema::Field for __typename {
+            type Type = super::super::String;
+            const NAME: &'static str = "__typename";
+        }
+        impl ::cynic::schema::HasField<__typename> for super::super::User {
+            type Type = super::super::String;
         }
     }
 }

--- a/cynic-codegen/tests/snapshots/use_schema__simple.graphql.snap
+++ b/cynic-codegen/tests/snapshots/use_schema__simple.graphql.snap
@@ -58,6 +58,14 @@ pub mod __fields {
         impl ::cynic::schema::HasField<optString> for super::super::Nested {
             type Type = Option<super::super::String>;
         }
+        pub struct __typename;
+        impl ::cynic::schema::Field for __typename {
+            type Type = super::super::String;
+            const NAME: &'static str = "__typename";
+        }
+        impl ::cynic::schema::HasField<__typename> for super::super::Nested {
+            type Type = super::super::String;
+        }
     }
     pub mod Query {
         pub struct testStruct;
@@ -75,6 +83,14 @@ pub mod __fields {
         }
         impl ::cynic::schema::HasField<myUnion> for super::super::Query {
             type Type = Option<super::super::MyUnionType>;
+        }
+        pub struct __typename;
+        impl ::cynic::schema::Field for __typename {
+            type Type = super::super::String;
+            const NAME: &'static str = "__typename";
+        }
+        impl ::cynic::schema::HasField<__typename> for super::super::Query {
+            type Type = super::super::String;
         }
     }
     pub mod TestStruct {
@@ -164,6 +180,14 @@ pub mod __fields {
         }
         impl ::cynic::schema::HasField<json> for super::super::TestStruct {
             type Type = Option<super::super::JSON>;
+        }
+        pub struct __typename;
+        impl ::cynic::schema::Field for __typename {
+            type Type = super::super::String;
+            const NAME: &'static str = "__typename";
+        }
+        impl ::cynic::schema::HasField<__typename> for super::super::TestStruct {
+            type Type = super::super::String;
         }
     }
 }

--- a/cynic-codegen/tests/snapshots/use_schema__starwars.schema.graphql.snap
+++ b/cynic-codegen/tests/snapshots/use_schema__starwars.schema.graphql.snap
@@ -447,6 +447,14 @@ pub mod __fields {
         impl ::cynic::schema::HasField<id> for super::super::Film {
             type Type = super::super::ID;
         }
+        pub struct __typename;
+        impl ::cynic::schema::Field for __typename {
+            type Type = super::super::String;
+            const NAME: &'static str = "__typename";
+        }
+        impl ::cynic::schema::HasField<__typename> for super::super::Film {
+            type Type = super::super::String;
+        }
     }
     pub mod FilmCharactersConnection {
         pub struct pageInfo;
@@ -481,6 +489,14 @@ pub mod __fields {
         impl ::cynic::schema::HasField<characters> for super::super::FilmCharactersConnection {
             type Type = Option<Vec<Option<super::super::Person>>>;
         }
+        pub struct __typename;
+        impl ::cynic::schema::Field for __typename {
+            type Type = super::super::String;
+            const NAME: &'static str = "__typename";
+        }
+        impl ::cynic::schema::HasField<__typename> for super::super::FilmCharactersConnection {
+            type Type = super::super::String;
+        }
     }
     pub mod FilmCharactersEdge {
         pub struct node;
@@ -497,6 +513,14 @@ pub mod __fields {
             const NAME: &'static str = "cursor";
         }
         impl ::cynic::schema::HasField<cursor> for super::super::FilmCharactersEdge {
+            type Type = super::super::String;
+        }
+        pub struct __typename;
+        impl ::cynic::schema::Field for __typename {
+            type Type = super::super::String;
+            const NAME: &'static str = "__typename";
+        }
+        impl ::cynic::schema::HasField<__typename> for super::super::FilmCharactersEdge {
             type Type = super::super::String;
         }
     }
@@ -533,6 +557,14 @@ pub mod __fields {
         impl ::cynic::schema::HasField<planets> for super::super::FilmPlanetsConnection {
             type Type = Option<Vec<Option<super::super::Planet>>>;
         }
+        pub struct __typename;
+        impl ::cynic::schema::Field for __typename {
+            type Type = super::super::String;
+            const NAME: &'static str = "__typename";
+        }
+        impl ::cynic::schema::HasField<__typename> for super::super::FilmPlanetsConnection {
+            type Type = super::super::String;
+        }
     }
     pub mod FilmPlanetsEdge {
         pub struct node;
@@ -549,6 +581,14 @@ pub mod __fields {
             const NAME: &'static str = "cursor";
         }
         impl ::cynic::schema::HasField<cursor> for super::super::FilmPlanetsEdge {
+            type Type = super::super::String;
+        }
+        pub struct __typename;
+        impl ::cynic::schema::Field for __typename {
+            type Type = super::super::String;
+            const NAME: &'static str = "__typename";
+        }
+        impl ::cynic::schema::HasField<__typename> for super::super::FilmPlanetsEdge {
             type Type = super::super::String;
         }
     }
@@ -585,6 +625,14 @@ pub mod __fields {
         impl ::cynic::schema::HasField<species> for super::super::FilmSpeciesConnection {
             type Type = Option<Vec<Option<super::super::Species>>>;
         }
+        pub struct __typename;
+        impl ::cynic::schema::Field for __typename {
+            type Type = super::super::String;
+            const NAME: &'static str = "__typename";
+        }
+        impl ::cynic::schema::HasField<__typename> for super::super::FilmSpeciesConnection {
+            type Type = super::super::String;
+        }
     }
     pub mod FilmSpeciesEdge {
         pub struct node;
@@ -601,6 +649,14 @@ pub mod __fields {
             const NAME: &'static str = "cursor";
         }
         impl ::cynic::schema::HasField<cursor> for super::super::FilmSpeciesEdge {
+            type Type = super::super::String;
+        }
+        pub struct __typename;
+        impl ::cynic::schema::Field for __typename {
+            type Type = super::super::String;
+            const NAME: &'static str = "__typename";
+        }
+        impl ::cynic::schema::HasField<__typename> for super::super::FilmSpeciesEdge {
             type Type = super::super::String;
         }
     }
@@ -637,6 +693,14 @@ pub mod __fields {
         impl ::cynic::schema::HasField<starships> for super::super::FilmStarshipsConnection {
             type Type = Option<Vec<Option<super::super::Starship>>>;
         }
+        pub struct __typename;
+        impl ::cynic::schema::Field for __typename {
+            type Type = super::super::String;
+            const NAME: &'static str = "__typename";
+        }
+        impl ::cynic::schema::HasField<__typename> for super::super::FilmStarshipsConnection {
+            type Type = super::super::String;
+        }
     }
     pub mod FilmStarshipsEdge {
         pub struct node;
@@ -653,6 +717,14 @@ pub mod __fields {
             const NAME: &'static str = "cursor";
         }
         impl ::cynic::schema::HasField<cursor> for super::super::FilmStarshipsEdge {
+            type Type = super::super::String;
+        }
+        pub struct __typename;
+        impl ::cynic::schema::Field for __typename {
+            type Type = super::super::String;
+            const NAME: &'static str = "__typename";
+        }
+        impl ::cynic::schema::HasField<__typename> for super::super::FilmStarshipsEdge {
             type Type = super::super::String;
         }
     }
@@ -689,6 +761,14 @@ pub mod __fields {
         impl ::cynic::schema::HasField<vehicles> for super::super::FilmVehiclesConnection {
             type Type = Option<Vec<Option<super::super::Vehicle>>>;
         }
+        pub struct __typename;
+        impl ::cynic::schema::Field for __typename {
+            type Type = super::super::String;
+            const NAME: &'static str = "__typename";
+        }
+        impl ::cynic::schema::HasField<__typename> for super::super::FilmVehiclesConnection {
+            type Type = super::super::String;
+        }
     }
     pub mod FilmVehiclesEdge {
         pub struct node;
@@ -705,6 +785,14 @@ pub mod __fields {
             const NAME: &'static str = "cursor";
         }
         impl ::cynic::schema::HasField<cursor> for super::super::FilmVehiclesEdge {
+            type Type = super::super::String;
+        }
+        pub struct __typename;
+        impl ::cynic::schema::Field for __typename {
+            type Type = super::super::String;
+            const NAME: &'static str = "__typename";
+        }
+        impl ::cynic::schema::HasField<__typename> for super::super::FilmVehiclesEdge {
             type Type = super::super::String;
         }
     }
@@ -741,6 +829,14 @@ pub mod __fields {
         impl ::cynic::schema::HasField<films> for super::super::FilmsConnection {
             type Type = Option<Vec<Option<super::super::Film>>>;
         }
+        pub struct __typename;
+        impl ::cynic::schema::Field for __typename {
+            type Type = super::super::String;
+            const NAME: &'static str = "__typename";
+        }
+        impl ::cynic::schema::HasField<__typename> for super::super::FilmsConnection {
+            type Type = super::super::String;
+        }
     }
     pub mod FilmsEdge {
         pub struct node;
@@ -759,6 +855,14 @@ pub mod __fields {
         impl ::cynic::schema::HasField<cursor> for super::super::FilmsEdge {
             type Type = super::super::String;
         }
+        pub struct __typename;
+        impl ::cynic::schema::Field for __typename {
+            type Type = super::super::String;
+            const NAME: &'static str = "__typename";
+        }
+        impl ::cynic::schema::HasField<__typename> for super::super::FilmsEdge {
+            type Type = super::super::String;
+        }
     }
     pub mod Node {
         pub struct id;
@@ -768,6 +872,14 @@ pub mod __fields {
         }
         impl ::cynic::schema::HasField<id> for super::super::Node {
             type Type = super::super::ID;
+        }
+        pub struct __typename;
+        impl ::cynic::schema::Field for __typename {
+            type Type = super::super::String;
+            const NAME: &'static str = "__typename";
+        }
+        impl ::cynic::schema::HasField<__typename> for super::super::Node {
+            type Type = super::super::String;
         }
     }
     pub mod PageInfo {
@@ -803,6 +915,14 @@ pub mod __fields {
         impl ::cynic::schema::HasField<endCursor> for super::super::PageInfo {
             type Type = Option<super::super::String>;
         }
+        pub struct __typename;
+        impl ::cynic::schema::Field for __typename {
+            type Type = super::super::String;
+            const NAME: &'static str = "__typename";
+        }
+        impl ::cynic::schema::HasField<__typename> for super::super::PageInfo {
+            type Type = super::super::String;
+        }
     }
     pub mod PeopleConnection {
         pub struct pageInfo;
@@ -837,6 +957,14 @@ pub mod __fields {
         impl ::cynic::schema::HasField<people> for super::super::PeopleConnection {
             type Type = Option<Vec<Option<super::super::Person>>>;
         }
+        pub struct __typename;
+        impl ::cynic::schema::Field for __typename {
+            type Type = super::super::String;
+            const NAME: &'static str = "__typename";
+        }
+        impl ::cynic::schema::HasField<__typename> for super::super::PeopleConnection {
+            type Type = super::super::String;
+        }
     }
     pub mod PeopleEdge {
         pub struct node;
@@ -853,6 +981,14 @@ pub mod __fields {
             const NAME: &'static str = "cursor";
         }
         impl ::cynic::schema::HasField<cursor> for super::super::PeopleEdge {
+            type Type = super::super::String;
+        }
+        pub struct __typename;
+        impl ::cynic::schema::Field for __typename {
+            type Type = super::super::String;
+            const NAME: &'static str = "__typename";
+        }
+        impl ::cynic::schema::HasField<__typename> for super::super::PeopleEdge {
             type Type = super::super::String;
         }
     }
@@ -1051,6 +1187,14 @@ pub mod __fields {
         impl ::cynic::schema::HasField<id> for super::super::Person {
             type Type = super::super::ID;
         }
+        pub struct __typename;
+        impl ::cynic::schema::Field for __typename {
+            type Type = super::super::String;
+            const NAME: &'static str = "__typename";
+        }
+        impl ::cynic::schema::HasField<__typename> for super::super::Person {
+            type Type = super::super::String;
+        }
     }
     pub mod PersonFilmsConnection {
         pub struct pageInfo;
@@ -1085,6 +1229,14 @@ pub mod __fields {
         impl ::cynic::schema::HasField<films> for super::super::PersonFilmsConnection {
             type Type = Option<Vec<Option<super::super::Film>>>;
         }
+        pub struct __typename;
+        impl ::cynic::schema::Field for __typename {
+            type Type = super::super::String;
+            const NAME: &'static str = "__typename";
+        }
+        impl ::cynic::schema::HasField<__typename> for super::super::PersonFilmsConnection {
+            type Type = super::super::String;
+        }
     }
     pub mod PersonFilmsEdge {
         pub struct node;
@@ -1101,6 +1253,14 @@ pub mod __fields {
             const NAME: &'static str = "cursor";
         }
         impl ::cynic::schema::HasField<cursor> for super::super::PersonFilmsEdge {
+            type Type = super::super::String;
+        }
+        pub struct __typename;
+        impl ::cynic::schema::Field for __typename {
+            type Type = super::super::String;
+            const NAME: &'static str = "__typename";
+        }
+        impl ::cynic::schema::HasField<__typename> for super::super::PersonFilmsEdge {
             type Type = super::super::String;
         }
     }
@@ -1137,6 +1297,14 @@ pub mod __fields {
         impl ::cynic::schema::HasField<starships> for super::super::PersonStarshipsConnection {
             type Type = Option<Vec<Option<super::super::Starship>>>;
         }
+        pub struct __typename;
+        impl ::cynic::schema::Field for __typename {
+            type Type = super::super::String;
+            const NAME: &'static str = "__typename";
+        }
+        impl ::cynic::schema::HasField<__typename> for super::super::PersonStarshipsConnection {
+            type Type = super::super::String;
+        }
     }
     pub mod PersonStarshipsEdge {
         pub struct node;
@@ -1153,6 +1321,14 @@ pub mod __fields {
             const NAME: &'static str = "cursor";
         }
         impl ::cynic::schema::HasField<cursor> for super::super::PersonStarshipsEdge {
+            type Type = super::super::String;
+        }
+        pub struct __typename;
+        impl ::cynic::schema::Field for __typename {
+            type Type = super::super::String;
+            const NAME: &'static str = "__typename";
+        }
+        impl ::cynic::schema::HasField<__typename> for super::super::PersonStarshipsEdge {
             type Type = super::super::String;
         }
     }
@@ -1189,6 +1365,14 @@ pub mod __fields {
         impl ::cynic::schema::HasField<vehicles> for super::super::PersonVehiclesConnection {
             type Type = Option<Vec<Option<super::super::Vehicle>>>;
         }
+        pub struct __typename;
+        impl ::cynic::schema::Field for __typename {
+            type Type = super::super::String;
+            const NAME: &'static str = "__typename";
+        }
+        impl ::cynic::schema::HasField<__typename> for super::super::PersonVehiclesConnection {
+            type Type = super::super::String;
+        }
     }
     pub mod PersonVehiclesEdge {
         pub struct node;
@@ -1205,6 +1389,14 @@ pub mod __fields {
             const NAME: &'static str = "cursor";
         }
         impl ::cynic::schema::HasField<cursor> for super::super::PersonVehiclesEdge {
+            type Type = super::super::String;
+        }
+        pub struct __typename;
+        impl ::cynic::schema::Field for __typename {
+            type Type = super::super::String;
+            const NAME: &'static str = "__typename";
+        }
+        impl ::cynic::schema::HasField<__typename> for super::super::PersonVehiclesEdge {
             type Type = super::super::String;
         }
     }
@@ -1365,6 +1557,14 @@ pub mod __fields {
         impl ::cynic::schema::HasField<id> for super::super::Planet {
             type Type = super::super::ID;
         }
+        pub struct __typename;
+        impl ::cynic::schema::Field for __typename {
+            type Type = super::super::String;
+            const NAME: &'static str = "__typename";
+        }
+        impl ::cynic::schema::HasField<__typename> for super::super::Planet {
+            type Type = super::super::String;
+        }
     }
     pub mod PlanetFilmsConnection {
         pub struct pageInfo;
@@ -1399,6 +1599,14 @@ pub mod __fields {
         impl ::cynic::schema::HasField<films> for super::super::PlanetFilmsConnection {
             type Type = Option<Vec<Option<super::super::Film>>>;
         }
+        pub struct __typename;
+        impl ::cynic::schema::Field for __typename {
+            type Type = super::super::String;
+            const NAME: &'static str = "__typename";
+        }
+        impl ::cynic::schema::HasField<__typename> for super::super::PlanetFilmsConnection {
+            type Type = super::super::String;
+        }
     }
     pub mod PlanetFilmsEdge {
         pub struct node;
@@ -1415,6 +1623,14 @@ pub mod __fields {
             const NAME: &'static str = "cursor";
         }
         impl ::cynic::schema::HasField<cursor> for super::super::PlanetFilmsEdge {
+            type Type = super::super::String;
+        }
+        pub struct __typename;
+        impl ::cynic::schema::Field for __typename {
+            type Type = super::super::String;
+            const NAME: &'static str = "__typename";
+        }
+        impl ::cynic::schema::HasField<__typename> for super::super::PlanetFilmsEdge {
             type Type = super::super::String;
         }
     }
@@ -1451,6 +1667,14 @@ pub mod __fields {
         impl ::cynic::schema::HasField<residents> for super::super::PlanetResidentsConnection {
             type Type = Option<Vec<Option<super::super::Person>>>;
         }
+        pub struct __typename;
+        impl ::cynic::schema::Field for __typename {
+            type Type = super::super::String;
+            const NAME: &'static str = "__typename";
+        }
+        impl ::cynic::schema::HasField<__typename> for super::super::PlanetResidentsConnection {
+            type Type = super::super::String;
+        }
     }
     pub mod PlanetResidentsEdge {
         pub struct node;
@@ -1467,6 +1691,14 @@ pub mod __fields {
             const NAME: &'static str = "cursor";
         }
         impl ::cynic::schema::HasField<cursor> for super::super::PlanetResidentsEdge {
+            type Type = super::super::String;
+        }
+        pub struct __typename;
+        impl ::cynic::schema::Field for __typename {
+            type Type = super::super::String;
+            const NAME: &'static str = "__typename";
+        }
+        impl ::cynic::schema::HasField<__typename> for super::super::PlanetResidentsEdge {
             type Type = super::super::String;
         }
     }
@@ -1503,6 +1735,14 @@ pub mod __fields {
         impl ::cynic::schema::HasField<planets> for super::super::PlanetsConnection {
             type Type = Option<Vec<Option<super::super::Planet>>>;
         }
+        pub struct __typename;
+        impl ::cynic::schema::Field for __typename {
+            type Type = super::super::String;
+            const NAME: &'static str = "__typename";
+        }
+        impl ::cynic::schema::HasField<__typename> for super::super::PlanetsConnection {
+            type Type = super::super::String;
+        }
     }
     pub mod PlanetsEdge {
         pub struct node;
@@ -1519,6 +1759,14 @@ pub mod __fields {
             const NAME: &'static str = "cursor";
         }
         impl ::cynic::schema::HasField<cursor> for super::super::PlanetsEdge {
+            type Type = super::super::String;
+        }
+        pub struct __typename;
+        impl ::cynic::schema::Field for __typename {
+            type Type = super::super::String;
+            const NAME: &'static str = "__typename";
+        }
+        impl ::cynic::schema::HasField<__typename> for super::super::PlanetsEdge {
             type Type = super::super::String;
         }
     }
@@ -1838,6 +2086,14 @@ pub mod __fields {
                 const NAME: &'static str = "id";
             }
         }
+        pub struct __typename;
+        impl ::cynic::schema::Field for __typename {
+            type Type = super::super::String;
+            const NAME: &'static str = "__typename";
+        }
+        impl ::cynic::schema::HasField<__typename> for super::super::Root {
+            type Type = super::super::String;
+        }
     }
     pub mod Species {
         pub struct name;
@@ -2004,6 +2260,14 @@ pub mod __fields {
         impl ::cynic::schema::HasField<id> for super::super::Species {
             type Type = super::super::ID;
         }
+        pub struct __typename;
+        impl ::cynic::schema::Field for __typename {
+            type Type = super::super::String;
+            const NAME: &'static str = "__typename";
+        }
+        impl ::cynic::schema::HasField<__typename> for super::super::Species {
+            type Type = super::super::String;
+        }
     }
     pub mod SpeciesConnection {
         pub struct pageInfo;
@@ -2038,6 +2302,14 @@ pub mod __fields {
         impl ::cynic::schema::HasField<species> for super::super::SpeciesConnection {
             type Type = Option<Vec<Option<super::super::Species>>>;
         }
+        pub struct __typename;
+        impl ::cynic::schema::Field for __typename {
+            type Type = super::super::String;
+            const NAME: &'static str = "__typename";
+        }
+        impl ::cynic::schema::HasField<__typename> for super::super::SpeciesConnection {
+            type Type = super::super::String;
+        }
     }
     pub mod SpeciesEdge {
         pub struct node;
@@ -2054,6 +2326,14 @@ pub mod __fields {
             const NAME: &'static str = "cursor";
         }
         impl ::cynic::schema::HasField<cursor> for super::super::SpeciesEdge {
+            type Type = super::super::String;
+        }
+        pub struct __typename;
+        impl ::cynic::schema::Field for __typename {
+            type Type = super::super::String;
+            const NAME: &'static str = "__typename";
+        }
+        impl ::cynic::schema::HasField<__typename> for super::super::SpeciesEdge {
             type Type = super::super::String;
         }
     }
@@ -2090,6 +2370,14 @@ pub mod __fields {
         impl ::cynic::schema::HasField<films> for super::super::SpeciesFilmsConnection {
             type Type = Option<Vec<Option<super::super::Film>>>;
         }
+        pub struct __typename;
+        impl ::cynic::schema::Field for __typename {
+            type Type = super::super::String;
+            const NAME: &'static str = "__typename";
+        }
+        impl ::cynic::schema::HasField<__typename> for super::super::SpeciesFilmsConnection {
+            type Type = super::super::String;
+        }
     }
     pub mod SpeciesFilmsEdge {
         pub struct node;
@@ -2106,6 +2394,14 @@ pub mod __fields {
             const NAME: &'static str = "cursor";
         }
         impl ::cynic::schema::HasField<cursor> for super::super::SpeciesFilmsEdge {
+            type Type = super::super::String;
+        }
+        pub struct __typename;
+        impl ::cynic::schema::Field for __typename {
+            type Type = super::super::String;
+            const NAME: &'static str = "__typename";
+        }
+        impl ::cynic::schema::HasField<__typename> for super::super::SpeciesFilmsEdge {
             type Type = super::super::String;
         }
     }
@@ -2142,6 +2438,14 @@ pub mod __fields {
         impl ::cynic::schema::HasField<people> for super::super::SpeciesPeopleConnection {
             type Type = Option<Vec<Option<super::super::Person>>>;
         }
+        pub struct __typename;
+        impl ::cynic::schema::Field for __typename {
+            type Type = super::super::String;
+            const NAME: &'static str = "__typename";
+        }
+        impl ::cynic::schema::HasField<__typename> for super::super::SpeciesPeopleConnection {
+            type Type = super::super::String;
+        }
     }
     pub mod SpeciesPeopleEdge {
         pub struct node;
@@ -2158,6 +2462,14 @@ pub mod __fields {
             const NAME: &'static str = "cursor";
         }
         impl ::cynic::schema::HasField<cursor> for super::super::SpeciesPeopleEdge {
+            type Type = super::super::String;
+        }
+        pub struct __typename;
+        impl ::cynic::schema::Field for __typename {
+            type Type = super::super::String;
+            const NAME: &'static str = "__typename";
+        }
+        impl ::cynic::schema::HasField<__typename> for super::super::SpeciesPeopleEdge {
             type Type = super::super::String;
         }
     }
@@ -2350,6 +2662,14 @@ pub mod __fields {
         impl ::cynic::schema::HasField<id> for super::super::Starship {
             type Type = super::super::ID;
         }
+        pub struct __typename;
+        impl ::cynic::schema::Field for __typename {
+            type Type = super::super::String;
+            const NAME: &'static str = "__typename";
+        }
+        impl ::cynic::schema::HasField<__typename> for super::super::Starship {
+            type Type = super::super::String;
+        }
     }
     pub mod StarshipFilmsConnection {
         pub struct pageInfo;
@@ -2384,6 +2704,14 @@ pub mod __fields {
         impl ::cynic::schema::HasField<films> for super::super::StarshipFilmsConnection {
             type Type = Option<Vec<Option<super::super::Film>>>;
         }
+        pub struct __typename;
+        impl ::cynic::schema::Field for __typename {
+            type Type = super::super::String;
+            const NAME: &'static str = "__typename";
+        }
+        impl ::cynic::schema::HasField<__typename> for super::super::StarshipFilmsConnection {
+            type Type = super::super::String;
+        }
     }
     pub mod StarshipFilmsEdge {
         pub struct node;
@@ -2400,6 +2728,14 @@ pub mod __fields {
             const NAME: &'static str = "cursor";
         }
         impl ::cynic::schema::HasField<cursor> for super::super::StarshipFilmsEdge {
+            type Type = super::super::String;
+        }
+        pub struct __typename;
+        impl ::cynic::schema::Field for __typename {
+            type Type = super::super::String;
+            const NAME: &'static str = "__typename";
+        }
+        impl ::cynic::schema::HasField<__typename> for super::super::StarshipFilmsEdge {
             type Type = super::super::String;
         }
     }
@@ -2436,6 +2772,14 @@ pub mod __fields {
         impl ::cynic::schema::HasField<pilots> for super::super::StarshipPilotsConnection {
             type Type = Option<Vec<Option<super::super::Person>>>;
         }
+        pub struct __typename;
+        impl ::cynic::schema::Field for __typename {
+            type Type = super::super::String;
+            const NAME: &'static str = "__typename";
+        }
+        impl ::cynic::schema::HasField<__typename> for super::super::StarshipPilotsConnection {
+            type Type = super::super::String;
+        }
     }
     pub mod StarshipPilotsEdge {
         pub struct node;
@@ -2452,6 +2796,14 @@ pub mod __fields {
             const NAME: &'static str = "cursor";
         }
         impl ::cynic::schema::HasField<cursor> for super::super::StarshipPilotsEdge {
+            type Type = super::super::String;
+        }
+        pub struct __typename;
+        impl ::cynic::schema::Field for __typename {
+            type Type = super::super::String;
+            const NAME: &'static str = "__typename";
+        }
+        impl ::cynic::schema::HasField<__typename> for super::super::StarshipPilotsEdge {
             type Type = super::super::String;
         }
     }
@@ -2488,6 +2840,14 @@ pub mod __fields {
         impl ::cynic::schema::HasField<starships> for super::super::StarshipsConnection {
             type Type = Option<Vec<Option<super::super::Starship>>>;
         }
+        pub struct __typename;
+        impl ::cynic::schema::Field for __typename {
+            type Type = super::super::String;
+            const NAME: &'static str = "__typename";
+        }
+        impl ::cynic::schema::HasField<__typename> for super::super::StarshipsConnection {
+            type Type = super::super::String;
+        }
     }
     pub mod StarshipsEdge {
         pub struct node;
@@ -2504,6 +2864,14 @@ pub mod __fields {
             const NAME: &'static str = "cursor";
         }
         impl ::cynic::schema::HasField<cursor> for super::super::StarshipsEdge {
+            type Type = super::super::String;
+        }
+        pub struct __typename;
+        impl ::cynic::schema::Field for __typename {
+            type Type = super::super::String;
+            const NAME: &'static str = "__typename";
+        }
+        impl ::cynic::schema::HasField<__typename> for super::super::StarshipsEdge {
             type Type = super::super::String;
         }
     }
@@ -2680,6 +3048,14 @@ pub mod __fields {
         impl ::cynic::schema::HasField<id> for super::super::Vehicle {
             type Type = super::super::ID;
         }
+        pub struct __typename;
+        impl ::cynic::schema::Field for __typename {
+            type Type = super::super::String;
+            const NAME: &'static str = "__typename";
+        }
+        impl ::cynic::schema::HasField<__typename> for super::super::Vehicle {
+            type Type = super::super::String;
+        }
     }
     pub mod VehicleFilmsConnection {
         pub struct pageInfo;
@@ -2714,6 +3090,14 @@ pub mod __fields {
         impl ::cynic::schema::HasField<films> for super::super::VehicleFilmsConnection {
             type Type = Option<Vec<Option<super::super::Film>>>;
         }
+        pub struct __typename;
+        impl ::cynic::schema::Field for __typename {
+            type Type = super::super::String;
+            const NAME: &'static str = "__typename";
+        }
+        impl ::cynic::schema::HasField<__typename> for super::super::VehicleFilmsConnection {
+            type Type = super::super::String;
+        }
     }
     pub mod VehicleFilmsEdge {
         pub struct node;
@@ -2730,6 +3114,14 @@ pub mod __fields {
             const NAME: &'static str = "cursor";
         }
         impl ::cynic::schema::HasField<cursor> for super::super::VehicleFilmsEdge {
+            type Type = super::super::String;
+        }
+        pub struct __typename;
+        impl ::cynic::schema::Field for __typename {
+            type Type = super::super::String;
+            const NAME: &'static str = "__typename";
+        }
+        impl ::cynic::schema::HasField<__typename> for super::super::VehicleFilmsEdge {
             type Type = super::super::String;
         }
     }
@@ -2766,6 +3158,14 @@ pub mod __fields {
         impl ::cynic::schema::HasField<pilots> for super::super::VehiclePilotsConnection {
             type Type = Option<Vec<Option<super::super::Person>>>;
         }
+        pub struct __typename;
+        impl ::cynic::schema::Field for __typename {
+            type Type = super::super::String;
+            const NAME: &'static str = "__typename";
+        }
+        impl ::cynic::schema::HasField<__typename> for super::super::VehiclePilotsConnection {
+            type Type = super::super::String;
+        }
     }
     pub mod VehiclePilotsEdge {
         pub struct node;
@@ -2782,6 +3182,14 @@ pub mod __fields {
             const NAME: &'static str = "cursor";
         }
         impl ::cynic::schema::HasField<cursor> for super::super::VehiclePilotsEdge {
+            type Type = super::super::String;
+        }
+        pub struct __typename;
+        impl ::cynic::schema::Field for __typename {
+            type Type = super::super::String;
+            const NAME: &'static str = "__typename";
+        }
+        impl ::cynic::schema::HasField<__typename> for super::super::VehiclePilotsEdge {
             type Type = super::super::String;
         }
     }
@@ -2818,6 +3226,14 @@ pub mod __fields {
         impl ::cynic::schema::HasField<vehicles> for super::super::VehiclesConnection {
             type Type = Option<Vec<Option<super::super::Vehicle>>>;
         }
+        pub struct __typename;
+        impl ::cynic::schema::Field for __typename {
+            type Type = super::super::String;
+            const NAME: &'static str = "__typename";
+        }
+        impl ::cynic::schema::HasField<__typename> for super::super::VehiclesConnection {
+            type Type = super::super::String;
+        }
     }
     pub mod VehiclesEdge {
         pub struct node;
@@ -2834,6 +3250,14 @@ pub mod __fields {
             const NAME: &'static str = "cursor";
         }
         impl ::cynic::schema::HasField<cursor> for super::super::VehiclesEdge {
+            type Type = super::super::String;
+        }
+        pub struct __typename;
+        impl ::cynic::schema::Field for __typename {
+            type Type = super::super::String;
+            const NAME: &'static str = "__typename";
+        }
+        impl ::cynic::schema::HasField<__typename> for super::super::VehiclesEdge {
             type Type = super::super::String;
         }
     }

--- a/cynic-codegen/tests/snapshots/use_schema__test_cases.graphql.snap
+++ b/cynic-codegen/tests/snapshots/use_schema__test_cases.graphql.snap
@@ -41,6 +41,14 @@ pub mod __fields {
         impl ::cynic::schema::HasField<name> for super::super::Bar {
             type Type = Option<super::super::String>;
         }
+        pub struct __typename;
+        impl ::cynic::schema::Field for __typename {
+            type Type = super::super::String;
+            const NAME: &'static str = "__typename";
+        }
+        impl ::cynic::schema::HasField<__typename> for super::super::Bar {
+            type Type = super::super::String;
+        }
     }
     pub mod Foo {
         pub struct _Underscore;
@@ -132,6 +140,14 @@ pub mod __fields {
                 type ArgumentType = Option<super::super::super::RecursiveInputParent>;
                 const NAME: &'static str = "recursive2";
             }
+        }
+        pub struct __typename;
+        impl ::cynic::schema::Field for __typename {
+            type Type = super::super::String;
+            const NAME: &'static str = "__typename";
+        }
+        impl ::cynic::schema::HasField<__typename> for super::super::Foo {
+            type Type = super::super::String;
         }
     }
     pub mod RecursiveInputChild {

--- a/cynic-querygen/Cargo.toml
+++ b/cynic-querygen/Cargo.toml
@@ -13,10 +13,10 @@ description = "QueryFragment generation for cynic, a GraphQL query builder & dat
 [dependencies]
 Inflector = { version = "0.11.4", default-features = false }
 graphql-parser = "0.4"
+once_cell = "1.9"
 rust_decimal = "1.22"
 thiserror = "1.0.30"
 uuid = { version = "0.8", features = ["v4"] }
-once_cell = "1.9"
 
 [dev-dependencies]
 assert_matches = "1.4"

--- a/cynic-querygen/src/query_parsing/inputs.rs
+++ b/cynic-querygen/src/query_parsing/inputs.rs
@@ -64,7 +64,7 @@ pub fn extract_whole_input_object_tree<'schema>(
 
     let rv = extract_whole_input_object(input_object, &mut object_map, &mut seen_objects)?;
 
-    input_objects.extend(object_map.into_iter().map(|(_, obj)| obj));
+    input_objects.extend(object_map.into_values());
 
     Ok(rv)
 }

--- a/cynic-querygen/src/query_parsing/snapshots/cynic_querygen__query_parsing__normalisation__tests__check_output_makes_sense.snap
+++ b/cynic-querygen/src/query_parsing/snapshots/cynic_querygen__query_parsing__normalisation__tests__check_output_makes_sense.snap
@@ -1,6 +1,5 @@
 ---
 source: cynic-querygen/src/query_parsing/normalisation.rs
-assertion_line: 663
 expression: normalised
 ---
 NormalisedDocument {
@@ -300,6 +299,17 @@ NormalisedDocument {
                                 NamedType(
                                     OutputTypeRef {
                                         type_name: "ID",
+                                    },
+                                ),
+                            ),
+                            arguments: [],
+                        },
+                        OutputField {
+                            name: "__typename",
+                            value_type: NonNullType(
+                                NamedType(
+                                    OutputTypeRef {
+                                        type_name: "String",
                                     },
                                 ),
                             ),
@@ -652,6 +662,17 @@ NormalisedDocument {
                             ),
                             arguments: [],
                         },
+                        OutputField {
+                            name: "__typename",
+                            value_type: NonNullType(
+                                NamedType(
+                                    OutputTypeRef {
+                                        type_name: "String",
+                                    },
+                                ),
+                            ),
+                            arguments: [],
+                        },
                     ],
                     implements_interfaces: [
                         InterfaceTypeRef {
@@ -722,6 +743,17 @@ NormalisedDocument {
                                 NamedType(
                                     OutputTypeRef {
                                         type_name: "Film",
+                                    },
+                                ),
+                            ),
+                            arguments: [],
+                        },
+                        OutputField {
+                            name: "__typename",
+                            value_type: NonNullType(
+                                NamedType(
+                                    OutputTypeRef {
+                                        type_name: "String",
                                     },
                                 ),
                             ),
@@ -1044,6 +1076,17 @@ NormalisedDocument {
                                                     NamedType(
                                                         OutputTypeRef {
                                                             type_name: "ID",
+                                                        },
+                                                    ),
+                                                ),
+                                                arguments: [],
+                                            },
+                                            OutputField {
+                                                name: "__typename",
+                                                value_type: NonNullType(
+                                                    NamedType(
+                                                        OutputTypeRef {
+                                                            type_name: "String",
                                                         },
                                                     ),
                                                 ),
@@ -1534,6 +1577,17 @@ NormalisedDocument {
                                 },
                             ],
                         },
+                        OutputField {
+                            name: "__typename",
+                            value_type: NonNullType(
+                                NamedType(
+                                    OutputTypeRef {
+                                        type_name: "String",
+                                    },
+                                ),
+                            ),
+                            arguments: [],
+                        },
                     ],
                     implements_interfaces: [],
                 },
@@ -1629,6 +1683,17 @@ NormalisedDocument {
                                                     NamedType(
                                                         OutputTypeRef {
                                                             type_name: "Film",
+                                                        },
+                                                    ),
+                                                ),
+                                                arguments: [],
+                                            },
+                                            OutputField {
+                                                name: "__typename",
+                                                value_type: NonNullType(
+                                                    NamedType(
+                                                        OutputTypeRef {
+                                                            type_name: "String",
                                                         },
                                                     ),
                                                 ),
@@ -1951,6 +2016,17 @@ NormalisedDocument {
                                                                         NamedType(
                                                                             OutputTypeRef {
                                                                                 type_name: "ID",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                    arguments: [],
+                                                                },
+                                                                OutputField {
+                                                                    name: "__typename",
+                                                                    value_type: NonNullType(
+                                                                        NamedType(
+                                                                            OutputTypeRef {
+                                                                                type_name: "String",
                                                                             },
                                                                         ),
                                                                     ),
@@ -2350,6 +2426,17 @@ NormalisedDocument {
                                                     NamedType(
                                                         OutputTypeRef {
                                                             type_name: "ID",
+                                                        },
+                                                    ),
+                                                ),
+                                                arguments: [],
+                                            },
+                                            OutputField {
+                                                name: "__typename",
+                                                value_type: NonNullType(
+                                                    NamedType(
+                                                        OutputTypeRef {
+                                                            type_name: "String",
                                                         },
                                                     ),
                                                 ),
@@ -2825,6 +2912,17 @@ NormalisedDocument {
                                     },
                                 ],
                             },
+                            OutputField {
+                                name: "__typename",
+                                value_type: NonNullType(
+                                    NamedType(
+                                        OutputTypeRef {
+                                            type_name: "String",
+                                        },
+                                    ),
+                                ),
+                                arguments: [],
+                            },
                         ],
                         implements_interfaces: [],
                     },
@@ -2920,6 +3018,17 @@ NormalisedDocument {
                                                         NamedType(
                                                             OutputTypeRef {
                                                                 type_name: "Film",
+                                                            },
+                                                        ),
+                                                    ),
+                                                    arguments: [],
+                                                },
+                                                OutputField {
+                                                    name: "__typename",
+                                                    value_type: NonNullType(
+                                                        NamedType(
+                                                            OutputTypeRef {
+                                                                type_name: "String",
                                                             },
                                                         ),
                                                     ),
@@ -3242,6 +3351,17 @@ NormalisedDocument {
                                                                             NamedType(
                                                                                 OutputTypeRef {
                                                                                     type_name: "ID",
+                                                                                },
+                                                                            ),
+                                                                        ),
+                                                                        arguments: [],
+                                                                    },
+                                                                    OutputField {
+                                                                        name: "__typename",
+                                                                        value_type: NonNullType(
+                                                                            NamedType(
+                                                                                OutputTypeRef {
+                                                                                    type_name: "String",
                                                                                 },
                                                                             ),
                                                                         ),
@@ -3641,6 +3761,17 @@ NormalisedDocument {
                                                         NamedType(
                                                             OutputTypeRef {
                                                                 type_name: "ID",
+                                                            },
+                                                        ),
+                                                    ),
+                                                    arguments: [],
+                                                },
+                                                OutputField {
+                                                    name: "__typename",
+                                                    value_type: NonNullType(
+                                                        NamedType(
+                                                            OutputTypeRef {
+                                                                type_name: "String",
                                                             },
                                                         ),
                                                     ),

--- a/cynic-querygen/src/query_parsing/variables.rs
+++ b/cynic-querygen/src/query_parsing/variables.rs
@@ -183,8 +183,8 @@ impl<'query, 'schema> VariableStructDetails<'query, 'schema> {
 
     pub fn variables_structs(self) -> Vec<output::VariablesStruct<'query, 'schema>> {
         self.selection_structs
-            .iter()
-            .map(|(_, arg_struct)| {
+            .values()
+            .map(|arg_struct| {
                 let name = self.namer.borrow_mut().name_subject(arg_struct);
                 output::VariablesStruct::new(
                     name,

--- a/cynic-querygen/src/schema/mod.rs
+++ b/cynic-querygen/src/schema/mod.rs
@@ -8,9 +8,9 @@ pub use parser::Document;
 pub use type_index::{GraphPath, TypeIndex};
 pub use type_refs::{InputTypeRef, InterfaceTypeRef, OutputTypeRef, TypeRef};
 
-use std::{convert::TryFrom, rc::Rc};
+use std::{convert::TryFrom, iter, rc::Rc};
 
-use crate::Error;
+use crate::{schema::parser::typename_field, Error};
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum Type<'schema> {
@@ -83,6 +83,7 @@ impl<'schema> Type<'schema> {
         type_index: &Rc<TypeIndex<'schema>>,
     ) -> Type<'schema> {
         use parser::TypeDefinition;
+        let typename_field = typename_field();
 
         match type_def {
             TypeDefinition::Scalar(scalar) => Type::Scalar(ScalarDetails { name: scalar.name }),
@@ -91,6 +92,7 @@ impl<'schema> Type<'schema> {
                 fields: obj
                     .fields
                     .iter()
+                    .chain(iter::once(&typename_field))
                     .map(|field| OutputField::from_parser(field, type_index))
                     .collect(),
                 implements_interfaces: obj
@@ -104,6 +106,7 @@ impl<'schema> Type<'schema> {
                 fields: iface
                     .fields
                     .iter()
+                    .chain(iter::once(&typename_field))
                     .map(|field| OutputField::from_parser(field, type_index))
                     .collect(),
             }),

--- a/cynic-querygen/src/schema/parser.rs
+++ b/cynic-querygen/src/schema/parser.rs
@@ -5,3 +5,14 @@ pub type Type<'a> = graphql_parser::schema::Type<'a, &'a str>;
 pub type Field<'a> = graphql_parser::schema::Field<'a, &'a str>;
 pub type TypeDefinition<'a> = graphql_parser::schema::TypeDefinition<'a, &'a str>;
 pub type InputValue<'a> = graphql_parser::schema::InputValue<'a, &'a str>;
+
+pub(super) fn typename_field<'a>() -> Field<'a> {
+    Field {
+        position: graphql_parser::Pos { line: 0, column: 0 },
+        description: None,
+        name: "__typename",
+        arguments: vec![],
+        field_type: Type::NonNullType(Box::new(Type::NamedType("String"))),
+        directives: vec![],
+    }
+}

--- a/cynic-querygen/tests/github-tests.rs
+++ b/cynic-querygen/tests/github-tests.rs
@@ -29,3 +29,4 @@ test_query!(
     "inline-fragment-with-arguments.graphql"
 );
 test_query!(field_on_interface, "field-on-interface.graphql");
+test_query!(queries_with_typename, "queries-with-typename.graphql");

--- a/cynic-querygen/tests/queries/github/queries-with-typename.graphql
+++ b/cynic-querygen/tests/queries/github/queries-with-typename.graphql
@@ -1,0 +1,28 @@
+query {
+  repository(owner: "obmarg", name: "cynic") {
+    issueOrPullRequest(number: 1) {
+      __typename
+      ... on Issue {
+        __typename
+        id
+        title
+        lastEditedAt
+      }
+      ... on PullRequest {
+        __typename
+        id
+        title
+      }
+    }
+    issues(first: 1) {
+      edges {
+        node {
+          __typename
+          author {
+            login
+          }
+        }
+      }
+    }
+  }
+}

--- a/cynic-querygen/tests/snapshots/github_tests__queries_with_typename.snap
+++ b/cynic-querygen/tests/snapshots/github_tests__queries_with_typename.snap
@@ -1,0 +1,82 @@
+---
+source: cynic-querygen/tests/github-tests.rs
+expression: "document_to_fragment_structs(query, schema,\n        &QueryGenOptions::default()).expect(\"QueryGen Failed\")"
+---
+#[cynic::schema_for_derives(
+    file = r#"schema.graphql"#,
+    module = "schema",
+)]
+mod queries {
+    use super::schema;
+
+    #[derive(cynic::QueryFragment, Debug)]
+    #[cynic(graphql_type = "Query")]
+    pub struct UnnamedQuery {
+        #[arguments(owner: "obmarg", name: "cynic")]
+        pub repository: Option<Repository>,
+    }
+
+    #[derive(cynic::QueryFragment, Debug)]
+    pub struct Repository {
+        #[arguments(number: 1)]
+        pub issue_or_pull_request: Option<IssueOrPullRequest>,
+        #[arguments(first: 1)]
+        pub issues: IssueConnection,
+    }
+
+    #[derive(cynic::QueryFragment, Debug)]
+    pub struct PullRequest {
+        pub __typename: String,
+        pub id: cynic::Id,
+        pub title: String,
+    }
+
+    #[derive(cynic::QueryFragment, Debug)]
+    pub struct IssueConnection {
+        pub edges: Option<Vec<Option<IssueEdge>>>,
+    }
+
+    #[derive(cynic::QueryFragment, Debug)]
+    pub struct IssueEdge {
+        pub node: Option<Issue>,
+    }
+
+    #[derive(cynic::QueryFragment, Debug)]
+    #[cynic(graphql_type = "Issue")]
+    pub struct Issue2 {
+        pub __typename: String,
+        pub id: cynic::Id,
+        pub title: String,
+        pub last_edited_at: Option<DateTime>,
+    }
+
+    #[derive(cynic::QueryFragment, Debug)]
+    pub struct Issue {
+        pub __typename: String,
+        pub author: Option<Actor>,
+    }
+
+    #[derive(cynic::QueryFragment, Debug)]
+    pub struct Actor {
+        pub login: String,
+    }
+
+    #[derive(cynic::InlineFragments, Debug)]
+    pub enum IssueOrPullRequest {
+        Issue2(Issue2),
+        PullRequest(PullRequest),
+        #[cynic(fallback)]
+        Unknown
+    }
+
+    #[derive(cynic::Scalar, Debug, Clone)]
+    pub struct DateTime(pub String);
+
+}
+
+#[allow(non_snake_case, non_camel_case_types)]
+mod schema {
+    cynic::use_schema!(r#"schema.graphql"#);
+}
+
+

--- a/tests/querygen-compile-run/build.rs
+++ b/tests/querygen-compile-run/build.rs
@@ -123,6 +123,11 @@ fn main() {
                 }
             )"#,
         ),
+        TestCase::query_norun(
+            &github_schema,
+            "../../cynic-querygen/tests/queries/github/queries-with-typename.graphql",
+            r#"queries::UnnamedQuery::build(())"#,
+        ),
         TestCase::mutation(
             &github_schema,
             "tests/queries/github/scalar-inside-input-object.graphql",
@@ -271,7 +276,7 @@ impl TestCase {
             schema_path: self.schema.path_for_generated_code.to_str().unwrap().into(),
             ..QueryGenOptions::default()
         };
-        let query_code = document_to_fragment_structs(&query, &schema, &options).unwrap();
+        let query_code = document_to_fragment_structs(query, schema, &options).unwrap();
 
         let test_filename = {
             let mut path = self.query_path.clone();

--- a/tests/querygen-compile-run/tests/queries/github/queries-with-typename.graphql
+++ b/tests/querygen-compile-run/tests/queries/github/queries-with-typename.graphql
@@ -1,0 +1,28 @@
+query {
+  repository(owner: "obmarg", name: "cynic") {
+    issueOrPullRequest(number: 1) {
+      __typename
+      ... on Issue {
+        __typename
+        id
+        title
+        lastEditedAt
+      }
+      ... on PullRequest {
+        __typename
+        id
+        title
+      }
+    }
+    issues(first: 1) {
+      edges {
+        node {
+          __typename
+          author {
+            login
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Every GQL object & interface has a `__typename` field that you can query
to get the name of the type.  Up till now cynic has only really
supported using this for its `InlineFragments` derive - the generator
would reject any queries that mentioned this field, as would the various
derive macros.

This commit updates the generator & macros to be aware that every type
has this field.

It also fixes a separate issue where the derive macros would strip
leading underscores from fields, which also affected `__typename`.