### PR TITLE
[Merged by Bors] - Put default on the `Extensions` parameter of `GraphQlError`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ## Unreleased - xxxx-xx-xx
 
+### Bug Fixes 
+
+- You no longer have to specify the `Extensions` parameter on `GraphQLError` if
+  you don't have any extensions.
+
 ## v2.2.6 - 2023-02-16
 
 ### Bug Fixes

--- a/cynic/src/result.rs
+++ b/cynic/src/result.rs
@@ -11,7 +11,7 @@ pub struct GraphQlResponse<T, ErrorExtensions = serde::de::IgnoredAny> {
 /// A model describing an error which has taken place during execution.
 #[derive(Clone, Debug, Eq, PartialEq, serde::Deserialize, thiserror::Error)]
 #[error("{message}")]
-pub struct GraphQlError<Extensions> {
+pub struct GraphQlError<Extensions = serde::de::IgnoredAny> {
     /// A description of the error which has taken place.
     pub message: String,
     /// Optional description of the locations where the errors have taken place.

--- a/cynic/tests/misc.rs
+++ b/cynic/tests/misc.rs
@@ -12,3 +12,8 @@ mod schema {
 struct TypeWithKey {
     key: String,
 }
+
+// This one is just a test that you can use the GraphQlErrors type without
+// _having_ to specify an Extensions type.
+#[allow(dead_code)]
+type Error = cynic::GraphQlError;


### PR DESCRIPTION
I had a default on `GraphQlResult` but not `GraphQlError`, which made it a bit confusing if you specifically wanted to use the `GraphQlError` type
