### PR TITLE
[Merged by Bors] - Add support for slices & arrays in `InputObject`s

### DIFF
--- a/cynic/src/core.rs
+++ b/cynic/src/core.rs
@@ -156,7 +156,29 @@ where
     type SchemaType = Vec<T::SchemaType>;
 }
 
+impl<T> InputObject for [T]
+where
+    T: InputObject,
+{
+    type SchemaType = Vec<T::SchemaType>;
+}
+
+impl<T, const SIZE: usize> InputObject for [T; SIZE]
+where
+    T: InputObject,
+    Self: serde::Serialize,
+{
+    type SchemaType = Vec<T::SchemaType>;
+}
+
 impl<T> InputObject for Box<T>
+where
+    T: InputObject,
+{
+    type SchemaType = T::SchemaType;
+}
+
+impl<T: ?Sized> InputObject for &T
 where
     T: InputObject,
 {

--- a/cynic/src/schema.rs
+++ b/cynic/src/schema.rs
@@ -88,6 +88,13 @@ where
     type SchemaType = Vec<U::SchemaType>;
 }
 
+impl<T, U, const SIZE: usize> IsScalar<Vec<T>> for [U; SIZE]
+where
+    U: IsScalar<T>,
+{
+    type SchemaType = Vec<U::SchemaType>;
+}
+
 impl<T, U: ?Sized> IsScalar<Box<T>> for Box<U>
 where
     U: IsScalar<T>,


### PR DESCRIPTION
This is a follow-up on #623, where these weren't completely supported yet - although we were pretty close.
