### PR TITLE
[Merged by Bors] - Don't use vars named key & map in QueryFragment Deserialize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ## Unreleased - xxxx-xx-xx
 
+### Bug Fixes
+
+- Fix an issue where you'd get extremely weird compiler errors if your
+  `QueryFragment` had fields named `key` or `map`.
+
 ## v2.2.3 - 2023-01-03
 
 ### Bug Fixes

--- a/cynic-codegen/src/fragment_derive/deserialize_impl.rs
+++ b/cynic-codegen/src/fragment_derive/deserialize_impl.rs
@@ -89,11 +89,11 @@ impl quote::ToTokens for StandardDeserializeImpl {
             let ty = &f.ty;
             if f.is_flattened {
                 quote! {
-                    #field_name = Some(map.next_value::<::cynic::__private::Flattened<#ty>>()?.into_inner());
+                    #field_name = Some(__map.next_value::<::cynic::__private::Flattened<#ty>>()?.into_inner());
                 }
             } else {
                 quote! {
-                    #field_name = Some(map.next_value()?);
+                    #field_name = Some(__map.next_value()?);
                 }
             }
         });
@@ -130,15 +130,15 @@ impl quote::ToTokens for StandardDeserializeImpl {
                             formatter.write_str(#expecting_str)
                         }
 
-                        fn visit_map<V>(self, mut map: V) -> Result<#target_struct, V::Error>
+                        fn visit_map<V>(self, mut __map: V) -> Result<#target_struct, V::Error>
                         where
                             V: ::cynic::serde::de::MapAccess<'de>,
                         {
                             #(
                                 let mut #field_names = None;
                             )*
-                            while let Some(key) = map.next_key()? {
-                                match key {
+                            while let Some(__key) = __map.next_key()? {
+                                match __key {
                                     #(
                                         Field::#field_variant_names => {
                                             if #field_names.is_some() {
@@ -148,7 +148,7 @@ impl quote::ToTokens for StandardDeserializeImpl {
                                         }
                                     )*
                                     Field::__Other => {
-                                        map.next_value::<::cynic::serde::de::IgnoredAny>()?;
+                                        __map.next_value::<::cynic::serde::de::IgnoredAny>()?;
                                     }
                                 }
                             }

--- a/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__argument_and_rename.snap
+++ b/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__argument_and_rename.snap
@@ -43,28 +43,28 @@ impl<'de> ::cynic::serde::Deserialize<'de> for MyQuery {
             fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
                 formatter.write_str("struct MyQuery")
             }
-            fn visit_map<V>(self, mut map: V) -> Result<MyQuery, V::Error>
+            fn visit_map<V>(self, mut __map: V) -> Result<MyQuery, V::Error>
             where
                 V: ::cynic::serde::de::MapAccess<'de>,
             {
                 let mut post = None;
                 let mut posts = None;
-                while let Some(key) = map.next_key()? {
-                    match key {
+                while let Some(__key) = __map.next_key()? {
+                    match __key {
                         Field::post => {
                             if post.is_some() {
                                 return Err(::cynic::serde::de::Error::duplicate_field("post"));
                             }
-                            post = Some(map.next_value()?);
+                            post = Some(__map.next_value()?);
                         }
                         Field::posts => {
                             if posts.is_some() {
                                 return Err(::cynic::serde::de::Error::duplicate_field("allPosts"));
                             }
-                            posts = Some(map.next_value()?);
+                            posts = Some(__map.next_value()?);
                         }
                         Field::__Other => {
-                            map.next_value::<::cynic::serde::de::IgnoredAny>()?;
+                            __map.next_value::<::cynic::serde::de::IgnoredAny>()?;
                         }
                     }
                 }

--- a/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__argument_literals.snap
+++ b/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__argument_literals.snap
@@ -57,23 +57,23 @@ impl<'de> ::cynic::serde::Deserialize<'de> for MyQuery {
             fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
                 formatter.write_str("struct MyQuery")
             }
-            fn visit_map<V>(self, mut map: V) -> Result<MyQuery, V::Error>
+            fn visit_map<V>(self, mut __map: V) -> Result<MyQuery, V::Error>
             where
                 V: ::cynic::serde::de::MapAccess<'de>,
             {
                 let mut filteredPosts = None;
-                while let Some(key) = map.next_key()? {
-                    match key {
+                while let Some(__key) = __map.next_key()? {
+                    match __key {
                         Field::filteredPosts => {
                             if filteredPosts.is_some() {
                                 return Err(::cynic::serde::de::Error::duplicate_field(
                                     "filteredPosts",
                                 ));
                             }
-                            filteredPosts = Some(map.next_value()?);
+                            filteredPosts = Some(__map.next_value()?);
                         }
                         Field::__Other => {
-                            map.next_value::<::cynic::serde::de::IgnoredAny>()?;
+                            __map.next_value::<::cynic::serde::de::IgnoredAny>()?;
                         }
                     }
                 }

--- a/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__flatten_attr.snap
+++ b/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__flatten_attr.snap
@@ -33,13 +33,13 @@ impl<'de> ::cynic::serde::Deserialize<'de> for Film {
             fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
                 formatter.write_str("struct Film")
             }
-            fn visit_map<V>(self, mut map: V) -> Result<Film, V::Error>
+            fn visit_map<V>(self, mut __map: V) -> Result<Film, V::Error>
             where
                 V: ::cynic::serde::de::MapAccess<'de>,
             {
                 let mut producers = None;
-                while let Some(key) = map.next_key()? {
-                    match key {
+                while let Some(__key) = __map.next_key()? {
+                    match __key {
                         Field::producers => {
                             if producers.is_some() {
                                 return Err(::cynic::serde::de::Error::duplicate_field(
@@ -47,12 +47,13 @@ impl<'de> ::cynic::serde::Deserialize<'de> for Film {
                                 ));
                             }
                             producers = Some(
-                                map.next_value::<::cynic::__private::Flattened<Vec<String>>>()?
+                                __map
+                                    .next_value::<::cynic::__private::Flattened<Vec<String>>>()?
                                     .into_inner(),
                             );
                         }
                         Field::__Other => {
-                            map.next_value::<::cynic::serde::de::IgnoredAny>()?;
+                            __map.next_value::<::cynic::serde::de::IgnoredAny>()?;
                         }
                     }
                 }

--- a/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__not_sure.snap
+++ b/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__not_sure.snap
@@ -67,23 +67,23 @@ impl<'de> ::cynic::serde::Deserialize<'de> for MyQuery {
             fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
                 formatter.write_str("struct MyQuery")
             }
-            fn visit_map<V>(self, mut map: V) -> Result<MyQuery, V::Error>
+            fn visit_map<V>(self, mut __map: V) -> Result<MyQuery, V::Error>
             where
                 V: ::cynic::serde::de::MapAccess<'de>,
             {
                 let mut filteredPosts = None;
-                while let Some(key) = map.next_key()? {
-                    match key {
+                while let Some(__key) = __map.next_key()? {
+                    match __key {
                         Field::filteredPosts => {
                             if filteredPosts.is_some() {
                                 return Err(::cynic::serde::de::Error::duplicate_field(
                                     "filteredPosts",
                                 ));
                             }
-                            filteredPosts = Some(map.next_value()?);
+                            filteredPosts = Some(__map.next_value()?);
                         }
                         Field::__Other => {
-                            map.next_value::<::cynic::serde::de::IgnoredAny>()?;
+                            __map.next_value::<::cynic::serde::de::IgnoredAny>()?;
                         }
                     }
                 }

--- a/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__simple_struct.snap
+++ b/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__simple_struct.snap
@@ -37,30 +37,30 @@ impl<'de> ::cynic::serde::Deserialize<'de> for BlogPostOutput {
             fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
                 formatter.write_str("struct BlogPostOutput")
             }
-            fn visit_map<V>(self, mut map: V) -> Result<BlogPostOutput, V::Error>
+            fn visit_map<V>(self, mut __map: V) -> Result<BlogPostOutput, V::Error>
             where
                 V: ::cynic::serde::de::MapAccess<'de>,
             {
                 let mut has_metadata = None;
                 let mut author = None;
-                while let Some(key) = map.next_key()? {
-                    match key {
+                while let Some(__key) = __map.next_key()? {
+                    match __key {
                         Field::has_metadata => {
                             if has_metadata.is_some() {
                                 return Err(::cynic::serde::de::Error::duplicate_field(
                                     "hasMetadata",
                                 ));
                             }
-                            has_metadata = Some(map.next_value()?);
+                            has_metadata = Some(__map.next_value()?);
                         }
                         Field::author => {
                             if author.is_some() {
                                 return Err(::cynic::serde::de::Error::duplicate_field("author"));
                             }
-                            author = Some(map.next_value()?);
+                            author = Some(__map.next_value()?);
                         }
                         Field::__Other => {
-                            map.next_value::<::cynic::serde::de::IgnoredAny>()?;
+                            __map.next_value::<::cynic::serde::de::IgnoredAny>()?;
                         }
                     }
                 }

--- a/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__variable_in_argument.snap
+++ b/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__variable_in_argument.snap
@@ -39,23 +39,23 @@ impl<'de> ::cynic::serde::Deserialize<'de> for MyQuery {
             fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
                 formatter.write_str("struct MyQuery")
             }
-            fn visit_map<V>(self, mut map: V) -> Result<MyQuery, V::Error>
+            fn visit_map<V>(self, mut __map: V) -> Result<MyQuery, V::Error>
             where
                 V: ::cynic::serde::de::MapAccess<'de>,
             {
                 let mut filteredPosts = None;
-                while let Some(key) = map.next_key()? {
-                    match key {
+                while let Some(__key) = __map.next_key()? {
+                    match __key {
                         Field::filteredPosts => {
                             if filteredPosts.is_some() {
                                 return Err(::cynic::serde::de::Error::duplicate_field(
                                     "filteredPosts",
                                 ));
                             }
-                            filteredPosts = Some(map.next_value()?);
+                            filteredPosts = Some(__map.next_value()?);
                         }
                         Field::__Other => {
-                            map.next_value::<::cynic::serde::de::IgnoredAny>()?;
+                            __map.next_value::<::cynic::serde::de::IgnoredAny>()?;
                         }
                     }
                 }

--- a/cynic/tests/misc.rs
+++ b/cynic/tests/misc.rs
@@ -1,0 +1,14 @@
+use cynic::QueryFragment;
+
+mod schema {
+    cynic::use_schema!("tests/test-schema.graphql");
+}
+
+/// Fields with the name `key` were failing to compile in some versions of cynic, so
+/// this struct is a test of that.
+#[allow(dead_code)]
+#[derive(QueryFragment)]
+#[cynic(schema_path = "tests/test-schema.graphql")]
+struct TypeWithKey {
+    key: String,
+}

--- a/cynic/tests/test-schema.graphql
+++ b/cynic/tests/test-schema.graphql
@@ -39,6 +39,10 @@ type EmptyType {
   _: Boolean
 }
 
+type TypeWithKey {
+  key: String!
+}
+
 type Query {
   allPosts: [BlogPost!]!
   post(id: ID!): BlogPost


### PR DESCRIPTION
If you derived `QueryFragment` on a struct with fields named either `key` or
`map`, you'd get some very weird compiler errors.  These were due to a clash
with variables used in the QueryFragment Deserialize output from the derive.

