### PR TITLE
[Merged by Bors] - Support __typename on variants inside inline fragment.

### DIFF
--- a/cynic/src/private/inline_fragment_de.rs
+++ b/cynic/src/private/inline_fragment_de.rs
@@ -41,6 +41,13 @@ where
             let key = key.into_inner();
             if key == "__typename" {
                 let typename = access.next_value::<CowStr<'_>>()?.into_inner();
+
+                // Put __typename into the buffer incase it's needed by the inner decoder
+                buffer.push((
+                    Cow::Borrowed("__typename"),
+                    Content::String(typename.as_ref().to_string()),
+                ));
+
                 return T::deserialize_variant(
                     typename.as_ref(),
                     BufferDeserializer { access, buffer },

--- a/examples/examples/querying-interfaces.rs
+++ b/examples/examples/querying-interfaces.rs
@@ -17,6 +17,7 @@ enum Node {
 #[derive(cynic::QueryFragment, Debug)]
 #[cynic(schema_path = "../schemas/starwars.schema.graphql")]
 struct Film {
+    __typename: String,
     title: Option<String>,
 }
 

--- a/examples/examples/snapshots/querying_interfaces__test__running_query_with_film.snap
+++ b/examples/examples/snapshots/querying_interfaces__test__running_query_with_film.snap
@@ -1,6 +1,5 @@
 ---
 source: examples/examples/querying-interfaces.rs
-assertion_line: 115
 expression: result.data
 ---
 Some(
@@ -8,6 +7,7 @@ Some(
         node: Some(
             Film(
                 Film {
+                    __typename: "Film",
                     title: Some(
                         "A New Hope",
                     ),

--- a/examples/examples/snapshots/querying_interfaces__test__snapshot_test_query.snap
+++ b/examples/examples/snapshots/querying_interfaces__test__snapshot_test_query.snap
@@ -1,12 +1,12 @@
 ---
 source: examples/examples/querying-interfaces.rs
-assertion_line: 106
 expression: query.query
 ---
 query($id: ID!) {
   node(id: $id) {
     __typename
     ... on Film {
+      __typename
       title
     }
     ... on Planet {


### PR DESCRIPTION
We were extracting the __typename to use for variant selection, but then not passing it into the inner type that we needed to deserialize, so it was failing.