### PR TITLE
[Merged by Bors] - Generics support

### DIFF
--- a/cynic-codegen/Cargo.toml
+++ b/cynic-codegen/Cargo.toml
@@ -19,7 +19,7 @@ rustfmt = []
 counter = "0.5"
 graphql-parser = "0.4.0"
 proc-macro2 = "1.0"
-syn = "1.0"
+syn = { version = "1.0", features = ["visit-mut"] }
 quote = "1.0"
 darling = "0.13"
 strsim = "0.10.0"

--- a/cynic-codegen/src/enum_derive/mod.rs
+++ b/cynic-codegen/src/enum_derive/mod.rs
@@ -1,5 +1,7 @@
-use proc_macro2::{Span, TokenStream};
-use std::collections::BTreeMap;
+use {
+    proc_macro2::{Span, TokenStream},
+    std::collections::BTreeMap,
+};
 
 use crate::{
     idents::RenameAll,
@@ -11,13 +13,14 @@ use crate::{
 };
 
 pub(crate) mod input;
-use crate::suggestions::{format_guess, guess_field};
 pub use input::EnumDeriveInput;
-use input::EnumDeriveVariant;
+use {
+    crate::suggestions::{format_guess, guess_field},
+    input::EnumDeriveVariant,
+};
 
 pub fn enum_derive(ast: &syn::DeriveInput) -> Result<TokenStream, syn::Error> {
-    use darling::FromDeriveInput;
-    use syn::spanned::Spanned;
+    use {darling::FromDeriveInput, syn::spanned::Spanned};
 
     let enum_span = ast.span();
 
@@ -89,9 +92,9 @@ pub fn enum_derive_impl(
 
             #[automatically_derived]
             impl ::cynic::serde::Serialize for #ident {
-                fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+                fn serialize<__S>(&self, serializer: __S) -> Result<__S::Ok, __S::Error>
                 where
-                    S: ::cynic::serde::Serializer {
+                    __S: ::cynic::serde::Serializer {
                         match self {
                             #(
                                 #ident::#variants => serializer.serialize_unit_variant(#graphql_type_name, #variant_indexes, #string_literals),
@@ -102,9 +105,9 @@ pub fn enum_derive_impl(
 
             #[automatically_derived]
             impl<'de> ::cynic::serde::Deserialize<'de> for #ident {
-                fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+                fn deserialize<__D>(deserializer: __D) -> Result<Self, __D::Error>
                 where
-                    D: ::cynic::serde::Deserializer<'de>,
+                    __D: ::cynic::serde::Deserializer<'de>,
                 {
                     match <String as ::cynic::serde::Deserialize>::deserialize(deserializer)?.as_ref() {
                         #(
@@ -203,14 +206,12 @@ fn join_variants<'a>(
 
 #[cfg(test)]
 mod tests {
-    use assert_matches::assert_matches;
-    use darling::util::SpannedValue;
-    use rstest::rstest;
-    use std::collections::HashSet;
-    use syn::parse_quote;
+    use {
+        assert_matches::assert_matches, darling::util::SpannedValue, rstest::rstest,
+        std::collections::HashSet, syn::parse_quote,
+    };
 
-    use super::*;
-    use crate::schema::FieldName;
+    use {super::*, crate::schema::FieldName};
 
     #[rstest(
         enum_variant_1,

--- a/cynic-codegen/src/enum_derive/snapshots/cynic_codegen__enum_derive__tests__snapshot_enum_derive.snap
+++ b/cynic-codegen/src/enum_derive/snapshots/cynic_codegen__enum_derive__tests__snapshot_enum_derive.snap
@@ -1,6 +1,5 @@
 ---
 source: cynic-codegen/src/enum_derive/mod.rs
-assertion_line: 390
 expression: "format_code(format!(\"{}\", tokens))"
 ---
 #[automatically_derived]
@@ -9,9 +8,9 @@ impl ::cynic::Enum for States {
 }
 #[automatically_derived]
 impl ::cynic::serde::Serialize for States {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    fn serialize<__S>(&self, serializer: __S) -> Result<__S::Ok, __S::Error>
     where
-        S: ::cynic::serde::Serializer,
+        __S: ::cynic::serde::Serializer,
     {
         match self {
             States::Closed => serializer.serialize_unit_variant("States", 0u32, "CLOSED"),
@@ -22,9 +21,9 @@ impl ::cynic::serde::Serialize for States {
 }
 #[automatically_derived]
 impl<'de> ::cynic::serde::Deserialize<'de> for States {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    fn deserialize<__D>(deserializer: __D) -> Result<Self, __D::Error>
     where
-        D: ::cynic::serde::Deserializer<'de>,
+        __D: ::cynic::serde::Deserializer<'de>,
     {
         match <String as ::cynic::serde::Deserialize>::deserialize(deserializer)?.as_ref() {
             "CLOSED" => Ok(States::Closed),

--- a/cynic-codegen/src/fragment_derive/arguments/mod.rs
+++ b/cynic-codegen/src/fragment_derive/arguments/mod.rs
@@ -15,10 +15,10 @@ pub fn process_arguments<'a>(
     literals: Vec<parsing::FieldArgument>,
     field: &crate::schema::types::Field<'a>,
     schema_module: syn::Path,
-    variables: Option<&syn::Path>,
+    variables_fields: Option<&syn::Path>,
     span: Span,
 ) -> Result<Output<'a>, Errors> {
-    let analysed = analyse::analyse(literals, field, variables, span)?;
+    let analysed = analyse::analyse(literals, field, variables_fields, span)?;
 
     Ok(Output {
         analysed,

--- a/cynic-codegen/src/fragment_derive/arguments/output.rs
+++ b/cynic-codegen/src/fragment_derive/arguments/output.rs
@@ -107,10 +107,10 @@ impl ToTokens for ArgumentValueTokens<'_> {
             }),
             ArgumentValue::Variable(var) => {
                 let var_ident = &var.ident;
-                let variables = &var.variable_struct;
+                let variables_fields = &var.variables_fields_struct;
 
                 tokens.append_all(quote! {
-                    .variable(<#variables as ::cynic::QueryVariables>::Fields::#var_ident())
+                    .variable(#variables_fields::#var_ident())
                 });
             }
             ArgumentValue::Some(inner) => {

--- a/cynic-codegen/src/fragment_derive/arguments/output.rs
+++ b/cynic-codegen/src/fragment_derive/arguments/output.rs
@@ -152,9 +152,9 @@ impl<'a> quote::ToTokens for VariantDetailsTokens<'a> {
             struct #ident;
 
             impl ::cynic::serde::Serialize for #ident {
-                fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+                fn serialize<__S>(&self, serializer: __S) -> Result<__S::Ok, __S::Error>
                 where
-                    S: ::cynic::serde::Serializer
+                    __S: ::cynic::serde::Serializer
                 {
                     serializer.serialize_unit_variant("", 0, #variant_str)
                 }

--- a/cynic-codegen/src/fragment_derive/arguments/snapshots/cynic_codegen__fragment_derive__arguments__tests__top_level_variable.snap
+++ b/cynic-codegen/src/fragment_derive/arguments/snapshots/cynic_codegen__fragment_derive__arguments__tests__top_level_variable.snap
@@ -23,7 +23,7 @@ Ok(
                     value_type: NamedInputType(
                         "BookFilters",
                     ),
-                    variable_struct: Path {
+                    variables_fields_struct: Path {
                         leading_colon: None,
                         segments: [
                             PathSegment {

--- a/cynic-codegen/src/fragment_derive/arguments/snapshots/cynic_codegen__fragment_derive__arguments__tests__top_level_variables.snap
+++ b/cynic-codegen/src/fragment_derive/arguments/snapshots/cynic_codegen__fragment_derive__arguments__tests__top_level_variables.snap
@@ -1,6 +1,5 @@
 ---
 source: cynic-codegen/src/fragment_derive/arguments/tests.rs
-assertion_line: 36
 expression: "analyse(literals, field, Some(&format_ident!(\"MyArguments\").into()),\n        Span::call_site()).map(|o| o.arguments)"
 ---
 Ok(
@@ -24,7 +23,7 @@ Ok(
                     value_type: NamedInputType(
                         "BookFilters",
                     ),
-                    variable_struct: Path {
+                    variables_fields_struct: Path {
                         leading_colon: None,
                         segments: [
                             PathSegment {
@@ -61,7 +60,7 @@ Ok(
                             "BookFilters",
                         ),
                     ),
-                    variable_struct: Path {
+                    variables_fields_struct: Path {
                         leading_colon: None,
                         segments: [
                             PathSegment {

--- a/cynic-codegen/src/fragment_derive/arguments/snapshots/cynic_codegen__fragment_derive__arguments__tests__variable_in_object.snap
+++ b/cynic-codegen/src/fragment_derive/arguments/snapshots/cynic_codegen__fragment_derive__arguments__tests__variable_in_object.snap
@@ -1,6 +1,5 @@
 ---
 source: cynic-codegen/src/fragment_derive/arguments/tests.rs
-assertion_line: 36
 expression: "analyse(literals, field, Some(&format_ident!(\"MyArguments\").into()),\n        Span::call_site()).map(|o| o.arguments)"
 ---
 Ok(
@@ -74,7 +73,7 @@ Ok(
                                             "BookState",
                                         ),
                                     ),
-                                    variable_struct: Path {
+                                    variables_fields_struct: Path {
                                         leading_colon: None,
                                         segments: [
                                             PathSegment {

--- a/cynic-codegen/src/fragment_derive/deserialize_impl.rs
+++ b/cynic-codegen/src/fragment_derive/deserialize_impl.rs
@@ -116,9 +116,9 @@ impl quote::ToTokens for StandardDeserializeImpl<'_> {
         tokens.append_all(quote! {
             #[automatically_derived]
             impl #impl_generics ::cynic::serde::Deserialize<'de> for #target_struct #ty_generics #where_clause {
-                fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+                fn deserialize<__D>(deserializer: __D) -> Result<Self, __D::Error>
                 where
-                    D: ::cynic::serde::Deserializer<'de>,
+                    __D: ::cynic::serde::Deserializer<'de>,
                 {
                     #[derive(::cynic::serde::Deserialize)]
                     #[serde(field_identifier, crate="::cynic::serde")]
@@ -236,11 +236,11 @@ impl quote::ToTokens for SpreadingDeserializeImpl<'_> {
         tokens.append_all(quote! {
             #[automatically_derived]
             impl #impl_generics ::cynic::serde::Deserialize<'de> for #target_struct #ty_generics #where_clause {
-                fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+                fn deserialize<__D>(deserializer: __D) -> Result<Self, __D::Error>
                 where
-                    D: ::cynic::serde::Deserializer<'de>,
+                    __D: ::cynic::serde::Deserializer<'de>,
                 {
-                    let spreadable = ::cynic::__private::Spreadable::<D::Error>::deserialize(deserializer)?;
+                    let spreadable = ::cynic::__private::Spreadable::<__D::Error>::deserialize(deserializer)?;
 
                     Ok(#target_struct {
                         #(#field_inserts)*

--- a/cynic-codegen/src/fragment_derive/deserialize_impl.rs
+++ b/cynic-codegen/src/fragment_derive/deserialize_impl.rs
@@ -1,21 +1,25 @@
 use proc_macro2::TokenStream;
 
-use super::FragmentDeriveField;
-use crate::schema::types as schema;
+use {
+    super::{FragmentDeriveField, Generics},
+    crate::schema::types as schema,
+};
 
-pub enum DeserializeImpl {
-    Standard(StandardDeserializeImpl),
-    Spreading(SpreadingDeserializeImpl),
+pub enum DeserializeImpl<'a> {
+    Standard(StandardDeserializeImpl<'a>),
+    Spreading(SpreadingDeserializeImpl<'a>),
 }
 
-pub struct StandardDeserializeImpl {
-    target_struct: syn::Ident,
+pub struct StandardDeserializeImpl<'a> {
+    target_struct: &'a syn::Ident,
     fields: Vec<Field>,
+    generics: &'a Generics<'a>,
 }
 
-pub struct SpreadingDeserializeImpl {
-    target_struct: syn::Ident,
+pub struct SpreadingDeserializeImpl<'a> {
+    target_struct: &'a syn::Ident,
     fields: Vec<Field>,
+    generics: &'a Generics<'a>,
 }
 
 struct Field {
@@ -27,14 +31,15 @@ struct Field {
     is_flattened: bool,
 }
 
-impl DeserializeImpl {
+impl<'a> DeserializeImpl<'a> {
     pub fn new(
         fields: &[(&FragmentDeriveField, Option<&schema::Field<'_>>)],
-        name: &syn::Ident,
-    ) -> DeserializeImpl {
+        name: &'a syn::Ident,
+        generics: &'a Generics<'a>,
+    ) -> Self {
         let spreading = fields.iter().any(|f| *f.0.spread);
 
-        let target_struct = name.clone();
+        let target_struct = name;
         let fields = fields
             .iter()
             .map(|(field, schema_field)| process_field(field, *schema_field))
@@ -44,16 +49,18 @@ impl DeserializeImpl {
             true => DeserializeImpl::Spreading(SpreadingDeserializeImpl {
                 target_struct,
                 fields,
+                generics,
             }),
             false => DeserializeImpl::Standard(StandardDeserializeImpl {
                 target_struct,
                 fields,
+                generics,
             }),
         }
     }
 }
 
-impl quote::ToTokens for DeserializeImpl {
+impl quote::ToTokens for DeserializeImpl<'_> {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         match self {
             DeserializeImpl::Standard(inner) => inner.to_tokens(tokens),
@@ -62,7 +69,7 @@ impl quote::ToTokens for DeserializeImpl {
     }
 }
 
-impl quote::ToTokens for StandardDeserializeImpl {
+impl quote::ToTokens for StandardDeserializeImpl<'_> {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         use quote::{quote, TokenStreamExt};
 
@@ -102,9 +109,13 @@ impl quote::ToTokens for StandardDeserializeImpl {
         let expecting_str = proc_macro2::Literal::string(&format!("struct {}", &struct_name));
         let struct_name = proc_macro2::Literal::string(&struct_name);
 
+        let (_, ty_generics, _) = self.generics.generics.split_for_impl();
+        let generics_with_de = &self.generics.generics_with_de_and_deserialize_bounds;
+        let (impl_generics, ty_generics_with_de, where_clause) = generics_with_de.split_for_impl();
+
         tokens.append_all(quote! {
             #[automatically_derived]
-            impl<'de> ::cynic::serde::Deserialize<'de> for #target_struct {
+            impl #impl_generics ::cynic::serde::Deserialize<'de> for #target_struct #ty_generics #where_clause {
                 fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
                 where
                     D: ::cynic::serde::Deserializer<'de>,
@@ -121,16 +132,19 @@ impl quote::ToTokens for StandardDeserializeImpl {
                         __Other
                     }
 
-                    struct Visitor;
+                    struct Visitor #generics_with_de #where_clause {
+                        marker: ::core::marker::PhantomData<#target_struct #ty_generics>,
+                        lifetime: ::core::marker::PhantomData<&'de ()>,
+                    }
 
-                    impl <'de> ::cynic::serde::de::Visitor<'de> for Visitor {
-                        type Value = #target_struct;
+                    impl #impl_generics ::cynic::serde::de::Visitor<'de> for Visitor #ty_generics_with_de #where_clause {
+                        type Value = #target_struct #ty_generics;
 
                         fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                             formatter.write_str(#expecting_str)
                         }
 
-                        fn visit_map<V>(self, mut __map: V) -> Result<#target_struct, V::Error>
+                        fn visit_map<V>(self, mut __map: V) -> Result<Self::Value, V::Error>
                         where
                             V: ::cynic::serde::de::MapAccess<'de>,
                         {
@@ -163,14 +177,21 @@ impl quote::ToTokens for StandardDeserializeImpl {
 
                     const FIELDS: &'static [&str] = &[#(#serialized_names),*];
 
-                    deserializer.deserialize_struct(#struct_name, FIELDS, Visitor)
+                    deserializer.deserialize_struct(
+                        #struct_name,
+                        FIELDS,
+                        Visitor {
+                            marker: ::core::marker::PhantomData,
+                            lifetime: ::core::marker::PhantomData,
+                        },
+                    )
                 }
             }
         });
     }
 }
 
-impl quote::ToTokens for SpreadingDeserializeImpl {
+impl quote::ToTokens for SpreadingDeserializeImpl<'_> {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         use quote::{quote, TokenStreamExt};
 
@@ -208,9 +229,15 @@ impl quote::ToTokens for SpreadingDeserializeImpl {
             }
         });
 
+        let (_, ty_generics, where_clause) = self.generics.generics.split_for_impl();
+        let (impl_generics, _, _) = self
+            .generics
+            .generics_with_de_and_deserialize_bounds
+            .split_for_impl();
+
         tokens.append_all(quote! {
             #[automatically_derived]
-            impl<'de> ::cynic::serde::Deserialize<'de> for #target_struct {
+            impl #impl_generics ::cynic::serde::Deserialize<'de> for #target_struct #ty_generics #where_clause {
                 fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
                 where
                     D: ::cynic::serde::Deserializer<'de>,

--- a/cynic-codegen/src/fragment_derive/fragment_impl.rs
+++ b/cynic-codegen/src/fragment_derive/fragment_impl.rs
@@ -89,9 +89,7 @@ impl<'a> FragmentImpl<'a> {
 
         let variables_fields = if let Some(vars) = variables_fields {
             let span = vars.span();
-
-            let variables_fields = quote_spanned! { span => #vars };
-            syn::parse2(variables_fields)?
+            syn::parse2(quote_spanned! { span => #vars })?
         } else {
             syn::parse2(quote! { () })?
         };

--- a/cynic-codegen/src/fragment_derive/fragment_impl.rs
+++ b/cynic-codegen/src/fragment_derive/fragment_impl.rs
@@ -7,7 +7,8 @@ use {
 use crate::{
     error::Errors,
     schema::types::{Field, OutputType},
-    types::{self, check_spread_type, check_types_are_compatible, CheckMode}, variables_fields_path,
+    types::{self, check_spread_type, check_types_are_compatible, CheckMode},
+    variables_fields_path,
 };
 
 use super::{
@@ -173,7 +174,7 @@ impl quote::ToTokens for FragmentImpl<'_> {
                 const TYPE: Option<&'static str> = Some(#graphql_type);
 
                 fn query(mut builder: ::cynic::queries::SelectionBuilder<'_, Self::SchemaType, Self::VariablesFields>)
-                where 
+                where
                 {
                     #![allow(unused_mut)]
 

--- a/cynic-codegen/src/fragment_derive/input.rs
+++ b/cynic-codegen/src/fragment_derive/input.rs
@@ -1,16 +1,15 @@
-use std::collections::HashSet;
-
-use darling::util::SpannedValue;
-use quote::quote_spanned;
+use {
+    darling::util::SpannedValue, proc_macro2::Span, quote::quote_spanned, std::collections::HashSet,
+};
 
 use crate::{idents::RenamableFieldIdent, types::CheckMode, Errors};
-use proc_macro2::Span;
 
 #[derive(darling::FromDeriveInput)]
 #[darling(attributes(cynic), supports(struct_named))]
 pub struct FragmentDeriveInput {
     pub(super) ident: proc_macro2::Ident,
     pub(super) data: darling::ast::Data<(), FragmentDeriveField>,
+    pub(super) generics: syn::Generics,
 
     pub schema_path: SpannedValue<String>,
 
@@ -216,8 +215,7 @@ impl FragmentDeriveField {
 mod tests {
     use super::*;
 
-    use assert_matches::assert_matches;
-    use quote::format_ident;
+    use {assert_matches::assert_matches, quote::format_ident};
 
     #[test]
     fn test_fragment_derive_validate_pass() {
@@ -268,6 +266,7 @@ mod tests {
                     },
                 ],
             )),
+            generics: Default::default(),
             schema_path: "abcd".to_string().into(),
             schema_module_: None,
             graphql_type: Some("abcd".to_string().into()),
@@ -347,6 +346,7 @@ mod tests {
                     },
                 ],
             )),
+            generics: Default::default(),
             schema_path: "abcd".to_string().into(),
             schema_module_: Some(syn::parse2(quote::quote! { abcd }).unwrap()),
             graphql_type: Some("abcd".to_string().into()),
@@ -366,6 +366,7 @@ mod tests {
                 darling::ast::Style::Struct,
                 vec![],
             )),
+            generics: Default::default(),
             schema_path: "abcd".to_string().into(),
             schema_module_: Some(syn::parse2(quote::quote! { abcd }).unwrap()),
             graphql_type: Some("abcd".to_string().into()),
@@ -419,6 +420,7 @@ mod tests {
                     },
                 ],
             )),
+            generics: Default::default(),
             schema_path: "abcd".to_string().into(),
             schema_module_: Some(syn::parse2(quote::quote! { abcd }).unwrap()),
             graphql_type: None,

--- a/cynic-codegen/src/fragment_derive/mod.rs
+++ b/cynic-codegen/src/fragment_derive/mod.rs
@@ -1,4 +1,7 @@
-use proc_macro2::{Span, TokenStream};
+use {
+    proc_macro2::{Span, TokenStream},
+    syn::parse_quote,
+};
 
 use crate::{
     schema::{
@@ -59,20 +62,21 @@ pub fn fragment_derive_impl(
     let schema_module = input.schema_module();
     let variables = input.variables();
     let deprecations = input.deprecations();
-    let ident = input.ident;
+    let generics = Generics::new(&input.generics);
     if let darling::ast::Data::Struct(fields) = input.data {
         let fields = pair_fields(fields.iter(), &schema_type)?;
 
         let fragment_impl = FragmentImpl::new_for(
             &fields,
-            &ident,
+            &input.ident,
+            generics.generics,
             &schema_type,
             &schema_module,
             graphql_name,
             variables.as_ref(),
         )?;
 
-        let deserialize_impl = DeserializeImpl::new(&fields, &ident);
+        let deserialize_impl = DeserializeImpl::new(&fields, &input.ident, &generics);
 
         Ok(quote::quote! {
             #fragment_impl
@@ -131,6 +135,36 @@ fn pair_fields<'a, 'b>(
         .collect();
 
     Err(errors)
+}
+
+pub struct Generics<'a> {
+    generics: &'a syn::Generics,
+    generics_with_de_and_deserialize_bounds: syn::Generics,
+}
+
+impl<'a> Generics<'a> {
+    fn new(generics: &'a syn::Generics) -> Self {
+        let mut generics_with_de_and_deserialize_bounds = generics.clone();
+        generics_with_de_and_deserialize_bounds
+            .params
+            .push(parse_quote!('de));
+        for generic in &generics.params {
+            match generic {
+                syn::GenericParam::Type(type_) => {
+                    let ident = &type_.ident;
+                    generics_with_de_and_deserialize_bounds
+                        .make_where_clause()
+                        .predicates
+                        .push(parse_quote! { #ident: ::cynic::serde::Deserialize<'de> })
+                }
+                syn::GenericParam::Lifetime(_) | syn::GenericParam::Const(_) => {}
+            }
+        }
+        Self {
+            generics,
+            generics_with_de_and_deserialize_bounds,
+        }
+    }
 }
 
 #[cfg(test)]

--- a/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__argument_and_rename.snap
+++ b/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__argument_and_rename.snap
@@ -3,25 +3,27 @@ source: cynic-codegen/src/fragment_derive/tests.rs
 expression: "format_code(format!(\"{}\", tokens))"
 ---
 #[automatically_derived]
-impl<'de> ::cynic::QueryFragment<'de> for MyQuery {
+impl ::cynic::QueryFragment for MyQuery {
     type SchemaType = schema::Query;
-    type Variables = ();
+    type VariablesFields = ();
     const TYPE: Option<&'static str> = Some("Query");
     fn query(
-        mut builder: ::cynic::queries::SelectionBuilder<'_, Self::SchemaType, Self::Variables>,
+        mut builder: ::cynic::queries::SelectionBuilder<
+            '_,
+            Self::SchemaType,
+            Self::VariablesFields,
+        >,
     ) {
         #![allow(unused_mut)]
-        let mut field_builder = builder . select_field :: < schema :: __fields :: Query :: post , < Option < BlogPostOutput > as :: cynic :: QueryFragment < '_ >> :: SchemaType > () ;
+        let mut field_builder = builder . select_field :: < schema :: __fields :: Query :: post , < Option < BlogPostOutput > as :: cynic :: QueryFragment > :: SchemaType > () ;
         {
             field_builder
                 .argument::<schema::__fields::Query::_post_arguments::id>()
                 .literal("1234");
         }
-        <Option<BlogPostOutput> as ::cynic::QueryFragment<'_>>::query(
-            field_builder.select_children(),
-        );
-        let mut field_builder = builder . select_field :: < schema :: __fields :: Query :: allPosts , < Vec < BlogPostOutput > as :: cynic :: QueryFragment < '_ >> :: SchemaType > () ;
-        <Vec<BlogPostOutput> as ::cynic::QueryFragment<'_>>::query(field_builder.select_children());
+        <Option<BlogPostOutput> as ::cynic::QueryFragment>::query(field_builder.select_children());
+        let mut field_builder = builder . select_field :: < schema :: __fields :: Query :: allPosts , < Vec < BlogPostOutput > as :: cynic :: QueryFragment > :: SchemaType > () ;
+        <Vec<BlogPostOutput> as ::cynic::QueryFragment>::query(field_builder.select_children());
     }
 }
 #[automatically_derived]
@@ -41,13 +43,16 @@ impl<'de> ::cynic::serde::Deserialize<'de> for MyQuery {
             #[serde(other)]
             __Other,
         }
-        struct Visitor;
-        impl<'de> ::cynic::serde::de::Visitor<'de> for Visitor {
+        struct Visitor<'de> {
+            marker: ::core::marker::PhantomData<MyQuery>,
+            lifetime: ::core::marker::PhantomData<&'de ()>,
+        }
+        impl<'de> ::cynic::serde::de::Visitor<'de> for Visitor<'de> {
             type Value = MyQuery;
             fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 formatter.write_str("struct MyQuery")
             }
-            fn visit_map<V>(self, mut __map: V) -> Result<MyQuery, V::Error>
+            fn visit_map<V>(self, mut __map: V) -> Result<Self::Value, V::Error>
             where
                 V: ::cynic::serde::de::MapAccess<'de>,
             {
@@ -79,7 +84,14 @@ impl<'de> ::cynic::serde::Deserialize<'de> for MyQuery {
             }
         }
         const FIELDS: &'static [&str] = &["post", "allPosts"];
-        deserializer.deserialize_struct("MyQuery", FIELDS, Visitor)
+        deserializer.deserialize_struct(
+            "MyQuery",
+            FIELDS,
+            Visitor {
+                marker: ::core::marker::PhantomData,
+                lifetime: ::core::marker::PhantomData,
+            },
+        )
     }
 }
 

--- a/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__argument_and_rename.snap
+++ b/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__argument_and_rename.snap
@@ -28,9 +28,9 @@ impl ::cynic::QueryFragment for MyQuery {
 }
 #[automatically_derived]
 impl<'de> ::cynic::serde::Deserialize<'de> for MyQuery {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    fn deserialize<__D>(deserializer: __D) -> Result<Self, __D::Error>
     where
-        D: ::cynic::serde::Deserializer<'de>,
+        __D: ::cynic::serde::Deserializer<'de>,
     {
         #[derive(:: cynic :: serde :: Deserialize)]
         #[serde(field_identifier, crate = "::cynic::serde")]

--- a/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__argument_literals.snap
+++ b/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__argument_literals.snap
@@ -19,9 +19,9 @@ impl ::cynic::QueryFragment for MyQuery {
         {
             struct PostStatePosted;
             impl ::cynic::serde::Serialize for PostStatePosted {
-                fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+                fn serialize<__S>(&self, serializer: __S) -> Result<__S::Ok, __S::Error>
                 where
-                    S: ::cynic::serde::Serializer,
+                    __S: ::cynic::serde::Serializer,
                 {
                     serializer.serialize_unit_variant("", 0, "POSTED")
                 }
@@ -44,9 +44,9 @@ impl ::cynic::QueryFragment for MyQuery {
 }
 #[automatically_derived]
 impl<'de> ::cynic::serde::Deserialize<'de> for MyQuery {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    fn deserialize<__D>(deserializer: __D) -> Result<Self, __D::Error>
     where
-        D: ::cynic::serde::Deserializer<'de>,
+        __D: ::cynic::serde::Deserializer<'de>,
     {
         #[derive(:: cynic :: serde :: Deserialize)]
         #[serde(field_identifier, crate = "::cynic::serde")]

--- a/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__argument_literals.snap
+++ b/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__argument_literals.snap
@@ -3,15 +3,19 @@ source: cynic-codegen/src/fragment_derive/tests.rs
 expression: "format_code(format!(\"{}\", tokens))"
 ---
 #[automatically_derived]
-impl<'de> ::cynic::QueryFragment<'de> for MyQuery {
+impl ::cynic::QueryFragment for MyQuery {
     type SchemaType = schema::Query;
-    type Variables = ();
+    type VariablesFields = ();
     const TYPE: Option<&'static str> = Some("Query");
     fn query(
-        mut builder: ::cynic::queries::SelectionBuilder<'_, Self::SchemaType, Self::Variables>,
+        mut builder: ::cynic::queries::SelectionBuilder<
+            '_,
+            Self::SchemaType,
+            Self::VariablesFields,
+        >,
     ) {
         #![allow(unused_mut)]
-        let mut field_builder = builder . select_field :: < schema :: __fields :: Query :: filteredPosts , < Vec < BlogPostOutput > as :: cynic :: QueryFragment < '_ >> :: SchemaType > () ;
+        let mut field_builder = builder . select_field :: < schema :: __fields :: Query :: filteredPosts , < Vec < BlogPostOutput > as :: cynic :: QueryFragment > :: SchemaType > () ;
         {
             struct PostStatePosted;
             impl ::cynic::serde::Serialize for PostStatePosted {
@@ -35,7 +39,7 @@ impl<'de> ::cynic::QueryFragment<'de> for MyQuery {
                         .item(|builder| builder.literal(PostStatePosted));
                 });
         }
-        <Vec<BlogPostOutput> as ::cynic::QueryFragment<'_>>::query(field_builder.select_children());
+        <Vec<BlogPostOutput> as ::cynic::QueryFragment>::query(field_builder.select_children());
     }
 }
 #[automatically_derived]
@@ -53,13 +57,16 @@ impl<'de> ::cynic::serde::Deserialize<'de> for MyQuery {
             #[serde(other)]
             __Other,
         }
-        struct Visitor;
-        impl<'de> ::cynic::serde::de::Visitor<'de> for Visitor {
+        struct Visitor<'de> {
+            marker: ::core::marker::PhantomData<MyQuery>,
+            lifetime: ::core::marker::PhantomData<&'de ()>,
+        }
+        impl<'de> ::cynic::serde::de::Visitor<'de> for Visitor<'de> {
             type Value = MyQuery;
             fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 formatter.write_str("struct MyQuery")
             }
-            fn visit_map<V>(self, mut __map: V) -> Result<MyQuery, V::Error>
+            fn visit_map<V>(self, mut __map: V) -> Result<Self::Value, V::Error>
             where
                 V: ::cynic::serde::de::MapAccess<'de>,
             {
@@ -85,7 +92,14 @@ impl<'de> ::cynic::serde::Deserialize<'de> for MyQuery {
             }
         }
         const FIELDS: &'static [&str] = &["filteredPosts"];
-        deserializer.deserialize_struct("MyQuery", FIELDS, Visitor)
+        deserializer.deserialize_struct(
+            "MyQuery",
+            FIELDS,
+            Visitor {
+                marker: ::core::marker::PhantomData,
+                lifetime: ::core::marker::PhantomData,
+            },
+        )
     }
 }
 

--- a/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__flatten_attr.snap
+++ b/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__flatten_attr.snap
@@ -3,12 +3,16 @@ source: cynic-codegen/src/fragment_derive/tests.rs
 expression: "format_code(format!(\"{}\", tokens))"
 ---
 #[automatically_derived]
-impl<'de> ::cynic::QueryFragment<'de> for Film {
+impl ::cynic::QueryFragment for Film {
     type SchemaType = schema::Film;
-    type Variables = ();
+    type VariablesFields = ();
     const TYPE: Option<&'static str> = Some("Film");
     fn query(
-        mut builder: ::cynic::queries::SelectionBuilder<'_, Self::SchemaType, Self::Variables>,
+        mut builder: ::cynic::queries::SelectionBuilder<
+            '_,
+            Self::SchemaType,
+            Self::VariablesFields,
+        >,
     ) {
         #![allow(unused_mut)]
         let mut field_builder = builder . select_flattened_field :: < schema :: __fields :: Film :: producers , < Vec < String > as :: cynic :: schema :: IsScalar < < schema :: __fields :: Film :: producers as :: cynic :: schema :: Field > :: Type >> :: SchemaType , < schema :: __fields :: Film :: producers as :: cynic :: schema :: Field > :: Type , > () ;
@@ -29,13 +33,16 @@ impl<'de> ::cynic::serde::Deserialize<'de> for Film {
             #[serde(other)]
             __Other,
         }
-        struct Visitor;
-        impl<'de> ::cynic::serde::de::Visitor<'de> for Visitor {
+        struct Visitor<'de> {
+            marker: ::core::marker::PhantomData<Film>,
+            lifetime: ::core::marker::PhantomData<&'de ()>,
+        }
+        impl<'de> ::cynic::serde::de::Visitor<'de> for Visitor<'de> {
             type Value = Film;
             fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 formatter.write_str("struct Film")
             }
-            fn visit_map<V>(self, mut __map: V) -> Result<Film, V::Error>
+            fn visit_map<V>(self, mut __map: V) -> Result<Self::Value, V::Error>
             where
                 V: ::cynic::serde::de::MapAccess<'de>,
             {
@@ -65,7 +72,14 @@ impl<'de> ::cynic::serde::Deserialize<'de> for Film {
             }
         }
         const FIELDS: &'static [&str] = &["producers"];
-        deserializer.deserialize_struct("Film", FIELDS, Visitor)
+        deserializer.deserialize_struct(
+            "Film",
+            FIELDS,
+            Visitor {
+                marker: ::core::marker::PhantomData,
+                lifetime: ::core::marker::PhantomData,
+            },
+        )
     }
 }
 

--- a/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__flatten_attr.snap
+++ b/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__flatten_attr.snap
@@ -20,9 +20,9 @@ impl ::cynic::QueryFragment for Film {
 }
 #[automatically_derived]
 impl<'de> ::cynic::serde::Deserialize<'de> for Film {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    fn deserialize<__D>(deserializer: __D) -> Result<Self, __D::Error>
     where
-        D: ::cynic::serde::Deserializer<'de>,
+        __D: ::cynic::serde::Deserializer<'de>,
     {
         #[derive(:: cynic :: serde :: Deserialize)]
         #[serde(field_identifier, crate = "::cynic::serde")]

--- a/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__not_sure.snap
+++ b/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__not_sure.snap
@@ -19,9 +19,9 @@ impl ::cynic::QueryFragment for MyQuery {
         {
             struct PostStateDraft;
             impl ::cynic::serde::Serialize for PostStateDraft {
-                fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+                fn serialize<__S>(&self, serializer: __S) -> Result<__S::Ok, __S::Error>
                 where
-                    S: ::cynic::serde::Serializer,
+                    __S: ::cynic::serde::Serializer,
                 {
                     serializer.serialize_unit_variant("", 0, "DRAFT")
                 }
@@ -29,9 +29,9 @@ impl ::cynic::QueryFragment for MyQuery {
             impl ::cynic::coercions::CoercesTo<schema::PostState> for PostStateDraft {};
             struct PostStatePosted;
             impl ::cynic::serde::Serialize for PostStatePosted {
-                fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+                fn serialize<__S>(&self, serializer: __S) -> Result<__S::Ok, __S::Error>
                 where
-                    S: ::cynic::serde::Serializer,
+                    __S: ::cynic::serde::Serializer,
                 {
                     serializer.serialize_unit_variant("", 0, "POSTED")
                 }
@@ -54,9 +54,9 @@ impl ::cynic::QueryFragment for MyQuery {
 }
 #[automatically_derived]
 impl<'de> ::cynic::serde::Deserialize<'de> for MyQuery {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    fn deserialize<__D>(deserializer: __D) -> Result<Self, __D::Error>
     where
-        D: ::cynic::serde::Deserializer<'de>,
+        __D: ::cynic::serde::Deserializer<'de>,
     {
         #[derive(:: cynic :: serde :: Deserialize)]
         #[serde(field_identifier, crate = "::cynic::serde")]

--- a/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__not_sure.snap
+++ b/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__not_sure.snap
@@ -3,15 +3,19 @@ source: cynic-codegen/src/fragment_derive/tests.rs
 expression: "format_code(format!(\"{}\", tokens))"
 ---
 #[automatically_derived]
-impl<'de> ::cynic::QueryFragment<'de> for MyQuery {
+impl ::cynic::QueryFragment for MyQuery {
     type SchemaType = schema::Query;
-    type Variables = ();
+    type VariablesFields = ();
     const TYPE: Option<&'static str> = Some("Query");
     fn query(
-        mut builder: ::cynic::queries::SelectionBuilder<'_, Self::SchemaType, Self::Variables>,
+        mut builder: ::cynic::queries::SelectionBuilder<
+            '_,
+            Self::SchemaType,
+            Self::VariablesFields,
+        >,
     ) {
         #![allow(unused_mut)]
-        let mut field_builder = builder . select_field :: < schema :: __fields :: Query :: filteredPosts , < Vec < BlogPostOutput > as :: cynic :: QueryFragment < '_ >> :: SchemaType > () ;
+        let mut field_builder = builder . select_field :: < schema :: __fields :: Query :: filteredPosts , < Vec < BlogPostOutput > as :: cynic :: QueryFragment > :: SchemaType > () ;
         {
             struct PostStateDraft;
             impl ::cynic::serde::Serialize for PostStateDraft {
@@ -45,7 +49,7 @@ impl<'de> ::cynic::QueryFragment<'de> for MyQuery {
                         .item(|builder| builder.literal(PostStateDraft));
                 });
         }
-        <Vec<BlogPostOutput> as ::cynic::QueryFragment<'_>>::query(field_builder.select_children());
+        <Vec<BlogPostOutput> as ::cynic::QueryFragment>::query(field_builder.select_children());
     }
 }
 #[automatically_derived]
@@ -63,13 +67,16 @@ impl<'de> ::cynic::serde::Deserialize<'de> for MyQuery {
             #[serde(other)]
             __Other,
         }
-        struct Visitor;
-        impl<'de> ::cynic::serde::de::Visitor<'de> for Visitor {
+        struct Visitor<'de> {
+            marker: ::core::marker::PhantomData<MyQuery>,
+            lifetime: ::core::marker::PhantomData<&'de ()>,
+        }
+        impl<'de> ::cynic::serde::de::Visitor<'de> for Visitor<'de> {
             type Value = MyQuery;
             fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 formatter.write_str("struct MyQuery")
             }
-            fn visit_map<V>(self, mut __map: V) -> Result<MyQuery, V::Error>
+            fn visit_map<V>(self, mut __map: V) -> Result<Self::Value, V::Error>
             where
                 V: ::cynic::serde::de::MapAccess<'de>,
             {
@@ -95,7 +102,14 @@ impl<'de> ::cynic::serde::Deserialize<'de> for MyQuery {
             }
         }
         const FIELDS: &'static [&str] = &["filteredPosts"];
-        deserializer.deserialize_struct("MyQuery", FIELDS, Visitor)
+        deserializer.deserialize_struct(
+            "MyQuery",
+            FIELDS,
+            Visitor {
+                marker: ::core::marker::PhantomData,
+                lifetime: ::core::marker::PhantomData,
+            },
+        )
     }
 }
 

--- a/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__simple_struct.snap
+++ b/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__simple_struct.snap
@@ -22,9 +22,9 @@ impl ::cynic::QueryFragment for BlogPostOutput {
 }
 #[automatically_derived]
 impl<'de> ::cynic::serde::Deserialize<'de> for BlogPostOutput {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    fn deserialize<__D>(deserializer: __D) -> Result<Self, __D::Error>
     where
-        D: ::cynic::serde::Deserializer<'de>,
+        __D: ::cynic::serde::Deserializer<'de>,
     {
         #[derive(:: cynic :: serde :: Deserialize)]
         #[serde(field_identifier, crate = "::cynic::serde")]

--- a/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__simple_struct.snap
+++ b/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__simple_struct.snap
@@ -3,17 +3,21 @@ source: cynic-codegen/src/fragment_derive/tests.rs
 expression: "format_code(format!(\"{}\", tokens))"
 ---
 #[automatically_derived]
-impl<'de> ::cynic::QueryFragment<'de> for BlogPostOutput {
+impl ::cynic::QueryFragment for BlogPostOutput {
     type SchemaType = schema::BlogPost;
-    type Variables = ();
+    type VariablesFields = ();
     const TYPE: Option<&'static str> = Some("BlogPost");
     fn query(
-        mut builder: ::cynic::queries::SelectionBuilder<'_, Self::SchemaType, Self::Variables>,
+        mut builder: ::cynic::queries::SelectionBuilder<
+            '_,
+            Self::SchemaType,
+            Self::VariablesFields,
+        >,
     ) {
         #![allow(unused_mut)]
         let mut field_builder = builder . select_field :: < schema :: __fields :: BlogPost :: hasMetadata , < Option < bool > as :: cynic :: schema :: IsScalar < < schema :: __fields :: BlogPost :: hasMetadata as :: cynic :: schema :: Field > :: Type >> :: SchemaType > () ;
-        let mut field_builder = builder . select_field :: < schema :: __fields :: BlogPost :: author , < AuthorOutput as :: cynic :: QueryFragment < '_ >> :: SchemaType > () ;
-        <AuthorOutput as ::cynic::QueryFragment<'_>>::query(field_builder.select_children());
+        let mut field_builder = builder . select_field :: < schema :: __fields :: BlogPost :: author , < AuthorOutput as :: cynic :: QueryFragment > :: SchemaType > () ;
+        <AuthorOutput as ::cynic::QueryFragment>::query(field_builder.select_children());
     }
 }
 #[automatically_derived]
@@ -33,13 +37,16 @@ impl<'de> ::cynic::serde::Deserialize<'de> for BlogPostOutput {
             #[serde(other)]
             __Other,
         }
-        struct Visitor;
-        impl<'de> ::cynic::serde::de::Visitor<'de> for Visitor {
+        struct Visitor<'de> {
+            marker: ::core::marker::PhantomData<BlogPostOutput>,
+            lifetime: ::core::marker::PhantomData<&'de ()>,
+        }
+        impl<'de> ::cynic::serde::de::Visitor<'de> for Visitor<'de> {
             type Value = BlogPostOutput;
             fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 formatter.write_str("struct BlogPostOutput")
             }
-            fn visit_map<V>(self, mut __map: V) -> Result<BlogPostOutput, V::Error>
+            fn visit_map<V>(self, mut __map: V) -> Result<Self::Value, V::Error>
             where
                 V: ::cynic::serde::de::MapAccess<'de>,
             {
@@ -77,7 +84,14 @@ impl<'de> ::cynic::serde::Deserialize<'de> for BlogPostOutput {
             }
         }
         const FIELDS: &'static [&str] = &["hasMetadata", "author"];
-        deserializer.deserialize_struct("BlogPostOutput", FIELDS, Visitor)
+        deserializer.deserialize_struct(
+            "BlogPostOutput",
+            FIELDS,
+            Visitor {
+                marker: ::core::marker::PhantomData,
+                lifetime: ::core::marker::PhantomData,
+            },
+        )
     }
 }
 

--- a/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__spread_attr.snap
+++ b/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__spread_attr.snap
@@ -3,15 +3,19 @@ source: cynic-codegen/src/fragment_derive/tests.rs
 expression: "format_code(format!(\"{}\", tokens))"
 ---
 #[automatically_derived]
-impl<'de> ::cynic::QueryFragment<'de> for Film {
+impl ::cynic::QueryFragment for Film {
     type SchemaType = schema::Film;
-    type Variables = ();
+    type VariablesFields = ();
     const TYPE: Option<&'static str> = Some("Film");
     fn query(
-        mut builder: ::cynic::queries::SelectionBuilder<'_, Self::SchemaType, Self::Variables>,
+        mut builder: ::cynic::queries::SelectionBuilder<
+            '_,
+            Self::SchemaType,
+            Self::VariablesFields,
+        >,
     ) {
         #![allow(unused_mut)]
-        <FilmDetails as ::cynic::QueryFragment<'_>>::query(builder)
+        <FilmDetails as ::cynic::QueryFragment>::query(builder)
     }
 }
 #[automatically_derived]

--- a/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__spread_attr.snap
+++ b/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__spread_attr.snap
@@ -20,11 +20,11 @@ impl ::cynic::QueryFragment for Film {
 }
 #[automatically_derived]
 impl<'de> ::cynic::serde::Deserialize<'de> for Film {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    fn deserialize<__D>(deserializer: __D) -> Result<Self, __D::Error>
     where
-        D: ::cynic::serde::Deserializer<'de>,
+        __D: ::cynic::serde::Deserializer<'de>,
     {
-        let spreadable = ::cynic::__private::Spreadable::<D::Error>::deserialize(deserializer)?;
+        let spreadable = ::cynic::__private::Spreadable::<__D::Error>::deserialize(deserializer)?;
         Ok(Film {
             details: <FilmDetails as ::cynic::serde::Deserialize<'de>>::deserialize(
                 spreadable.spread_deserializer(),

--- a/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__variable_in_argument.snap
+++ b/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__variable_in_argument.snap
@@ -3,21 +3,25 @@ source: cynic-codegen/src/fragment_derive/tests.rs
 expression: "format_code(format!(\"{}\", tokens))"
 ---
 #[automatically_derived]
-impl<'de> ::cynic::QueryFragment<'de> for MyQuery {
+impl ::cynic::QueryFragment for MyQuery {
     type SchemaType = schema::Query;
-    type Variables = AnArgumentStruct;
+    type VariablesFields = AnArgumentStructFields;
     const TYPE: Option<&'static str> = Some("Query");
     fn query(
-        mut builder: ::cynic::queries::SelectionBuilder<'_, Self::SchemaType, Self::Variables>,
+        mut builder: ::cynic::queries::SelectionBuilder<
+            '_,
+            Self::SchemaType,
+            Self::VariablesFields,
+        >,
     ) {
         #![allow(unused_mut)]
-        let mut field_builder = builder . select_field :: < schema :: __fields :: Query :: filteredPosts , < Vec < BlogPostOutput > as :: cynic :: QueryFragment < '_ >> :: SchemaType > () ;
+        let mut field_builder = builder . select_field :: < schema :: __fields :: Query :: filteredPosts , < Vec < BlogPostOutput > as :: cynic :: QueryFragment > :: SchemaType > () ;
         {
             field_builder
                 .argument::<schema::__fields::Query::_filtered_posts_arguments::filters>()
-                .variable(<AnArgumentStruct as ::cynic::QueryVariables>::Fields::filters());
+                .variable(AnArgumentStructFields::filters());
         }
-        <Vec<BlogPostOutput> as ::cynic::QueryFragment<'_>>::query(field_builder.select_children());
+        <Vec<BlogPostOutput> as ::cynic::QueryFragment>::query(field_builder.select_children());
     }
 }
 #[automatically_derived]
@@ -35,13 +39,16 @@ impl<'de> ::cynic::serde::Deserialize<'de> for MyQuery {
             #[serde(other)]
             __Other,
         }
-        struct Visitor;
-        impl<'de> ::cynic::serde::de::Visitor<'de> for Visitor {
+        struct Visitor<'de> {
+            marker: ::core::marker::PhantomData<MyQuery>,
+            lifetime: ::core::marker::PhantomData<&'de ()>,
+        }
+        impl<'de> ::cynic::serde::de::Visitor<'de> for Visitor<'de> {
             type Value = MyQuery;
             fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 formatter.write_str("struct MyQuery")
             }
-            fn visit_map<V>(self, mut __map: V) -> Result<MyQuery, V::Error>
+            fn visit_map<V>(self, mut __map: V) -> Result<Self::Value, V::Error>
             where
                 V: ::cynic::serde::de::MapAccess<'de>,
             {
@@ -67,7 +74,14 @@ impl<'de> ::cynic::serde::Deserialize<'de> for MyQuery {
             }
         }
         const FIELDS: &'static [&str] = &["filteredPosts"];
-        deserializer.deserialize_struct("MyQuery", FIELDS, Visitor)
+        deserializer.deserialize_struct(
+            "MyQuery",
+            FIELDS,
+            Visitor {
+                marker: ::core::marker::PhantomData,
+                lifetime: ::core::marker::PhantomData,
+            },
+        )
     }
 }
 

--- a/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__variable_in_argument.snap
+++ b/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__variable_in_argument.snap
@@ -26,9 +26,9 @@ impl ::cynic::QueryFragment for MyQuery {
 }
 #[automatically_derived]
 impl<'de> ::cynic::serde::Deserialize<'de> for MyQuery {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    fn deserialize<__D>(deserializer: __D) -> Result<Self, __D::Error>
     where
-        D: ::cynic::serde::Deserializer<'de>,
+        __D: ::cynic::serde::Deserializer<'de>,
     {
         #[derive(:: cynic :: serde :: Deserialize)]
         #[serde(field_identifier, crate = "::cynic::serde")]

--- a/cynic-codegen/src/generics_for_serde.rs
+++ b/cynic-codegen/src/generics_for_serde.rs
@@ -1,0 +1,38 @@
+use syn::parse_quote;
+
+pub(crate) fn with_de_and_deserialize_bounds(generics: &syn::Generics) -> syn::Generics {
+    let mut generics_with_de_and_deserialize_bounds = generics.clone();
+    generics_with_de_and_deserialize_bounds
+        .params
+        .push(parse_quote!('de));
+    for generic in &generics.params {
+        match generic {
+            syn::GenericParam::Type(type_) => {
+                let ident = &type_.ident;
+                generics_with_de_and_deserialize_bounds
+                    .make_where_clause()
+                    .predicates
+                    .push(parse_quote! { #ident: ::cynic::serde::Deserialize<'de> })
+            }
+            syn::GenericParam::Lifetime(_) | syn::GenericParam::Const(_) => {}
+        }
+    }
+    generics_with_de_and_deserialize_bounds
+}
+
+pub(crate) fn with_serialize_bounds(generics: &syn::Generics) -> syn::Generics {
+    let mut generics_with_serialize_bounds = generics.clone();
+    for generic in &generics.params {
+        match generic {
+            syn::GenericParam::Type(type_) => {
+                let ident = &type_.ident;
+                generics_with_serialize_bounds
+                    .make_where_clause()
+                    .predicates
+                    .push(parse_quote! { #ident: ::cynic::serde::Serialize })
+            }
+            syn::GenericParam::Lifetime(_) | syn::GenericParam::Const(_) => {}
+        }
+    }
+    generics_with_serialize_bounds
+}

--- a/cynic-codegen/src/inline_fragments_derive/inline_fragments_impl.rs
+++ b/cynic-codegen/src/inline_fragments_derive/inline_fragments_impl.rs
@@ -60,9 +60,9 @@ impl quote::ToTokens for InlineFragmentsImpl<'_> {
         tokens.append_all(quote! {
             #[automatically_derived]
             impl #impl_generics_with_de ::cynic::serde::Deserialize<'de> for #target_enum #ty_generics #where_clause_with_de {
-                fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+                fn deserialize<__D>(deserializer: __D) -> Result<Self, __D::Error>
                 where
-                    D: ::cynic::serde::Deserializer<'de>,
+                    __D: ::cynic::serde::Deserializer<'de>,
                 {
                     deserializer.deserialize_map(::cynic::__private::InlineFragmentVisitor::<Self>::new())
                 }
@@ -70,9 +70,9 @@ impl quote::ToTokens for InlineFragmentsImpl<'_> {
 
             #[automatically_derived]
             impl #impl_generics_with_de ::cynic::InlineFragments<'de> for #target_enum #ty_generics #where_clause_with_de {
-                fn deserialize_variant<D>(typename: &str, deserializer: D) -> Result<Self, D::Error>
+                fn deserialize_variant<__D>(typename: &str, deserializer: __D) -> Result<Self, __D::Error>
                 where
-                    D: ::cynic::serde::Deserializer<'de>
+                    __D: ::cynic::serde::Deserializer<'de>
                 {
                     #(
                         if Some(typename) == <#inner_types as ::cynic::QueryFragment>::TYPE {

--- a/cynic-codegen/src/inline_fragments_derive/inline_fragments_impl.rs
+++ b/cynic-codegen/src/inline_fragments_derive/inline_fragments_impl.rs
@@ -1,6 +1,4 @@
-use proc_macro2::TokenStream;
-use quote::quote_spanned;
-use syn::spanned::Spanned;
+use {proc_macro2::TokenStream, quote::quote_spanned, syn::spanned::Spanned};
 
 #[derive(Clone)]
 pub enum Fallback {
@@ -70,7 +68,7 @@ impl quote::ToTokens for InlineFragmentsImpl<'_> {
                     D: ::cynic::serde::Deserializer<'de>
                 {
                     #(
-                        if Some(typename) == <#inner_types as ::cynic::QueryFragment<'de>>::TYPE {
+                        if Some(typename) == <#inner_types as ::cynic::QueryFragment>::TYPE {
                             return <#inner_types as ::cynic::serde::Deserialize<'de>>::deserialize(deserializer).map(
                                 #target_enum::#variant_names
                             )

--- a/cynic-codegen/src/inline_fragments_derive/input.rs
+++ b/cynic-codegen/src/inline_fragments_derive/input.rs
@@ -1,6 +1,4 @@
-use darling::util::SpannedValue;
-use proc_macro2::Span;
-use quote::quote_spanned;
+use {darling::util::SpannedValue, proc_macro2::Span, quote::quote_spanned};
 
 use crate::error::Errors;
 
@@ -9,6 +7,7 @@ use crate::error::Errors;
 pub struct InlineFragmentsDeriveInput {
     pub(super) ident: proc_macro2::Ident,
     pub(super) data: darling::ast::Data<SpannedValue<InlineFragmentsDeriveVariant>, ()>,
+    pub(super) generics: syn::Generics,
 
     pub schema_path: SpannedValue<String>,
 
@@ -141,8 +140,10 @@ pub(super) enum ValidationMode {
 
 impl InlineFragmentsDeriveVariant {
     fn validate(&self, mode: ValidationMode, span: proc_macro2::Span) -> Result<(), Errors> {
-        use darling::ast::Style::{Struct, Tuple, Unit};
-        use ValidationMode::{Interface, Union};
+        use {
+            darling::ast::Style::{Struct, Tuple, Unit},
+            ValidationMode::{Interface, Union},
+        };
 
         if let Struct = self.fields.style {}
 
@@ -206,8 +207,7 @@ impl InlineFragmentsDeriveVariant {
 
 #[cfg(test)]
 mod tests {
-    use darling::FromDeriveInput;
-    use syn::parse_quote;
+    use {darling::FromDeriveInput, syn::parse_quote};
 
     use super::*;
 

--- a/cynic-codegen/src/inline_fragments_derive/mod.rs
+++ b/cynic-codegen/src/inline_fragments_derive/mod.rs
@@ -64,6 +64,7 @@ pub(crate) fn inline_fragments_derive_impl(
 
         let query_fragment_impl = QueryFragmentImpl {
             target_enum: input.ident.clone(),
+            generics: &input.generics,
             type_lock,
             variables,
             fragments: &fragments,
@@ -73,6 +74,7 @@ pub(crate) fn inline_fragments_derive_impl(
 
         let inline_fragments_impl = inline_fragments_impl::InlineFragmentsImpl {
             target_enum: input.ident.clone(),
+            generics: &input.generics,
             fragments: &fragments,
             fallback,
         };
@@ -177,6 +179,7 @@ fn check_fallback(
 
 struct QueryFragmentImpl<'a> {
     target_enum: syn::Ident,
+    generics: &'a syn::Generics,
     type_lock: syn::Path,
     variables: Option<syn::Path>,
     fragments: &'a [Fragment],
@@ -208,9 +211,11 @@ impl quote::ToTokens for QueryFragmentImpl<'_> {
             _ => quote! {},
         };
 
+        let (impl_generics, ty_generics, where_clause) = self.generics.split_for_impl();
+
         tokens.append_all(quote! {
             #[automatically_derived]
-            impl ::cynic::QueryFragment for #target_struct {
+            impl #impl_generics ::cynic::QueryFragment for #target_struct #ty_generics #where_clause {
                 type SchemaType = #type_lock;
                 type VariablesFields = #variables_fields;
 

--- a/cynic-codegen/src/inline_fragments_derive/snapshots/cynic_codegen__inline_fragments_derive__tests__interface.snap
+++ b/cynic-codegen/src/inline_fragments_derive/snapshots/cynic_codegen__inline_fragments_derive__tests__interface.snap
@@ -4,18 +4,18 @@ expression: "format_code(format!(\"{}\", tokens))"
 ---
 #[automatically_derived]
 impl<'de> ::cynic::serde::Deserialize<'de> for Node {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    fn deserialize<__D>(deserializer: __D) -> Result<Self, __D::Error>
     where
-        D: ::cynic::serde::Deserializer<'de>,
+        __D: ::cynic::serde::Deserializer<'de>,
     {
         deserializer.deserialize_map(::cynic::__private::InlineFragmentVisitor::<Self>::new())
     }
 }
 #[automatically_derived]
 impl<'de> ::cynic::InlineFragments<'de> for Node {
-    fn deserialize_variant<D>(typename: &str, deserializer: D) -> Result<Self, D::Error>
+    fn deserialize_variant<__D>(typename: &str, deserializer: __D) -> Result<Self, __D::Error>
     where
-        D: ::cynic::serde::Deserializer<'de>,
+        __D: ::cynic::serde::Deserializer<'de>,
     {
         if Some(typename) == <Post as ::cynic::QueryFragment>::TYPE {
             return <Post as ::cynic::serde::Deserialize<'de>>::deserialize(deserializer)

--- a/cynic-codegen/src/inline_fragments_derive/snapshots/cynic_codegen__inline_fragments_derive__tests__interface.snap
+++ b/cynic-codegen/src/inline_fragments_derive/snapshots/cynic_codegen__inline_fragments_derive__tests__interface.snap
@@ -17,11 +17,11 @@ impl<'de> ::cynic::InlineFragments<'de> for Node {
     where
         D: ::cynic::serde::Deserializer<'de>,
     {
-        if Some(typename) == <Post as ::cynic::QueryFragment<'de>>::TYPE {
+        if Some(typename) == <Post as ::cynic::QueryFragment>::TYPE {
             return <Post as ::cynic::serde::Deserialize<'de>>::deserialize(deserializer)
                 .map(Node::Post);
         }
-        if Some(typename) == <Author as ::cynic::QueryFragment<'de>>::TYPE {
+        if Some(typename) == <Author as ::cynic::QueryFragment>::TYPE {
             return <Author as ::cynic::serde::Deserialize<'de>>::deserialize(deserializer)
                 .map(Node::Author);
         }
@@ -29,21 +29,25 @@ impl<'de> ::cynic::InlineFragments<'de> for Node {
     }
 }
 #[automatically_derived]
-impl<'de> ::cynic::QueryFragment<'de> for Node {
+impl ::cynic::QueryFragment for Node {
     type SchemaType = schema::Node;
-    type Variables = ();
+    type VariablesFields = ();
     const TYPE: Option<&'static str> = Some("Node");
     fn query(
-        mut builder: ::cynic::queries::SelectionBuilder<'_, Self::SchemaType, Self::Variables>,
+        mut builder: ::cynic::queries::SelectionBuilder<
+            '_,
+            Self::SchemaType,
+            Self::VariablesFields,
+        >,
     ) {
         let fragment_builder = builder.inline_fragment();
         let mut fragment_builder =
-            fragment_builder.on::<<Post as ::cynic::QueryFragment<'_>>::SchemaType>();
-        <Post as ::cynic::QueryFragment<'_>>::query(fragment_builder.select_children());
+            fragment_builder.on::<<Post as ::cynic::QueryFragment>::SchemaType>();
+        <Post as ::cynic::QueryFragment>::query(fragment_builder.select_children());
         let fragment_builder = builder.inline_fragment();
         let mut fragment_builder =
-            fragment_builder.on::<<Author as ::cynic::QueryFragment<'_>>::SchemaType>();
-        <Author as ::cynic::QueryFragment<'_>>::query(fragment_builder.select_children());
+            fragment_builder.on::<<Author as ::cynic::QueryFragment>::SchemaType>();
+        <Author as ::cynic::QueryFragment>::query(fragment_builder.select_children());
     }
 }
 #[allow(clippy::no_effect, non_camel_case_types)]

--- a/cynic-codegen/src/inline_fragments_derive/snapshots/cynic_codegen__inline_fragments_derive__tests__union_type.snap
+++ b/cynic-codegen/src/inline_fragments_derive/snapshots/cynic_codegen__inline_fragments_derive__tests__union_type.snap
@@ -17,11 +17,11 @@ impl<'de> ::cynic::InlineFragments<'de> for PostOrAuthor {
     where
         D: ::cynic::serde::Deserializer<'de>,
     {
-        if Some(typename) == <Post as ::cynic::QueryFragment<'de>>::TYPE {
+        if Some(typename) == <Post as ::cynic::QueryFragment>::TYPE {
             return <Post as ::cynic::serde::Deserialize<'de>>::deserialize(deserializer)
                 .map(PostOrAuthor::Post);
         }
-        if Some(typename) == <Author as ::cynic::QueryFragment<'de>>::TYPE {
+        if Some(typename) == <Author as ::cynic::QueryFragment>::TYPE {
             return <Author as ::cynic::serde::Deserialize<'de>>::deserialize(deserializer)
                 .map(PostOrAuthor::Author);
         }
@@ -29,21 +29,25 @@ impl<'de> ::cynic::InlineFragments<'de> for PostOrAuthor {
     }
 }
 #[automatically_derived]
-impl<'de> ::cynic::QueryFragment<'de> for PostOrAuthor {
+impl ::cynic::QueryFragment for PostOrAuthor {
     type SchemaType = schema::PostOrAuthor;
-    type Variables = ();
+    type VariablesFields = ();
     const TYPE: Option<&'static str> = Some("PostOrAuthor");
     fn query(
-        mut builder: ::cynic::queries::SelectionBuilder<'_, Self::SchemaType, Self::Variables>,
+        mut builder: ::cynic::queries::SelectionBuilder<
+            '_,
+            Self::SchemaType,
+            Self::VariablesFields,
+        >,
     ) {
         let fragment_builder = builder.inline_fragment();
         let mut fragment_builder =
-            fragment_builder.on::<<Post as ::cynic::QueryFragment<'_>>::SchemaType>();
-        <Post as ::cynic::QueryFragment<'_>>::query(fragment_builder.select_children());
+            fragment_builder.on::<<Post as ::cynic::QueryFragment>::SchemaType>();
+        <Post as ::cynic::QueryFragment>::query(fragment_builder.select_children());
         let fragment_builder = builder.inline_fragment();
         let mut fragment_builder =
-            fragment_builder.on::<<Author as ::cynic::QueryFragment<'_>>::SchemaType>();
-        <Author as ::cynic::QueryFragment<'_>>::query(fragment_builder.select_children());
+            fragment_builder.on::<<Author as ::cynic::QueryFragment>::SchemaType>();
+        <Author as ::cynic::QueryFragment>::query(fragment_builder.select_children());
     }
 }
 

--- a/cynic-codegen/src/inline_fragments_derive/snapshots/cynic_codegen__inline_fragments_derive__tests__union_type.snap
+++ b/cynic-codegen/src/inline_fragments_derive/snapshots/cynic_codegen__inline_fragments_derive__tests__union_type.snap
@@ -4,18 +4,18 @@ expression: "format_code(format!(\"{}\", tokens))"
 ---
 #[automatically_derived]
 impl<'de> ::cynic::serde::Deserialize<'de> for PostOrAuthor {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    fn deserialize<__D>(deserializer: __D) -> Result<Self, __D::Error>
     where
-        D: ::cynic::serde::Deserializer<'de>,
+        __D: ::cynic::serde::Deserializer<'de>,
     {
         deserializer.deserialize_map(::cynic::__private::InlineFragmentVisitor::<Self>::new())
     }
 }
 #[automatically_derived]
 impl<'de> ::cynic::InlineFragments<'de> for PostOrAuthor {
-    fn deserialize_variant<D>(typename: &str, deserializer: D) -> Result<Self, D::Error>
+    fn deserialize_variant<__D>(typename: &str, deserializer: __D) -> Result<Self, __D::Error>
     where
-        D: ::cynic::serde::Deserializer<'de>,
+        __D: ::cynic::serde::Deserializer<'de>,
     {
         if Some(typename) == <Post as ::cynic::QueryFragment>::TYPE {
             return <Post as ::cynic::serde::Deserialize<'de>>::deserialize(deserializer)

--- a/cynic-codegen/src/inline_fragments_derive/snapshots/cynic_codegen__inline_fragments_derive__tests__union_with_rename.snap
+++ b/cynic-codegen/src/inline_fragments_derive/snapshots/cynic_codegen__inline_fragments_derive__tests__union_with_rename.snap
@@ -4,18 +4,18 @@ expression: "format_code(format!(\"{}\", tokens))"
 ---
 #[automatically_derived]
 impl<'de> ::cynic::serde::Deserialize<'de> for PostOrAuthor {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    fn deserialize<__D>(deserializer: __D) -> Result<Self, __D::Error>
     where
-        D: ::cynic::serde::Deserializer<'de>,
+        __D: ::cynic::serde::Deserializer<'de>,
     {
         deserializer.deserialize_map(::cynic::__private::InlineFragmentVisitor::<Self>::new())
     }
 }
 #[automatically_derived]
 impl<'de> ::cynic::InlineFragments<'de> for PostOrAuthor {
-    fn deserialize_variant<D>(typename: &str, deserializer: D) -> Result<Self, D::Error>
+    fn deserialize_variant<__D>(typename: &str, deserializer: __D) -> Result<Self, __D::Error>
     where
-        D: ::cynic::serde::Deserializer<'de>,
+        __D: ::cynic::serde::Deserializer<'de>,
     {
         if Some(typename) == <Post as ::cynic::QueryFragment>::TYPE {
             return <Post as ::cynic::serde::Deserialize<'de>>::deserialize(deserializer)

--- a/cynic-codegen/src/inline_fragments_derive/snapshots/cynic_codegen__inline_fragments_derive__tests__union_with_rename.snap
+++ b/cynic-codegen/src/inline_fragments_derive/snapshots/cynic_codegen__inline_fragments_derive__tests__union_with_rename.snap
@@ -17,11 +17,11 @@ impl<'de> ::cynic::InlineFragments<'de> for PostOrAuthor {
     where
         D: ::cynic::serde::Deserializer<'de>,
     {
-        if Some(typename) == <Post as ::cynic::QueryFragment<'de>>::TYPE {
+        if Some(typename) == <Post as ::cynic::QueryFragment>::TYPE {
             return <Post as ::cynic::serde::Deserialize<'de>>::deserialize(deserializer)
                 .map(PostOrAuthor::Post);
         }
-        if Some(typename) == <Author as ::cynic::QueryFragment<'de>>::TYPE {
+        if Some(typename) == <Author as ::cynic::QueryFragment>::TYPE {
             return <Author as ::cynic::serde::Deserialize<'de>>::deserialize(deserializer)
                 .map(PostOrAuthor::Author);
         }
@@ -29,21 +29,25 @@ impl<'de> ::cynic::InlineFragments<'de> for PostOrAuthor {
     }
 }
 #[automatically_derived]
-impl<'de> ::cynic::QueryFragment<'de> for PostOrAuthor {
+impl ::cynic::QueryFragment for PostOrAuthor {
     type SchemaType = schema::PostOrAuthor;
-    type Variables = ();
+    type VariablesFields = ();
     const TYPE: Option<&'static str> = Some("PostOrAuthor");
     fn query(
-        mut builder: ::cynic::queries::SelectionBuilder<'_, Self::SchemaType, Self::Variables>,
+        mut builder: ::cynic::queries::SelectionBuilder<
+            '_,
+            Self::SchemaType,
+            Self::VariablesFields,
+        >,
     ) {
         let fragment_builder = builder.inline_fragment();
         let mut fragment_builder =
-            fragment_builder.on::<<Post as ::cynic::QueryFragment<'_>>::SchemaType>();
-        <Post as ::cynic::QueryFragment<'_>>::query(fragment_builder.select_children());
+            fragment_builder.on::<<Post as ::cynic::QueryFragment>::SchemaType>();
+        <Post as ::cynic::QueryFragment>::query(fragment_builder.select_children());
         let fragment_builder = builder.inline_fragment();
         let mut fragment_builder =
-            fragment_builder.on::<<Author as ::cynic::QueryFragment<'_>>::SchemaType>();
-        <Author as ::cynic::QueryFragment<'_>>::query(fragment_builder.select_children());
+            fragment_builder.on::<<Author as ::cynic::QueryFragment>::SchemaType>();
+        <Author as ::cynic::QueryFragment>::query(fragment_builder.select_children());
     }
 }
 #[allow(clippy::no_effect, non_camel_case_types)]

--- a/cynic-codegen/src/input_object_derive/input.rs
+++ b/cynic-codegen/src/input_object_derive/input.rs
@@ -1,13 +1,15 @@
-use darling::util::SpannedValue;
-use syn::spanned::Spanned;
+use {darling::util::SpannedValue, syn::spanned::Spanned};
 
-use crate::idents::{RenamableFieldIdent, RenameAll};
-use proc_macro2::Span;
+use {
+    crate::idents::{RenamableFieldIdent, RenameAll},
+    proc_macro2::Span,
+};
 
 #[derive(darling::FromDeriveInput)]
 #[darling(attributes(cynic), supports(struct_named))]
 pub struct InputObjectDeriveInput {
     pub(super) ident: proc_macro2::Ident,
+    pub(super) generics: syn::Generics,
     pub(super) data: darling::ast::Data<(), InputObjectDeriveField>,
 
     pub schema_path: SpannedValue<String>,

--- a/cynic-codegen/src/input_object_derive/mod.rs
+++ b/cynic-codegen/src/input_object_derive/mod.rs
@@ -110,9 +110,9 @@ pub fn input_object_derive_impl(
 
             #[automatically_derived]
             impl #impl_generics_with_ser ::cynic::serde::Serialize for #ident #ty_generics #where_clause_with_ser {
-                fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+                fn serialize<__S>(&self, serializer: __S) -> Result<__S::Ok, __S::Error>
                 where
-                    S: ::cynic::serde::Serializer,
+                    __S: ::cynic::serde::Serializer,
                 {
                     use ::cynic::serde::ser::SerializeMap;
                     #(#typechecks)*

--- a/cynic-codegen/src/input_object_derive/mod.rs
+++ b/cynic-codegen/src/input_object_derive/mod.rs
@@ -87,7 +87,9 @@ pub fn input_object_derive_impl(
             return Ok(errors.to_compile_errors());
         }
 
-        let typechecks = field_serializers.iter().map(|fs| fs.type_check());
+        let typechecks = field_serializers
+            .iter()
+            .map(|fs| fs.type_check(&impl_generics, where_clause));
         let map_serializer_ident = proc_macro2::Ident::new("map_serializer", Span::call_site());
         let field_inserts = field_serializers
             .iter()

--- a/cynic-codegen/src/input_object_derive/snapshots/cynic_codegen__input_object_derive__tests__snapshot_input_object_derive.snap
+++ b/cynic-codegen/src/input_object_derive/snapshots/cynic_codegen__input_object_derive__tests__snapshot_input_object_derive.snap
@@ -8,9 +8,9 @@ impl ::cynic::InputObject for IssueOrder {
 }
 #[automatically_derived]
 impl ::cynic::serde::Serialize for IssueOrder {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    fn serialize<__S>(&self, serializer: __S) -> Result<__S::Ok, __S::Error>
     where
-        S: ::cynic::serde::Serializer,
+        __S: ::cynic::serde::Serializer,
     {
         use cynic::serde::ser::SerializeMap;
         :: cynic :: assert_impl ! (OrderDirection [] [] : :: cynic :: Enum < SchemaType = schema :: OrderDirection >);

--- a/cynic-codegen/src/input_object_derive/snapshots/cynic_codegen__input_object_derive__tests__snapshot_input_object_derive.snap
+++ b/cynic-codegen/src/input_object_derive/snapshots/cynic_codegen__input_object_derive__tests__snapshot_input_object_derive.snap
@@ -1,6 +1,5 @@
 ---
 source: cynic-codegen/src/input_object_derive/tests.rs
-assertion_line: 24
 expression: "format_code(format!(\"{}\", tokens))"
 ---
 #[automatically_derived]
@@ -14,15 +13,15 @@ impl ::cynic::serde::Serialize for IssueOrder {
         S: ::cynic::serde::Serializer,
     {
         use cynic::serde::ser::SerializeMap;
-        ::cynic::assert_impl!(OrderDirection: ::cynic::Enum<SchemaType = schema::OrderDirection>);
-        ::cynic::assert_impl!(IssueOrderField: ::cynic::Enum<SchemaType = schema::IssueOrderField>);
+        :: cynic :: assert_impl ! (OrderDirection [] [] : :: cynic :: Enum < SchemaType = schema :: OrderDirection >);
+        :: cynic :: assert_impl ! (IssueOrderField [] [] : :: cynic :: Enum < SchemaType = schema :: IssueOrderField >);
         let mut map_serializer = serializer.serialize_map(Some(2usize))?;
         map_serializer.serialize_entry("direction", &self.direction)?;
         map_serializer.serialize_entry("field", &self.field)?;
         map_serializer.end()
     }
 }
-::cynic::impl_coercions!(IssueOrder, schema::IssueOrder);
+:: cynic :: impl_coercions ! (IssueOrder [] [] , schema :: IssueOrder);
 #[automatically_derived]
 impl schema::variable::Variable for IssueOrder {
     const TYPE: ::cynic::variables::VariableType =

--- a/cynic-codegen/src/lib.rs
+++ b/cynic-codegen/src/lib.rs
@@ -1,6 +1,7 @@
 #![deny(rust_2018_idioms)]
 pub mod enum_derive;
 pub mod fragment_derive;
+pub mod generics_for_serde;
 pub mod inline_fragments_derive;
 pub mod input_object_derive;
 pub mod query_variables_derive;

--- a/cynic-codegen/src/lib.rs
+++ b/cynic-codegen/src/lib.rs
@@ -53,9 +53,12 @@ fn variables_fields_path(variables: Option<&syn::Path>) -> Option<syn::Path> {
     variables.cloned().map(|mut variables| {
         // Find VariablesField struct name from Variables struct name
         if let Some(last) = variables.segments.last_mut() {
-            last.ident =
-                proc_macro2::Ident::new(&format!("{}Fields", last.ident), last.ident.span());
+            last.ident = variables_fields_ident(&last.ident);
         }
         variables
     })
+}
+
+fn variables_fields_ident(ident: &syn::Ident) -> syn::Ident {
+    proc_macro2::Ident::new(&format!("{}Fields", ident), ident.span())
 }

--- a/cynic-codegen/src/lib.rs
+++ b/cynic-codegen/src/lib.rs
@@ -16,15 +16,13 @@ mod types;
 
 pub use idents::RenameAll;
 
-use error::Errors;
-use schema::load_schema;
+use {error::Errors, schema::load_schema};
 
 pub fn output_schema_module(
     schema: impl AsRef<std::path::Path>,
     output_path: impl AsRef<std::path::Path>,
 ) -> Result<(), Errors> {
-    use std::io::Write;
-    use use_schema::UseSchemaParams;
+    use {std::io::Write, use_schema::UseSchemaParams};
 
     let tokens = use_schema::use_schema(UseSchemaParams {
         schema_filename: schema.as_ref().to_str().unwrap().to_string(),
@@ -49,4 +47,15 @@ fn format_code(filename: &std::path::Path) {
             .spawn()
             .expect("failed to execute process");
     }
+}
+
+fn variables_fields_path(variables: Option<&syn::Path>) -> Option<syn::Path> {
+    variables.cloned().map(|mut variables| {
+        // Find VariablesField struct name from Variables struct name
+        if let Some(last) = variables.segments.last_mut() {
+            last.ident =
+                proc_macro2::Ident::new(&format!("{}Fields", last.ident), last.ident.span());
+        }
+        variables
+    })
 }

--- a/cynic-codegen/src/query_variables_derive/input.rs
+++ b/cynic-codegen/src/query_variables_derive/input.rs
@@ -24,6 +24,9 @@ pub(super) struct QueryVariableField {
     pub(super) ty: syn::Type,
 
     #[darling(default)]
+    pub(super) graphql_type: Option<syn::Ident>,
+
+    #[darling(default)]
     pub(super) rename: Option<SpannedValue<String>>,
 }
 

--- a/cynic-codegen/src/query_variables_derive/input.rs
+++ b/cynic-codegen/src/query_variables_derive/input.rs
@@ -1,5 +1,4 @@
-use darling::util::SpannedValue;
-use syn::spanned::Spanned;
+use {darling::util::SpannedValue, syn::spanned::Spanned};
 
 use crate::idents::{RenamableFieldIdent, RenameAll};
 
@@ -8,6 +7,7 @@ use crate::idents::{RenamableFieldIdent, RenameAll};
 pub struct QueryVariablesDeriveInput {
     pub(super) ident: proc_macro2::Ident,
     pub(super) vis: syn::Visibility,
+    pub(super) generics: syn::Generics,
     pub(super) data: darling::ast::Data<(), QueryVariableField>,
 
     #[darling(default)]

--- a/cynic-codegen/src/query_variables_derive/mod.rs
+++ b/cynic-codegen/src/query_variables_derive/mod.rs
@@ -6,7 +6,7 @@ use {
 
 mod input;
 
-use crate::variables_fields_ident;
+use crate::{generics_for_serde, variables_fields_ident};
 
 use self::input::QueryVariablesDeriveInput;
 
@@ -23,7 +23,11 @@ pub fn query_variables_derive_impl(
     input: QueryVariablesDeriveInput,
 ) -> Result<TokenStream, syn::Error> {
     let ident = &input.ident;
+
     let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
+    let generics_with_ser = generics_for_serde::with_serialize_bounds(&input.generics);
+    let (impl_generics_with_ser, _, where_clause_with_ser) = generics_with_ser.split_for_impl();
+
     let vis = &input.vis;
     let schema_module = &input.schema_module();
     let fields_struct_ident = variables_fields_ident(ident);
@@ -129,7 +133,7 @@ pub fn query_variables_derive_impl(
         }
 
         #[automatically_derived]
-        impl #impl_generics ::cynic::serde::Serialize for #ident #ty_generics #where_clause {
+        impl #impl_generics_with_ser ::cynic::serde::Serialize for #ident #ty_generics #where_clause_with_ser {
             fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
             where
                 S: ::cynic::serde::Serializer,

--- a/cynic-codegen/src/query_variables_derive/mod.rs
+++ b/cynic-codegen/src/query_variables_derive/mod.rs
@@ -33,16 +33,56 @@ pub fn query_variables_derive_impl(
     let mut field_funcs = Vec::new();
     let mut variables = Vec::new();
     let mut field_inserts = Vec::new();
+    let mut coercion_checks = Vec::new();
+    let mut field_output_types = Vec::new();
 
-    for f in input_fields {
+    for (field_idx, f) in input_fields.into_iter().enumerate() {
         let name = f.ident.as_ref().unwrap();
-        let mut ty = f.ty.clone();
-        TurnLifetimesToStatic.visit_type_mut(&mut ty);
+        let ty = &f.ty;
+        let mut ty_for_fields_struct = match f.graphql_type {
+            None => ty.clone(),
+            Some(ref graphql_type) => {
+                // This enables to support generics. Normally we have every Variable type that
+                // implements `CoercesTo<schema::SchemaType>`. Here that is also
+                // the case, but:
+                // - The XxxVariablesFields struct needs to not be generic, as it needs to be
+                //   referenced explicitly by the `QueryFragment` type (to have access to the
+                //   functions that enable to typecheck for the presence of variables), and we
+                //   like the QueryFragment itself to not be generic on the variables type to
+                //   generate the query.
+                // - Normally we use the type of the fields of the XxxVariables directly in
+                //   these return types of the functions of XxxVariablesFields, and that type
+                //   implements `CoercesTo<schema::CorrespondingType>` (as derived by
+                //   `InputObject`, or specified by cynic if it's a litteral)
+                // - Now we want to still typecheck that our concrete (specialized) types have
+                //   all their fields implement `CoercesTo` the correct schema type, but we also
+                //   want to not be generic in the `Fields` struct. This is achieved by:
+                //   - Creating a proxy type that will be used in the XxxVariablesFields struct
+                //   - Implementing `CoercesTo<SchemaType>` for it (so that the regular
+                //     typecheck passes)
+                //   - Adding a separate typecheck in the concrete type for the
+                //     `CoercesTo<schema_type>` (so that we still check for correctness)
+
+                let new_type_that_coerces_to_schema_type =
+                    format_ident!("CoercionProxyForField{field_idx}");
+                field_output_types.push(quote! {
+                    #vis struct #new_type_that_coerces_to_schema_type;
+                    ::cynic::impl_coercions!(#new_type_that_coerces_to_schema_type [] [], #schema_module::#graphql_type);
+                });
+                coercion_checks.push(quote! {
+                    ::cynic::assert_impl!(#ty [#impl_generics] [#where_clause]: ::cynic::coercions::CoercesTo<#schema_module::#graphql_type>);
+                });
+
+                // Turn that from an ident into a type
+                syn::parse_quote! { #new_type_that_coerces_to_schema_type }
+            }
+        };
+        TurnLifetimesToStatic.visit_type_mut(&mut ty_for_fields_struct);
         let name_str =
             proc_macro2::Literal::string(&f.graphql_ident(input.rename_all).graphql_name());
 
         field_funcs.push(quote! {
-            #vis fn #name() -> ::cynic::variables::VariableDefinition<Self, #ty> {
+            #vis fn #name() -> ::cynic::variables::VariableDefinition<Self, #ty_for_fields_struct> {
                 ::cynic::variables::VariableDefinition::new(#name_str)
             }
         });
@@ -62,18 +102,21 @@ pub fn query_variables_derive_impl(
     let fields_struct = quote_spanned! { ident_span =>
         #vis struct #fields_struct_ident;
 
-        impl ::cynic::QueryVariablesFields for #fields_struct_ident {
-            const VARIABLES: &'static [(&'static str, ::cynic::variables::VariableType)]
-                = &[#(#variables),*];
-        }
+        impl ::cynic::QueryVariablesFields for #fields_struct_ident {}
 
         impl ::cynic::queries::VariableMatch<#fields_struct_ident> for #fields_struct_ident {}
 
-        impl #fields_struct_ident {
+        const _: () = {
             #(
-                #field_funcs
+                #field_output_types
             )*
-        }
+
+            impl #fields_struct_ident {
+                #(
+                    #field_funcs
+                )*
+            }
+        };
     };
 
     Ok(quote! {
@@ -81,6 +124,8 @@ pub fn query_variables_derive_impl(
         #[automatically_derived]
         impl #impl_generics ::cynic::QueryVariables for #ident #ty_generics #where_clause {
             type Fields = #fields_struct_ident;
+            const VARIABLES: &'static [(&'static str, ::cynic::variables::VariableType)]
+                = &[#(#variables),*];
         }
 
         #[automatically_derived]
@@ -90,6 +135,7 @@ pub fn query_variables_derive_impl(
                 S: ::cynic::serde::Serializer,
             {
                 use ::cynic::serde::ser::SerializeMap;
+                #(#coercion_checks)*
 
                 let mut map_serializer = serializer.serialize_map(Some(#map_len))?;
 

--- a/cynic-codegen/src/query_variables_derive/mod.rs
+++ b/cynic-codegen/src/query_variables_derive/mod.rs
@@ -134,9 +134,9 @@ pub fn query_variables_derive_impl(
 
         #[automatically_derived]
         impl #impl_generics_with_ser ::cynic::serde::Serialize for #ident #ty_generics #where_clause_with_ser {
-            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+            fn serialize<__S>(&self, serializer: __S) -> Result<__S::Ok, __S::Error>
             where
-                S: ::cynic::serde::Serializer,
+                __S: ::cynic::serde::Serializer,
             {
                 use ::cynic::serde::ser::SerializeMap;
                 #(#coercion_checks)*

--- a/cynic-codegen/src/scalar_derive/input.rs
+++ b/cynic-codegen/src/scalar_derive/input.rs
@@ -5,6 +5,7 @@ use darling::util::SpannedValue;
 pub struct ScalarDeriveInput {
     pub(super) ident: proc_macro2::Ident,
     pub(super) data: darling::ast::Data<(), ScalarDeriveField>,
+    pub(super) generics: syn::Generics,
 
     #[darling(default, rename = "schema_module")]
     schema_module_: Option<syn::Path>,

--- a/cynic-codegen/src/scalar_derive/mod.rs
+++ b/cynic-codegen/src/scalar_derive/mod.rs
@@ -63,9 +63,9 @@ pub fn scalar_derive_impl(input: ScalarDeriveInput) -> Result<TokenStream, syn::
     Ok(quote! {
         #[automatically_derived]
         impl #impl_generics_with_ser ::cynic::serde::Serialize for #ident #ty_generics #where_clause_with_ser {
-            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+            fn serialize<__S>(&self, serializer: __S) -> Result<__S::Ok, __S::Error>
             where
-                S: ::cynic::serde::Serializer,
+                __S: ::cynic::serde::Serializer,
             {
                 self.0.serialize(serializer)
             }
@@ -73,9 +73,9 @@ pub fn scalar_derive_impl(input: ScalarDeriveInput) -> Result<TokenStream, syn::
 
         #[automatically_derived]
         impl #impl_generics_with_de ::cynic::serde::Deserialize<'de> for #ident #ty_generics #where_clause_with_de {
-            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            fn deserialize<__D>(deserializer: __D) -> Result<Self, __D::Error>
             where
-                D: ::cynic::serde::Deserializer<'de>,
+                __D: ::cynic::serde::Deserializer<'de>,
             {
                 <#inner_type as ::cynic::serde::Deserialize<'de>>::deserialize(deserializer).map(Self)
             }

--- a/cynic-codegen/src/scalar_derive/snapshots/cynic_codegen__scalar_derive__tests__snapshot_scalar_derive.snap
+++ b/cynic-codegen/src/scalar_derive/snapshots/cynic_codegen__scalar_derive__tests__snapshot_scalar_derive.snap
@@ -1,6 +1,5 @@
 ---
 source: cynic-codegen/src/scalar_derive/tests.rs
-assertion_line: 20
 expression: "format_code(format!(\"{}\", tokens))"
 ---
 #[automatically_derived]
@@ -30,5 +29,5 @@ impl schema::variable::Variable for DateTime {
     const TYPE: ::cynic::variables::VariableType =
         ::cynic::variables::VariableType::Named("DateTime");
 }
-::cynic::impl_coercions!(DateTime, schema::DateTime);
+:: cynic :: impl_coercions ! (DateTime [] [] , schema :: DateTime);
 

--- a/cynic-codegen/src/scalar_derive/snapshots/cynic_codegen__scalar_derive__tests__snapshot_scalar_derive.snap
+++ b/cynic-codegen/src/scalar_derive/snapshots/cynic_codegen__scalar_derive__tests__snapshot_scalar_derive.snap
@@ -4,18 +4,18 @@ expression: "format_code(format!(\"{}\", tokens))"
 ---
 #[automatically_derived]
 impl ::cynic::serde::Serialize for DateTime {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    fn serialize<__S>(&self, serializer: __S) -> Result<__S::Ok, __S::Error>
     where
-        S: ::cynic::serde::Serializer,
+        __S: ::cynic::serde::Serializer,
     {
         self.0.serialize(serializer)
     }
 }
 #[automatically_derived]
 impl<'de> ::cynic::serde::Deserialize<'de> for DateTime {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    fn deserialize<__D>(deserializer: __D) -> Result<Self, __D::Error>
     where
-        D: ::cynic::serde::Deserializer<'de>,
+        __D: ::cynic::serde::Deserializer<'de>,
     {
         <String as ::cynic::serde::Deserialize<'de>>::deserialize(deserializer).map(Self)
     }

--- a/cynic-codegen/src/use_schema/mod.rs
+++ b/cynic-codegen/src/use_schema/mod.rs
@@ -166,6 +166,13 @@ pub fn use_schema(input: UseSchemaParams) -> Result<TokenStream, Errors> {
                 const TYPE: VariableType = T::TYPE;
             }
 
+            impl<T> Variable for std::borrow::Cow<'_, T>
+            where
+                T: ?::core::marker::Sized + Variable + ToOwned,
+            {
+                const TYPE: VariableType = T::TYPE;
+            }
+
             impl Variable for bool {
                 const TYPE: VariableType = VariableType::Named("Boolean");
             }

--- a/cynic-codegen/tests/snapshots/use_schema__books.graphql.snap
+++ b/cynic-codegen/tests/snapshots/use_schema__books.graphql.snap
@@ -214,7 +214,7 @@ pub mod variable {
     }
     impl<T> Variable for &T
     where
-        T: Variable,
+        T: ?::core::marker::Sized + Variable,
     {
         const TYPE: VariableType = T::TYPE;
     }
@@ -224,11 +224,17 @@ pub mod variable {
     {
         const TYPE: VariableType = VariableType::Nullable(&T::TYPE);
     }
-    impl<T> Variable for Vec<T>
+    impl<T> Variable for [T]
     where
         T: Variable,
     {
         const TYPE: VariableType = VariableType::List(&T::TYPE);
+    }
+    impl<T> Variable for Vec<T>
+    where
+        T: Variable,
+    {
+        const TYPE: VariableType = <Vec<T> as Variable>::TYPE;
     }
     impl<T> Variable for Box<T>
     where
@@ -248,11 +254,20 @@ pub mod variable {
     {
         const TYPE: VariableType = T::TYPE;
     }
+    impl<T> Variable for std::borrow::Cow<'_, T>
+    where
+        T: ?::core::marker::Sized + Variable + ToOwned,
+    {
+        const TYPE: VariableType = T::TYPE;
+    }
     impl Variable for bool {
         const TYPE: VariableType = VariableType::Named("Boolean");
     }
-    impl Variable for String {
+    impl Variable for str {
         const TYPE: VariableType = VariableType::Named("String");
+    }
+    impl Variable for String {
+        const TYPE: VariableType = <str as Variable>::TYPE;
     }
     impl Variable for f64 {
         const TYPE: VariableType = VariableType::Named("Float");

--- a/cynic-codegen/tests/snapshots/use_schema__graphql.jobs.graphql.snap
+++ b/cynic-codegen/tests/snapshots/use_schema__graphql.jobs.graphql.snap
@@ -7263,7 +7263,7 @@ pub mod variable {
     }
     impl<T> Variable for &T
     where
-        T: Variable,
+        T: ?::core::marker::Sized + Variable,
     {
         const TYPE: VariableType = T::TYPE;
     }
@@ -7273,11 +7273,17 @@ pub mod variable {
     {
         const TYPE: VariableType = VariableType::Nullable(&T::TYPE);
     }
-    impl<T> Variable for Vec<T>
+    impl<T> Variable for [T]
     where
         T: Variable,
     {
         const TYPE: VariableType = VariableType::List(&T::TYPE);
+    }
+    impl<T> Variable for Vec<T>
+    where
+        T: Variable,
+    {
+        const TYPE: VariableType = <Vec<T> as Variable>::TYPE;
     }
     impl<T> Variable for Box<T>
     where
@@ -7297,11 +7303,20 @@ pub mod variable {
     {
         const TYPE: VariableType = T::TYPE;
     }
+    impl<T> Variable for std::borrow::Cow<'_, T>
+    where
+        T: ?::core::marker::Sized + Variable + ToOwned,
+    {
+        const TYPE: VariableType = T::TYPE;
+    }
     impl Variable for bool {
         const TYPE: VariableType = VariableType::Named("Boolean");
     }
-    impl Variable for String {
+    impl Variable for str {
         const TYPE: VariableType = VariableType::Named("String");
+    }
+    impl Variable for String {
+        const TYPE: VariableType = <str as Variable>::TYPE;
     }
     impl Variable for f64 {
         const TYPE: VariableType = VariableType::Named("Float");

--- a/cynic-codegen/tests/snapshots/use_schema__simple.graphql.snap
+++ b/cynic-codegen/tests/snapshots/use_schema__simple.graphql.snap
@@ -205,7 +205,7 @@ pub mod variable {
     }
     impl<T> Variable for &T
     where
-        T: Variable,
+        T: ?::core::marker::Sized + Variable,
     {
         const TYPE: VariableType = T::TYPE;
     }
@@ -215,11 +215,17 @@ pub mod variable {
     {
         const TYPE: VariableType = VariableType::Nullable(&T::TYPE);
     }
-    impl<T> Variable for Vec<T>
+    impl<T> Variable for [T]
     where
         T: Variable,
     {
         const TYPE: VariableType = VariableType::List(&T::TYPE);
+    }
+    impl<T> Variable for Vec<T>
+    where
+        T: Variable,
+    {
+        const TYPE: VariableType = <Vec<T> as Variable>::TYPE;
     }
     impl<T> Variable for Box<T>
     where
@@ -239,11 +245,20 @@ pub mod variable {
     {
         const TYPE: VariableType = T::TYPE;
     }
+    impl<T> Variable for std::borrow::Cow<'_, T>
+    where
+        T: ?::core::marker::Sized + Variable + ToOwned,
+    {
+        const TYPE: VariableType = T::TYPE;
+    }
     impl Variable for bool {
         const TYPE: VariableType = VariableType::Named("Boolean");
     }
-    impl Variable for String {
+    impl Variable for str {
         const TYPE: VariableType = VariableType::Named("String");
+    }
+    impl Variable for String {
+        const TYPE: VariableType = <str as Variable>::TYPE;
     }
     impl Variable for f64 {
         const TYPE: VariableType = VariableType::Named("Float");

--- a/cynic-codegen/tests/snapshots/use_schema__starwars.schema.graphql.snap
+++ b/cynic-codegen/tests/snapshots/use_schema__starwars.schema.graphql.snap
@@ -3276,7 +3276,7 @@ pub mod variable {
     }
     impl<T> Variable for &T
     where
-        T: Variable,
+        T: ?::core::marker::Sized + Variable,
     {
         const TYPE: VariableType = T::TYPE;
     }
@@ -3286,11 +3286,17 @@ pub mod variable {
     {
         const TYPE: VariableType = VariableType::Nullable(&T::TYPE);
     }
-    impl<T> Variable for Vec<T>
+    impl<T> Variable for [T]
     where
         T: Variable,
     {
         const TYPE: VariableType = VariableType::List(&T::TYPE);
+    }
+    impl<T> Variable for Vec<T>
+    where
+        T: Variable,
+    {
+        const TYPE: VariableType = <Vec<T> as Variable>::TYPE;
     }
     impl<T> Variable for Box<T>
     where
@@ -3310,11 +3316,20 @@ pub mod variable {
     {
         const TYPE: VariableType = T::TYPE;
     }
+    impl<T> Variable for std::borrow::Cow<'_, T>
+    where
+        T: ?::core::marker::Sized + Variable + ToOwned,
+    {
+        const TYPE: VariableType = T::TYPE;
+    }
     impl Variable for bool {
         const TYPE: VariableType = VariableType::Named("Boolean");
     }
-    impl Variable for String {
+    impl Variable for str {
         const TYPE: VariableType = VariableType::Named("String");
+    }
+    impl Variable for String {
+        const TYPE: VariableType = <str as Variable>::TYPE;
     }
     impl Variable for f64 {
         const TYPE: VariableType = VariableType::Named("Float");

--- a/cynic-codegen/tests/snapshots/use_schema__test_cases.graphql.snap
+++ b/cynic-codegen/tests/snapshots/use_schema__test_cases.graphql.snap
@@ -198,7 +198,7 @@ pub mod variable {
     }
     impl<T> Variable for &T
     where
-        T: Variable,
+        T: ?::core::marker::Sized + Variable,
     {
         const TYPE: VariableType = T::TYPE;
     }
@@ -208,11 +208,17 @@ pub mod variable {
     {
         const TYPE: VariableType = VariableType::Nullable(&T::TYPE);
     }
-    impl<T> Variable for Vec<T>
+    impl<T> Variable for [T]
     where
         T: Variable,
     {
         const TYPE: VariableType = VariableType::List(&T::TYPE);
+    }
+    impl<T> Variable for Vec<T>
+    where
+        T: Variable,
+    {
+        const TYPE: VariableType = <Vec<T> as Variable>::TYPE;
     }
     impl<T> Variable for Box<T>
     where
@@ -232,11 +238,20 @@ pub mod variable {
     {
         const TYPE: VariableType = T::TYPE;
     }
+    impl<T> Variable for std::borrow::Cow<'_, T>
+    where
+        T: ?::core::marker::Sized + Variable + ToOwned,
+    {
+        const TYPE: VariableType = T::TYPE;
+    }
     impl Variable for bool {
         const TYPE: VariableType = VariableType::Named("Boolean");
     }
-    impl Variable for String {
+    impl Variable for str {
         const TYPE: VariableType = VariableType::Named("String");
+    }
+    impl Variable for String {
+        const TYPE: VariableType = <str as Variable>::TYPE;
     }
     impl Variable for f64 {
         const TYPE: VariableType = VariableType::Named("Float");

--- a/cynic/src/builders.rs
+++ b/cynic/src/builders.rs
@@ -1,70 +1,63 @@
-use super::{Operation, QueryFragment, StreamingOperation};
+use super::{Operation, QueryFragment, QueryVariables, StreamingOperation};
+
+// TODO maybe swap into `let operation = variables.build_query();`
 
 /// Provides a `build` function on `QueryFragment`s that represent a query
-pub trait QueryBuilder<'de>: Sized {
-    /// The type that this query takes as variables.
-    /// May be `()` if no variables are accepted.
-    type Variables;
-
+pub trait QueryBuilder<Variables>: Sized {
     /// Constructs a query operation for this QueryFragment.
-    fn build(vars: Self::Variables) -> Operation<Self, Self::Variables>;
+    fn build(vars: Variables) -> Operation<Self, Variables>;
 }
 
-impl<'de, T> QueryBuilder<'de> for T
+impl<T, Variables> QueryBuilder<Variables> for T
 where
-    T: QueryFragment<'de>,
+    Variables: QueryVariables,
+    T: QueryFragment<VariablesFields = Variables::Fields>,
     T::SchemaType: crate::schema::QueryRoot,
 {
-    type Variables = T::Variables;
-
-    fn build(vars: Self::Variables) -> Operation<T, Self::Variables> {
-        Operation::<T, T::Variables>::query(vars)
+    fn build(vars: Variables) -> Operation<T, Variables> {
+        Operation::<T, Variables>::query(vars)
     }
 }
 
 // TODO: update mutation builder to support new query structure stuff...
 
 /// Provides a `build` function on `QueryFragment`s that represent a mutation
-pub trait MutationBuilder<'de>: Sized {
+pub trait MutationBuilder<Variables>: Sized {
     /// The type that this mutation takes as variables.
     /// May be `()` if no variables are accepted.
-    type Variables;
 
     /// Constructs a mutation operation for this QueryFragment.
-    fn build(args: Self::Variables) -> Operation<Self, Self::Variables>;
+    fn build(args: Variables) -> Operation<Self, Variables>;
 }
 
-impl<'de, T> MutationBuilder<'de> for T
+impl<T, Variables> MutationBuilder<Variables> for T
 where
-    T: QueryFragment<'de>,
+    Variables: QueryVariables,
+    T: QueryFragment<VariablesFields = Variables::Fields>,
     T::SchemaType: crate::schema::MutationRoot,
 {
-    type Variables = T::Variables;
-
-    fn build(vars: Self::Variables) -> Operation<Self, Self::Variables> {
-        Operation::<T, T::Variables>::mutation(vars)
+    fn build(vars: Variables) -> Operation<Self, Variables> {
+        Operation::<T, Variables>::mutation(vars)
     }
 }
 
 /// Provides a `build` function on `QueryFragment`s that represent a subscription
-pub trait SubscriptionBuilder<'a>: Sized {
+pub trait SubscriptionBuilder<Variables>: Sized {
     /// The type that this subscription takes as variables.
     /// May be `()` if no variables are accepted.
-    type Variables;
 
     /// Constructs a subscription operation for this QueryFragment.
-    fn build(vars: Self::Variables) -> StreamingOperation<Self, Self::Variables>;
+    fn build(vars: Variables) -> StreamingOperation<Self, Variables>;
 }
 
-impl<'de, T> SubscriptionBuilder<'de> for T
+impl<T, Variables> SubscriptionBuilder<Variables> for T
 where
-    T: QueryFragment<'de>,
+    Variables: QueryVariables,
+    T: QueryFragment<VariablesFields = Variables::Fields>,
     T::SchemaType: crate::schema::SubscriptionRoot,
 {
-    type Variables = T::Variables;
-
     /// Constructs a subscription operation for this QueryFragment.
-    fn build(vars: Self::Variables) -> StreamingOperation<Self, T::Variables> {
-        StreamingOperation::<T, T::Variables>::subscription(vars)
+    fn build(vars: Variables) -> StreamingOperation<Self, Variables> {
+        StreamingOperation::<T, Variables>::subscription(vars)
     }
 }

--- a/cynic/src/coercions.rs
+++ b/cynic/src/coercions.rs
@@ -15,7 +15,7 @@ pub trait CoercesTo<T> {}
 impl<T, TypeLock> CoercesTo<Option<TypeLock>> for Option<T> where T: CoercesTo<TypeLock> {}
 impl<T, TypeLock> CoercesTo<Vec<TypeLock>> for Vec<T> where T: CoercesTo<TypeLock> {}
 
-impl CoercesTo<Id> for &str {}
+impl<Target: ?Sized, Typelock> CoercesTo<Typelock> for &'_ Target where Target: CoercesTo<Typelock> {}
 
 #[macro_export(local_inner_macros)]
 /// Implements the default GraphQL list & option coercion rules for a type.
@@ -48,7 +48,8 @@ mod scalars {
     impl_coercions_for_scalar!(bool);
     impl_coercions_for_scalar!(Id);
     impl_coercions_for_scalar!(String);
-    impl_coercions!(&str, String);
+    impl_coercions!(str, String);
+    impl_coercions!(str, Id);
 }
 
 #[cfg(test)]

--- a/cynic/src/coercions.rs
+++ b/cynic/src/coercions.rs
@@ -17,17 +17,20 @@ impl<T, TypeLock> CoercesTo<Vec<TypeLock>> for Vec<T> where T: CoercesTo<TypeLoc
 
 impl CoercesTo<Id> for &str {}
 
-#[macro_export]
+#[macro_export(local_inner_macros)]
 /// Implements the default GraphQL list & option coercion rules for a type.
 macro_rules! impl_coercions {
     ($target:ty, $typelock:ty) => {
-        impl $crate::coercions::CoercesTo<$typelock> for $target {}
-        impl $crate::coercions::CoercesTo<Option<$typelock>> for $target {}
-        impl $crate::coercions::CoercesTo<Vec<$typelock>> for $target {}
-        impl $crate::coercions::CoercesTo<Option<Vec<$typelock>>> for $target {}
-        impl $crate::coercions::CoercesTo<Option<Vec<Option<$typelock>>>> for $target {}
-        impl $crate::coercions::CoercesTo<Option<Option<$typelock>>> for $target {}
-        impl $crate::coercions::CoercesTo<Vec<Vec<$typelock>>> for $target {}
+        impl_coercions!($target[][], $typelock);
+    };
+    ($target:ty [$($impl_generics: tt)*] [$($where_clause: tt)*], $typelock:ty) => {
+        impl $($impl_generics)* $crate::coercions::CoercesTo<$typelock> for $target $($where_clause)* {}
+        impl $($impl_generics)* $crate::coercions::CoercesTo<Option<$typelock>> for $target $($where_clause)* {}
+        impl $($impl_generics)* $crate::coercions::CoercesTo<Vec<$typelock>> for $target $($where_clause)* {}
+        impl $($impl_generics)* $crate::coercions::CoercesTo<Option<Vec<$typelock>>> for $target $($where_clause)* {}
+        impl $($impl_generics)* $crate::coercions::CoercesTo<Option<Vec<Option<$typelock>>>> for $target $($where_clause)* {}
+        impl $($impl_generics)* $crate::coercions::CoercesTo<Option<Option<$typelock>>> for $target $($where_clause)* {}
+        impl $($impl_generics)* $crate::coercions::CoercesTo<Vec<Vec<$typelock>>> for $target $($where_clause)* {}
     };
 }
 

--- a/cynic/src/core.rs
+++ b/cynic/src/core.rs
@@ -1,103 +1,101 @@
-use crate::{queries::SelectionBuilder, QueryVariables};
+use crate::{queries::SelectionBuilder, QueryVariablesFields};
 
 /// Indicates that a type may be used as part of a graphql query.
 ///
 /// This will usually be derived, but can be manually implemented if required.
-pub trait QueryFragment<'de>: serde::Deserialize<'de> {
+pub trait QueryFragment: Sized {
     /// The type in a schema that this `QueryFragment` represents
     type SchemaType;
 
     /// The variables that are required to execute this `QueryFragment`
-    type Variables: QueryVariables;
+    type VariablesFields: QueryVariablesFields;
 
     /// The name of the type in the GraphQL schema
     const TYPE: Option<&'static str> = None;
 
     /// Adds this fragment to the query being built by `builder`
-    fn query(builder: SelectionBuilder<'_, Self::SchemaType, Self::Variables>);
+    fn query(builder: SelectionBuilder<'_, Self::SchemaType, Self::VariablesFields>);
 }
 
-impl<'de, T> QueryFragment<'de> for Option<T>
+impl<T> QueryFragment for Option<T>
 where
-    T: QueryFragment<'de>,
+    T: QueryFragment,
 {
     type SchemaType = Option<T::SchemaType>;
-    type Variables = T::Variables;
+    type VariablesFields = T::VariablesFields;
 
-    fn query(builder: SelectionBuilder<'_, Self::SchemaType, Self::Variables>) {
+    fn query(builder: SelectionBuilder<'_, Self::SchemaType, Self::VariablesFields>) {
         T::query(builder.into_inner())
     }
 }
 
-impl<'de, T> QueryFragment<'de> for Vec<T>
+impl<T> QueryFragment for Vec<T>
 where
-    T: QueryFragment<'de>,
+    T: QueryFragment,
 {
     type SchemaType = Vec<T::SchemaType>;
-    type Variables = T::Variables;
+    type VariablesFields = T::VariablesFields;
 
-    fn query(builder: SelectionBuilder<'_, Self::SchemaType, Self::Variables>) {
+    fn query(builder: SelectionBuilder<'_, Self::SchemaType, Self::VariablesFields>) {
         T::query(builder.into_inner())
     }
 }
 
-impl<'de, T> QueryFragment<'de> for Box<T>
+impl<T> QueryFragment for Box<T>
 where
-    T: QueryFragment<'de>,
+    T: QueryFragment,
 {
     type SchemaType = T::SchemaType;
-    type Variables = T::Variables;
+    type VariablesFields = T::VariablesFields;
 
-    fn query(builder: SelectionBuilder<'_, Self::SchemaType, Self::Variables>) {
+    fn query(builder: SelectionBuilder<'_, Self::SchemaType, Self::VariablesFields>) {
         T::query(builder)
     }
 }
 
-impl<'de, T> QueryFragment<'de> for std::rc::Rc<T>
+impl<T> QueryFragment for std::rc::Rc<T>
 where
-    Self: serde::Deserialize<'de>,
-    T: QueryFragment<'de>,
+    T: QueryFragment,
 {
     type SchemaType = T::SchemaType;
-    type Variables = T::Variables;
+    type VariablesFields = T::VariablesFields;
 
-    fn query(builder: SelectionBuilder<'_, Self::SchemaType, Self::Variables>) {
+    fn query(builder: SelectionBuilder<'_, Self::SchemaType, Self::VariablesFields>) {
         T::query(builder)
     }
 }
 
-impl<'de, T> QueryFragment<'de> for std::sync::Arc<T>
+impl<T> QueryFragment for std::sync::Arc<T>
 where
-    Self: serde::Deserialize<'de>,
-    T: QueryFragment<'de>,
+    T: QueryFragment,
 {
     type SchemaType = T::SchemaType;
-    type Variables = T::Variables;
+    type VariablesFields = T::VariablesFields;
 
-    fn query(builder: SelectionBuilder<'_, Self::SchemaType, Self::Variables>) {
+    fn query(builder: SelectionBuilder<'_, Self::SchemaType, Self::VariablesFields>) {
         T::query(builder)
     }
 }
 
-impl<'de> QueryFragment<'de> for bool {
+impl QueryFragment for bool {
     type SchemaType = bool;
-    type Variables = ();
+    type VariablesFields = ();
 
-    fn query(_builder: SelectionBuilder<'_, Self::SchemaType, Self::Variables>) {}
+    fn query(_builder: SelectionBuilder<'_, Self::SchemaType, Self::VariablesFields>) {}
 }
 
-impl<'de> QueryFragment<'de> for String {
+impl QueryFragment for String {
     type SchemaType = String;
-    type Variables = ();
+    type VariablesFields = ();
 
-    fn query(_builder: SelectionBuilder<'_, Self::SchemaType, Self::Variables>) {}
+    fn query(_builder: SelectionBuilder<'_, Self::SchemaType, Self::VariablesFields>) {}
 }
 
 /// A QueryFragment that contains a set of inline fragments
 ///
 /// This should be derived on an enum with newtype variants where each
 /// inner type is a `QueryFragment` for an appropriate type.
-pub trait InlineFragments<'de>: QueryFragment<'de> {
+pub trait InlineFragments<'de>: QueryFragment + serde::de::Deserialize<'de> {
     /// Attempts to deserialize a variant with the given typename.
     fn deserialize_variant<D>(typename: &str, deserializer: D) -> Result<Self, D::Error>
     where

--- a/cynic/src/core.rs
+++ b/cynic/src/core.rs
@@ -104,7 +104,8 @@ pub trait InlineFragments<'de>: QueryFragment + serde::de::Deserialize<'de> {
 
 /// A GraphQL Enum.
 ///
-/// Note that in GraphQL these can't contain data - they are just a set of strings.
+/// Note that in GraphQL these can't contain data - they are just a set of
+/// strings.
 ///
 /// This should be be derived on an enum with unit variants.
 pub trait Enum: serde::de::DeserializeOwned + serde::Serialize {

--- a/cynic/src/lib.rs
+++ b/cynic/src/lib.rs
@@ -27,7 +27,7 @@
 //! 1. Some structs to represent the Input types the underlying schema.
 //!    You may need to use these to build mutations or as parameters to queries.
 //! 2. Definitions of all the Enums in the provided schema.  You'll need these
-//! if    you want to use any enum types.
+//!    if you want to use any enum types.
 //! 3. Type safe selection set functions.  These can be used to build up a query
 //!    manually, though it's usually easier to use the `QueryFragment` derive
 //!    functionality explained below.  Hopefully you'll not need to use these

--- a/cynic/src/lib.rs
+++ b/cynic/src/lib.rs
@@ -198,7 +198,7 @@ pub use cynic_proc_macros::{
     QueryFragment, QueryVariables, Scalar,
 };
 
-pub use static_assertions::{assert_impl_all as assert_impl, assert_type_eq_all};
+pub use static_assertions::assert_type_eq_all;
 
 // We re-export serde as the output from a lot of our derive macros require it,
 // and this way we can point at our copy rather than forcing users to add it to
@@ -249,5 +249,19 @@ macro_rules! impl_scalar {
                 <$schema_module$(::$schema_module_rest)*::$type_lock as $crate::schema::NamedType>::NAME,
             );
         }
+    };
+}
+
+#[macro_export(local_inner_macros)]
+/// Asserts that the type implements _all_ of the given traits.
+macro_rules! assert_impl {
+    ($type:ty [$($impl_generics: tt)*] [$($where_clause: tt)*]: $($trait:path),+ $(,)?) => {
+        const _: () = {
+            // Only callable when `$type` implements all traits in `$($trait)+`.
+            fn assert_impl_all<T: ?Sized $(+ $trait)+>() {}
+            fn do_assert $($impl_generics)* () $($where_clause)* {
+                assert_impl_all::<$type>();
+            }
+        };
     };
 }

--- a/cynic/src/lib.rs
+++ b/cynic/src/lib.rs
@@ -3,13 +3,13 @@
 //!
 //! Cynic is a GraphQL query builder & data mapper for Rust.
 //!
-//! This documentation is primarily intended to be a reference for specific functions,
-//! for a guide to using `Cynic` see the website: [cynic-rs.dev](https://cynic-rs.dev).
+//! This documentation is primarily intended to be a reference for specific
+//! functions, for a guide to using `Cynic` see the website: [cynic-rs.dev](https://cynic-rs.dev).
 //!
 //! ## Overview
 //!
-//! To get started with Cynic you'll need a GraphQL schema for the API you wish to
-//! query.  The examples will be using the star wars API.
+//! To get started with Cynic you'll need a GraphQL schema for the API you wish
+//! to query.  The examples will be using the star wars API.
 //!
 //! ### Generating a Query DSL
 //!
@@ -26,24 +26,25 @@
 //!
 //! 1. Some structs to represent the Input types the underlying schema.
 //!    You may need to use these to build mutations or as parameters to queries.
-//! 2. Definitions of all the Enums in the provided schema.  You'll need these if
-//!    you want to use any enum types.
+//! 2. Definitions of all the Enums in the provided schema.  You'll need these
+//! if    you want to use any enum types.
 //! 3. Type safe selection set functions.  These can be used to build up a query
 //!    manually, though it's usually easier to use the `QueryFragment` derive
 //!    functionality explained below.  Hopefully you'll not need to use these
 //!    directly too often.
 //!
-//! Though using macros to generate these is convenient, it does leave a lot of code
-//! to the imagination.  You can get a glimpse of the things this defines by running
-//! `cargo doc --document-private-items` and having a look in the `schema` module.
-//! It's not ideal, but at least provides some visibility into the various enum types.
+//! Though using macros to generate these is convenient, it does leave a lot of
+//! code to the imagination.  You can get a glimpse of the things this defines
+//! by running `cargo doc --document-private-items` and having a look in the
+//! `schema` module. It's not ideal, but at least provides some visibility into
+//! the various enum types.
 //!
 //! ### Creating QueryFragments
 //!
 //! Now that you have a schema defined, you can start building some queries.
-//! Cynic lets you do this by deriving `QueryFragment` for a struct.  For example,
-//! if we wanted to know what director title & director a Star Wars film had, we
-//! could define this `QueryFragment`:
+//! Cynic lets you do this by deriving `QueryFragment` for a struct.  For
+//! example, if we wanted to know what director title & director a Star Wars
+//! film had, we could define this `QueryFragment`:
 //!
 //! ```rust
 //! # mod schema {
@@ -54,7 +55,7 @@
 //! #[cynic(schema_path = "../schemas/starwars.schema.graphql")]
 //! struct Film {
 //!     title: Option<String>,
-//!     director: Option<String>
+//!     director: Option<String>,
 //! }
 //!
 //! // This `Film` struct can now be used as the type of a field on any other
@@ -78,14 +79,14 @@
 //! }
 //!
 //! // You can then build a `cynic::Operation` from this fragment
-//! use cynic::{QueryBuilder};
+//! use cynic::QueryBuilder;
 //! let operation = FilmDirectorQuery::build(());
-//!
 //! ```
 //!
 //! `operation` above implements `serde::Serialize` so can be used with any HTTP
 //! client.  A selection of HTTP client integrations are provided in
-//! `cynic::http` - see the docs there for examples of using a `cynic::Operation`
+//! `cynic::http` - see the docs there for examples of using a
+//! `cynic::Operation`
 //!
 //! ```rust,ignore
 //! let response = reqwest::blocking::Client::new()
@@ -95,14 +96,14 @@
 //! let result = response.json::<GraphQlResponse<FilmDirectorQuery>>()?;
 //! ```
 //!
-//! After this code has run, result will be an instance of `GraphQlResponse<FilmDirectorQuery>`
-//! with the film populated appropriately.
+//! After this code has run, result will be an instance of
+//! `GraphQlResponse<FilmDirectorQuery>` with the film populated appropriately.
 //!
 //! ### Dynamic Query Arguments
 //!
-//! The query above was useful for demonstration, but you'll usually want to be able to
-//! provide parameters to your query.  To do this, you should define a struct that contains
-//! all of the parameters you want to provide:
+//! The query above was useful for demonstration, but you'll usually want to be
+//! able to provide parameters to your query.  To do this, you should define a
+//! struct that contains all of the parameters you want to provide:
 //!
 //! ```rust
 //! # mod schema {
@@ -121,7 +122,7 @@
 //! // `QueryFragment`, whether it represents part of a query or a whole query.
 //! #[derive(cynic::QueryVariables)]
 //! struct FilmArguments {
-//!     id: Option<cynic::Id>
+//!     id: Option<cynic::Id>,
 //! }
 //!
 //! // You can now define a query to use these arguments on.  For example, to make
@@ -142,9 +143,9 @@
 //!
 //! // Then we can build a query using this new struct;
 //! use cynic::QueryBuilder;
-//! let operation = FilmDirectorQueryWithArgs::build(
-//!     FilmArguments{ id: Some("ZmlsbXM6MQ==".into()) }
-//! );
+//! let operation = FilmDirectorQueryWithArgs::build(FilmArguments {
+//!     id: Some("ZmlsbXM6MQ==".into()),
+//! });
 //! ```
 //!
 //! ## Feature Flags
@@ -153,10 +154,10 @@
 //!
 //! - `surf` adds integration with the [`surf`](https://github.com/http-rs/surf)
 //!   http client.
-//! - `reqwest` adds async integration with the
-//!   [`reqwest`](https://github.com/seanmonstar/reqwest) http client.
-//! - `reqwest-blocking` adds blocking integration with the
-//!   [`reqwest`](https://github.com/seanmonstar/reqwest) http client.
+//! - `reqwest` adds async integration with the [`reqwest`](https://github.com/seanmonstar/reqwest)
+//!   http client.
+//! - `reqwest-blocking` adds blocking integration with the [`reqwest`](https://github.com/seanmonstar/reqwest)
+//!   http client.
 //!
 //! It's worth noting that each of these features pulls in extra
 //! dependencies, which may impact your build size.  Particularly
@@ -183,12 +184,14 @@ pub mod schema;
 #[path = "private/mod.rs"]
 pub mod __private;
 
-pub use self::core::{Enum, InlineFragments, InputObject, QueryFragment};
-pub use builders::{MutationBuilder, QueryBuilder, SubscriptionBuilder};
-pub use id::Id;
-pub use operation::{Operation, StreamingOperation};
-pub use result::{GraphQlError, GraphQlResponse};
-pub use variables::QueryVariables;
+pub use {
+    self::core::{Enum, InlineFragments, InputObject, QueryFragment},
+    builders::{MutationBuilder, QueryBuilder, SubscriptionBuilder},
+    id::Id,
+    operation::{Operation, StreamingOperation},
+    result::{GraphQlError, GraphQlResponse},
+    variables::{QueryVariables, QueryVariablesFields},
+};
 
 pub use cynic_proc_macros::{
     schema_for_derives, use_schema, Enum, FragmentArguments, InlineFragments, InputObject,

--- a/cynic/src/operation.rs
+++ b/cynic/src/operation.rs
@@ -5,7 +5,7 @@ use crate::{
     queries::{SelectionBuilder, SelectionSet},
     schema::{MutationRoot, QueryRoot, SubscriptionRoot},
     variables::VariableType,
-    QueryVariables,
+    QueryVariables, QueryVariablesFields,
 };
 
 /// An Operation that can be sent to a remote GraphQL server.
@@ -41,7 +41,7 @@ where
 
 impl<'de, Fragment, Variables> Operation<Fragment, Variables>
 where
-    Fragment: QueryFragment<'de>,
+    Fragment: QueryFragment,
     Variables: QueryVariables,
 {
     /// Constructs a new Operation for a query
@@ -52,7 +52,7 @@ where
         use std::fmt::Write;
 
         let mut selection_set = SelectionSet::default();
-        let builder = SelectionBuilder::new(&mut selection_set);
+        let builder = SelectionBuilder::<_, Fragment::VariablesFields>::new(&mut selection_set);
         Fragment::query(builder);
 
         let vars = VariableDefinitions::new::<Variables>();
@@ -75,7 +75,7 @@ where
         use std::fmt::Write;
 
         let mut selection_set = SelectionSet::default();
-        let builder = SelectionBuilder::new(&mut selection_set);
+        let builder = SelectionBuilder::<_, Fragment::VariablesFields>::new(&mut selection_set);
         Fragment::query(builder);
 
         let vars = VariableDefinitions::new::<Variables>();
@@ -100,7 +100,7 @@ pub struct StreamingOperation<ResponseData, Variables = ()> {
 
 impl<'de, Fragment, Variables> StreamingOperation<Fragment, Variables>
 where
-    Fragment: QueryFragment<'de>,
+    Fragment: QueryFragment,
     Variables: QueryVariables,
 {
     /// Constructs a new Operation for a subscription
@@ -111,7 +111,7 @@ where
         use std::fmt::Write;
 
         let mut selection_set = SelectionSet::default();
-        let builder = SelectionBuilder::new(&mut selection_set);
+        let builder = SelectionBuilder::<_, Fragment::VariablesFields>::new(&mut selection_set);
         Fragment::query(builder);
 
         let vars = VariableDefinitions::new::<Variables>();
@@ -148,7 +148,9 @@ struct VariableDefinitions {
 
 impl VariableDefinitions {
     fn new<T: QueryVariables>() -> Self {
-        VariableDefinitions { vars: T::VARIABLES }
+        VariableDefinitions {
+            vars: <T::Fields as QueryVariablesFields>::VARIABLES,
+        }
     }
 }
 

--- a/cynic/src/operation.rs
+++ b/cynic/src/operation.rs
@@ -5,7 +5,7 @@ use crate::{
     queries::{SelectionBuilder, SelectionSet},
     schema::{MutationRoot, QueryRoot, SubscriptionRoot},
     variables::VariableType,
-    QueryVariables, QueryVariablesFields,
+    QueryVariables,
 };
 
 /// An Operation that can be sent to a remote GraphQL server.
@@ -148,9 +148,7 @@ struct VariableDefinitions {
 
 impl VariableDefinitions {
     fn new<T: QueryVariables>() -> Self {
-        VariableDefinitions {
-            vars: <T::Fields as QueryVariablesFields>::VARIABLES,
-        }
+        VariableDefinitions { vars: T::VARIABLES }
     }
 }
 

--- a/cynic/src/queries/builders.rs
+++ b/cynic/src/queries/builders.rs
@@ -4,9 +4,9 @@ use crate::{coercions::CoercesTo, schema, variables::VariableDefinition};
 
 use super::{ast::*, to_input_literal, FlattensInto, IsFieldType, Recursable};
 
-/// Builds a SelectionSet for the given `SchemaType` and `Variables`
-pub struct SelectionBuilder<'a, SchemaType, Variables> {
-    phantom: PhantomData<fn() -> (SchemaType, Variables)>,
+/// Builds a SelectionSet for the given `SchemaType` and `VariablesFields`
+pub struct SelectionBuilder<'a, SchemaType, VariablesFields> {
+    phantom: PhantomData<fn() -> (SchemaType, VariablesFields)>,
     selection_set: &'a mut SelectionSet,
     has_typename: bool,
     recurse_depth: Option<u8>,
@@ -34,7 +34,7 @@ impl<'a, T, U> SelectionBuilder<'a, Option<T>, U> {
     }
 }
 
-impl<'a, SchemaType, Variables> SelectionBuilder<'a, SchemaType, Variables> {
+impl<'a, SchemaType, VariablesFields> SelectionBuilder<'a, SchemaType, VariablesFields> {
     pub(crate) fn new(selection_set: &'a mut SelectionSet) -> Self {
         SelectionBuilder {
             phantom: PhantomData,
@@ -50,7 +50,7 @@ impl<'a, SchemaType, Variables> SelectionBuilder<'a, SchemaType, Variables> {
     /// implement these rules if calling this function.
     pub fn select_flattened_field<FieldMarker, Flattened, FieldType>(
         &'_ mut self,
-    ) -> FieldSelectionBuilder<'_, FieldMarker, Flattened, Variables>
+    ) -> FieldSelectionBuilder<'_, FieldMarker, Flattened, VariablesFields>
     where
         FieldMarker: schema::Field,
         FieldType: FlattensInto<Flattened>,
@@ -72,7 +72,7 @@ impl<'a, SchemaType, Variables> SelectionBuilder<'a, SchemaType, Variables> {
     /// arguments, aliases, and to build an inner selection.
     pub fn select_field<FieldMarker, FieldType>(
         &'_ mut self,
-    ) -> FieldSelectionBuilder<'_, FieldMarker, FieldType, Variables>
+    ) -> FieldSelectionBuilder<'_, FieldMarker, FieldType, VariablesFields>
     where
         FieldMarker: schema::Field,
         SchemaType: schema::HasField<FieldMarker>,
@@ -92,7 +92,7 @@ impl<'a, SchemaType, Variables> SelectionBuilder<'a, SchemaType, Variables> {
     pub fn recurse<FieldMarker, FieldType>(
         &'_ mut self,
         max_depth: u8,
-    ) -> Option<FieldSelectionBuilder<'_, FieldMarker, FieldType, Variables>>
+    ) -> Option<FieldSelectionBuilder<'_, FieldMarker, FieldType, VariablesFields>>
     where
         FieldMarker: schema::Field,
         SchemaType: schema::HasField<FieldMarker>,
@@ -122,7 +122,7 @@ impl<'a, SchemaType, Variables> SelectionBuilder<'a, SchemaType, Variables> {
     }
 
     /// Adds an inline fragment to the SelectionSet
-    pub fn inline_fragment(&'_ mut self) -> InlineFragmentBuilder<'_, SchemaType, Variables> {
+    pub fn inline_fragment(&'_ mut self) -> InlineFragmentBuilder<'_, SchemaType, VariablesFields> {
         if !self.has_typename {
             self.selection_set
                 .selections
@@ -147,15 +147,15 @@ impl<'a, SchemaType, Variables> SelectionBuilder<'a, SchemaType, Variables> {
 }
 
 /// Builds the selection of a field
-pub struct FieldSelectionBuilder<'a, Field, SchemaType, Variables> {
+pub struct FieldSelectionBuilder<'a, Field, SchemaType, VariablesFields> {
     #[allow(clippy::type_complexity)]
-    phantom: PhantomData<fn() -> (Field, SchemaType, Variables)>,
+    phantom: PhantomData<fn() -> (Field, SchemaType, VariablesFields)>,
     field: &'a mut FieldSelection,
     recurse_depth: Option<u8>,
 }
 
-impl<'a, Field, FieldSchemaType, Variables>
-    FieldSelectionBuilder<'a, Field, FieldSchemaType, Variables>
+impl<'a, Field, FieldSchemaType, VariablesFields>
+    FieldSelectionBuilder<'a, Field, FieldSchemaType, VariablesFields>
 {
     /// Adds an alias to this field.
     ///
@@ -166,8 +166,11 @@ impl<'a, Field, FieldSchemaType, Variables>
 
     /// Adds an argument to this field.
     ///
-    /// Accepts `ArgumentName` - the schema marker struct for the argument you wish to add.
-    pub fn argument<ArgumentName>(&'_ mut self) -> InputBuilder<'_, Field::ArgumentType, Variables>
+    /// Accepts `ArgumentName` - the schema marker struct for the argument you
+    /// wish to add.
+    pub fn argument<ArgumentName>(
+        &'_ mut self,
+    ) -> InputBuilder<'_, Field::ArgumentType, VariablesFields>
     where
         Field: schema::HasArgument<ArgumentName>,
     {
@@ -183,7 +186,7 @@ impl<'a, Field, FieldSchemaType, Variables>
         &'_ mut self,
     ) -> SelectionBuilder<'_, FieldSchemaType, InnerVariables>
     where
-        Variables: VariableMatch<InnerVariables>,
+        VariablesFields: VariableMatch<InnerVariables>,
     {
         SelectionBuilder {
             recurse_depth: self.recurse_depth,
@@ -193,17 +196,17 @@ impl<'a, Field, FieldSchemaType, Variables>
 }
 
 /// Builds an inline fragment in a selection
-pub struct InlineFragmentBuilder<'a, SchemaType, Variables> {
-    phantom: PhantomData<fn() -> (SchemaType, Variables)>,
+pub struct InlineFragmentBuilder<'a, SchemaType, VariablesFields> {
+    phantom: PhantomData<fn() -> (SchemaType, VariablesFields)>,
     inline_fragment: &'a mut InlineFragment,
 }
 
-impl<'a, SchemaType, Variables> InlineFragmentBuilder<'a, SchemaType, Variables> {
+impl<'a, SchemaType, VariablesFields> InlineFragmentBuilder<'a, SchemaType, VariablesFields> {
     /// Adds an on clause for the given `Subtype` to the inline fragment.
     ///
-    /// `Subtype` should be the schema marker type for the type you wish this fragment
-    /// to match.
-    pub fn on<Subtype>(self) -> InlineFragmentBuilder<'a, Subtype, Variables>
+    /// `Subtype` should be the schema marker type for the type you wish this
+    /// fragment to match.
+    pub fn on<Subtype>(self) -> InlineFragmentBuilder<'a, Subtype, VariablesFields>
     where
         Subtype: crate::schema::NamedType,
         SchemaType: crate::schema::HasSubtype<Subtype>,
@@ -217,25 +220,25 @@ impl<'a, SchemaType, Variables> InlineFragmentBuilder<'a, SchemaType, Variables>
 
     /// Returns a SelectionBuilder that can be used to select the fields
     /// of this fragment.
-    pub fn select_children<InnerVariables>(
+    pub fn select_children<InnerVariablesFields>(
         &'_ mut self,
-    ) -> SelectionBuilder<'_, SchemaType, InnerVariables>
+    ) -> SelectionBuilder<'_, SchemaType, InnerVariablesFields>
     where
-        Variables: VariableMatch<InnerVariables>,
+        VariablesFields: VariableMatch<InnerVariablesFields>,
     {
         SelectionBuilder::new(&mut self.inline_fragment.children)
     }
 }
 
-pub struct InputBuilder<'a, SchemaType, Variables> {
+pub struct InputBuilder<'a, SchemaType, VariablesFields> {
     destination: InputLiteralContainer<'a>,
 
-    phantom: PhantomData<fn() -> (SchemaType, Variables)>,
+    phantom: PhantomData<fn() -> (SchemaType, VariablesFields)>,
 }
 
-impl<'a, SchemaType, Variables> InputBuilder<'a, SchemaType, Variables> {
+impl<'a, SchemaType, VariablesFields> InputBuilder<'a, SchemaType, VariablesFields> {
     /// Puts a variable into the input.
-    pub fn variable<Type>(self, def: VariableDefinition<Variables, Type>)
+    pub fn variable<Type>(self, def: VariableDefinition<VariablesFields, Type>)
     where
         Type: CoercesTo<SchemaType>,
     {
@@ -266,12 +269,12 @@ impl<'a, T, ArgStruct> InputBuilder<'a, T, ArgStruct> {
     }
 }
 
-impl<'a, SchemaType, Variables> InputBuilder<'a, SchemaType, Variables>
+impl<'a, SchemaType, VariablesFields> InputBuilder<'a, SchemaType, VariablesFields>
 where
     SchemaType: schema::InputObjectMarker,
 {
     /// Puts an object literal into the input
-    pub fn object(self) -> ObjectArgumentBuilder<'a, SchemaType, Variables> {
+    pub fn object(self) -> ObjectArgumentBuilder<'a, SchemaType, VariablesFields> {
         let fields = match self.destination.push(InputLiteral::Object(Vec::new())) {
             InputLiteral::Object(fields) => fields,
             _ => panic!("This should be impossible"),
@@ -285,14 +288,14 @@ where
 }
 
 /// Builds an object literal into some input.
-pub struct ObjectArgumentBuilder<'a, ItemType, Variables> {
+pub struct ObjectArgumentBuilder<'a, ItemType, VariablesFields> {
     fields: &'a mut Vec<Argument>,
-    phantom: PhantomData<fn() -> (ItemType, Variables)>,
+    phantom: PhantomData<fn() -> (ItemType, VariablesFields)>,
 }
 
 impl<'a, SchemaType, ArgStruct> ObjectArgumentBuilder<'a, SchemaType, ArgStruct> {
-    /// Adds a field to the object literal, using the field_fn to determine the contents
-    /// of that field.
+    /// Adds a field to the object literal, using the field_fn to determine the
+    /// contents of that field.
     pub fn field<FieldMarker, F>(self, field_fn: F) -> Self
     where
         FieldMarker: schema::Field,
@@ -308,9 +311,9 @@ impl<'a, SchemaType, ArgStruct> ObjectArgumentBuilder<'a, SchemaType, ArgStruct>
     }
 }
 
-impl<'a, SchemaType, Variables> InputBuilder<'a, Vec<SchemaType>, Variables> {
+impl<'a, SchemaType, VariablesFields> InputBuilder<'a, Vec<SchemaType>, VariablesFields> {
     /// Adds a list literal into some input
-    pub fn list(self) -> ListArgumentBuilder<'a, SchemaType, Variables> {
+    pub fn list(self) -> ListArgumentBuilder<'a, SchemaType, VariablesFields> {
         let items = match self.destination.push(InputLiteral::List(Vec::new())) {
             InputLiteral::List(items) => items,
             _ => panic!("This should be impossible"),
@@ -323,15 +326,15 @@ impl<'a, SchemaType, Variables> InputBuilder<'a, Vec<SchemaType>, Variables> {
     }
 }
 
-pub struct ListArgumentBuilder<'a, ItemType, Variables> {
+pub struct ListArgumentBuilder<'a, ItemType, VariablesFields> {
     items: &'a mut Vec<InputLiteral>,
-    phantom: PhantomData<fn() -> (ItemType, Variables)>,
+    phantom: PhantomData<fn() -> (ItemType, VariablesFields)>,
 }
 
-impl<'a, ItemType, Variables> ListArgumentBuilder<'a, ItemType, Variables> {
-    /// Adds an item to the list literal, using the item_fn to determine the contents
-    /// of that item.
-    pub fn item(self, item_fn: impl FnOnce(InputBuilder<'_, ItemType, Variables>)) -> Self {
+impl<'a, ItemType, VariablesFields> ListArgumentBuilder<'a, ItemType, VariablesFields> {
+    /// Adds an item to the list literal, using the item_fn to determine the
+    /// contents of that item.
+    pub fn item(self, item_fn: impl FnOnce(InputBuilder<'_, ItemType, VariablesFields>)) -> Self {
         item_fn(InputBuilder {
             destination: InputLiteralContainer::list(self.items),
             phantom: PhantomData,
@@ -383,10 +386,10 @@ impl<'a> InputLiteralContainer<'a> {
     }
 }
 
-/// Enforces type equality on a VariableFields struct.
+/// Enforces type equality on a VariablesFields struct.
 ///
-/// Each `crate::QueryVariablesFields` implementation should also implement this for `()` for
-/// compatibility with QueryFragments that don't need variables.
+/// Each `crate::QueryVariablesFields` implementation should also implement this
+/// for `()` for compatibility with QueryFragments that don't need variables.
 pub trait VariableMatch<T> {}
 
 impl<T> VariableMatch<()> for T where T: crate::QueryVariablesFields {}

--- a/cynic/src/queries/builders.rs
+++ b/cynic/src/queries/builders.rs
@@ -383,10 +383,10 @@ impl<'a> InputLiteralContainer<'a> {
     }
 }
 
-/// Enforces type equality on a Variable struct.
+/// Enforces type equality on a VariableFields struct.
 ///
-/// Each `crate::QueryVariables` implementation should also implement this for `()` for
+/// Each `crate::QueryVariablesFields` implementation should also implement this for `()` for
 /// compatibility with QueryFragments that don't need variables.
 pub trait VariableMatch<T> {}
 
-impl<T> VariableMatch<()> for T where T: crate::QueryVariables {}
+impl<T> VariableMatch<()> for T where T: crate::QueryVariablesFields {}

--- a/cynic/src/schema.rs
+++ b/cynic/src/schema.rs
@@ -42,7 +42,8 @@ pub trait HasInputField<FieldMarker, FieldType> {}
 /// Indicates that a field has an argument
 ///
 /// This should be implemented on the field marker type for each argument
-/// that field has.  `ArgumentMarker` should be the marker type for the argument.
+/// that field has.  `ArgumentMarker` should be the marker type for the
+/// argument.
 pub trait HasArgument<ArgumentMarker> {
     /// The schema marker type of this argument.
     type ArgumentType;
@@ -59,6 +60,13 @@ pub trait IsScalar<SchemaType> {
     type SchemaType;
 }
 
+impl<T, U: ?Sized> IsScalar<T> for &U
+where
+    U: IsScalar<T>,
+{
+    type SchemaType = U::SchemaType;
+}
+
 impl<T, U> IsScalar<Option<T>> for Option<U>
 where
     U: IsScalar<T>,
@@ -73,7 +81,14 @@ where
     type SchemaType = Vec<U::SchemaType>;
 }
 
-impl<T, U> IsScalar<Box<T>> for Box<U>
+impl<T, U> IsScalar<Vec<T>> for [U]
+where
+    U: IsScalar<T>,
+{
+    type SchemaType = Vec<U::SchemaType>;
+}
+
+impl<T, U: ?Sized> IsScalar<Box<T>> for Box<U>
 where
     U: IsScalar<T>,
 {
@@ -85,6 +100,10 @@ impl IsScalar<bool> for bool {
 }
 
 impl IsScalar<String> for String {
+    type SchemaType = String;
+}
+
+impl IsScalar<String> for str {
     type SchemaType = String;
 }
 
@@ -100,16 +119,16 @@ impl IsScalar<crate::Id> for crate::Id {
     type SchemaType = crate::Id;
 }
 
-/// A marker trait that indicates a particular type is at the root of a GraphQL schemas query
-/// hierarchy.
+/// A marker trait that indicates a particular type is at the root of a GraphQL
+/// schemas query hierarchy.
 pub trait QueryRoot {}
 
-/// A marker trait that indicates a particular type is at the root of a GraphQL schemas
-/// mutation hierarchy.
+/// A marker trait that indicates a particular type is at the root of a GraphQL
+/// schemas mutation hierarchy.
 pub trait MutationRoot {}
 
-/// A marker trait that indicates a particular type is at the root of a GraphQL schemas
-/// subscription hierarchy.
+/// A marker trait that indicates a particular type is at the root of a GraphQL
+/// schemas subscription hierarchy.
 pub trait SubscriptionRoot {}
 
 /// Indicates that a type has a subtype relationship with another type

--- a/cynic/src/schema.rs
+++ b/cynic/src/schema.rs
@@ -95,6 +95,13 @@ where
     type SchemaType = Box<U::SchemaType>;
 }
 
+impl<T, U: ?Sized> IsScalar<T> for std::borrow::Cow<'_, U>
+where
+    U: IsScalar<T> + ToOwned,
+{
+    type SchemaType = U::SchemaType;
+}
+
 impl IsScalar<bool> for bool {
     type SchemaType = bool;
 }

--- a/cynic/src/variables.rs
+++ b/cynic/src/variables.rs
@@ -15,13 +15,20 @@ pub enum VariableType {
 
 /// Allows a struct to be used as variables in a GraphQL query.
 ///
-/// Users should not implement this themselves, and should use the `QueryVariables`
-/// derive.  All the fields on a `QueryVariables` struct should be available as
-/// variables in the query, using `$variable_name` notation.
+/// Users should not implement this themselves, and should use the
+/// `QueryVariables` derive.  All the fields on a `QueryVariables` struct should
+/// be available as variables in the query, using `$variable_name` notation.
 pub trait QueryVariables {
-    /// A struct that determines which variables are available when using this struct.
-    type Fields;
+    /// A struct that determines which variables are available when using this
+    /// struct.
+    type Fields: QueryVariablesFields;
+}
 
+/// Represents a set of named fields that are required for a query
+///
+/// These types also hold general type information, (something that tells to ~
+/// what it serializes)
+pub trait QueryVariablesFields {
     /// An associated constant that contains the variable names & their types.
     ///
     /// This is used to construct the query string we send to a server.
@@ -30,7 +37,8 @@ pub trait QueryVariables {
 
 impl QueryVariables for () {
     type Fields = ();
-
+}
+impl QueryVariablesFields for () {
     const VARIABLES: &'static [(&'static str, VariableType)] = &[];
 }
 

--- a/cynic/src/variables.rs
+++ b/cynic/src/variables.rs
@@ -22,25 +22,20 @@ pub trait QueryVariables {
     /// A struct that determines which variables are available when using this
     /// struct.
     type Fields: QueryVariablesFields;
-}
-
-/// Represents a set of named fields that are required for a query
-///
-/// These types also hold general type information, (something that tells to ~
-/// what it serializes)
-pub trait QueryVariablesFields {
     /// An associated constant that contains the variable names & their types.
     ///
     /// This is used to construct the query string we send to a server.
     const VARIABLES: &'static [(&'static str, VariableType)];
 }
 
+/// Represents a set of named fields that are required for a query
+pub trait QueryVariablesFields {}
+
 impl QueryVariables for () {
     type Fields = ();
-}
-impl QueryVariablesFields for () {
     const VARIABLES: &'static [(&'static str, VariableType)] = &[];
 }
+impl QueryVariablesFields for () {}
 
 #[doc(hidden)]
 /// A VariableDefinition.

--- a/cynic/tests/generics_simple.rs
+++ b/cynic/tests/generics_simple.rs
@@ -1,0 +1,34 @@
+mod schema {
+    cynic::use_schema!("src/bin/simple.graphql");
+}
+
+#[derive(cynic::QueryVariables)]
+struct TestArgs<'a> {
+    a_str: Option<&'a str>,
+}
+
+#[derive(cynic::QueryFragment, PartialEq, Debug)]
+#[cynic(schema_path = "src/bin/simple.graphql", variables = "TestArgs")]
+struct TestStruct {
+    #[arguments(x: 1, y: $a_str)]
+    field_one: String,
+}
+
+#[derive(cynic::QueryFragment, PartialEq, Debug)]
+#[cynic(
+    schema_path = "src/bin/simple.graphql",
+    graphql_type = "Query",
+    variables = "TestArgs"
+)]
+struct TestQuery {
+    test_struct: Option<TestStruct>,
+}
+
+#[test]
+fn test_query_building() {
+    use cynic::QueryBuilder;
+
+    let operation = TestQuery::build(TestArgs { a_str: Some("1") });
+
+    insta::assert_snapshot!(operation.query);
+}

--- a/cynic/tests/inline-fragments.rs
+++ b/cynic/tests/inline-fragments.rs
@@ -1,6 +1,4 @@
-use rstest::rstest;
-use serde::Serialize;
-use serde_json::json;
+use {rstest::rstest, serde::Serialize, serde_json::json};
 
 use cynic::{InlineFragments, QueryFragment};
 
@@ -38,6 +36,18 @@ enum PostOrAuthor {
 enum Node {
     Post(Post),
     Author(Author),
+    #[cynic(fallback)]
+    Other,
+}
+
+#[derive(InlineFragments, Serialize, PartialEq, Debug)]
+#[cynic(
+    schema_path = "tests/test-schema.graphql",
+    graphql_type = "PostOrAuthor"
+)]
+enum PostOrAuthorGeneric<A: QueryFragment<SchemaType = schema::Author, VariablesFields = ()>> {
+    Post(Post),
+    Author(A),
     #[cynic(fallback)]
     Other,
 }

--- a/cynic/tests/mutation_generics.rs
+++ b/cynic/tests/mutation_generics.rs
@@ -8,6 +8,15 @@ pub struct SignInVariables<'a> {
     pub input: SignInInput<'a, String>,
 }
 
+#[derive(cynic::QueryVariables, Debug)]
+pub struct SignInVariablesMoreGeneric<
+    'a,
+    Username: serde::Serialize + cynic::schema::IsScalar<String>,
+> {
+    #[cynic(graphql_type = "SignInInput")]
+    pub input: SignInInput<'a, Username>,
+}
+
 #[derive(cynic::InputObject, Debug)]
 #[cynic(schema_path = "../schemas/raindancer.graphql")]
 pub struct SignInInput<'a, Username: serde::Serialize + cynic::schema::IsScalar<String>> {
@@ -26,6 +35,17 @@ pub struct SignIn {
     pub sign_in: String,
 }
 
+#[derive(cynic::QueryFragment, Debug)]
+#[cynic(
+    graphql_type = "MutationRoot",
+    variables = "SignInVariablesMoreGeneric",
+    schema_path = "../schemas/raindancer.graphql"
+)]
+pub struct SignInMoreGeneric {
+    #[arguments(input: $input)]
+    pub sign_in: String,
+}
+
 #[test]
 fn test_query_building() {
     use cynic::MutationBuilder;
@@ -34,6 +54,20 @@ fn test_query_building() {
         input: SignInInput {
             password: "password?",
             username: "username".to_owned(),
+        },
+    });
+
+    insta::assert_snapshot!(operation.query);
+}
+
+#[test]
+fn test_query_building_more_generic() {
+    use cynic::MutationBuilder;
+
+    let operation = SignInMoreGeneric::build(SignInVariablesMoreGeneric {
+        input: SignInInput {
+            password: "password!",
+            username: &&&"username",
         },
     });
 

--- a/cynic/tests/mutation_generics.rs
+++ b/cynic/tests/mutation_generics.rs
@@ -5,14 +5,14 @@ mod schema {
 
 #[derive(cynic::QueryVariables, Debug)]
 pub struct SignInVariables<'a> {
-    pub input: SignInInput<'a>,
+    pub input: SignInInput<'a, String>,
 }
 
 #[derive(cynic::InputObject, Debug)]
 #[cynic(schema_path = "../schemas/raindancer.graphql")]
-pub struct SignInInput<'a> {
+pub struct SignInInput<'a, Username: serde::Serialize + cynic::schema::IsScalar<String>> {
     pub password: &'a str,
-    pub username: String,
+    pub username: Username,
 }
 
 #[derive(cynic::QueryFragment, Debug)]

--- a/cynic/tests/mutation_generics.rs
+++ b/cynic/tests/mutation_generics.rs
@@ -11,17 +11,14 @@ pub struct SignInVariables<'a> {
 }
 
 #[derive(cynic::QueryVariables, Debug)]
-pub struct SignInVariablesMoreGeneric<
-    'a,
-    Username: serde::Serialize + cynic::schema::IsScalar<String>,
-> {
+pub struct SignInVariablesMoreGeneric<'a, Username: cynic::schema::IsScalar<String>> {
     #[cynic(graphql_type = "SignInInput")]
     pub input: SignInInput<'a, Username>,
 }
 
 #[derive(cynic::InputObject, Debug)]
 #[cynic(schema_path = "../schemas/raindancer.graphql")]
-pub struct SignInInput<'a, Username: serde::Serialize + cynic::schema::IsScalar<String>> {
+pub struct SignInInput<'a, Username: cynic::schema::IsScalar<String>> {
     pub password: &'a str,
     pub username: Username,
 }

--- a/cynic/tests/mutation_generics.rs
+++ b/cynic/tests/mutation_generics.rs
@@ -43,9 +43,12 @@ pub struct SignIn {
     variables = "SignInVariablesMoreGeneric",
     schema_path = "../schemas/raindancer.graphql"
 )]
-pub struct SignInMoreGeneric {
+pub struct SignInMoreGeneric<SI: cynic::schema::IsScalar<String>>
+where
+    <SI as cynic::schema::IsScalar<String>>::SchemaType: cynic::queries::IsFieldType<String>,
+{
     #[arguments(input: $input)]
-    pub sign_in: String,
+    pub sign_in: SI,
 }
 
 #[test]
@@ -66,7 +69,7 @@ fn test_query_building() {
 fn test_query_building_more_generic() {
     use cynic::MutationBuilder;
 
-    let operation = SignInMoreGeneric::build(SignInVariablesMoreGeneric {
+    let operation = SignInMoreGeneric::<Cow<'static, str>>::build(SignInVariablesMoreGeneric {
         input: SignInInput {
             password: "password!",
             username: &&&"username",

--- a/cynic/tests/mutation_generics.rs
+++ b/cynic/tests/mutation_generics.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 #[allow(non_snake_case, non_camel_case_types)]
 mod schema {
     cynic::use_schema!("../schemas/raindancer.graphql");
@@ -5,7 +7,7 @@ mod schema {
 
 #[derive(cynic::QueryVariables, Debug)]
 pub struct SignInVariables<'a> {
-    pub input: SignInInput<'a, String>,
+    pub input: SignInInput<'a, Cow<'a, str>>,
 }
 
 #[derive(cynic::QueryVariables, Debug)]
@@ -53,7 +55,7 @@ fn test_query_building() {
     let operation = SignIn::build(SignInVariables {
         input: SignInInput {
             password: "password?",
-            username: "username".to_owned(),
+            username: Cow::Borrowed("username"),
         },
     });
 

--- a/cynic/tests/mutation_generics.rs
+++ b/cynic/tests/mutation_generics.rs
@@ -1,0 +1,41 @@
+#[allow(non_snake_case, non_camel_case_types)]
+mod schema {
+    cynic::use_schema!("../schemas/raindancer.graphql");
+}
+
+#[derive(cynic::QueryVariables, Debug)]
+pub struct SignInVariables<'a> {
+    pub input: SignInInput<'a>,
+}
+
+#[derive(cynic::InputObject, Debug)]
+#[cynic(schema_path = "../schemas/raindancer.graphql")]
+pub struct SignInInput<'a> {
+    pub password: &'a str,
+    pub username: String,
+}
+
+#[derive(cynic::QueryFragment, Debug)]
+#[cynic(
+    graphql_type = "MutationRoot",
+    variables = "SignInVariables",
+    schema_path = "../schemas/raindancer.graphql"
+)]
+pub struct SignIn {
+    #[arguments(input: $input)]
+    pub sign_in: String,
+}
+
+#[test]
+fn test_query_building() {
+    use cynic::MutationBuilder;
+
+    let operation = SignIn::build(SignInVariables {
+        input: SignInInput {
+            password: "password?",
+            username: "username".to_owned(),
+        },
+    });
+
+    insta::assert_snapshot!(operation.query);
+}

--- a/cynic/tests/scalars.rs
+++ b/cynic/tests/scalars.rs
@@ -8,3 +8,7 @@ pub struct DateTime(pub chrono::DateTime<chrono::Utc>);
 
 // Make sure we can impl_scalar for third party types.
 cynic::impl_scalar!(chrono::DateTime<chrono::Utc>, schema::DateTime);
+
+#[derive(cynic::Scalar)]
+#[cynic(graphql_type = "DateTime")]
+pub struct DateTimeInner<DT>(pub DT);

--- a/cynic/tests/snapshots/generics_simple__query_building.snap
+++ b/cynic/tests/snapshots/generics_simple__query_building.snap
@@ -1,0 +1,12 @@
+---
+source: cynic/tests/generics.rs
+assertion_line: 33
+expression: operation.query
+---
+query($aStr: String) {
+  testStruct {
+    fieldOne(x: 1, y: $aStr)
+  }
+}
+
+

--- a/cynic/tests/snapshots/mutation_generics__query_building.snap
+++ b/cynic/tests/snapshots/mutation_generics__query_building.snap
@@ -1,0 +1,10 @@
+---
+source: cynic/tests/mutation_generics.rs
+assertion_line: 40
+expression: operation.query
+---
+mutation($input: SignInInput!) {
+  signIn(input: $input)
+}
+
+

--- a/cynic/tests/snapshots/mutation_generics__query_building_more_generic.snap
+++ b/cynic/tests/snapshots/mutation_generics__query_building_more_generic.snap
@@ -1,0 +1,10 @@
+---
+source: cynic/tests/mutation_generics.rs
+assertion_line: 75
+expression: operation.query
+---
+mutation($input: SignInInput!) {
+  signIn(input: $input)
+}
+
+

--- a/tests/ui-tests/tests/cases/wrong-enum-type.stderr
+++ b/tests/ui-tests/tests/cases/wrong-enum-type.stderr
@@ -4,8 +4,8 @@ error[E0277]: the trait bound `schema::CheckConclusionState: IsFieldType<CheckSt
 14 |         pub status: CheckConclusionState,
    |                     ^^^^^^^^^^^^^^^^^^^^ the trait `IsFieldType<CheckStatusState>` is not implemented for `schema::CheckConclusionState`
    |
-note: required by a bound in `SelectionBuilder::<'a, SchemaType, Variables>::select_field`
+note: required by a bound in `SelectionBuilder::<'a, SchemaType, VariablesFields>::select_field`
   --> $WORKSPACE/cynic/src/queries/builders.rs
    |
    |         FieldType: IsFieldType<SchemaType::Type>,
-   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `SelectionBuilder::<'a, SchemaType, Variables>::select_field`
+   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `SelectionBuilder::<'a, SchemaType, VariablesFields>::select_field`

--- a/tests/ui-tests/tests/cases/wrong-variable-type.stderr
+++ b/tests/ui-tests/tests/cases/wrong-variable-type.stderr
@@ -14,9 +14,9 @@ error[E0277]: the trait bound `i32: CoercesTo<std::option::Option<cynic::Id>>` i
               <f64 as CoercesTo<std::option::Option<std::option::Option<f64>>>>
               <i32 as CoercesTo<Vec<Vec<i32>>>>
             and 6 others
-note: required by a bound in `cynic::queries::builders::InputBuilder::<'a, SchemaType, Variables>::variable`
+note: required by a bound in `cynic::queries::builders::InputBuilder::<'a, SchemaType, VariablesFields>::variable`
    --> $WORKSPACE/cynic/src/queries/builders.rs
     |
     |         Type: CoercesTo<SchemaType>,
-    |               ^^^^^^^^^^^^^^^^^^^^^ required by this bound in `cynic::queries::builders::InputBuilder::<'a, SchemaType, Variables>::variable`
+    |               ^^^^^^^^^^^^^^^^^^^^^ required by this bound in `cynic::queries::builders::InputBuilder::<'a, SchemaType, VariablesFields>::variable`
     = note: this error originates in the derive macro `cynic::QueryFragment` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
> I've been keeping an eye on your fork btw, very interesting changes.

I was writing the issues as you sent this message! ❤️

Fixes #621
Fixes #622

**What it does:**
- Decouples query building from output deserialization lifetime
- Makes query building generic on Variables (but associated to variables ~coerced types, to enable generics in Variables)
- Supports generics in all derives! 🎉

**Notes:**
- This is a backwards-incompatible change, probably including for users who ~only use the derives, because if they were not using the client integration features and instead relying on something similar to
   ```rust
	pub fn send<'cynic_weird_lifetime, Q>(&self, variables: Q::Variables) -> InternalResult<Q>
	where
		Q: DeserializeOwned + cynic::QueryBuilder<'cynic_weird_lifetime>,
		Q::Variables: Serialize + Sync,
	{
		 todo!()
    }
   ```
   to write their SDKs, this interface changes to:
   ```rust
	pub fn send<Q, V>(&self, variables: V) -> InternalResult<Q>
	where
		Q: DeserializeOwned + cynic::QueryBuilder<V>,
		V: Serialize + Sync,
	{
		 todo!()
	}
   ```
   That being said, that's very likely the only change a typical user would have to make. But that still probably means 3.0.
- If we do this, we probably want to update the querygen tool so that it generates inputs with `&str` by default in a `3.0`-compatible version, and have the current version hosted at v2.generator.cynic-rs.dev, to encourage users to write their queries this way unless they specifically need otherwise, as that is likely generally better.