### PR TITLE
[Merged by Bors] - Stop using Rust 2018 idioms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ## Unreleased - xxxx-xx-xx
 
+### Bug Fixes
+
+- The macro generated code now compiles under `-D rust-2018-idioms`
+
 ## v2.2.4 - 2023-01-18
 
 ### Bug Fixes

--- a/cynic-codegen/src/enum_derive/mod.rs
+++ b/cynic-codegen/src/enum_derive/mod.rs
@@ -42,7 +42,7 @@ pub fn enum_derive_impl(
     use quote::quote;
 
     let enum_def = schema
-        .lookup::<EnumType>(&input.graphql_type_name())
+        .lookup::<EnumType<'_>>(&input.graphql_type_name())
         .map_err(|e| syn::Error::new(input.graphql_type_span(), e))?;
 
     let rename_all = input.rename_all.unwrap_or(RenameAll::ScreamingSnakeCase);

--- a/cynic-codegen/src/fragment_derive/arguments/parsing.rs
+++ b/cynic-codegen/src/fragment_derive/arguments/parsing.rs
@@ -27,7 +27,7 @@ pub struct CynicArguments {
 }
 
 impl Parse for CynicArguments {
-    fn parse(input: ParseStream) -> Result<Self> {
+    fn parse(input: ParseStream<'_>) -> Result<Self> {
         Ok(CynicArguments {
             arguments: Punctuated::parse_terminated(input)?,
         })
@@ -47,7 +47,7 @@ pub enum FieldArgumentValue {
 }
 
 impl Parse for FieldArgument {
-    fn parse(input: ParseStream) -> Result<Self> {
+    fn parse(input: ParseStream<'_>) -> Result<Self> {
         let argument_name = input.call(Ident::parse_any)?;
         let lookahead = input.lookahead1();
         let value;
@@ -92,7 +92,7 @@ impl ArgumentLiteral {
 }
 
 impl Parse for ArgumentLiteral {
-    fn parse(input: ParseStream) -> Result<Self> {
+    fn parse(input: ParseStream<'_>) -> Result<Self> {
         let lookahead = input.lookahead1();
         if lookahead.peek(syn::token::Brace) {
             let span = input.span();

--- a/cynic-codegen/src/fragment_derive/arguments/tests.rs
+++ b/cynic-codegen/src/fragment_derive/arguments/tests.rs
@@ -28,7 +28,7 @@ fn test_analyse(
 
     let schema_doc = parse_schema(SCHEMA).unwrap();
     let schema = Schema::new(&schema_doc).validate().unwrap();
-    let ty = schema.lookup::<Type>("Query").ok().unwrap();
+    let ty = schema.lookup::<Type<'_>>("Query").ok().unwrap();
     let field = &ty.object().unwrap().field(field).unwrap();
 
     let literals = literals.arguments.into_iter().collect::<Vec<_>>();
@@ -49,7 +49,7 @@ fn test_analyse(
 fn test_analyse_errors_without_argument_struct() {
     let schema_doc = parse_schema(SCHEMA).unwrap();
     let schema = Schema::new(&schema_doc).validate().unwrap();
-    let ty = schema.lookup::<Type>("Query").ok().unwrap();
+    let ty = schema.lookup::<Type<'_>>("Query").ok().unwrap();
     let field = &ty.object().unwrap().field("filteredBooks").unwrap();
 
     let literals: CynicArguments =

--- a/cynic-codegen/src/fragment_derive/deserialize_impl.rs
+++ b/cynic-codegen/src/fragment_derive/deserialize_impl.rs
@@ -126,7 +126,7 @@ impl quote::ToTokens for StandardDeserializeImpl {
                     impl <'de> ::cynic::serde::de::Visitor<'de> for Visitor {
                         type Value = #target_struct;
 
-                        fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                        fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                             formatter.write_str(#expecting_str)
                         }
 
@@ -161,7 +161,7 @@ impl quote::ToTokens for StandardDeserializeImpl {
                         }
                     }
 
-                    const FIELDS: &'static [&'static str] = &[#(#serialized_names),*];
+                    const FIELDS: &'static [&str] = &[#(#serialized_names),*];
 
                     deserializer.deserialize_struct(#struct_name, FIELDS, Visitor)
                 }

--- a/cynic-codegen/src/fragment_derive/fragment_impl.rs
+++ b/cynic-codegen/src/fragment_derive/fragment_impl.rs
@@ -56,7 +56,7 @@ impl<'a> FragmentImpl<'a> {
     pub fn new_for(
         fields: &[(&FragmentDeriveField, Option<&'a Field<'a>>)],
         name: &syn::Ident,
-        schema_type: &FragmentDeriveType,
+        schema_type: &FragmentDeriveType<'_>,
         schema_module_path: &syn::Path,
         graphql_type_name: &str,
         variables: Option<&syn::Path>,
@@ -163,7 +163,7 @@ impl quote::ToTokens for FragmentImpl<'_> {
 
                 const TYPE: Option<&'static str> = Some(#graphql_type);
 
-                fn query(mut builder: ::cynic::queries::SelectionBuilder<Self::SchemaType, Self::Variables>) {
+                fn query(mut builder: ::cynic::queries::SelectionBuilder<'_, Self::SchemaType, Self::Variables>) {
                     #![allow(unused_mut)]
 
                     #(#selections)*
@@ -229,7 +229,7 @@ impl quote::ToTokens for FieldSelection<'_> {
         let schema_type_lookup = match self.graphql_field_kind {
             FieldKind::Interface | FieldKind::Composite | FieldKind::Union => {
                 quote_spanned! { self.span =>
-                    <#aligned_type as ::cynic::QueryFragment>::SchemaType
+                    <#aligned_type as ::cynic::QueryFragment<'_>>::SchemaType
                 }
             }
             FieldKind::Scalar => quote_spanned! { self.span =>
@@ -254,7 +254,7 @@ impl quote::ToTokens for FieldSelection<'_> {
                     #alias
                     #arguments
 
-                    <#aligned_type as ::cynic::QueryFragment>::query(
+                    <#aligned_type as ::cynic::QueryFragment<'_>>::query(
                         field_builder.select_children()
                     );
                 }
@@ -271,7 +271,7 @@ impl quote::ToTokens for FieldSelection<'_> {
                     #alias
                     #arguments
 
-                    <#aligned_type as ::cynic::QueryFragment>::query(
+                    <#aligned_type as ::cynic::QueryFragment<'_>>::query(
                         field_builder.select_children()
                     );
                 }
@@ -300,7 +300,7 @@ impl quote::ToTokens for FieldSelection<'_> {
                         #alias
                         #arguments
 
-                        <#aligned_type as ::cynic::QueryFragment>::query(
+                        <#aligned_type as ::cynic::QueryFragment<'_>>::query(
                             field_builder.select_children()
                         );
                     }
@@ -328,7 +328,7 @@ impl quote::ToTokens for SpreadSelection {
         let field_type = &self.rust_field_type;
 
         tokens.append_all(quote_spanned! { self.span =>
-            <#field_type as ::cynic::QueryFragment>::query(
+            <#field_type as ::cynic::QueryFragment<'_>>::query(
                 builder
             )
         })

--- a/cynic-codegen/src/fragment_derive/mod.rs
+++ b/cynic-codegen/src/fragment_derive/mod.rs
@@ -52,7 +52,7 @@ pub fn fragment_derive_impl(
     input.detect_aliases();
 
     let schema_type = schema
-        .lookup::<FragmentDeriveType>(&input.graphql_type_name())
+        .lookup::<FragmentDeriveType<'_>>(&input.graphql_type_name())
         .map_err(|e| syn::Error::new(input.graphql_type_span(), e))?;
 
     let graphql_name = &(input.graphql_type_name());

--- a/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__argument_and_rename.snap
+++ b/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__argument_and_rename.snap
@@ -7,17 +7,21 @@ impl<'de> ::cynic::QueryFragment<'de> for MyQuery {
     type SchemaType = schema::Query;
     type Variables = ();
     const TYPE: Option<&'static str> = Some("Query");
-    fn query(mut builder: ::cynic::queries::SelectionBuilder<Self::SchemaType, Self::Variables>) {
+    fn query(
+        mut builder: ::cynic::queries::SelectionBuilder<'_, Self::SchemaType, Self::Variables>,
+    ) {
         #![allow(unused_mut)]
-        let mut field_builder = builder . select_field :: < schema :: __fields :: Query :: post , < Option < BlogPostOutput > as :: cynic :: QueryFragment > :: SchemaType > () ;
+        let mut field_builder = builder . select_field :: < schema :: __fields :: Query :: post , < Option < BlogPostOutput > as :: cynic :: QueryFragment < '_ >> :: SchemaType > () ;
         {
             field_builder
                 .argument::<schema::__fields::Query::_post_arguments::id>()
                 .literal("1234");
         }
-        <Option<BlogPostOutput> as ::cynic::QueryFragment>::query(field_builder.select_children());
-        let mut field_builder = builder . select_field :: < schema :: __fields :: Query :: allPosts , < Vec < BlogPostOutput > as :: cynic :: QueryFragment > :: SchemaType > () ;
-        <Vec<BlogPostOutput> as ::cynic::QueryFragment>::query(field_builder.select_children());
+        <Option<BlogPostOutput> as ::cynic::QueryFragment<'_>>::query(
+            field_builder.select_children(),
+        );
+        let mut field_builder = builder . select_field :: < schema :: __fields :: Query :: allPosts , < Vec < BlogPostOutput > as :: cynic :: QueryFragment < '_ >> :: SchemaType > () ;
+        <Vec<BlogPostOutput> as ::cynic::QueryFragment<'_>>::query(field_builder.select_children());
     }
 }
 #[automatically_derived]
@@ -74,7 +78,7 @@ impl<'de> ::cynic::serde::Deserialize<'de> for MyQuery {
                 Ok(MyQuery { post, posts })
             }
         }
-        const FIELDS: &'static [&'static str] = &["post", "allPosts"];
+        const FIELDS: &'static [&str] = &["post", "allPosts"];
         deserializer.deserialize_struct("MyQuery", FIELDS, Visitor)
     }
 }

--- a/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__argument_and_rename.snap
+++ b/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__argument_and_rename.snap
@@ -40,7 +40,7 @@ impl<'de> ::cynic::serde::Deserialize<'de> for MyQuery {
         struct Visitor;
         impl<'de> ::cynic::serde::de::Visitor<'de> for Visitor {
             type Value = MyQuery;
-            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 formatter.write_str("struct MyQuery")
             }
             fn visit_map<V>(self, mut __map: V) -> Result<MyQuery, V::Error>

--- a/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__argument_literals.snap
+++ b/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__argument_literals.snap
@@ -7,9 +7,11 @@ impl<'de> ::cynic::QueryFragment<'de> for MyQuery {
     type SchemaType = schema::Query;
     type Variables = ();
     const TYPE: Option<&'static str> = Some("Query");
-    fn query(mut builder: ::cynic::queries::SelectionBuilder<Self::SchemaType, Self::Variables>) {
+    fn query(
+        mut builder: ::cynic::queries::SelectionBuilder<'_, Self::SchemaType, Self::Variables>,
+    ) {
         #![allow(unused_mut)]
-        let mut field_builder = builder . select_field :: < schema :: __fields :: Query :: filteredPosts , < Vec < BlogPostOutput > as :: cynic :: QueryFragment > :: SchemaType > () ;
+        let mut field_builder = builder . select_field :: < schema :: __fields :: Query :: filteredPosts , < Vec < BlogPostOutput > as :: cynic :: QueryFragment < '_ >> :: SchemaType > () ;
         {
             struct PostStatePosted;
             impl ::cynic::serde::Serialize for PostStatePosted {
@@ -33,7 +35,7 @@ impl<'de> ::cynic::QueryFragment<'de> for MyQuery {
                         .item(|builder| builder.literal(PostStatePosted));
                 });
         }
-        <Vec<BlogPostOutput> as ::cynic::QueryFragment>::query(field_builder.select_children());
+        <Vec<BlogPostOutput> as ::cynic::QueryFragment<'_>>::query(field_builder.select_children());
     }
 }
 #[automatically_derived]
@@ -82,7 +84,7 @@ impl<'de> ::cynic::serde::Deserialize<'de> for MyQuery {
                 Ok(MyQuery { filteredPosts })
             }
         }
-        const FIELDS: &'static [&'static str] = &["filteredPosts"];
+        const FIELDS: &'static [&str] = &["filteredPosts"];
         deserializer.deserialize_struct("MyQuery", FIELDS, Visitor)
     }
 }

--- a/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__argument_literals.snap
+++ b/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__argument_literals.snap
@@ -54,7 +54,7 @@ impl<'de> ::cynic::serde::Deserialize<'de> for MyQuery {
         struct Visitor;
         impl<'de> ::cynic::serde::de::Visitor<'de> for Visitor {
             type Value = MyQuery;
-            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 formatter.write_str("struct MyQuery")
             }
             fn visit_map<V>(self, mut __map: V) -> Result<MyQuery, V::Error>

--- a/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__flatten_attr.snap
+++ b/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__flatten_attr.snap
@@ -7,7 +7,9 @@ impl<'de> ::cynic::QueryFragment<'de> for Film {
     type SchemaType = schema::Film;
     type Variables = ();
     const TYPE: Option<&'static str> = Some("Film");
-    fn query(mut builder: ::cynic::queries::SelectionBuilder<Self::SchemaType, Self::Variables>) {
+    fn query(
+        mut builder: ::cynic::queries::SelectionBuilder<'_, Self::SchemaType, Self::Variables>,
+    ) {
         #![allow(unused_mut)]
         let mut field_builder = builder . select_flattened_field :: < schema :: __fields :: Film :: producers , < Vec < String > as :: cynic :: schema :: IsScalar < < schema :: __fields :: Film :: producers as :: cynic :: schema :: Field > :: Type >> :: SchemaType , < schema :: __fields :: Film :: producers as :: cynic :: schema :: Field > :: Type , > () ;
     }
@@ -62,7 +64,7 @@ impl<'de> ::cynic::serde::Deserialize<'de> for Film {
                 Ok(Film { producers })
             }
         }
-        const FIELDS: &'static [&'static str] = &["producers"];
+        const FIELDS: &'static [&str] = &["producers"];
         deserializer.deserialize_struct("Film", FIELDS, Visitor)
     }
 }

--- a/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__flatten_attr.snap
+++ b/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__flatten_attr.snap
@@ -30,7 +30,7 @@ impl<'de> ::cynic::serde::Deserialize<'de> for Film {
         struct Visitor;
         impl<'de> ::cynic::serde::de::Visitor<'de> for Visitor {
             type Value = Film;
-            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 formatter.write_str("struct Film")
             }
             fn visit_map<V>(self, mut __map: V) -> Result<Film, V::Error>

--- a/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__not_sure.snap
+++ b/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__not_sure.snap
@@ -7,9 +7,11 @@ impl<'de> ::cynic::QueryFragment<'de> for MyQuery {
     type SchemaType = schema::Query;
     type Variables = ();
     const TYPE: Option<&'static str> = Some("Query");
-    fn query(mut builder: ::cynic::queries::SelectionBuilder<Self::SchemaType, Self::Variables>) {
+    fn query(
+        mut builder: ::cynic::queries::SelectionBuilder<'_, Self::SchemaType, Self::Variables>,
+    ) {
         #![allow(unused_mut)]
-        let mut field_builder = builder . select_field :: < schema :: __fields :: Query :: filteredPosts , < Vec < BlogPostOutput > as :: cynic :: QueryFragment > :: SchemaType > () ;
+        let mut field_builder = builder . select_field :: < schema :: __fields :: Query :: filteredPosts , < Vec < BlogPostOutput > as :: cynic :: QueryFragment < '_ >> :: SchemaType > () ;
         {
             struct PostStateDraft;
             impl ::cynic::serde::Serialize for PostStateDraft {
@@ -43,7 +45,7 @@ impl<'de> ::cynic::QueryFragment<'de> for MyQuery {
                         .item(|builder| builder.literal(PostStateDraft));
                 });
         }
-        <Vec<BlogPostOutput> as ::cynic::QueryFragment>::query(field_builder.select_children());
+        <Vec<BlogPostOutput> as ::cynic::QueryFragment<'_>>::query(field_builder.select_children());
     }
 }
 #[automatically_derived]
@@ -92,7 +94,7 @@ impl<'de> ::cynic::serde::Deserialize<'de> for MyQuery {
                 Ok(MyQuery { filteredPosts })
             }
         }
-        const FIELDS: &'static [&'static str] = &["filteredPosts"];
+        const FIELDS: &'static [&str] = &["filteredPosts"];
         deserializer.deserialize_struct("MyQuery", FIELDS, Visitor)
     }
 }

--- a/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__not_sure.snap
+++ b/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__not_sure.snap
@@ -64,7 +64,7 @@ impl<'de> ::cynic::serde::Deserialize<'de> for MyQuery {
         struct Visitor;
         impl<'de> ::cynic::serde::de::Visitor<'de> for Visitor {
             type Value = MyQuery;
-            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 formatter.write_str("struct MyQuery")
             }
             fn visit_map<V>(self, mut __map: V) -> Result<MyQuery, V::Error>

--- a/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__simple_struct.snap
+++ b/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__simple_struct.snap
@@ -34,7 +34,7 @@ impl<'de> ::cynic::serde::Deserialize<'de> for BlogPostOutput {
         struct Visitor;
         impl<'de> ::cynic::serde::de::Visitor<'de> for Visitor {
             type Value = BlogPostOutput;
-            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 formatter.write_str("struct BlogPostOutput")
             }
             fn visit_map<V>(self, mut __map: V) -> Result<BlogPostOutput, V::Error>

--- a/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__simple_struct.snap
+++ b/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__simple_struct.snap
@@ -7,11 +7,13 @@ impl<'de> ::cynic::QueryFragment<'de> for BlogPostOutput {
     type SchemaType = schema::BlogPost;
     type Variables = ();
     const TYPE: Option<&'static str> = Some("BlogPost");
-    fn query(mut builder: ::cynic::queries::SelectionBuilder<Self::SchemaType, Self::Variables>) {
+    fn query(
+        mut builder: ::cynic::queries::SelectionBuilder<'_, Self::SchemaType, Self::Variables>,
+    ) {
         #![allow(unused_mut)]
         let mut field_builder = builder . select_field :: < schema :: __fields :: BlogPost :: hasMetadata , < Option < bool > as :: cynic :: schema :: IsScalar < < schema :: __fields :: BlogPost :: hasMetadata as :: cynic :: schema :: Field > :: Type >> :: SchemaType > () ;
-        let mut field_builder = builder . select_field :: < schema :: __fields :: BlogPost :: author , < AuthorOutput as :: cynic :: QueryFragment > :: SchemaType > () ;
-        <AuthorOutput as ::cynic::QueryFragment>::query(field_builder.select_children());
+        let mut field_builder = builder . select_field :: < schema :: __fields :: BlogPost :: author , < AuthorOutput as :: cynic :: QueryFragment < '_ >> :: SchemaType > () ;
+        <AuthorOutput as ::cynic::QueryFragment<'_>>::query(field_builder.select_children());
     }
 }
 #[automatically_derived]
@@ -74,7 +76,7 @@ impl<'de> ::cynic::serde::Deserialize<'de> for BlogPostOutput {
                 })
             }
         }
-        const FIELDS: &'static [&'static str] = &["hasMetadata", "author"];
+        const FIELDS: &'static [&str] = &["hasMetadata", "author"];
         deserializer.deserialize_struct("BlogPostOutput", FIELDS, Visitor)
     }
 }

--- a/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__spread_attr.snap
+++ b/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__spread_attr.snap
@@ -1,6 +1,5 @@
 ---
 source: cynic-codegen/src/fragment_derive/tests.rs
-assertion_line: 114
 expression: "format_code(format!(\"{}\", tokens))"
 ---
 #[automatically_derived]
@@ -8,9 +7,11 @@ impl<'de> ::cynic::QueryFragment<'de> for Film {
     type SchemaType = schema::Film;
     type Variables = ();
     const TYPE: Option<&'static str> = Some("Film");
-    fn query(mut builder: ::cynic::queries::SelectionBuilder<Self::SchemaType, Self::Variables>) {
+    fn query(
+        mut builder: ::cynic::queries::SelectionBuilder<'_, Self::SchemaType, Self::Variables>,
+    ) {
         #![allow(unused_mut)]
-        <FilmDetails as ::cynic::QueryFragment>::query(builder)
+        <FilmDetails as ::cynic::QueryFragment<'_>>::query(builder)
     }
 }
 #[automatically_derived]

--- a/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__variable_in_argument.snap
+++ b/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__variable_in_argument.snap
@@ -36,7 +36,7 @@ impl<'de> ::cynic::serde::Deserialize<'de> for MyQuery {
         struct Visitor;
         impl<'de> ::cynic::serde::de::Visitor<'de> for Visitor {
             type Value = MyQuery;
-            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 formatter.write_str("struct MyQuery")
             }
             fn visit_map<V>(self, mut __map: V) -> Result<MyQuery, V::Error>

--- a/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__variable_in_argument.snap
+++ b/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__variable_in_argument.snap
@@ -7,15 +7,17 @@ impl<'de> ::cynic::QueryFragment<'de> for MyQuery {
     type SchemaType = schema::Query;
     type Variables = AnArgumentStruct;
     const TYPE: Option<&'static str> = Some("Query");
-    fn query(mut builder: ::cynic::queries::SelectionBuilder<Self::SchemaType, Self::Variables>) {
+    fn query(
+        mut builder: ::cynic::queries::SelectionBuilder<'_, Self::SchemaType, Self::Variables>,
+    ) {
         #![allow(unused_mut)]
-        let mut field_builder = builder . select_field :: < schema :: __fields :: Query :: filteredPosts , < Vec < BlogPostOutput > as :: cynic :: QueryFragment > :: SchemaType > () ;
+        let mut field_builder = builder . select_field :: < schema :: __fields :: Query :: filteredPosts , < Vec < BlogPostOutput > as :: cynic :: QueryFragment < '_ >> :: SchemaType > () ;
         {
             field_builder
                 .argument::<schema::__fields::Query::_filtered_posts_arguments::filters>()
                 .variable(<AnArgumentStruct as ::cynic::QueryVariables>::Fields::filters());
         }
-        <Vec<BlogPostOutput> as ::cynic::QueryFragment>::query(field_builder.select_children());
+        <Vec<BlogPostOutput> as ::cynic::QueryFragment<'_>>::query(field_builder.select_children());
     }
 }
 #[automatically_derived]
@@ -64,7 +66,7 @@ impl<'de> ::cynic::serde::Deserialize<'de> for MyQuery {
                 Ok(MyQuery { filteredPosts })
             }
         }
-        const FIELDS: &'static [&'static str] = &["filteredPosts"];
+        const FIELDS: &'static [&str] = &["filteredPosts"];
         deserializer.deserialize_struct("MyQuery", FIELDS, Visitor)
     }
 }

--- a/cynic-codegen/src/inline_fragments_derive/mod.rs
+++ b/cynic-codegen/src/inline_fragments_derive/mod.rs
@@ -44,7 +44,7 @@ pub(crate) fn inline_fragments_derive_impl(
 
     let schema = Schema::new(&schema);
 
-    let target_type = schema.lookup::<InlineFragmentType>(&input.graphql_type_name())?;
+    let target_type = schema.lookup::<InlineFragmentType<'_>>(&input.graphql_type_name())?;
 
     input.validate(match target_type {
         InlineFragmentType::Union(_) => ValidationMode::Union,
@@ -122,7 +122,7 @@ fn fragments_from_variants(
 
 fn check_fallback(
     variants: &[SpannedValue<InlineFragmentsDeriveVariant>],
-    target_type: &InlineFragmentType,
+    target_type: &InlineFragmentType<'_>,
 ) -> Result<Option<Fallback>, Errors> {
     let fallbacks = variants.iter().filter(|v| *v.fallback).collect::<Vec<_>>();
 
@@ -213,11 +213,11 @@ impl quote::ToTokens for QueryFragmentImpl<'_> {
 
                 const TYPE: Option<&'static str> = Some(#graphql_type);
 
-                fn query(mut builder: ::cynic::queries::SelectionBuilder<Self::SchemaType, Self::Variables>) {
+                fn query(mut builder: ::cynic::queries::SelectionBuilder<'_, Self::SchemaType, Self::Variables>) {
                     #(
                         let fragment_builder = builder.inline_fragment();
-                        let mut fragment_builder = fragment_builder.on::<<#inner_types as ::cynic::QueryFragment>::SchemaType>();
-                        <#inner_types as ::cynic::QueryFragment>::query(
+                        let mut fragment_builder = fragment_builder.on::<<#inner_types as ::cynic::QueryFragment<'_>>::SchemaType>();
+                        <#inner_types as ::cynic::QueryFragment<'_>>::query(
                             fragment_builder.select_children()
                         );
                     )*

--- a/cynic-codegen/src/inline_fragments_derive/snapshots/cynic_codegen__inline_fragments_derive__tests__interface.snap
+++ b/cynic-codegen/src/inline_fragments_derive/snapshots/cynic_codegen__inline_fragments_derive__tests__interface.snap
@@ -1,6 +1,5 @@
 ---
 source: cynic-codegen/src/inline_fragments_derive/tests.rs
-assertion_line: 55
 expression: "format_code(format!(\"{}\", tokens))"
 ---
 #[automatically_derived]
@@ -34,15 +33,17 @@ impl<'de> ::cynic::QueryFragment<'de> for Node {
     type SchemaType = schema::Node;
     type Variables = ();
     const TYPE: Option<&'static str> = Some("Node");
-    fn query(mut builder: ::cynic::queries::SelectionBuilder<Self::SchemaType, Self::Variables>) {
+    fn query(
+        mut builder: ::cynic::queries::SelectionBuilder<'_, Self::SchemaType, Self::Variables>,
+    ) {
         let fragment_builder = builder.inline_fragment();
         let mut fragment_builder =
-            fragment_builder.on::<<Post as ::cynic::QueryFragment>::SchemaType>();
-        <Post as ::cynic::QueryFragment>::query(fragment_builder.select_children());
+            fragment_builder.on::<<Post as ::cynic::QueryFragment<'_>>::SchemaType>();
+        <Post as ::cynic::QueryFragment<'_>>::query(fragment_builder.select_children());
         let fragment_builder = builder.inline_fragment();
         let mut fragment_builder =
-            fragment_builder.on::<<Author as ::cynic::QueryFragment>::SchemaType>();
-        <Author as ::cynic::QueryFragment>::query(fragment_builder.select_children());
+            fragment_builder.on::<<Author as ::cynic::QueryFragment<'_>>::SchemaType>();
+        <Author as ::cynic::QueryFragment<'_>>::query(fragment_builder.select_children());
     }
 }
 #[allow(clippy::no_effect, non_camel_case_types)]

--- a/cynic-codegen/src/inline_fragments_derive/snapshots/cynic_codegen__inline_fragments_derive__tests__union_type.snap
+++ b/cynic-codegen/src/inline_fragments_derive/snapshots/cynic_codegen__inline_fragments_derive__tests__union_type.snap
@@ -1,6 +1,5 @@
 ---
 source: cynic-codegen/src/inline_fragments_derive/tests.rs
-assertion_line: 55
 expression: "format_code(format!(\"{}\", tokens))"
 ---
 #[automatically_derived]
@@ -34,15 +33,17 @@ impl<'de> ::cynic::QueryFragment<'de> for PostOrAuthor {
     type SchemaType = schema::PostOrAuthor;
     type Variables = ();
     const TYPE: Option<&'static str> = Some("PostOrAuthor");
-    fn query(mut builder: ::cynic::queries::SelectionBuilder<Self::SchemaType, Self::Variables>) {
+    fn query(
+        mut builder: ::cynic::queries::SelectionBuilder<'_, Self::SchemaType, Self::Variables>,
+    ) {
         let fragment_builder = builder.inline_fragment();
         let mut fragment_builder =
-            fragment_builder.on::<<Post as ::cynic::QueryFragment>::SchemaType>();
-        <Post as ::cynic::QueryFragment>::query(fragment_builder.select_children());
+            fragment_builder.on::<<Post as ::cynic::QueryFragment<'_>>::SchemaType>();
+        <Post as ::cynic::QueryFragment<'_>>::query(fragment_builder.select_children());
         let fragment_builder = builder.inline_fragment();
         let mut fragment_builder =
-            fragment_builder.on::<<Author as ::cynic::QueryFragment>::SchemaType>();
-        <Author as ::cynic::QueryFragment>::query(fragment_builder.select_children());
+            fragment_builder.on::<<Author as ::cynic::QueryFragment<'_>>::SchemaType>();
+        <Author as ::cynic::QueryFragment<'_>>::query(fragment_builder.select_children());
     }
 }
 

--- a/cynic-codegen/src/inline_fragments_derive/snapshots/cynic_codegen__inline_fragments_derive__tests__union_with_rename.snap
+++ b/cynic-codegen/src/inline_fragments_derive/snapshots/cynic_codegen__inline_fragments_derive__tests__union_with_rename.snap
@@ -1,6 +1,5 @@
 ---
 source: cynic-codegen/src/inline_fragments_derive/tests.rs
-assertion_line: 55
 expression: "format_code(format!(\"{}\", tokens))"
 ---
 #[automatically_derived]
@@ -34,15 +33,17 @@ impl<'de> ::cynic::QueryFragment<'de> for PostOrAuthor {
     type SchemaType = schema::PostOrAuthor;
     type Variables = ();
     const TYPE: Option<&'static str> = Some("PostOrAuthor");
-    fn query(mut builder: ::cynic::queries::SelectionBuilder<Self::SchemaType, Self::Variables>) {
+    fn query(
+        mut builder: ::cynic::queries::SelectionBuilder<'_, Self::SchemaType, Self::Variables>,
+    ) {
         let fragment_builder = builder.inline_fragment();
         let mut fragment_builder =
-            fragment_builder.on::<<Post as ::cynic::QueryFragment>::SchemaType>();
-        <Post as ::cynic::QueryFragment>::query(fragment_builder.select_children());
+            fragment_builder.on::<<Post as ::cynic::QueryFragment<'_>>::SchemaType>();
+        <Post as ::cynic::QueryFragment<'_>>::query(fragment_builder.select_children());
         let fragment_builder = builder.inline_fragment();
         let mut fragment_builder =
-            fragment_builder.on::<<Author as ::cynic::QueryFragment>::SchemaType>();
-        <Author as ::cynic::QueryFragment>::query(fragment_builder.select_children());
+            fragment_builder.on::<<Author as ::cynic::QueryFragment<'_>>::SchemaType>();
+        <Author as ::cynic::QueryFragment<'_>>::query(fragment_builder.select_children());
     }
 }
 #[allow(clippy::no_effect, non_camel_case_types)]

--- a/cynic-codegen/src/input_object_derive/field_serializer.rs
+++ b/cynic-codegen/src/input_object_derive/field_serializer.rs
@@ -17,7 +17,7 @@ pub struct FieldSerializer<'a> {
 impl<'a> FieldSerializer<'a> {
     pub fn new(
         rust_field: &'a InputObjectDeriveField,
-        graphql_field: &'a InputValue,
+        graphql_field: &'a InputValue<'_>,
         schema_module: &'a syn::Path,
     ) -> FieldSerializer<'a> {
         FieldSerializer {

--- a/cynic-codegen/src/input_object_derive/mod.rs
+++ b/cynic-codegen/src/input_object_derive/mod.rs
@@ -51,7 +51,7 @@ pub fn input_object_derive_impl(
     use quote::quote;
 
     let input_object = schema
-        .lookup::<InputObjectType>(&input.graphql_type_name())
+        .lookup::<InputObjectType<'_>>(&input.graphql_type_name())
         .map_err(|e| syn::Error::new(input.graphql_type_span(), e))?;
 
     let rename_all = input.rename_all.unwrap_or(RenameAll::CamelCase);

--- a/cynic-codegen/src/lib.rs
+++ b/cynic-codegen/src/lib.rs
@@ -1,3 +1,4 @@
+#![deny(rust_2018_idioms)]
 pub mod enum_derive;
 pub mod fragment_derive;
 pub mod inline_fragments_derive;

--- a/cynic-codegen/src/schema/keywords.rs
+++ b/cynic-codegen/src/schema/keywords.rs
@@ -78,7 +78,7 @@ static NON_RAW_KEYWORDS: Lazy<HashSet<&'static str>> = Lazy::new(|| {
     set
 });
 
-pub fn transform_keywords(s: &str) -> Cow<str> {
+pub fn transform_keywords(s: &str) -> Cow<'_, str> {
     let s_ref: &str = s;
     if NON_RAW_KEYWORDS.contains(s_ref) {
         format!("{}_", s).into()

--- a/cynic-codegen/src/schema/parser.rs
+++ b/cynic-codegen/src/schema/parser.rs
@@ -52,8 +52,8 @@ pub(crate) fn parse_schema(schema: &str) -> Result<Document, SchemaLoadError> {
     Ok(schema_into_static(borrowed_schema))
 }
 
-fn schema_into_static<'a>(
-    doc: graphql_parser::schema::Document<'a, String>,
+fn schema_into_static(
+    doc: graphql_parser::schema::Document<'_, String>,
 ) -> graphql_parser::schema::Document<'static, String> {
     // A workaround until https://github.com/graphql-rust/graphql-parser/pull/33 is
     // merged upstream.

--- a/cynic-codegen/src/schema/type_index.rs
+++ b/cynic-codegen/src/schema/type_index.rs
@@ -349,7 +349,7 @@ fn convert_input_value<'a>(
         name: FieldName {
             graphql_name: &val.name,
         },
-        value_type: build_type_ref::<InputType>(&val.value_type, type_index),
+        value_type: build_type_ref::<InputType<'_>>(&val.value_type, type_index),
         has_default: val.default_value.is_some(),
     }
 }
@@ -396,7 +396,7 @@ fn build_field<'a>(
             .iter()
             .map(|arg| convert_input_value(type_index, arg))
             .collect(),
-        field_type: build_type_ref::<OutputType>(&field.field_type, type_index),
+        field_type: build_type_ref::<OutputType<'_>>(&field.field_type, type_index),
         parent_type_name,
     }
 }
@@ -426,7 +426,7 @@ mod tests {
             parser::Type::NonNullType(Box::new(parser::Type::NamedType("User".to_string())));
 
         assert_matches!(
-            build_type_ref::<InputType>(&non_null_type, index),
+            build_type_ref::<InputType<'_>>(&non_null_type, index),
             TypeRef::Named("User", _, _)
         );
     }
@@ -438,7 +438,7 @@ mod tests {
         let nullable_type = parser::Type::NamedType("User".to_string());
 
         assert_matches!(
-            build_type_ref::<InputType>(&nullable_type, index),
+            build_type_ref::<InputType<'_>>(&nullable_type, index),
             TypeRef::Nullable(inner) => {
                 assert_matches!(*inner, TypeRef::Named("User", _, _))
             }
@@ -454,7 +454,7 @@ mod tests {
         ))));
 
         assert_matches!(
-            build_type_ref::<InputType>(&required_list, index),
+            build_type_ref::<InputType<'_>>(&required_list, index),
             TypeRef::List(inner) => {
                 assert_matches!(*inner, TypeRef::Named("User", _, _))
             }
@@ -469,7 +469,7 @@ mod tests {
             parser::Type::ListType(Box::new(parser::Type::NamedType("User".to_string())));
 
         assert_matches!(
-            build_type_ref::<InputType>(&optional_list, index),
+            build_type_ref::<InputType<'_>>(&optional_list, index),
             TypeRef::Nullable(inner) => {
                 assert_matches!(*inner, TypeRef::List(inner) => {
                     assert_matches!(*inner, TypeRef::Nullable(inner) => {

--- a/cynic-codegen/src/types/alignment.rs
+++ b/cynic-codegen/src/types/alignment.rs
@@ -143,7 +143,7 @@ mod tests {
     )]
     fn test_align_output_type(
         #[case] rust_type: TokenStream,
-        #[case] graphql_type: TypeRef<'_, OutputType>,
+        #[case] graphql_type: TypeRef<'_, OutputType<'_>>,
         #[case] aligned_type: TokenStream,
     ) {
         let rust_type = parse2(rust_type).unwrap();
@@ -187,7 +187,7 @@ mod tests {
     )]
     fn test_align_output_type_with_no_changes(
         #[case] rust_type: TokenStream,
-        #[case] graphql_type: TypeRef<'_, OutputType>,
+        #[case] graphql_type: TypeRef<'_, OutputType<'_>>,
     ) {
         let input = parse2::<syn::Type>(rust_type).unwrap();
 
@@ -256,7 +256,7 @@ mod tests {
     )]
     fn test_align_input_type(
         #[case] rust_type: TokenStream,
-        #[case] graphql_type: TypeRef<'_, InputType>,
+        #[case] graphql_type: TypeRef<'_, InputType<'_>>,
         #[case] graphql_type_is_optional: bool,
         #[case] aligned_type: TokenStream,
     ) {
@@ -337,7 +337,7 @@ mod tests {
     )]
     fn test_align_input_type_with_no_changes(
         #[case] rust_type: TokenStream,
-        #[case] graphql_type: TypeRef<'_, InputType>,
+        #[case] graphql_type: TypeRef<'_, InputType<'_>>,
         #[case] graphql_type_is_optional: bool,
     ) {
         let input = parse2(rust_type).unwrap();

--- a/cynic-codegen/src/types/parsing.rs
+++ b/cynic-codegen/src/types/parsing.rs
@@ -232,11 +232,11 @@ impl<'a> RustType<'a> {
 }
 
 trait TypePathExt {
-    fn replace_generic_param(&mut self, replacement: &RustType);
+    fn replace_generic_param(&mut self, replacement: &RustType<'_>);
 }
 
 impl TypePathExt for syn::TypePath {
-    fn replace_generic_param(&mut self, replacement: &RustType) {
+    fn replace_generic_param(&mut self, replacement: &RustType<'_>) {
         fn get_generic_argument(type_path: &mut syn::TypePath) -> Option<&mut GenericArgument> {
             let segment = type_path.path.segments.last_mut()?;
 

--- a/cynic-codegen/src/types/validation.rs
+++ b/cynic-codegen/src/types/validation.rs
@@ -14,8 +14,8 @@ pub enum CheckMode {
     Spreading,
 }
 
-pub fn check_types_are_compatible<'a>(
-    gql_type: &TypeRef<'a, OutputType>,
+pub fn check_types_are_compatible(
+    gql_type: &TypeRef<'_, OutputType<'_>>,
     rust_type: &syn::Type,
     mode: CheckMode,
 ) -> Result<(), syn::Error> {
@@ -32,8 +32,8 @@ pub fn check_types_are_compatible<'a>(
     Ok(())
 }
 
-pub fn check_input_types_are_compatible<'a>(
-    gql_type: &InputValue<'a>,
+pub fn check_input_types_are_compatible(
+    gql_type: &InputValue<'_>,
     rust_type: &syn::Type,
 ) -> Result<(), syn::Error> {
     let parsed_type = parse_rust_type(rust_type);
@@ -44,7 +44,7 @@ pub fn check_input_types_are_compatible<'a>(
 }
 
 pub fn check_spread_type(rust_type: &syn::Type) -> Result<(), syn::Error> {
-    fn inner_fn(rust_type: &RustType) -> Result<(), syn::Error> {
+    fn inner_fn(rust_type: &RustType<'_>) -> Result<(), syn::Error> {
         match rust_type {
             RustType::Unknown { .. } => {
                 // If we can't parse the type just ignore it - the compiler will still tell us if it's
@@ -78,7 +78,7 @@ pub fn check_spread_type(rust_type: &syn::Type) -> Result<(), syn::Error> {
 /// Returns the type inside `Option` if the type is `Option`.
 /// Otherwise returns None
 pub fn outer_type_is_option(rust_type: &syn::Type) -> bool {
-    fn inner_fn(rust_type: &RustType) -> bool {
+    fn inner_fn(rust_type: &RustType<'_>) -> bool {
         match rust_type {
             RustType::Optional { .. } => true,
             RustType::List { .. } => false,
@@ -150,7 +150,7 @@ fn output_type_check<'a>(
 fn input_type_check<'a>(
     gql_type: &TypeRef<'a, InputType<'a>>,
     has_default: bool,
-    rust_type: &RustType,
+    rust_type: &RustType<'_>,
 ) -> Result<(), TypeValidationError> {
     match (&gql_type, rust_type) {
         (gql_type, RustType::Box { inner, .. }) => {
@@ -200,9 +200,9 @@ fn input_type_check<'a>(
     }
 }
 
-fn recursing_check<'a>(
-    gql_type: &TypeRef<'a, OutputType>,
-    rust_type: &RustType,
+fn recursing_check(
+    gql_type: &TypeRef<'_, OutputType<'_>>,
+    rust_type: &RustType<'_>,
 ) -> Result<(), TypeValidationError> {
     if let RustType::Unknown { .. } = rust_type {
         return Err(TypeValidationError::UnknownType {
@@ -314,8 +314,8 @@ mod tests {
     type OutputTypeRef<'a> = super::TypeRef<'a, OutputType<'a>>;
     type InputTypeRef<'a> = super::TypeRef<'a, InputType<'a>>;
 
-    fn call_output_type_check<'a>(
-        gql_type: &OutputTypeRef<'a>,
+    fn call_output_type_check(
+        gql_type: &OutputTypeRef<'_>,
         rust_type: &syn::Type,
         flattening: bool,
     ) -> Result<(), TypeValidationError> {
@@ -536,8 +536,8 @@ mod tests {
         );
     }
 
-    fn call_input_type_check<'a>(
-        gql_type: &InputTypeRef<'a>,
+    fn call_input_type_check(
+        gql_type: &InputTypeRef<'_>,
         has_default: bool,
         rust_type: &syn::Type,
     ) -> Result<(), TypeValidationError> {

--- a/cynic-codegen/src/use_schema/params.rs
+++ b/cynic-codegen/src/use_schema/params.rs
@@ -4,7 +4,7 @@ pub struct UseSchemaParams {
 }
 
 impl syn::parse::Parse for UseSchemaParams {
-    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+    fn parse(input: syn::parse::ParseStream<'_>) -> syn::Result<Self> {
         let lit_str = input.parse::<syn::LitStr>()?;
 
         Ok(UseSchemaParams {

--- a/cynic-codegen/src/use_schema/schema_roots.rs
+++ b/cynic-codegen/src/use_schema/schema_roots.rs
@@ -29,10 +29,11 @@ impl<'a> RootTypes<'a> {
         }
 
         Ok(RootTypes {
-            query: schema.lookup::<ObjectType>(&query_name)?,
-            mutation: mutation_name.and_then(|name| schema.try_lookup::<ObjectType>(&name).ok()),
+            query: schema.lookup::<ObjectType<'_>>(&query_name)?,
+            mutation: mutation_name
+                .and_then(|name| schema.try_lookup::<ObjectType<'_>>(&name).ok()),
             subscription: subscription_name
-                .and_then(|name| schema.try_lookup::<ObjectType>(&name).ok()),
+                .and_then(|name| schema.try_lookup::<ObjectType<'_>>(&name).ok()),
         })
     }
 }

--- a/cynic-proc-macros/src/lib.rs
+++ b/cynic-proc-macros/src/lib.rs
@@ -3,7 +3,7 @@
 #![allow(clippy::let_and_return)]
 #![warn(missing_docs)]
 
-extern crate proc_macro;
+// extern crate proc_macro;
 
 use proc_macro::TokenStream;
 

--- a/cynic-querygen/src/query_parsing/inputs.rs
+++ b/cynic-querygen/src/query_parsing/inputs.rs
@@ -36,8 +36,8 @@ impl<'schema> Vertex for InputObject<'schema> {
 
 pub type InputObjectSet<'schema> = BTreeSet<Rc<InputObject<'schema>>>;
 
-pub fn extract_input_objects<'query, 'schema>(
-    doc: &NormalisedDocument<'query, 'schema>,
+pub fn extract_input_objects<'schema>(
+    doc: &NormalisedDocument<'_, 'schema>,
 ) -> Result<InputObjectSet<'schema>, Error> {
     let mut result = InputObjectSet::new();
 

--- a/cynic-querygen/src/query_parsing/leaf_types.rs
+++ b/cynic-querygen/src/query_parsing/leaf_types.rs
@@ -8,8 +8,8 @@ use crate::{
     Error,
 };
 
-pub fn extract_leaf_types<'query, 'schema>(
-    doc: &NormalisedDocument<'query, 'schema>,
+pub fn extract_leaf_types<'schema>(
+    doc: &NormalisedDocument<'_, 'schema>,
     inputs: &InputObjectSet<'schema>,
 ) -> Result<(Vec<EnumDetails<'schema>>, Vec<Scalar<'schema>>), Error> {
     let mut leaf_types = doc

--- a/cynic/src/core.rs
+++ b/cynic/src/core.rs
@@ -14,7 +14,7 @@ pub trait QueryFragment<'de>: serde::Deserialize<'de> {
     const TYPE: Option<&'static str> = None;
 
     /// Adds this fragment to the query being built by `builder`
-    fn query(builder: SelectionBuilder<Self::SchemaType, Self::Variables>);
+    fn query(builder: SelectionBuilder<'_, Self::SchemaType, Self::Variables>);
 }
 
 impl<'de, T> QueryFragment<'de> for Option<T>
@@ -24,7 +24,7 @@ where
     type SchemaType = Option<T::SchemaType>;
     type Variables = T::Variables;
 
-    fn query(builder: SelectionBuilder<Self::SchemaType, Self::Variables>) {
+    fn query(builder: SelectionBuilder<'_, Self::SchemaType, Self::Variables>) {
         T::query(builder.into_inner())
     }
 }
@@ -36,7 +36,7 @@ where
     type SchemaType = Vec<T::SchemaType>;
     type Variables = T::Variables;
 
-    fn query(builder: SelectionBuilder<Self::SchemaType, Self::Variables>) {
+    fn query(builder: SelectionBuilder<'_, Self::SchemaType, Self::Variables>) {
         T::query(builder.into_inner())
     }
 }
@@ -48,7 +48,7 @@ where
     type SchemaType = T::SchemaType;
     type Variables = T::Variables;
 
-    fn query(builder: SelectionBuilder<Self::SchemaType, Self::Variables>) {
+    fn query(builder: SelectionBuilder<'_, Self::SchemaType, Self::Variables>) {
         T::query(builder)
     }
 }
@@ -61,7 +61,7 @@ where
     type SchemaType = T::SchemaType;
     type Variables = T::Variables;
 
-    fn query(builder: SelectionBuilder<Self::SchemaType, Self::Variables>) {
+    fn query(builder: SelectionBuilder<'_, Self::SchemaType, Self::Variables>) {
         T::query(builder)
     }
 }
@@ -74,7 +74,7 @@ where
     type SchemaType = T::SchemaType;
     type Variables = T::Variables;
 
-    fn query(builder: SelectionBuilder<Self::SchemaType, Self::Variables>) {
+    fn query(builder: SelectionBuilder<'_, Self::SchemaType, Self::Variables>) {
         T::query(builder)
     }
 }
@@ -83,14 +83,14 @@ impl<'de> QueryFragment<'de> for bool {
     type SchemaType = bool;
     type Variables = ();
 
-    fn query(_builder: SelectionBuilder<Self::SchemaType, Self::Variables>) {}
+    fn query(_builder: SelectionBuilder<'_, Self::SchemaType, Self::Variables>) {}
 }
 
 impl<'de> QueryFragment<'de> for String {
     type SchemaType = String;
     type Variables = ();
 
-    fn query(_builder: SelectionBuilder<Self::SchemaType, Self::Variables>) {}
+    fn query(_builder: SelectionBuilder<'_, Self::SchemaType, Self::Variables>) {}
 }
 
 /// A QueryFragment that contains a set of inline fragments

--- a/cynic/src/lib.rs
+++ b/cynic/src/lib.rs
@@ -1,3 +1,4 @@
+#![deny(rust_2018_idioms)]
 //! # Cynic
 //!
 //! Cynic is a GraphQL query builder & data mapper for Rust.

--- a/cynic/src/private/content.rs
+++ b/cynic/src/private/content.rs
@@ -49,7 +49,7 @@ pub enum Content<'de> {
 
 impl<'de> Content<'de> {
     #[cold]
-    fn unexpected(&self) -> Unexpected {
+    fn unexpected(&self) -> Unexpected<'_> {
         match *self {
             Content::Bool(b) => Unexpected::Bool(b),
             Content::U8(n) => Unexpected::Unsigned(n as u64),
@@ -92,7 +92,7 @@ struct ContentVisitor<'de> {
 impl<'de> Visitor<'de> for ContentVisitor<'de> {
     type Value = Content<'de>;
 
-    fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+    fn expecting(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt.write_str("any value")
     }
 
@@ -695,7 +695,7 @@ where
     }
 }
 
-pub struct ContentRefDeserializer<'a, 'de: 'a, E> {
+pub struct ContentRefDeserializer<'a, 'de, E> {
     content: &'a Content<'de>,
     err: PhantomData<E>,
 }
@@ -775,7 +775,7 @@ where
     V: Visitor<'de>,
     E: de::Error,
 {
-    let map = content.iter().map(|&(ref k, ref v)| {
+    let map = content.iter().map(|(k, v)| {
         (
             KeyDeserializer::new(k.clone()),
             ContentRefDeserializer::new(v),

--- a/cynic/src/private/cow_str.rs
+++ b/cynic/src/private/cow_str.rs
@@ -29,7 +29,7 @@ struct CowStrVisitor;
 impl<'de> Visitor<'de> for CowStrVisitor {
     type Value = CowStr<'de>;
 
-    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter.write_str("a string")
     }
 

--- a/cynic/src/private/inline_fragment_de.rs
+++ b/cynic/src/private/inline_fragment_de.rs
@@ -27,7 +27,7 @@ where
 {
     type Value = T;
 
-    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         formatter.write_str("a map")
     }
 
@@ -37,16 +37,16 @@ where
     {
         let mut buffer = Vec::new();
 
-        while let Some(key) = access.next_key::<CowStr>()? {
+        while let Some(key) = access.next_key::<CowStr<'_>>()? {
             let key = key.into_inner();
             if key == "__typename" {
-                let typename = access.next_value::<CowStr>()?.into_inner();
+                let typename = access.next_value::<CowStr<'_>>()?.into_inner();
                 return T::deserialize_variant(
                     typename.as_ref(),
                     BufferDeserializer { access, buffer },
                 );
             }
-            buffer.push((key, access.next_value::<Content>()?))
+            buffer.push((key, access.next_value::<Content<'_>>()?))
         }
 
         Err(M::Error::missing_field("__typename"))


### PR DESCRIPTION
#### Why are we making this change?

Some users of cynic build with `-D rust-2018-idioms` and our generated code
does not compile under that flag.

#### What effects does this change have?

Fixes the various bits of code that use rust-2018-idioms (mostly just omitting
lifetime parameters).  Also updated cynic itself similarly.
