### PR TITLE
[Merged by Bors] - Add `cynic_introspection::Schema`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 - Added `cynic-introspection` for running an introspection query against a
   remote server.
+- Added `cynic-introspection::Schema` which converts the introspection output
+  into a friendlier format for working with.
 - The derive macros now support structs that are generic on lifetimes _and_ types.
 - The derive macros now fields that are references.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -661,6 +661,7 @@ dependencies = [
  "insta",
  "maplit",
  "reqwest",
+ "thiserror",
 ]
 
 [[package]]

--- a/cynic-introspection/Cargo.toml
+++ b/cynic-introspection/Cargo.toml
@@ -2,12 +2,17 @@
 name = "cynic-introspection"
 version = "0.1.0"
 authors = ["Graeme Coupar <grambo@grambo.me.uk>"]
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-cynic = { path = "../cynic", version = "2.2.8", features = ["http-reqwest-blocking"] }
+thiserror = "1"
+
+[dependencies.cynic]
+path = "../cynic"
+version = "2.2.8"
+features = ["http-reqwest-blocking"]
 
 [dev-dependencies]
 assert_matches = "1.4"

--- a/cynic-introspection/src/lib.rs
+++ b/cynic-introspection/src/lib.rs
@@ -1,3 +1,4 @@
-mod query;
+pub mod query;
+mod schema;
 
-pub use query::*;
+pub use schema::*;

--- a/cynic-introspection/src/query.rs
+++ b/cynic-introspection/src/query.rs
@@ -14,9 +14,9 @@ mod queries {
     #[derive(cynic::QueryFragment, Debug)]
     #[cynic(graphql_type = "__Schema")]
     pub struct Schema {
-        pub query_type: SimpleType,
-        pub mutation_type: Option<SimpleType>,
-        pub subscription_type: Option<SimpleType>,
+        pub query_type: NamedType,
+        pub mutation_type: Option<NamedType>,
+        pub subscription_type: Option<NamedType>,
         pub types: Vec<Type>,
         pub directives: Vec<Directive>,
     }
@@ -39,10 +39,10 @@ mod queries {
         #[arguments(includeDeprecated: true)]
         pub fields: Option<Vec<Field>>,
         pub input_fields: Option<Vec<InputValue>>,
-        pub interfaces: Option<Vec<NestedType>>,
+        pub interfaces: Option<Vec<NamedType>>,
         #[arguments(includeDeprecated: true)]
         pub enum_values: Option<Vec<EnumValue>>,
-        pub possible_types: Option<Vec<NestedType>>,
+        pub possible_types: Option<Vec<NamedType>>,
     }
 
     #[derive(cynic::QueryFragment, Debug)]
@@ -61,7 +61,7 @@ mod queries {
         pub description: Option<String>,
         pub args: Vec<InputValue>,
         #[cynic(rename = "type")]
-        pub ty: NestedType,
+        pub ty: FieldType,
         pub is_deprecated: bool,
         pub deprecation_reason: Option<String>,
     }
@@ -73,49 +73,26 @@ mod queries {
         pub name: String,
         pub description: Option<String>,
         #[cynic(rename = "type")]
-        pub ty: NestedType,
+        pub ty: FieldType,
         pub default_value: Option<String>,
     }
 
     #[derive(cynic::QueryFragment, Debug)]
     #[cynic(graphql_type = "__Type")]
-    pub struct NestedType {
+    pub struct FieldType {
         pub kind: TypeKind,
         pub name: Option<String>,
         #[cynic(recurse = 5)]
-        pub of_type: Option<Box<NestedType>>,
+        pub of_type: Option<Box<FieldType>>,
     }
 
     #[derive(cynic::QueryFragment, Debug)]
     #[cynic(graphql_type = "__Type")]
-    pub struct __Type4 {
-        pub kind: TypeKind,
-        pub name: Option<String>,
-        pub of_type: Option<__Type5>,
-    }
-
-    #[derive(cynic::QueryFragment, Debug)]
-    #[cynic(graphql_type = "__Type")]
-    pub struct __Type5 {
-        pub kind: TypeKind,
-        pub name: Option<String>,
-        pub of_type: Option<__Type6>,
-    }
-
-    #[derive(cynic::QueryFragment, Debug)]
-    #[cynic(graphql_type = "__Type")]
-    pub struct __Type6 {
-        pub kind: TypeKind,
+    pub struct NamedType {
         pub name: Option<String>,
     }
 
-    #[derive(cynic::QueryFragment, Debug)]
-    #[cynic(graphql_type = "__Type")]
-    pub struct SimpleType {
-        pub name: Option<String>,
-    }
-
-    #[derive(cynic::Enum, Clone, Copy, Debug)]
+    #[derive(cynic::Enum, Clone, Copy, Debug, PartialEq, Eq)]
     #[cynic(graphql_type = "__DirectiveLocation")]
     pub enum DirectiveLocation {
         Query,

--- a/cynic-introspection/src/schema.rs
+++ b/cynic-introspection/src/schema.rs
@@ -1,0 +1,383 @@
+pub use crate::query::DirectiveLocation;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct Schema {
+    pub query_type: String,
+    pub mutation_type: Option<String>,
+    pub subscription_type: Option<String>,
+    pub types: Vec<Type>,
+    pub directives: Vec<Directive>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct Directive {
+    pub name: String,
+    pub description: Option<String>,
+    pub args: Vec<InputValue>,
+    pub locations: Vec<DirectiveLocation>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum Type {
+    Object(ObjectType),
+    InputObject(InputObjectType),
+    Enum(EnumType),
+    Interface(InterfaceType),
+    Union(UnionType),
+    Scalar(ScalarType),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ObjectType {
+    pub name: String,
+    pub description: Option<String>,
+    pub fields: Vec<Field>,
+    pub interfaces: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct InputObjectType {
+    pub name: String,
+    pub description: Option<String>,
+    pub fields: Vec<InputValue>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct EnumType {
+    pub name: String,
+    pub description: Option<String>,
+    pub values: Vec<EnumValue>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct InterfaceType {
+    pub name: String,
+    pub description: Option<String>,
+    pub fields: Vec<Field>,
+    pub interfaces: Vec<String>,
+    pub possible_types: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct UnionType {
+    pub name: String,
+    pub description: Option<String>,
+    pub possible_types: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct ScalarType {
+    pub name: String,
+    pub description: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct EnumValue {
+    pub name: String,
+    pub description: Option<String>,
+    pub deprecated: Deprecated,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum Deprecated {
+    No,
+    Yes,
+    YesWithReason(String),
+}
+
+impl Deprecated {
+    fn new(is_deprecated: bool, deprecation_reason: Option<String>) -> Deprecated {
+        match (is_deprecated, deprecation_reason) {
+            (false, _) => Deprecated::No,
+            (true, None) => Deprecated::Yes,
+            (true, Some(reason)) => Deprecated::YesWithReason(reason),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct Field {
+    pub name: String,
+    pub description: Option<String>,
+    pub args: Vec<InputValue>,
+    pub ty: FieldType,
+    pub deprecated: Deprecated,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+
+pub struct InputValue {
+    pub name: String,
+    pub description: Option<String>,
+    pub ty: FieldType,
+    pub default_value: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct FieldType {
+    pub wrapping: FieldWrapping,
+    pub name: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FieldWrapping([u8; 8]);
+
+impl IntoIterator for FieldWrapping {
+    type Item = WrappingType;
+
+    type IntoIter = Box<dyn Iterator<Item = WrappingType>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        Box::new(
+            self.0
+                .into_iter()
+                .take_while(|&item| item != 0)
+                .flat_map(|item| match item {
+                    1 => std::iter::once(WrappingType::List),
+                    2 => std::iter::once(WrappingType::NonNull),
+                }),
+        )
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WrappingType {
+    List,
+    NonNull,
+}
+
+#[derive(thiserror::Error, Debug, Eq, PartialEq)]
+enum SchemaError {
+    #[error("A type in the introspection output was missing a name")]
+    TypeMissingName,
+    #[error("Found a list wrapper type in a position that should contain a named type")]
+    UnexpectedList,
+    #[error("Found a non-null wrapper type in a position that should contain a named type")]
+    UnexpectedNonNull,
+    #[error("Found a wrapping type that had no inner ofType")]
+    WrappingTypeWithNoInner,
+    #[error("Found a wrapping type that was too nested")]
+    TooMuchWrapping,
+}
+
+impl TryFrom<crate::query::Schema> for Schema {
+    type Error = SchemaError;
+
+    fn try_from(schema: crate::query::Schema) -> Result<Self, Self::Error> {
+        Ok(Schema {
+            query_type: schema.query_type.into_name()?,
+            mutation_type: schema.mutation_type.map(|ty| ty.into_name()).transpose()?,
+            subscription_type: schema
+                .subscription_type
+                .map(|ty| ty.into_name())
+                .transpose()?,
+            types: schema
+                .types
+                .into_iter()
+                .map(TryInto::try_into)
+                .collect::<Result<Vec<_>, _>>()?,
+            directives: schema
+                .directives
+                .into_iter()
+                .map(TryInto::try_into)
+                .collect::<Result<Vec<_>, _>>()?,
+        })
+    }
+}
+
+impl TryFrom<crate::query::Type> for Type {
+    type Error = SchemaError;
+
+    fn try_from(ty: crate::query::Type) -> Result<Self, Self::Error> {
+        match ty.kind {
+            crate::query::TypeKind::Scalar => Ok(Type::Scalar(ScalarType {
+                name: ty.name.ok_or(SchemaError::TypeMissingName)?,
+                description: ty.description,
+            })),
+            crate::query::TypeKind::Object => Ok(Type::Object(ObjectType {
+                name: ty.name.ok_or(SchemaError::TypeMissingName)?,
+                fields: ty
+                    .fields
+                    .unwrap_or_default()
+                    .into_iter()
+                    .map(TryInto::try_into)
+                    .collect::<Result<Vec<_>, _>>()?,
+                description: ty.description,
+                interfaces: ty
+                    .interfaces
+                    .unwrap_or_default()
+                    .into_iter()
+                    .map(|ty| ty.into_name())
+                    .collect::<Result<Vec<_>, _>>()?,
+            })),
+            crate::query::TypeKind::Interface => Ok(Type::Interface(InterfaceType {
+                name: ty.name.ok_or(SchemaError::TypeMissingName)?,
+                description: ty.description,
+                fields: ty
+                    .fields
+                    .unwrap_or_default()
+                    .into_iter()
+                    .map(TryInto::try_into)
+                    .collect::<Result<Vec<_>, _>>()?,
+                interfaces: ty
+                    .interfaces
+                    .unwrap_or_default()
+                    .into_iter()
+                    .map(|ty| ty.into_name())
+                    .collect::<Result<Vec<_>, _>>()?,
+                possible_types: ty
+                    .possible_types
+                    .unwrap_or_default()
+                    .into_iter()
+                    .map(|ty| ty.into_name())
+                    .collect::<Result<Vec<_>, _>>()?,
+            })),
+            crate::query::TypeKind::Union => Ok(Type::Union(UnionType {
+                name: ty.name.ok_or(SchemaError::TypeMissingName)?,
+                description: ty.description,
+                possible_types: ty
+                    .possible_types
+                    .unwrap_or_default()
+                    .into_iter()
+                    .map(|ty| ty.into_name())
+                    .collect::<Result<Vec<_>, _>>()?,
+            })),
+            crate::query::TypeKind::Enum => Ok(Type::Enum(EnumType {
+                name: ty.name.ok_or(SchemaError::TypeMissingName)?,
+                description: ty.description,
+                values: ty
+                    .enum_values
+                    .unwrap_or_default()
+                    .into_iter()
+                    .map(Into::into)
+                    .collect(),
+            })),
+            crate::query::TypeKind::InputObject => Ok(Type::InputObject(InputObjectType {
+                name: ty.name.ok_or(SchemaError::TypeMissingName)?,
+                description: ty.description,
+                fields: ty
+                    .input_fields
+                    .unwrap_or_default()
+                    .into_iter()
+                    .map(InputValue::try_from)
+                    .collect::<Result<Vec<_>, _>>()?,
+            })),
+            crate::query::TypeKind::List => Err(SchemaError::UnexpectedList),
+            crate::query::TypeKind::NonNull => Err(SchemaError::UnexpectedNonNull),
+        }
+    }
+}
+
+impl TryFrom<crate::query::Field> for Field {
+    type Error = SchemaError;
+
+    fn try_from(field: crate::query::Field) -> Result<Self, Self::Error> {
+        Ok(Field {
+            name: field.name,
+            description: field.description,
+            args: field
+                .args
+                .into_iter()
+                .map(TryInto::try_into)
+                .collect::<Result<Vec<_>, _>>()?,
+            ty: field.ty.try_into()?,
+            deprecated: Deprecated::new(field.is_deprecated, field.deprecation_reason),
+        })
+    }
+}
+
+impl TryFrom<crate::query::FieldType> for FieldType {
+    type Error = SchemaError;
+
+    fn try_from(field_type: crate::query::FieldType) -> Result<Self, Self::Error> {
+        let mut wrapping = [0; 8];
+        let mut wrapping_pos = 0;
+        let current_ty = field_type;
+        loop {
+            if wrapping_pos >= wrapping.len() {
+                return Err(SchemaError::TooMuchWrapping);
+            }
+            match current_ty.kind {
+                crate::query::TypeKind::List => {
+                    wrapping[wrapping_pos] = 1;
+                    wrapping_pos += 1;
+                    current_ty = *current_ty
+                        .of_type
+                        .ok_or(SchemaError::WrappingTypeWithNoInner)?;
+                }
+                crate::query::TypeKind::NonNull => {
+                    wrapping[wrapping_pos] = 2;
+                    wrapping_pos += 1;
+                    current_ty = *current_ty
+                        .of_type
+                        .ok_or(SchemaError::WrappingTypeWithNoInner)?;
+                }
+                _ => {
+                    return Ok(FieldType {
+                        name: current_ty.name.ok_or(SchemaError::TypeMissingName)?,
+                        wrapping: FieldWrapping(wrapping),
+                    })
+                }
+            };
+        }
+    }
+}
+
+impl TryFrom<crate::query::InputValue> for InputValue {
+    type Error = SchemaError;
+
+    fn try_from(value: crate::query::InputValue) -> Result<Self, Self::Error> {
+        Ok(InputValue {
+            name: value.name,
+            description: value.description,
+            ty: value.ty.try_into()?,
+            default_value: value.default_value,
+        })
+    }
+}
+
+impl From<crate::query::EnumValue> for EnumValue {
+    fn from(value: crate::query::EnumValue) -> Self {
+        EnumValue {
+            name: value.name,
+            description: value.description,
+            deprecated: Deprecated::new(value.is_deprecated, value.deprecation_reason),
+        }
+    }
+}
+
+impl TryFrom<crate::query::Directive> for Directive {
+    type Error = SchemaError;
+
+    fn try_from(value: crate::query::Directive) -> Result<Self, Self::Error> {
+        Ok(Directive {
+            name: value.name,
+            description: value.description,
+            args: value
+                .args
+                .into_iter()
+                .map(TryInto::try_into)
+                .collect::<Result<Vec<_>, _>>()?,
+            locations: value.locations,
+        })
+    }
+}
+
+impl crate::query::NamedType {
+    fn into_name(self) -> Result<String, SchemaError> {
+        self.name.ok_or(SchemaError::TypeMissingName)
+    }
+}

--- a/cynic-introspection/src/schema.rs
+++ b/cynic-introspection/src/schema.rs
@@ -91,16 +91,14 @@ pub struct EnumValue {
 #[non_exhaustive]
 pub enum Deprecated {
     No,
-    Yes,
-    YesWithReason(String),
+    Yes(Option<String>),
 }
 
 impl Deprecated {
     fn new(is_deprecated: bool, deprecation_reason: Option<String>) -> Deprecated {
         match (is_deprecated, deprecation_reason) {
             (false, _) => Deprecated::No,
-            (true, None) => Deprecated::Yes,
-            (true, Some(reason)) => Deprecated::YesWithReason(reason),
+            (true, reason) => Deprecated::Yes(reason),
         }
     }
 }

--- a/cynic-introspection/tests/snapshots/tests__introspection_query.snap
+++ b/cynic-introspection/tests/snapshots/tests__introspection_query.snap
@@ -106,28 +106,7 @@ query {
         defaultValue
       }
       interfaces {
-        kind
         name
-        ofType {
-          kind
-          name
-          ofType {
-            kind
-            name
-            ofType {
-              kind
-              name
-              ofType {
-                kind
-                name
-                ofType {
-                  kind
-                  name
-                }
-              }
-            }
-          }
-        }
       }
       enumValues(includeDeprecated: true) {
         name
@@ -136,28 +115,7 @@ query {
         deprecationReason
       }
       possibleTypes {
-        kind
         name
-        ofType {
-          kind
-          name
-          ofType {
-            kind
-            name
-            ofType {
-              kind
-              name
-              ofType {
-                kind
-                name
-                ofType {
-                  kind
-                  name
-                }
-              }
-            }
-          }
-        }
       }
     }
     directives {

--- a/cynic-introspection/tests/snapshots/tests__running_query.snap
+++ b/cynic-introspection/tests/snapshots/tests__running_query.snap
@@ -5,7 +5,7 @@ expression: result.data
 Some(
     IntrospectionQuery {
         schema: Schema {
-            query_type: SimpleType {
+            query_type: NamedType {
                 name: Some(
                     "Root",
                 ),
@@ -28,7 +28,7 @@ Some(
                                     InputValue {
                                         name: "after",
                                         description: None,
-                                        ty: NestedType {
+                                        ty: FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "String",
@@ -40,7 +40,7 @@ Some(
                                     InputValue {
                                         name: "first",
                                         description: None,
-                                        ty: NestedType {
+                                        ty: FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "Int",
@@ -52,7 +52,7 @@ Some(
                                     InputValue {
                                         name: "before",
                                         description: None,
-                                        ty: NestedType {
+                                        ty: FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "String",
@@ -64,7 +64,7 @@ Some(
                                     InputValue {
                                         name: "last",
                                         description: None,
-                                        ty: NestedType {
+                                        ty: FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "Int",
@@ -74,7 +74,7 @@ Some(
                                         default_value: None,
                                     },
                                 ],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Object,
                                     name: Some(
                                         "FilmsConnection",
@@ -91,7 +91,7 @@ Some(
                                     InputValue {
                                         name: "id",
                                         description: None,
-                                        ty: NestedType {
+                                        ty: FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "ID",
@@ -103,7 +103,7 @@ Some(
                                     InputValue {
                                         name: "filmID",
                                         description: None,
-                                        ty: NestedType {
+                                        ty: FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "ID",
@@ -113,7 +113,7 @@ Some(
                                         default_value: None,
                                     },
                                 ],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Object,
                                     name: Some(
                                         "Film",
@@ -130,7 +130,7 @@ Some(
                                     InputValue {
                                         name: "after",
                                         description: None,
-                                        ty: NestedType {
+                                        ty: FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "String",
@@ -142,7 +142,7 @@ Some(
                                     InputValue {
                                         name: "first",
                                         description: None,
-                                        ty: NestedType {
+                                        ty: FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "Int",
@@ -154,7 +154,7 @@ Some(
                                     InputValue {
                                         name: "before",
                                         description: None,
-                                        ty: NestedType {
+                                        ty: FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "String",
@@ -166,7 +166,7 @@ Some(
                                     InputValue {
                                         name: "last",
                                         description: None,
-                                        ty: NestedType {
+                                        ty: FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "Int",
@@ -176,7 +176,7 @@ Some(
                                         default_value: None,
                                     },
                                 ],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Object,
                                     name: Some(
                                         "PeopleConnection",
@@ -193,7 +193,7 @@ Some(
                                     InputValue {
                                         name: "id",
                                         description: None,
-                                        ty: NestedType {
+                                        ty: FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "ID",
@@ -205,7 +205,7 @@ Some(
                                     InputValue {
                                         name: "personID",
                                         description: None,
-                                        ty: NestedType {
+                                        ty: FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "ID",
@@ -215,7 +215,7 @@ Some(
                                         default_value: None,
                                     },
                                 ],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Object,
                                     name: Some(
                                         "Person",
@@ -232,7 +232,7 @@ Some(
                                     InputValue {
                                         name: "after",
                                         description: None,
-                                        ty: NestedType {
+                                        ty: FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "String",
@@ -244,7 +244,7 @@ Some(
                                     InputValue {
                                         name: "first",
                                         description: None,
-                                        ty: NestedType {
+                                        ty: FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "Int",
@@ -256,7 +256,7 @@ Some(
                                     InputValue {
                                         name: "before",
                                         description: None,
-                                        ty: NestedType {
+                                        ty: FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "String",
@@ -268,7 +268,7 @@ Some(
                                     InputValue {
                                         name: "last",
                                         description: None,
-                                        ty: NestedType {
+                                        ty: FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "Int",
@@ -278,7 +278,7 @@ Some(
                                         default_value: None,
                                     },
                                 ],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Object,
                                     name: Some(
                                         "PlanetsConnection",
@@ -295,7 +295,7 @@ Some(
                                     InputValue {
                                         name: "id",
                                         description: None,
-                                        ty: NestedType {
+                                        ty: FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "ID",
@@ -307,7 +307,7 @@ Some(
                                     InputValue {
                                         name: "planetID",
                                         description: None,
-                                        ty: NestedType {
+                                        ty: FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "ID",
@@ -317,7 +317,7 @@ Some(
                                         default_value: None,
                                     },
                                 ],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Object,
                                     name: Some(
                                         "Planet",
@@ -334,7 +334,7 @@ Some(
                                     InputValue {
                                         name: "after",
                                         description: None,
-                                        ty: NestedType {
+                                        ty: FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "String",
@@ -346,7 +346,7 @@ Some(
                                     InputValue {
                                         name: "first",
                                         description: None,
-                                        ty: NestedType {
+                                        ty: FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "Int",
@@ -358,7 +358,7 @@ Some(
                                     InputValue {
                                         name: "before",
                                         description: None,
-                                        ty: NestedType {
+                                        ty: FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "String",
@@ -370,7 +370,7 @@ Some(
                                     InputValue {
                                         name: "last",
                                         description: None,
-                                        ty: NestedType {
+                                        ty: FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "Int",
@@ -380,7 +380,7 @@ Some(
                                         default_value: None,
                                     },
                                 ],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Object,
                                     name: Some(
                                         "SpeciesConnection",
@@ -397,7 +397,7 @@ Some(
                                     InputValue {
                                         name: "id",
                                         description: None,
-                                        ty: NestedType {
+                                        ty: FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "ID",
@@ -409,7 +409,7 @@ Some(
                                     InputValue {
                                         name: "speciesID",
                                         description: None,
-                                        ty: NestedType {
+                                        ty: FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "ID",
@@ -419,7 +419,7 @@ Some(
                                         default_value: None,
                                     },
                                 ],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Object,
                                     name: Some(
                                         "Species",
@@ -436,7 +436,7 @@ Some(
                                     InputValue {
                                         name: "after",
                                         description: None,
-                                        ty: NestedType {
+                                        ty: FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "String",
@@ -448,7 +448,7 @@ Some(
                                     InputValue {
                                         name: "first",
                                         description: None,
-                                        ty: NestedType {
+                                        ty: FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "Int",
@@ -460,7 +460,7 @@ Some(
                                     InputValue {
                                         name: "before",
                                         description: None,
-                                        ty: NestedType {
+                                        ty: FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "String",
@@ -472,7 +472,7 @@ Some(
                                     InputValue {
                                         name: "last",
                                         description: None,
-                                        ty: NestedType {
+                                        ty: FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "Int",
@@ -482,7 +482,7 @@ Some(
                                         default_value: None,
                                     },
                                 ],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Object,
                                     name: Some(
                                         "StarshipsConnection",
@@ -499,7 +499,7 @@ Some(
                                     InputValue {
                                         name: "id",
                                         description: None,
-                                        ty: NestedType {
+                                        ty: FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "ID",
@@ -511,7 +511,7 @@ Some(
                                     InputValue {
                                         name: "starshipID",
                                         description: None,
-                                        ty: NestedType {
+                                        ty: FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "ID",
@@ -521,7 +521,7 @@ Some(
                                         default_value: None,
                                     },
                                 ],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Object,
                                     name: Some(
                                         "Starship",
@@ -538,7 +538,7 @@ Some(
                                     InputValue {
                                         name: "after",
                                         description: None,
-                                        ty: NestedType {
+                                        ty: FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "String",
@@ -550,7 +550,7 @@ Some(
                                     InputValue {
                                         name: "first",
                                         description: None,
-                                        ty: NestedType {
+                                        ty: FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "Int",
@@ -562,7 +562,7 @@ Some(
                                     InputValue {
                                         name: "before",
                                         description: None,
-                                        ty: NestedType {
+                                        ty: FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "String",
@@ -574,7 +574,7 @@ Some(
                                     InputValue {
                                         name: "last",
                                         description: None,
-                                        ty: NestedType {
+                                        ty: FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "Int",
@@ -584,7 +584,7 @@ Some(
                                         default_value: None,
                                     },
                                 ],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Object,
                                     name: Some(
                                         "VehiclesConnection",
@@ -601,7 +601,7 @@ Some(
                                     InputValue {
                                         name: "id",
                                         description: None,
-                                        ty: NestedType {
+                                        ty: FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "ID",
@@ -613,7 +613,7 @@ Some(
                                     InputValue {
                                         name: "vehicleID",
                                         description: None,
-                                        ty: NestedType {
+                                        ty: FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "ID",
@@ -623,7 +623,7 @@ Some(
                                         default_value: None,
                                     },
                                 ],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Object,
                                     name: Some(
                                         "Vehicle",
@@ -644,11 +644,11 @@ Some(
                                         description: Some(
                                             "The ID of an object",
                                         ),
-                                        ty: NestedType {
+                                        ty: FieldType {
                                             kind: NonNull,
                                             name: None,
                                             of_type: Some(
-                                                NestedType {
+                                                FieldType {
                                                     kind: Scalar,
                                                     name: Some(
                                                         "ID",
@@ -660,7 +660,7 @@ Some(
                                         default_value: None,
                                     },
                                 ],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Interface,
                                     name: Some(
                                         "Node",
@@ -723,11 +723,11 @@ Some(
                                     "Information to aid in pagination.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: NonNull,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: Object,
                                             name: Some(
                                                 "PageInfo",
@@ -745,11 +745,11 @@ Some(
                                     "A list of edges.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: List,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: Object,
                                             name: Some(
                                                 "FilmsEdge",
@@ -767,7 +767,7 @@ Some(
                                     "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Scalar,
                                     name: Some(
                                         "Int",
@@ -783,11 +783,11 @@ Some(
                                     "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: List,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: Object,
                                             name: Some(
                                                 "Film",
@@ -824,11 +824,11 @@ Some(
                                     "When paginating forwards, are there more items?",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: NonNull,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "Boolean",
@@ -846,11 +846,11 @@ Some(
                                     "When paginating backwards, are there more items?",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: NonNull,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "Boolean",
@@ -868,7 +868,7 @@ Some(
                                     "When paginating backwards, the cursor to continue.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Scalar,
                                     name: Some(
                                         "String",
@@ -884,7 +884,7 @@ Some(
                                     "When paginating forwards, the cursor to continue.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Scalar,
                                     name: Some(
                                         "String",
@@ -933,7 +933,7 @@ Some(
                                     "The item at the end of the edge",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Object,
                                     name: Some(
                                         "Film",
@@ -949,11 +949,11 @@ Some(
                                     "A cursor for use in pagination",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: NonNull,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "String",
@@ -990,7 +990,7 @@ Some(
                                     "The title of this film.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Scalar,
                                     name: Some(
                                         "String",
@@ -1006,7 +1006,7 @@ Some(
                                     "The episode number of this film.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Scalar,
                                     name: Some(
                                         "Int",
@@ -1022,7 +1022,7 @@ Some(
                                     "The opening paragraphs at the beginning of this film.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Scalar,
                                     name: Some(
                                         "String",
@@ -1038,7 +1038,7 @@ Some(
                                     "The name of the director of this film.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Scalar,
                                     name: Some(
                                         "String",
@@ -1054,11 +1054,11 @@ Some(
                                     "The name(s) of the producer(s) of this film.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: List,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "String",
@@ -1076,7 +1076,7 @@ Some(
                                     "The ISO 8601 date format of film release at original creator country.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Scalar,
                                     name: Some(
                                         "String",
@@ -1093,7 +1093,7 @@ Some(
                                     InputValue {
                                         name: "after",
                                         description: None,
-                                        ty: NestedType {
+                                        ty: FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "String",
@@ -1105,7 +1105,7 @@ Some(
                                     InputValue {
                                         name: "first",
                                         description: None,
-                                        ty: NestedType {
+                                        ty: FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "Int",
@@ -1117,7 +1117,7 @@ Some(
                                     InputValue {
                                         name: "before",
                                         description: None,
-                                        ty: NestedType {
+                                        ty: FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "String",
@@ -1129,7 +1129,7 @@ Some(
                                     InputValue {
                                         name: "last",
                                         description: None,
-                                        ty: NestedType {
+                                        ty: FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "Int",
@@ -1139,7 +1139,7 @@ Some(
                                         default_value: None,
                                     },
                                 ],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Object,
                                     name: Some(
                                         "FilmSpeciesConnection",
@@ -1156,7 +1156,7 @@ Some(
                                     InputValue {
                                         name: "after",
                                         description: None,
-                                        ty: NestedType {
+                                        ty: FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "String",
@@ -1168,7 +1168,7 @@ Some(
                                     InputValue {
                                         name: "first",
                                         description: None,
-                                        ty: NestedType {
+                                        ty: FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "Int",
@@ -1180,7 +1180,7 @@ Some(
                                     InputValue {
                                         name: "before",
                                         description: None,
-                                        ty: NestedType {
+                                        ty: FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "String",
@@ -1192,7 +1192,7 @@ Some(
                                     InputValue {
                                         name: "last",
                                         description: None,
-                                        ty: NestedType {
+                                        ty: FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "Int",
@@ -1202,7 +1202,7 @@ Some(
                                         default_value: None,
                                     },
                                 ],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Object,
                                     name: Some(
                                         "FilmStarshipsConnection",
@@ -1219,7 +1219,7 @@ Some(
                                     InputValue {
                                         name: "after",
                                         description: None,
-                                        ty: NestedType {
+                                        ty: FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "String",
@@ -1231,7 +1231,7 @@ Some(
                                     InputValue {
                                         name: "first",
                                         description: None,
-                                        ty: NestedType {
+                                        ty: FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "Int",
@@ -1243,7 +1243,7 @@ Some(
                                     InputValue {
                                         name: "before",
                                         description: None,
-                                        ty: NestedType {
+                                        ty: FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "String",
@@ -1255,7 +1255,7 @@ Some(
                                     InputValue {
                                         name: "last",
                                         description: None,
-                                        ty: NestedType {
+                                        ty: FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "Int",
@@ -1265,7 +1265,7 @@ Some(
                                         default_value: None,
                                     },
                                 ],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Object,
                                     name: Some(
                                         "FilmVehiclesConnection",
@@ -1282,7 +1282,7 @@ Some(
                                     InputValue {
                                         name: "after",
                                         description: None,
-                                        ty: NestedType {
+                                        ty: FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "String",
@@ -1294,7 +1294,7 @@ Some(
                                     InputValue {
                                         name: "first",
                                         description: None,
-                                        ty: NestedType {
+                                        ty: FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "Int",
@@ -1306,7 +1306,7 @@ Some(
                                     InputValue {
                                         name: "before",
                                         description: None,
-                                        ty: NestedType {
+                                        ty: FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "String",
@@ -1318,7 +1318,7 @@ Some(
                                     InputValue {
                                         name: "last",
                                         description: None,
-                                        ty: NestedType {
+                                        ty: FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "Int",
@@ -1328,7 +1328,7 @@ Some(
                                         default_value: None,
                                     },
                                 ],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Object,
                                     name: Some(
                                         "FilmCharactersConnection",
@@ -1345,7 +1345,7 @@ Some(
                                     InputValue {
                                         name: "after",
                                         description: None,
-                                        ty: NestedType {
+                                        ty: FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "String",
@@ -1357,7 +1357,7 @@ Some(
                                     InputValue {
                                         name: "first",
                                         description: None,
-                                        ty: NestedType {
+                                        ty: FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "Int",
@@ -1369,7 +1369,7 @@ Some(
                                     InputValue {
                                         name: "before",
                                         description: None,
-                                        ty: NestedType {
+                                        ty: FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "String",
@@ -1381,7 +1381,7 @@ Some(
                                     InputValue {
                                         name: "last",
                                         description: None,
-                                        ty: NestedType {
+                                        ty: FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "Int",
@@ -1391,7 +1391,7 @@ Some(
                                         default_value: None,
                                     },
                                 ],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Object,
                                     name: Some(
                                         "FilmPlanetsConnection",
@@ -1407,7 +1407,7 @@ Some(
                                     "The ISO 8601 date format of the time that this resource was created.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Scalar,
                                     name: Some(
                                         "String",
@@ -1423,7 +1423,7 @@ Some(
                                     "The ISO 8601 date format of the time that this resource was edited.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Scalar,
                                     name: Some(
                                         "String",
@@ -1439,11 +1439,11 @@ Some(
                                     "The ID of an object",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: NonNull,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "ID",
@@ -1460,12 +1460,10 @@ Some(
                     input_fields: None,
                     interfaces: Some(
                         [
-                            NestedType {
-                                kind: Interface,
+                            NamedType {
                                 name: Some(
                                     "Node",
                                 ),
-                                of_type: None,
                             },
                         ],
                     ),
@@ -1488,11 +1486,11 @@ Some(
                                     "The id of the object.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: NonNull,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "ID",
@@ -1511,47 +1509,35 @@ Some(
                     enum_values: None,
                     possible_types: Some(
                         [
-                            NestedType {
-                                kind: Object,
+                            NamedType {
                                 name: Some(
                                     "Film",
                                 ),
-                                of_type: None,
                             },
-                            NestedType {
-                                kind: Object,
+                            NamedType {
                                 name: Some(
                                     "Species",
                                 ),
-                                of_type: None,
                             },
-                            NestedType {
-                                kind: Object,
+                            NamedType {
                                 name: Some(
                                     "Planet",
                                 ),
-                                of_type: None,
                             },
-                            NestedType {
-                                kind: Object,
+                            NamedType {
                                 name: Some(
                                     "Person",
                                 ),
-                                of_type: None,
                             },
-                            NestedType {
-                                kind: Object,
+                            NamedType {
                                 name: Some(
                                     "Starship",
                                 ),
-                                of_type: None,
                             },
-                            NestedType {
-                                kind: Object,
+                            NamedType {
                                 name: Some(
                                     "Vehicle",
                                 ),
-                                of_type: None,
                             },
                         ],
                     ),
@@ -1586,11 +1572,11 @@ Some(
                                     "Information to aid in pagination.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: NonNull,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: Object,
                                             name: Some(
                                                 "PageInfo",
@@ -1608,11 +1594,11 @@ Some(
                                     "A list of edges.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: List,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: Object,
                                             name: Some(
                                                 "FilmSpeciesEdge",
@@ -1630,7 +1616,7 @@ Some(
                                     "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Scalar,
                                     name: Some(
                                         "Int",
@@ -1646,11 +1632,11 @@ Some(
                                     "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: List,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: Object,
                                             name: Some(
                                                 "Species",
@@ -1687,7 +1673,7 @@ Some(
                                     "The item at the end of the edge",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Object,
                                     name: Some(
                                         "Species",
@@ -1703,11 +1689,11 @@ Some(
                                     "A cursor for use in pagination",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: NonNull,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "String",
@@ -1744,7 +1730,7 @@ Some(
                                     "The name of this species.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Scalar,
                                     name: Some(
                                         "String",
@@ -1760,7 +1746,7 @@ Some(
                                     "The classification of this species, such as \"mammal\" or \"reptile\".",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Scalar,
                                     name: Some(
                                         "String",
@@ -1776,7 +1762,7 @@ Some(
                                     "The designation of this species, such as \"sentient\".",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Scalar,
                                     name: Some(
                                         "String",
@@ -1792,7 +1778,7 @@ Some(
                                     "The average height of this species in centimeters.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Scalar,
                                     name: Some(
                                         "Float",
@@ -1808,7 +1794,7 @@ Some(
                                     "The average lifespan of this species in years, null if unknown.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Scalar,
                                     name: Some(
                                         "Int",
@@ -1824,11 +1810,11 @@ Some(
                                     "Common eye colors for this species, null if this species does not typically\nhave eyes.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: List,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "String",
@@ -1846,11 +1832,11 @@ Some(
                                     "Common hair colors for this species, null if this species does not typically\nhave hair.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: List,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "String",
@@ -1868,11 +1854,11 @@ Some(
                                     "Common skin colors for this species, null if this species does not typically\nhave skin.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: List,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "String",
@@ -1890,7 +1876,7 @@ Some(
                                     "The language commonly spoken by this species.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Scalar,
                                     name: Some(
                                         "String",
@@ -1906,7 +1892,7 @@ Some(
                                     "A planet that this species originates from.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Object,
                                     name: Some(
                                         "Planet",
@@ -1923,7 +1909,7 @@ Some(
                                     InputValue {
                                         name: "after",
                                         description: None,
-                                        ty: NestedType {
+                                        ty: FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "String",
@@ -1935,7 +1921,7 @@ Some(
                                     InputValue {
                                         name: "first",
                                         description: None,
-                                        ty: NestedType {
+                                        ty: FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "Int",
@@ -1947,7 +1933,7 @@ Some(
                                     InputValue {
                                         name: "before",
                                         description: None,
-                                        ty: NestedType {
+                                        ty: FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "String",
@@ -1959,7 +1945,7 @@ Some(
                                     InputValue {
                                         name: "last",
                                         description: None,
-                                        ty: NestedType {
+                                        ty: FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "Int",
@@ -1969,7 +1955,7 @@ Some(
                                         default_value: None,
                                     },
                                 ],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Object,
                                     name: Some(
                                         "SpeciesPeopleConnection",
@@ -1986,7 +1972,7 @@ Some(
                                     InputValue {
                                         name: "after",
                                         description: None,
-                                        ty: NestedType {
+                                        ty: FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "String",
@@ -1998,7 +1984,7 @@ Some(
                                     InputValue {
                                         name: "first",
                                         description: None,
-                                        ty: NestedType {
+                                        ty: FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "Int",
@@ -2010,7 +1996,7 @@ Some(
                                     InputValue {
                                         name: "before",
                                         description: None,
-                                        ty: NestedType {
+                                        ty: FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "String",
@@ -2022,7 +2008,7 @@ Some(
                                     InputValue {
                                         name: "last",
                                         description: None,
-                                        ty: NestedType {
+                                        ty: FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "Int",
@@ -2032,7 +2018,7 @@ Some(
                                         default_value: None,
                                     },
                                 ],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Object,
                                     name: Some(
                                         "SpeciesFilmsConnection",
@@ -2048,7 +2034,7 @@ Some(
                                     "The ISO 8601 date format of the time that this resource was created.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Scalar,
                                     name: Some(
                                         "String",
@@ -2064,7 +2050,7 @@ Some(
                                     "The ISO 8601 date format of the time that this resource was edited.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Scalar,
                                     name: Some(
                                         "String",
@@ -2080,11 +2066,11 @@ Some(
                                     "The ID of an object",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: NonNull,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "ID",
@@ -2101,12 +2087,10 @@ Some(
                     input_fields: None,
                     interfaces: Some(
                         [
-                            NestedType {
-                                kind: Interface,
+                            NamedType {
                                 name: Some(
                                     "Node",
                                 ),
-                                of_type: None,
                             },
                         ],
                     ),
@@ -2143,7 +2127,7 @@ Some(
                                     "The name of this planet.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Scalar,
                                     name: Some(
                                         "String",
@@ -2159,7 +2143,7 @@ Some(
                                     "The diameter of this planet in kilometers.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Scalar,
                                     name: Some(
                                         "Int",
@@ -2175,7 +2159,7 @@ Some(
                                     "The number of standard hours it takes for this planet to complete a single\nrotation on its axis.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Scalar,
                                     name: Some(
                                         "Int",
@@ -2191,7 +2175,7 @@ Some(
                                     "The number of standard days it takes for this planet to complete a single orbit\nof its local star.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Scalar,
                                     name: Some(
                                         "Int",
@@ -2207,7 +2191,7 @@ Some(
                                     "A number denoting the gravity of this planet, where \"1\" is normal or 1 standard\nG. \"2\" is twice or 2 standard Gs. \"0.5\" is half or 0.5 standard Gs.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Scalar,
                                     name: Some(
                                         "String",
@@ -2223,7 +2207,7 @@ Some(
                                     "The average population of sentient beings inhabiting this planet.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Scalar,
                                     name: Some(
                                         "Float",
@@ -2239,11 +2223,11 @@ Some(
                                     "The climates of this planet.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: List,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "String",
@@ -2261,11 +2245,11 @@ Some(
                                     "The terrains of this planet.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: List,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "String",
@@ -2283,7 +2267,7 @@ Some(
                                     "The percentage of the planet surface that is naturally occurring water or bodies\nof water.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Scalar,
                                     name: Some(
                                         "Float",
@@ -2300,7 +2284,7 @@ Some(
                                     InputValue {
                                         name: "after",
                                         description: None,
-                                        ty: NestedType {
+                                        ty: FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "String",
@@ -2312,7 +2296,7 @@ Some(
                                     InputValue {
                                         name: "first",
                                         description: None,
-                                        ty: NestedType {
+                                        ty: FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "Int",
@@ -2324,7 +2308,7 @@ Some(
                                     InputValue {
                                         name: "before",
                                         description: None,
-                                        ty: NestedType {
+                                        ty: FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "String",
@@ -2336,7 +2320,7 @@ Some(
                                     InputValue {
                                         name: "last",
                                         description: None,
-                                        ty: NestedType {
+                                        ty: FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "Int",
@@ -2346,7 +2330,7 @@ Some(
                                         default_value: None,
                                     },
                                 ],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Object,
                                     name: Some(
                                         "PlanetResidentsConnection",
@@ -2363,7 +2347,7 @@ Some(
                                     InputValue {
                                         name: "after",
                                         description: None,
-                                        ty: NestedType {
+                                        ty: FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "String",
@@ -2375,7 +2359,7 @@ Some(
                                     InputValue {
                                         name: "first",
                                         description: None,
-                                        ty: NestedType {
+                                        ty: FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "Int",
@@ -2387,7 +2371,7 @@ Some(
                                     InputValue {
                                         name: "before",
                                         description: None,
-                                        ty: NestedType {
+                                        ty: FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "String",
@@ -2399,7 +2383,7 @@ Some(
                                     InputValue {
                                         name: "last",
                                         description: None,
-                                        ty: NestedType {
+                                        ty: FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "Int",
@@ -2409,7 +2393,7 @@ Some(
                                         default_value: None,
                                     },
                                 ],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Object,
                                     name: Some(
                                         "PlanetFilmsConnection",
@@ -2425,7 +2409,7 @@ Some(
                                     "The ISO 8601 date format of the time that this resource was created.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Scalar,
                                     name: Some(
                                         "String",
@@ -2441,7 +2425,7 @@ Some(
                                     "The ISO 8601 date format of the time that this resource was edited.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Scalar,
                                     name: Some(
                                         "String",
@@ -2457,11 +2441,11 @@ Some(
                                     "The ID of an object",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: NonNull,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "ID",
@@ -2478,12 +2462,10 @@ Some(
                     input_fields: None,
                     interfaces: Some(
                         [
-                            NestedType {
-                                kind: Interface,
+                            NamedType {
                                 name: Some(
                                     "Node",
                                 ),
-                                of_type: None,
                             },
                         ],
                     ),
@@ -2506,11 +2488,11 @@ Some(
                                     "Information to aid in pagination.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: NonNull,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: Object,
                                             name: Some(
                                                 "PageInfo",
@@ -2528,11 +2510,11 @@ Some(
                                     "A list of edges.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: List,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: Object,
                                             name: Some(
                                                 "PlanetResidentsEdge",
@@ -2550,7 +2532,7 @@ Some(
                                     "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Scalar,
                                     name: Some(
                                         "Int",
@@ -2566,11 +2548,11 @@ Some(
                                     "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: List,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: Object,
                                             name: Some(
                                                 "Person",
@@ -2607,7 +2589,7 @@ Some(
                                     "The item at the end of the edge",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Object,
                                     name: Some(
                                         "Person",
@@ -2623,11 +2605,11 @@ Some(
                                     "A cursor for use in pagination",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: NonNull,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "String",
@@ -2664,7 +2646,7 @@ Some(
                                     "The name of this person.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Scalar,
                                     name: Some(
                                         "String",
@@ -2680,7 +2662,7 @@ Some(
                                     "The birth year of the person, using the in-universe standard of BBY or ABY -\nBefore the Battle of Yavin or After the Battle of Yavin. The Battle of Yavin is\na battle that occurs at the end of Star Wars episode IV: A New Hope.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Scalar,
                                     name: Some(
                                         "String",
@@ -2696,7 +2678,7 @@ Some(
                                     "The eye color of this person. Will be \"unknown\" if not known or \"n/a\" if the\nperson does not have an eye.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Scalar,
                                     name: Some(
                                         "String",
@@ -2712,7 +2694,7 @@ Some(
                                     "The gender of this person. Either \"Male\", \"Female\" or \"unknown\",\n\"n/a\" if the person does not have a gender.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Scalar,
                                     name: Some(
                                         "String",
@@ -2728,7 +2710,7 @@ Some(
                                     "The hair color of this person. Will be \"unknown\" if not known or \"n/a\" if the\nperson does not have hair.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Scalar,
                                     name: Some(
                                         "String",
@@ -2744,7 +2726,7 @@ Some(
                                     "The height of the person in centimeters.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Scalar,
                                     name: Some(
                                         "Int",
@@ -2760,7 +2742,7 @@ Some(
                                     "The mass of the person in kilograms.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Scalar,
                                     name: Some(
                                         "Float",
@@ -2776,7 +2758,7 @@ Some(
                                     "The skin color of this person.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Scalar,
                                     name: Some(
                                         "String",
@@ -2792,7 +2774,7 @@ Some(
                                     "A planet that this person was born on or inhabits.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Object,
                                     name: Some(
                                         "Planet",
@@ -2809,7 +2791,7 @@ Some(
                                     InputValue {
                                         name: "after",
                                         description: None,
-                                        ty: NestedType {
+                                        ty: FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "String",
@@ -2821,7 +2803,7 @@ Some(
                                     InputValue {
                                         name: "first",
                                         description: None,
-                                        ty: NestedType {
+                                        ty: FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "Int",
@@ -2833,7 +2815,7 @@ Some(
                                     InputValue {
                                         name: "before",
                                         description: None,
-                                        ty: NestedType {
+                                        ty: FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "String",
@@ -2845,7 +2827,7 @@ Some(
                                     InputValue {
                                         name: "last",
                                         description: None,
-                                        ty: NestedType {
+                                        ty: FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "Int",
@@ -2855,7 +2837,7 @@ Some(
                                         default_value: None,
                                     },
                                 ],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Object,
                                     name: Some(
                                         "PersonFilmsConnection",
@@ -2871,7 +2853,7 @@ Some(
                                     "The species that this person belongs to, or null if unknown.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Object,
                                     name: Some(
                                         "Species",
@@ -2888,7 +2870,7 @@ Some(
                                     InputValue {
                                         name: "after",
                                         description: None,
-                                        ty: NestedType {
+                                        ty: FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "String",
@@ -2900,7 +2882,7 @@ Some(
                                     InputValue {
                                         name: "first",
                                         description: None,
-                                        ty: NestedType {
+                                        ty: FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "Int",
@@ -2912,7 +2894,7 @@ Some(
                                     InputValue {
                                         name: "before",
                                         description: None,
-                                        ty: NestedType {
+                                        ty: FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "String",
@@ -2924,7 +2906,7 @@ Some(
                                     InputValue {
                                         name: "last",
                                         description: None,
-                                        ty: NestedType {
+                                        ty: FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "Int",
@@ -2934,7 +2916,7 @@ Some(
                                         default_value: None,
                                     },
                                 ],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Object,
                                     name: Some(
                                         "PersonStarshipsConnection",
@@ -2951,7 +2933,7 @@ Some(
                                     InputValue {
                                         name: "after",
                                         description: None,
-                                        ty: NestedType {
+                                        ty: FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "String",
@@ -2963,7 +2945,7 @@ Some(
                                     InputValue {
                                         name: "first",
                                         description: None,
-                                        ty: NestedType {
+                                        ty: FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "Int",
@@ -2975,7 +2957,7 @@ Some(
                                     InputValue {
                                         name: "before",
                                         description: None,
-                                        ty: NestedType {
+                                        ty: FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "String",
@@ -2987,7 +2969,7 @@ Some(
                                     InputValue {
                                         name: "last",
                                         description: None,
-                                        ty: NestedType {
+                                        ty: FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "Int",
@@ -2997,7 +2979,7 @@ Some(
                                         default_value: None,
                                     },
                                 ],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Object,
                                     name: Some(
                                         "PersonVehiclesConnection",
@@ -3013,7 +2995,7 @@ Some(
                                     "The ISO 8601 date format of the time that this resource was created.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Scalar,
                                     name: Some(
                                         "String",
@@ -3029,7 +3011,7 @@ Some(
                                     "The ISO 8601 date format of the time that this resource was edited.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Scalar,
                                     name: Some(
                                         "String",
@@ -3045,11 +3027,11 @@ Some(
                                     "The ID of an object",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: NonNull,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "ID",
@@ -3066,12 +3048,10 @@ Some(
                     input_fields: None,
                     interfaces: Some(
                         [
-                            NestedType {
-                                kind: Interface,
+                            NamedType {
                                 name: Some(
                                     "Node",
                                 ),
-                                of_type: None,
                             },
                         ],
                     ),
@@ -3094,11 +3074,11 @@ Some(
                                     "Information to aid in pagination.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: NonNull,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: Object,
                                             name: Some(
                                                 "PageInfo",
@@ -3116,11 +3096,11 @@ Some(
                                     "A list of edges.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: List,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: Object,
                                             name: Some(
                                                 "PersonFilmsEdge",
@@ -3138,7 +3118,7 @@ Some(
                                     "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Scalar,
                                     name: Some(
                                         "Int",
@@ -3154,11 +3134,11 @@ Some(
                                     "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: List,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: Object,
                                             name: Some(
                                                 "Film",
@@ -3195,7 +3175,7 @@ Some(
                                     "The item at the end of the edge",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Object,
                                     name: Some(
                                         "Film",
@@ -3211,11 +3191,11 @@ Some(
                                     "A cursor for use in pagination",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: NonNull,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "String",
@@ -3252,11 +3232,11 @@ Some(
                                     "Information to aid in pagination.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: NonNull,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: Object,
                                             name: Some(
                                                 "PageInfo",
@@ -3274,11 +3254,11 @@ Some(
                                     "A list of edges.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: List,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: Object,
                                             name: Some(
                                                 "PersonStarshipsEdge",
@@ -3296,7 +3276,7 @@ Some(
                                     "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Scalar,
                                     name: Some(
                                         "Int",
@@ -3312,11 +3292,11 @@ Some(
                                     "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: List,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: Object,
                                             name: Some(
                                                 "Starship",
@@ -3353,7 +3333,7 @@ Some(
                                     "The item at the end of the edge",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Object,
                                     name: Some(
                                         "Starship",
@@ -3369,11 +3349,11 @@ Some(
                                     "A cursor for use in pagination",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: NonNull,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "String",
@@ -3410,7 +3390,7 @@ Some(
                                     "The name of this starship. The common name, such as \"Death Star\".",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Scalar,
                                     name: Some(
                                         "String",
@@ -3426,7 +3406,7 @@ Some(
                                     "The model or official name of this starship. Such as \"T-65 X-wing\" or \"DS-1\nOrbital Battle Station\".",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Scalar,
                                     name: Some(
                                         "String",
@@ -3442,7 +3422,7 @@ Some(
                                     "The class of this starship, such as \"Starfighter\" or \"Deep Space Mobile\nBattlestation\"",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Scalar,
                                     name: Some(
                                         "String",
@@ -3458,11 +3438,11 @@ Some(
                                     "The manufacturers of this starship.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: List,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "String",
@@ -3480,7 +3460,7 @@ Some(
                                     "The cost of this starship new, in galactic credits.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Scalar,
                                     name: Some(
                                         "Float",
@@ -3496,7 +3476,7 @@ Some(
                                     "The length of this starship in meters.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Scalar,
                                     name: Some(
                                         "Float",
@@ -3512,7 +3492,7 @@ Some(
                                     "The number of personnel needed to run or pilot this starship.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Scalar,
                                     name: Some(
                                         "String",
@@ -3528,7 +3508,7 @@ Some(
                                     "The number of non-essential people this starship can transport.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Scalar,
                                     name: Some(
                                         "String",
@@ -3544,7 +3524,7 @@ Some(
                                     "The maximum speed of this starship in atmosphere. null if this starship is\nincapable of atmosphering flight.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Scalar,
                                     name: Some(
                                         "Int",
@@ -3560,7 +3540,7 @@ Some(
                                     "The class of this starships hyperdrive.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Scalar,
                                     name: Some(
                                         "Float",
@@ -3576,7 +3556,7 @@ Some(
                                     "The Maximum number of Megalights this starship can travel in a standard hour.\nA \"Megalight\" is a standard unit of distance and has never been defined before\nwithin the Star Wars universe. This figure is only really useful for measuring\nthe difference in speed of starships. We can assume it is similar to AU, the\ndistance between our Sun (Sol) and Earth.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Scalar,
                                     name: Some(
                                         "Int",
@@ -3592,7 +3572,7 @@ Some(
                                     "The maximum number of kilograms that this starship can transport.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Scalar,
                                     name: Some(
                                         "Float",
@@ -3608,7 +3588,7 @@ Some(
                                     "The maximum length of time that this starship can provide consumables for its\nentire crew without having to resupply.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Scalar,
                                     name: Some(
                                         "String",
@@ -3625,7 +3605,7 @@ Some(
                                     InputValue {
                                         name: "after",
                                         description: None,
-                                        ty: NestedType {
+                                        ty: FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "String",
@@ -3637,7 +3617,7 @@ Some(
                                     InputValue {
                                         name: "first",
                                         description: None,
-                                        ty: NestedType {
+                                        ty: FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "Int",
@@ -3649,7 +3629,7 @@ Some(
                                     InputValue {
                                         name: "before",
                                         description: None,
-                                        ty: NestedType {
+                                        ty: FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "String",
@@ -3661,7 +3641,7 @@ Some(
                                     InputValue {
                                         name: "last",
                                         description: None,
-                                        ty: NestedType {
+                                        ty: FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "Int",
@@ -3671,7 +3651,7 @@ Some(
                                         default_value: None,
                                     },
                                 ],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Object,
                                     name: Some(
                                         "StarshipPilotsConnection",
@@ -3688,7 +3668,7 @@ Some(
                                     InputValue {
                                         name: "after",
                                         description: None,
-                                        ty: NestedType {
+                                        ty: FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "String",
@@ -3700,7 +3680,7 @@ Some(
                                     InputValue {
                                         name: "first",
                                         description: None,
-                                        ty: NestedType {
+                                        ty: FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "Int",
@@ -3712,7 +3692,7 @@ Some(
                                     InputValue {
                                         name: "before",
                                         description: None,
-                                        ty: NestedType {
+                                        ty: FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "String",
@@ -3724,7 +3704,7 @@ Some(
                                     InputValue {
                                         name: "last",
                                         description: None,
-                                        ty: NestedType {
+                                        ty: FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "Int",
@@ -3734,7 +3714,7 @@ Some(
                                         default_value: None,
                                     },
                                 ],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Object,
                                     name: Some(
                                         "StarshipFilmsConnection",
@@ -3750,7 +3730,7 @@ Some(
                                     "The ISO 8601 date format of the time that this resource was created.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Scalar,
                                     name: Some(
                                         "String",
@@ -3766,7 +3746,7 @@ Some(
                                     "The ISO 8601 date format of the time that this resource was edited.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Scalar,
                                     name: Some(
                                         "String",
@@ -3782,11 +3762,11 @@ Some(
                                     "The ID of an object",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: NonNull,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "ID",
@@ -3803,12 +3783,10 @@ Some(
                     input_fields: None,
                     interfaces: Some(
                         [
-                            NestedType {
-                                kind: Interface,
+                            NamedType {
                                 name: Some(
                                     "Node",
                                 ),
-                                of_type: None,
                             },
                         ],
                     ),
@@ -3831,11 +3809,11 @@ Some(
                                     "Information to aid in pagination.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: NonNull,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: Object,
                                             name: Some(
                                                 "PageInfo",
@@ -3853,11 +3831,11 @@ Some(
                                     "A list of edges.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: List,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: Object,
                                             name: Some(
                                                 "StarshipPilotsEdge",
@@ -3875,7 +3853,7 @@ Some(
                                     "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Scalar,
                                     name: Some(
                                         "Int",
@@ -3891,11 +3869,11 @@ Some(
                                     "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: List,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: Object,
                                             name: Some(
                                                 "Person",
@@ -3932,7 +3910,7 @@ Some(
                                     "The item at the end of the edge",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Object,
                                     name: Some(
                                         "Person",
@@ -3948,11 +3926,11 @@ Some(
                                     "A cursor for use in pagination",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: NonNull,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "String",
@@ -3989,11 +3967,11 @@ Some(
                                     "Information to aid in pagination.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: NonNull,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: Object,
                                             name: Some(
                                                 "PageInfo",
@@ -4011,11 +3989,11 @@ Some(
                                     "A list of edges.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: List,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: Object,
                                             name: Some(
                                                 "StarshipFilmsEdge",
@@ -4033,7 +4011,7 @@ Some(
                                     "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Scalar,
                                     name: Some(
                                         "Int",
@@ -4049,11 +4027,11 @@ Some(
                                     "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: List,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: Object,
                                             name: Some(
                                                 "Film",
@@ -4090,7 +4068,7 @@ Some(
                                     "The item at the end of the edge",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Object,
                                     name: Some(
                                         "Film",
@@ -4106,11 +4084,11 @@ Some(
                                     "A cursor for use in pagination",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: NonNull,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "String",
@@ -4147,11 +4125,11 @@ Some(
                                     "Information to aid in pagination.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: NonNull,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: Object,
                                             name: Some(
                                                 "PageInfo",
@@ -4169,11 +4147,11 @@ Some(
                                     "A list of edges.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: List,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: Object,
                                             name: Some(
                                                 "PersonVehiclesEdge",
@@ -4191,7 +4169,7 @@ Some(
                                     "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Scalar,
                                     name: Some(
                                         "Int",
@@ -4207,11 +4185,11 @@ Some(
                                     "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: List,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: Object,
                                             name: Some(
                                                 "Vehicle",
@@ -4248,7 +4226,7 @@ Some(
                                     "The item at the end of the edge",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Object,
                                     name: Some(
                                         "Vehicle",
@@ -4264,11 +4242,11 @@ Some(
                                     "A cursor for use in pagination",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: NonNull,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "String",
@@ -4305,7 +4283,7 @@ Some(
                                     "The name of this vehicle. The common name, such as \"Sand Crawler\" or \"Speeder\nbike\".",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Scalar,
                                     name: Some(
                                         "String",
@@ -4321,7 +4299,7 @@ Some(
                                     "The model or official name of this vehicle. Such as \"All-Terrain Attack\nTransport\".",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Scalar,
                                     name: Some(
                                         "String",
@@ -4337,7 +4315,7 @@ Some(
                                     "The class of this vehicle, such as \"Wheeled\" or \"Repulsorcraft\".",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Scalar,
                                     name: Some(
                                         "String",
@@ -4353,11 +4331,11 @@ Some(
                                     "The manufacturers of this vehicle.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: List,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "String",
@@ -4375,7 +4353,7 @@ Some(
                                     "The cost of this vehicle new, in Galactic Credits.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Scalar,
                                     name: Some(
                                         "Float",
@@ -4391,7 +4369,7 @@ Some(
                                     "The length of this vehicle in meters.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Scalar,
                                     name: Some(
                                         "Float",
@@ -4407,7 +4385,7 @@ Some(
                                     "The number of personnel needed to run or pilot this vehicle.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Scalar,
                                     name: Some(
                                         "String",
@@ -4423,7 +4401,7 @@ Some(
                                     "The number of non-essential people this vehicle can transport.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Scalar,
                                     name: Some(
                                         "String",
@@ -4439,7 +4417,7 @@ Some(
                                     "The maximum speed of this vehicle in atmosphere.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Scalar,
                                     name: Some(
                                         "Int",
@@ -4455,7 +4433,7 @@ Some(
                                     "The maximum number of kilograms that this vehicle can transport.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Scalar,
                                     name: Some(
                                         "Float",
@@ -4471,7 +4449,7 @@ Some(
                                     "The maximum length of time that this vehicle can provide consumables for its\nentire crew without having to resupply.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Scalar,
                                     name: Some(
                                         "String",
@@ -4488,7 +4466,7 @@ Some(
                                     InputValue {
                                         name: "after",
                                         description: None,
-                                        ty: NestedType {
+                                        ty: FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "String",
@@ -4500,7 +4478,7 @@ Some(
                                     InputValue {
                                         name: "first",
                                         description: None,
-                                        ty: NestedType {
+                                        ty: FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "Int",
@@ -4512,7 +4490,7 @@ Some(
                                     InputValue {
                                         name: "before",
                                         description: None,
-                                        ty: NestedType {
+                                        ty: FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "String",
@@ -4524,7 +4502,7 @@ Some(
                                     InputValue {
                                         name: "last",
                                         description: None,
-                                        ty: NestedType {
+                                        ty: FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "Int",
@@ -4534,7 +4512,7 @@ Some(
                                         default_value: None,
                                     },
                                 ],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Object,
                                     name: Some(
                                         "VehiclePilotsConnection",
@@ -4551,7 +4529,7 @@ Some(
                                     InputValue {
                                         name: "after",
                                         description: None,
-                                        ty: NestedType {
+                                        ty: FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "String",
@@ -4563,7 +4541,7 @@ Some(
                                     InputValue {
                                         name: "first",
                                         description: None,
-                                        ty: NestedType {
+                                        ty: FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "Int",
@@ -4575,7 +4553,7 @@ Some(
                                     InputValue {
                                         name: "before",
                                         description: None,
-                                        ty: NestedType {
+                                        ty: FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "String",
@@ -4587,7 +4565,7 @@ Some(
                                     InputValue {
                                         name: "last",
                                         description: None,
-                                        ty: NestedType {
+                                        ty: FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "Int",
@@ -4597,7 +4575,7 @@ Some(
                                         default_value: None,
                                     },
                                 ],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Object,
                                     name: Some(
                                         "VehicleFilmsConnection",
@@ -4613,7 +4591,7 @@ Some(
                                     "The ISO 8601 date format of the time that this resource was created.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Scalar,
                                     name: Some(
                                         "String",
@@ -4629,7 +4607,7 @@ Some(
                                     "The ISO 8601 date format of the time that this resource was edited.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Scalar,
                                     name: Some(
                                         "String",
@@ -4645,11 +4623,11 @@ Some(
                                     "The ID of an object",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: NonNull,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "ID",
@@ -4666,12 +4644,10 @@ Some(
                     input_fields: None,
                     interfaces: Some(
                         [
-                            NestedType {
-                                kind: Interface,
+                            NamedType {
                                 name: Some(
                                     "Node",
                                 ),
-                                of_type: None,
                             },
                         ],
                     ),
@@ -4694,11 +4670,11 @@ Some(
                                     "Information to aid in pagination.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: NonNull,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: Object,
                                             name: Some(
                                                 "PageInfo",
@@ -4716,11 +4692,11 @@ Some(
                                     "A list of edges.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: List,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: Object,
                                             name: Some(
                                                 "VehiclePilotsEdge",
@@ -4738,7 +4714,7 @@ Some(
                                     "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Scalar,
                                     name: Some(
                                         "Int",
@@ -4754,11 +4730,11 @@ Some(
                                     "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: List,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: Object,
                                             name: Some(
                                                 "Person",
@@ -4795,7 +4771,7 @@ Some(
                                     "The item at the end of the edge",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Object,
                                     name: Some(
                                         "Person",
@@ -4811,11 +4787,11 @@ Some(
                                     "A cursor for use in pagination",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: NonNull,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "String",
@@ -4852,11 +4828,11 @@ Some(
                                     "Information to aid in pagination.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: NonNull,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: Object,
                                             name: Some(
                                                 "PageInfo",
@@ -4874,11 +4850,11 @@ Some(
                                     "A list of edges.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: List,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: Object,
                                             name: Some(
                                                 "VehicleFilmsEdge",
@@ -4896,7 +4872,7 @@ Some(
                                     "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Scalar,
                                     name: Some(
                                         "Int",
@@ -4912,11 +4888,11 @@ Some(
                                     "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: List,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: Object,
                                             name: Some(
                                                 "Film",
@@ -4953,7 +4929,7 @@ Some(
                                     "The item at the end of the edge",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Object,
                                     name: Some(
                                         "Film",
@@ -4969,11 +4945,11 @@ Some(
                                     "A cursor for use in pagination",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: NonNull,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "String",
@@ -5010,11 +4986,11 @@ Some(
                                     "Information to aid in pagination.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: NonNull,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: Object,
                                             name: Some(
                                                 "PageInfo",
@@ -5032,11 +5008,11 @@ Some(
                                     "A list of edges.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: List,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: Object,
                                             name: Some(
                                                 "PlanetFilmsEdge",
@@ -5054,7 +5030,7 @@ Some(
                                     "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Scalar,
                                     name: Some(
                                         "Int",
@@ -5070,11 +5046,11 @@ Some(
                                     "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: List,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: Object,
                                             name: Some(
                                                 "Film",
@@ -5111,7 +5087,7 @@ Some(
                                     "The item at the end of the edge",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Object,
                                     name: Some(
                                         "Film",
@@ -5127,11 +5103,11 @@ Some(
                                     "A cursor for use in pagination",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: NonNull,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "String",
@@ -5168,11 +5144,11 @@ Some(
                                     "Information to aid in pagination.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: NonNull,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: Object,
                                             name: Some(
                                                 "PageInfo",
@@ -5190,11 +5166,11 @@ Some(
                                     "A list of edges.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: List,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: Object,
                                             name: Some(
                                                 "SpeciesPeopleEdge",
@@ -5212,7 +5188,7 @@ Some(
                                     "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Scalar,
                                     name: Some(
                                         "Int",
@@ -5228,11 +5204,11 @@ Some(
                                     "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: List,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: Object,
                                             name: Some(
                                                 "Person",
@@ -5269,7 +5245,7 @@ Some(
                                     "The item at the end of the edge",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Object,
                                     name: Some(
                                         "Person",
@@ -5285,11 +5261,11 @@ Some(
                                     "A cursor for use in pagination",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: NonNull,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "String",
@@ -5326,11 +5302,11 @@ Some(
                                     "Information to aid in pagination.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: NonNull,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: Object,
                                             name: Some(
                                                 "PageInfo",
@@ -5348,11 +5324,11 @@ Some(
                                     "A list of edges.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: List,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: Object,
                                             name: Some(
                                                 "SpeciesFilmsEdge",
@@ -5370,7 +5346,7 @@ Some(
                                     "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Scalar,
                                     name: Some(
                                         "Int",
@@ -5386,11 +5362,11 @@ Some(
                                     "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: List,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: Object,
                                             name: Some(
                                                 "Film",
@@ -5427,7 +5403,7 @@ Some(
                                     "The item at the end of the edge",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Object,
                                     name: Some(
                                         "Film",
@@ -5443,11 +5419,11 @@ Some(
                                     "A cursor for use in pagination",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: NonNull,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "String",
@@ -5484,11 +5460,11 @@ Some(
                                     "Information to aid in pagination.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: NonNull,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: Object,
                                             name: Some(
                                                 "PageInfo",
@@ -5506,11 +5482,11 @@ Some(
                                     "A list of edges.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: List,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: Object,
                                             name: Some(
                                                 "FilmStarshipsEdge",
@@ -5528,7 +5504,7 @@ Some(
                                     "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Scalar,
                                     name: Some(
                                         "Int",
@@ -5544,11 +5520,11 @@ Some(
                                     "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: List,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: Object,
                                             name: Some(
                                                 "Starship",
@@ -5585,7 +5561,7 @@ Some(
                                     "The item at the end of the edge",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Object,
                                     name: Some(
                                         "Starship",
@@ -5601,11 +5577,11 @@ Some(
                                     "A cursor for use in pagination",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: NonNull,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "String",
@@ -5642,11 +5618,11 @@ Some(
                                     "Information to aid in pagination.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: NonNull,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: Object,
                                             name: Some(
                                                 "PageInfo",
@@ -5664,11 +5640,11 @@ Some(
                                     "A list of edges.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: List,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: Object,
                                             name: Some(
                                                 "FilmVehiclesEdge",
@@ -5686,7 +5662,7 @@ Some(
                                     "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Scalar,
                                     name: Some(
                                         "Int",
@@ -5702,11 +5678,11 @@ Some(
                                     "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: List,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: Object,
                                             name: Some(
                                                 "Vehicle",
@@ -5743,7 +5719,7 @@ Some(
                                     "The item at the end of the edge",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Object,
                                     name: Some(
                                         "Vehicle",
@@ -5759,11 +5735,11 @@ Some(
                                     "A cursor for use in pagination",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: NonNull,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "String",
@@ -5800,11 +5776,11 @@ Some(
                                     "Information to aid in pagination.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: NonNull,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: Object,
                                             name: Some(
                                                 "PageInfo",
@@ -5822,11 +5798,11 @@ Some(
                                     "A list of edges.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: List,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: Object,
                                             name: Some(
                                                 "FilmCharactersEdge",
@@ -5844,7 +5820,7 @@ Some(
                                     "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Scalar,
                                     name: Some(
                                         "Int",
@@ -5860,11 +5836,11 @@ Some(
                                     "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: List,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: Object,
                                             name: Some(
                                                 "Person",
@@ -5901,7 +5877,7 @@ Some(
                                     "The item at the end of the edge",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Object,
                                     name: Some(
                                         "Person",
@@ -5917,11 +5893,11 @@ Some(
                                     "A cursor for use in pagination",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: NonNull,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "String",
@@ -5958,11 +5934,11 @@ Some(
                                     "Information to aid in pagination.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: NonNull,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: Object,
                                             name: Some(
                                                 "PageInfo",
@@ -5980,11 +5956,11 @@ Some(
                                     "A list of edges.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: List,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: Object,
                                             name: Some(
                                                 "FilmPlanetsEdge",
@@ -6002,7 +5978,7 @@ Some(
                                     "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Scalar,
                                     name: Some(
                                         "Int",
@@ -6018,11 +5994,11 @@ Some(
                                     "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: List,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: Object,
                                             name: Some(
                                                 "Planet",
@@ -6059,7 +6035,7 @@ Some(
                                     "The item at the end of the edge",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Object,
                                     name: Some(
                                         "Planet",
@@ -6075,11 +6051,11 @@ Some(
                                     "A cursor for use in pagination",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: NonNull,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "String",
@@ -6116,11 +6092,11 @@ Some(
                                     "Information to aid in pagination.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: NonNull,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: Object,
                                             name: Some(
                                                 "PageInfo",
@@ -6138,11 +6114,11 @@ Some(
                                     "A list of edges.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: List,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: Object,
                                             name: Some(
                                                 "PeopleEdge",
@@ -6160,7 +6136,7 @@ Some(
                                     "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Scalar,
                                     name: Some(
                                         "Int",
@@ -6176,11 +6152,11 @@ Some(
                                     "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: List,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: Object,
                                             name: Some(
                                                 "Person",
@@ -6217,7 +6193,7 @@ Some(
                                     "The item at the end of the edge",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Object,
                                     name: Some(
                                         "Person",
@@ -6233,11 +6209,11 @@ Some(
                                     "A cursor for use in pagination",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: NonNull,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "String",
@@ -6274,11 +6250,11 @@ Some(
                                     "Information to aid in pagination.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: NonNull,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: Object,
                                             name: Some(
                                                 "PageInfo",
@@ -6296,11 +6272,11 @@ Some(
                                     "A list of edges.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: List,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: Object,
                                             name: Some(
                                                 "PlanetsEdge",
@@ -6318,7 +6294,7 @@ Some(
                                     "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Scalar,
                                     name: Some(
                                         "Int",
@@ -6334,11 +6310,11 @@ Some(
                                     "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: List,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: Object,
                                             name: Some(
                                                 "Planet",
@@ -6375,7 +6351,7 @@ Some(
                                     "The item at the end of the edge",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Object,
                                     name: Some(
                                         "Planet",
@@ -6391,11 +6367,11 @@ Some(
                                     "A cursor for use in pagination",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: NonNull,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "String",
@@ -6432,11 +6408,11 @@ Some(
                                     "Information to aid in pagination.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: NonNull,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: Object,
                                             name: Some(
                                                 "PageInfo",
@@ -6454,11 +6430,11 @@ Some(
                                     "A list of edges.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: List,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: Object,
                                             name: Some(
                                                 "SpeciesEdge",
@@ -6476,7 +6452,7 @@ Some(
                                     "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Scalar,
                                     name: Some(
                                         "Int",
@@ -6492,11 +6468,11 @@ Some(
                                     "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: List,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: Object,
                                             name: Some(
                                                 "Species",
@@ -6533,7 +6509,7 @@ Some(
                                     "The item at the end of the edge",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Object,
                                     name: Some(
                                         "Species",
@@ -6549,11 +6525,11 @@ Some(
                                     "A cursor for use in pagination",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: NonNull,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "String",
@@ -6590,11 +6566,11 @@ Some(
                                     "Information to aid in pagination.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: NonNull,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: Object,
                                             name: Some(
                                                 "PageInfo",
@@ -6612,11 +6588,11 @@ Some(
                                     "A list of edges.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: List,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: Object,
                                             name: Some(
                                                 "StarshipsEdge",
@@ -6634,7 +6610,7 @@ Some(
                                     "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Scalar,
                                     name: Some(
                                         "Int",
@@ -6650,11 +6626,11 @@ Some(
                                     "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: List,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: Object,
                                             name: Some(
                                                 "Starship",
@@ -6691,7 +6667,7 @@ Some(
                                     "The item at the end of the edge",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Object,
                                     name: Some(
                                         "Starship",
@@ -6707,11 +6683,11 @@ Some(
                                     "A cursor for use in pagination",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: NonNull,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "String",
@@ -6748,11 +6724,11 @@ Some(
                                     "Information to aid in pagination.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: NonNull,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: Object,
                                             name: Some(
                                                 "PageInfo",
@@ -6770,11 +6746,11 @@ Some(
                                     "A list of edges.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: List,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: Object,
                                             name: Some(
                                                 "VehiclesEdge",
@@ -6792,7 +6768,7 @@ Some(
                                     "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Scalar,
                                     name: Some(
                                         "Int",
@@ -6808,11 +6784,11 @@ Some(
                                     "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: List,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: Object,
                                             name: Some(
                                                 "Vehicle",
@@ -6849,7 +6825,7 @@ Some(
                                     "The item at the end of the edge",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Object,
                                     name: Some(
                                         "Vehicle",
@@ -6865,11 +6841,11 @@ Some(
                                     "A cursor for use in pagination",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: NonNull,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "String",
@@ -6906,19 +6882,19 @@ Some(
                                     "A list of all types supported by this server.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: NonNull,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: List,
                                             name: None,
                                             of_type: Some(
-                                                NestedType {
+                                                FieldType {
                                                     kind: NonNull,
                                                     name: None,
                                                     of_type: Some(
-                                                        NestedType {
+                                                        FieldType {
                                                             kind: Object,
                                                             name: Some(
                                                                 "__Type",
@@ -6940,11 +6916,11 @@ Some(
                                     "The type that query operations will be rooted at.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: NonNull,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: Object,
                                             name: Some(
                                                 "__Type",
@@ -6962,7 +6938,7 @@ Some(
                                     "If this server supports mutation, the type that mutation operations will be rooted at.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Object,
                                     name: Some(
                                         "__Type",
@@ -6978,7 +6954,7 @@ Some(
                                     "If this server support subscription, the type that subscription operations will be rooted at.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Object,
                                     name: Some(
                                         "__Type",
@@ -6994,19 +6970,19 @@ Some(
                                     "A list of all directives supported by this server.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: NonNull,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: List,
                                             name: None,
                                             of_type: Some(
-                                                NestedType {
+                                                FieldType {
                                                     kind: NonNull,
                                                     name: None,
                                                     of_type: Some(
-                                                        NestedType {
+                                                        FieldType {
                                                             kind: Object,
                                                             name: Some(
                                                                 "__Directive",
@@ -7045,11 +7021,11 @@ Some(
                                 name: "kind",
                                 description: None,
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: NonNull,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: Enum,
                                             name: Some(
                                                 "__TypeKind",
@@ -7065,7 +7041,7 @@ Some(
                                 name: "name",
                                 description: None,
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Scalar,
                                     name: Some(
                                         "String",
@@ -7079,7 +7055,7 @@ Some(
                                 name: "description",
                                 description: None,
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Scalar,
                                     name: Some(
                                         "String",
@@ -7096,7 +7072,7 @@ Some(
                                     InputValue {
                                         name: "includeDeprecated",
                                         description: None,
-                                        ty: NestedType {
+                                        ty: FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "Boolean",
@@ -7108,15 +7084,15 @@ Some(
                                         ),
                                     },
                                 ],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: List,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: NonNull,
                                             name: None,
                                             of_type: Some(
-                                                NestedType {
+                                                FieldType {
                                                     kind: Object,
                                                     name: Some(
                                                         "__Field",
@@ -7134,15 +7110,15 @@ Some(
                                 name: "interfaces",
                                 description: None,
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: List,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: NonNull,
                                             name: None,
                                             of_type: Some(
-                                                NestedType {
+                                                FieldType {
                                                     kind: Object,
                                                     name: Some(
                                                         "__Type",
@@ -7160,15 +7136,15 @@ Some(
                                 name: "possibleTypes",
                                 description: None,
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: List,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: NonNull,
                                             name: None,
                                             of_type: Some(
-                                                NestedType {
+                                                FieldType {
                                                     kind: Object,
                                                     name: Some(
                                                         "__Type",
@@ -7189,7 +7165,7 @@ Some(
                                     InputValue {
                                         name: "includeDeprecated",
                                         description: None,
-                                        ty: NestedType {
+                                        ty: FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "Boolean",
@@ -7201,15 +7177,15 @@ Some(
                                         ),
                                     },
                                 ],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: List,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: NonNull,
                                             name: None,
                                             of_type: Some(
-                                                NestedType {
+                                                FieldType {
                                                     kind: Object,
                                                     name: Some(
                                                         "__EnumValue",
@@ -7227,15 +7203,15 @@ Some(
                                 name: "inputFields",
                                 description: None,
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: List,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: NonNull,
                                             name: None,
                                             of_type: Some(
-                                                NestedType {
+                                                FieldType {
                                                     kind: Object,
                                                     name: Some(
                                                         "__InputValue",
@@ -7253,7 +7229,7 @@ Some(
                                 name: "ofType",
                                 description: None,
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Object,
                                     name: Some(
                                         "__Type",
@@ -7367,11 +7343,11 @@ Some(
                                 name: "name",
                                 description: None,
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: NonNull,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "String",
@@ -7387,7 +7363,7 @@ Some(
                                 name: "description",
                                 description: None,
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Scalar,
                                     name: Some(
                                         "String",
@@ -7401,19 +7377,19 @@ Some(
                                 name: "args",
                                 description: None,
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: NonNull,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: List,
                                             name: None,
                                             of_type: Some(
-                                                NestedType {
+                                                FieldType {
                                                     kind: NonNull,
                                                     name: None,
                                                     of_type: Some(
-                                                        NestedType {
+                                                        FieldType {
                                                             kind: Object,
                                                             name: Some(
                                                                 "__InputValue",
@@ -7433,11 +7409,11 @@ Some(
                                 name: "type",
                                 description: None,
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: NonNull,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: Object,
                                             name: Some(
                                                 "__Type",
@@ -7453,11 +7429,11 @@ Some(
                                 name: "isDeprecated",
                                 description: None,
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: NonNull,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "Boolean",
@@ -7473,7 +7449,7 @@ Some(
                                 name: "deprecationReason",
                                 description: None,
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Scalar,
                                     name: Some(
                                         "String",
@@ -7506,11 +7482,11 @@ Some(
                                 name: "name",
                                 description: None,
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: NonNull,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "String",
@@ -7526,7 +7502,7 @@ Some(
                                 name: "description",
                                 description: None,
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Scalar,
                                     name: Some(
                                         "String",
@@ -7540,11 +7516,11 @@ Some(
                                 name: "type",
                                 description: None,
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: NonNull,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: Object,
                                             name: Some(
                                                 "__Type",
@@ -7562,7 +7538,7 @@ Some(
                                     "A GraphQL-formatted string representing the default value for this input value.",
                                 ),
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Scalar,
                                     name: Some(
                                         "String",
@@ -7595,11 +7571,11 @@ Some(
                                 name: "name",
                                 description: None,
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: NonNull,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "String",
@@ -7615,7 +7591,7 @@ Some(
                                 name: "description",
                                 description: None,
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Scalar,
                                     name: Some(
                                         "String",
@@ -7629,11 +7605,11 @@ Some(
                                 name: "isDeprecated",
                                 description: None,
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: NonNull,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "Boolean",
@@ -7649,7 +7625,7 @@ Some(
                                 name: "deprecationReason",
                                 description: None,
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Scalar,
                                     name: Some(
                                         "String",
@@ -7682,11 +7658,11 @@ Some(
                                 name: "name",
                                 description: None,
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: NonNull,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: Scalar,
                                             name: Some(
                                                 "String",
@@ -7702,7 +7678,7 @@ Some(
                                 name: "description",
                                 description: None,
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: Scalar,
                                     name: Some(
                                         "String",
@@ -7716,19 +7692,19 @@ Some(
                                 name: "locations",
                                 description: None,
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: NonNull,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: List,
                                             name: None,
                                             of_type: Some(
-                                                NestedType {
+                                                FieldType {
                                                     kind: NonNull,
                                                     name: None,
                                                     of_type: Some(
-                                                        NestedType {
+                                                        FieldType {
                                                             kind: Enum,
                                                             name: Some(
                                                                 "__DirectiveLocation",
@@ -7748,19 +7724,19 @@ Some(
                                 name: "args",
                                 description: None,
                                 args: [],
-                                ty: NestedType {
+                                ty: FieldType {
                                     kind: NonNull,
                                     name: None,
                                     of_type: Some(
-                                        NestedType {
+                                        FieldType {
                                             kind: List,
                                             name: None,
                                             of_type: Some(
-                                                NestedType {
+                                                FieldType {
                                                     kind: NonNull,
                                                     name: None,
                                                     of_type: Some(
-                                                        NestedType {
+                                                        FieldType {
                                                             kind: Object,
                                                             name: Some(
                                                                 "__InputValue",
@@ -7967,11 +7943,11 @@ Some(
                             description: Some(
                                 "Included when true.",
                             ),
-                            ty: NestedType {
+                            ty: FieldType {
                                 kind: NonNull,
                                 name: None,
                                 of_type: Some(
-                                    NestedType {
+                                    FieldType {
                                         kind: Scalar,
                                         name: Some(
                                             "Boolean",
@@ -8000,11 +7976,11 @@ Some(
                             description: Some(
                                 "Skipped when true.",
                             ),
-                            ty: NestedType {
+                            ty: FieldType {
                                 kind: NonNull,
                                 name: None,
                                 of_type: Some(
-                                    NestedType {
+                                    FieldType {
                                         kind: Scalar,
                                         name: Some(
                                             "Boolean",
@@ -8033,7 +8009,7 @@ Some(
                             description: Some(
                                 "Explains why this element was deprecated, usually also including a suggestion for how to access supported similar data. Formatted using the Markdown syntax (as specified by [CommonMark](https://commonmark.org/).",
                             ),
-                            ty: NestedType {
+                            ty: FieldType {
                                 kind: Scalar,
                                 name: Some(
                                     "String",

--- a/cynic-introspection/tests/snapshots/tests__schema_conversion.snap
+++ b/cynic-introspection/tests/snapshots/tests__schema_conversion.snap
@@ -1,0 +1,5158 @@
+---
+source: cynic-introspection/tests/tests.rs
+expression: "Schema::try_from(result.data.unwrap().schema).unwrap()"
+---
+Schema {
+    query_type: "Root",
+    mutation_type: None,
+    subscription_type: None,
+    types: [
+        Object(
+            ObjectType {
+                name: "Root",
+                description: None,
+                fields: [
+                    Field {
+                        name: "allFilms",
+                        description: None,
+                        args: [
+                            InputValue {
+                                name: "after",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "String",
+                                },
+                                default_value: None,
+                            },
+                            InputValue {
+                                name: "first",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "Int",
+                                },
+                                default_value: None,
+                            },
+                            InputValue {
+                                name: "before",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "String",
+                                },
+                                default_value: None,
+                            },
+                            InputValue {
+                                name: "last",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "Int",
+                                },
+                                default_value: None,
+                            },
+                        ],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "FilmsConnection",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "film",
+                        description: None,
+                        args: [
+                            InputValue {
+                                name: "id",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "ID",
+                                },
+                                default_value: None,
+                            },
+                            InputValue {
+                                name: "filmID",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "ID",
+                                },
+                                default_value: None,
+                            },
+                        ],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "Film",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "allPeople",
+                        description: None,
+                        args: [
+                            InputValue {
+                                name: "after",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "String",
+                                },
+                                default_value: None,
+                            },
+                            InputValue {
+                                name: "first",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "Int",
+                                },
+                                default_value: None,
+                            },
+                            InputValue {
+                                name: "before",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "String",
+                                },
+                                default_value: None,
+                            },
+                            InputValue {
+                                name: "last",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "Int",
+                                },
+                                default_value: None,
+                            },
+                        ],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "PeopleConnection",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "person",
+                        description: None,
+                        args: [
+                            InputValue {
+                                name: "id",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "ID",
+                                },
+                                default_value: None,
+                            },
+                            InputValue {
+                                name: "personID",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "ID",
+                                },
+                                default_value: None,
+                            },
+                        ],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "Person",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "allPlanets",
+                        description: None,
+                        args: [
+                            InputValue {
+                                name: "after",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "String",
+                                },
+                                default_value: None,
+                            },
+                            InputValue {
+                                name: "first",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "Int",
+                                },
+                                default_value: None,
+                            },
+                            InputValue {
+                                name: "before",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "String",
+                                },
+                                default_value: None,
+                            },
+                            InputValue {
+                                name: "last",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "Int",
+                                },
+                                default_value: None,
+                            },
+                        ],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "PlanetsConnection",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "planet",
+                        description: None,
+                        args: [
+                            InputValue {
+                                name: "id",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "ID",
+                                },
+                                default_value: None,
+                            },
+                            InputValue {
+                                name: "planetID",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "ID",
+                                },
+                                default_value: None,
+                            },
+                        ],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "Planet",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "allSpecies",
+                        description: None,
+                        args: [
+                            InputValue {
+                                name: "after",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "String",
+                                },
+                                default_value: None,
+                            },
+                            InputValue {
+                                name: "first",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "Int",
+                                },
+                                default_value: None,
+                            },
+                            InputValue {
+                                name: "before",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "String",
+                                },
+                                default_value: None,
+                            },
+                            InputValue {
+                                name: "last",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "Int",
+                                },
+                                default_value: None,
+                            },
+                        ],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "SpeciesConnection",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "species",
+                        description: None,
+                        args: [
+                            InputValue {
+                                name: "id",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "ID",
+                                },
+                                default_value: None,
+                            },
+                            InputValue {
+                                name: "speciesID",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "ID",
+                                },
+                                default_value: None,
+                            },
+                        ],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "Species",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "allStarships",
+                        description: None,
+                        args: [
+                            InputValue {
+                                name: "after",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "String",
+                                },
+                                default_value: None,
+                            },
+                            InputValue {
+                                name: "first",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "Int",
+                                },
+                                default_value: None,
+                            },
+                            InputValue {
+                                name: "before",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "String",
+                                },
+                                default_value: None,
+                            },
+                            InputValue {
+                                name: "last",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "Int",
+                                },
+                                default_value: None,
+                            },
+                        ],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "StarshipsConnection",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "starship",
+                        description: None,
+                        args: [
+                            InputValue {
+                                name: "id",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "ID",
+                                },
+                                default_value: None,
+                            },
+                            InputValue {
+                                name: "starshipID",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "ID",
+                                },
+                                default_value: None,
+                            },
+                        ],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "Starship",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "allVehicles",
+                        description: None,
+                        args: [
+                            InputValue {
+                                name: "after",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "String",
+                                },
+                                default_value: None,
+                            },
+                            InputValue {
+                                name: "first",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "Int",
+                                },
+                                default_value: None,
+                            },
+                            InputValue {
+                                name: "before",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "String",
+                                },
+                                default_value: None,
+                            },
+                            InputValue {
+                                name: "last",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "Int",
+                                },
+                                default_value: None,
+                            },
+                        ],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "VehiclesConnection",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "vehicle",
+                        description: None,
+                        args: [
+                            InputValue {
+                                name: "id",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "ID",
+                                },
+                                default_value: None,
+                            },
+                            InputValue {
+                                name: "vehicleID",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "ID",
+                                },
+                                default_value: None,
+                            },
+                        ],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "Vehicle",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "node",
+                        description: Some(
+                            "Fetches an object given its ID",
+                        ),
+                        args: [
+                            InputValue {
+                                name: "id",
+                                description: Some(
+                                    "The ID of an object",
+                                ),
+                                ty: FieldType {
+                                    wrapping: [NonNull],
+                                    name: "ID",
+                                },
+                                default_value: None,
+                            },
+                        ],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "Node",
+                        },
+                        deprecated: No,
+                    },
+                ],
+                interfaces: [],
+            },
+        ),
+        Scalar(
+            ScalarType {
+                name: "String",
+                description: Some(
+                    "The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text.",
+                ),
+            },
+        ),
+        Scalar(
+            ScalarType {
+                name: "Int",
+                description: Some(
+                    "The `Int` scalar type represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1.",
+                ),
+            },
+        ),
+        Object(
+            ObjectType {
+                name: "FilmsConnection",
+                description: Some(
+                    "A connection to a list of items.",
+                ),
+                fields: [
+                    Field {
+                        name: "pageInfo",
+                        description: Some(
+                            "Information to aid in pagination.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [NonNull],
+                            name: "PageInfo",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "edges",
+                        description: Some(
+                            "A list of edges.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [List],
+                            name: "FilmsEdge",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "totalCount",
+                        description: Some(
+                            "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "Int",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "films",
+                        description: Some(
+                            "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [List],
+                            name: "Film",
+                        },
+                        deprecated: No,
+                    },
+                ],
+                interfaces: [],
+            },
+        ),
+        Object(
+            ObjectType {
+                name: "PageInfo",
+                description: Some(
+                    "Information about pagination in a connection.",
+                ),
+                fields: [
+                    Field {
+                        name: "hasNextPage",
+                        description: Some(
+                            "When paginating forwards, are there more items?",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [NonNull],
+                            name: "Boolean",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "hasPreviousPage",
+                        description: Some(
+                            "When paginating backwards, are there more items?",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [NonNull],
+                            name: "Boolean",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "startCursor",
+                        description: Some(
+                            "When paginating backwards, the cursor to continue.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "endCursor",
+                        description: Some(
+                            "When paginating forwards, the cursor to continue.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                ],
+                interfaces: [],
+            },
+        ),
+        Scalar(
+            ScalarType {
+                name: "Boolean",
+                description: Some(
+                    "The `Boolean` scalar type represents `true` or `false`.",
+                ),
+            },
+        ),
+        Object(
+            ObjectType {
+                name: "FilmsEdge",
+                description: Some(
+                    "An edge in a connection.",
+                ),
+                fields: [
+                    Field {
+                        name: "node",
+                        description: Some(
+                            "The item at the end of the edge",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "Film",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "cursor",
+                        description: Some(
+                            "A cursor for use in pagination",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [NonNull],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                ],
+                interfaces: [],
+            },
+        ),
+        Object(
+            ObjectType {
+                name: "Film",
+                description: Some(
+                    "A single film.",
+                ),
+                fields: [
+                    Field {
+                        name: "title",
+                        description: Some(
+                            "The title of this film.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "episodeID",
+                        description: Some(
+                            "The episode number of this film.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "Int",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "openingCrawl",
+                        description: Some(
+                            "The opening paragraphs at the beginning of this film.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "director",
+                        description: Some(
+                            "The name of the director of this film.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "producers",
+                        description: Some(
+                            "The name(s) of the producer(s) of this film.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [List],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "releaseDate",
+                        description: Some(
+                            "The ISO 8601 date format of film release at original creator country.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "speciesConnection",
+                        description: None,
+                        args: [
+                            InputValue {
+                                name: "after",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "String",
+                                },
+                                default_value: None,
+                            },
+                            InputValue {
+                                name: "first",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "Int",
+                                },
+                                default_value: None,
+                            },
+                            InputValue {
+                                name: "before",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "String",
+                                },
+                                default_value: None,
+                            },
+                            InputValue {
+                                name: "last",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "Int",
+                                },
+                                default_value: None,
+                            },
+                        ],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "FilmSpeciesConnection",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "starshipConnection",
+                        description: None,
+                        args: [
+                            InputValue {
+                                name: "after",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "String",
+                                },
+                                default_value: None,
+                            },
+                            InputValue {
+                                name: "first",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "Int",
+                                },
+                                default_value: None,
+                            },
+                            InputValue {
+                                name: "before",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "String",
+                                },
+                                default_value: None,
+                            },
+                            InputValue {
+                                name: "last",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "Int",
+                                },
+                                default_value: None,
+                            },
+                        ],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "FilmStarshipsConnection",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "vehicleConnection",
+                        description: None,
+                        args: [
+                            InputValue {
+                                name: "after",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "String",
+                                },
+                                default_value: None,
+                            },
+                            InputValue {
+                                name: "first",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "Int",
+                                },
+                                default_value: None,
+                            },
+                            InputValue {
+                                name: "before",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "String",
+                                },
+                                default_value: None,
+                            },
+                            InputValue {
+                                name: "last",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "Int",
+                                },
+                                default_value: None,
+                            },
+                        ],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "FilmVehiclesConnection",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "characterConnection",
+                        description: None,
+                        args: [
+                            InputValue {
+                                name: "after",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "String",
+                                },
+                                default_value: None,
+                            },
+                            InputValue {
+                                name: "first",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "Int",
+                                },
+                                default_value: None,
+                            },
+                            InputValue {
+                                name: "before",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "String",
+                                },
+                                default_value: None,
+                            },
+                            InputValue {
+                                name: "last",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "Int",
+                                },
+                                default_value: None,
+                            },
+                        ],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "FilmCharactersConnection",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "planetConnection",
+                        description: None,
+                        args: [
+                            InputValue {
+                                name: "after",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "String",
+                                },
+                                default_value: None,
+                            },
+                            InputValue {
+                                name: "first",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "Int",
+                                },
+                                default_value: None,
+                            },
+                            InputValue {
+                                name: "before",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "String",
+                                },
+                                default_value: None,
+                            },
+                            InputValue {
+                                name: "last",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "Int",
+                                },
+                                default_value: None,
+                            },
+                        ],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "FilmPlanetsConnection",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "created",
+                        description: Some(
+                            "The ISO 8601 date format of the time that this resource was created.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "edited",
+                        description: Some(
+                            "The ISO 8601 date format of the time that this resource was edited.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "id",
+                        description: Some(
+                            "The ID of an object",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [NonNull],
+                            name: "ID",
+                        },
+                        deprecated: No,
+                    },
+                ],
+                interfaces: [
+                    "Node",
+                ],
+            },
+        ),
+        Interface(
+            InterfaceType {
+                name: "Node",
+                description: Some(
+                    "An object with an ID",
+                ),
+                fields: [
+                    Field {
+                        name: "id",
+                        description: Some(
+                            "The id of the object.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [NonNull],
+                            name: "ID",
+                        },
+                        deprecated: No,
+                    },
+                ],
+                interfaces: [],
+                possible_types: [
+                    "Film",
+                    "Species",
+                    "Planet",
+                    "Person",
+                    "Starship",
+                    "Vehicle",
+                ],
+            },
+        ),
+        Scalar(
+            ScalarType {
+                name: "ID",
+                description: Some(
+                    "The `ID` scalar type represents a unique identifier, often used to refetch an object or as key for a cache. The ID type appears in a JSON response as a String; however, it is not intended to be human-readable. When expected as an input type, any string (such as `\"4\"`) or integer (such as `4`) input value will be accepted as an ID.",
+                ),
+            },
+        ),
+        Object(
+            ObjectType {
+                name: "FilmSpeciesConnection",
+                description: Some(
+                    "A connection to a list of items.",
+                ),
+                fields: [
+                    Field {
+                        name: "pageInfo",
+                        description: Some(
+                            "Information to aid in pagination.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [NonNull],
+                            name: "PageInfo",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "edges",
+                        description: Some(
+                            "A list of edges.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [List],
+                            name: "FilmSpeciesEdge",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "totalCount",
+                        description: Some(
+                            "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "Int",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "species",
+                        description: Some(
+                            "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [List],
+                            name: "Species",
+                        },
+                        deprecated: No,
+                    },
+                ],
+                interfaces: [],
+            },
+        ),
+        Object(
+            ObjectType {
+                name: "FilmSpeciesEdge",
+                description: Some(
+                    "An edge in a connection.",
+                ),
+                fields: [
+                    Field {
+                        name: "node",
+                        description: Some(
+                            "The item at the end of the edge",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "Species",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "cursor",
+                        description: Some(
+                            "A cursor for use in pagination",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [NonNull],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                ],
+                interfaces: [],
+            },
+        ),
+        Object(
+            ObjectType {
+                name: "Species",
+                description: Some(
+                    "A type of person or character within the Star Wars Universe.",
+                ),
+                fields: [
+                    Field {
+                        name: "name",
+                        description: Some(
+                            "The name of this species.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "classification",
+                        description: Some(
+                            "The classification of this species, such as \"mammal\" or \"reptile\".",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "designation",
+                        description: Some(
+                            "The designation of this species, such as \"sentient\".",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "averageHeight",
+                        description: Some(
+                            "The average height of this species in centimeters.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "Float",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "averageLifespan",
+                        description: Some(
+                            "The average lifespan of this species in years, null if unknown.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "Int",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "eyeColors",
+                        description: Some(
+                            "Common eye colors for this species, null if this species does not typically\nhave eyes.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [List],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "hairColors",
+                        description: Some(
+                            "Common hair colors for this species, null if this species does not typically\nhave hair.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [List],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "skinColors",
+                        description: Some(
+                            "Common skin colors for this species, null if this species does not typically\nhave skin.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [List],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "language",
+                        description: Some(
+                            "The language commonly spoken by this species.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "homeworld",
+                        description: Some(
+                            "A planet that this species originates from.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "Planet",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "personConnection",
+                        description: None,
+                        args: [
+                            InputValue {
+                                name: "after",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "String",
+                                },
+                                default_value: None,
+                            },
+                            InputValue {
+                                name: "first",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "Int",
+                                },
+                                default_value: None,
+                            },
+                            InputValue {
+                                name: "before",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "String",
+                                },
+                                default_value: None,
+                            },
+                            InputValue {
+                                name: "last",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "Int",
+                                },
+                                default_value: None,
+                            },
+                        ],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "SpeciesPeopleConnection",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "filmConnection",
+                        description: None,
+                        args: [
+                            InputValue {
+                                name: "after",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "String",
+                                },
+                                default_value: None,
+                            },
+                            InputValue {
+                                name: "first",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "Int",
+                                },
+                                default_value: None,
+                            },
+                            InputValue {
+                                name: "before",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "String",
+                                },
+                                default_value: None,
+                            },
+                            InputValue {
+                                name: "last",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "Int",
+                                },
+                                default_value: None,
+                            },
+                        ],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "SpeciesFilmsConnection",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "created",
+                        description: Some(
+                            "The ISO 8601 date format of the time that this resource was created.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "edited",
+                        description: Some(
+                            "The ISO 8601 date format of the time that this resource was edited.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "id",
+                        description: Some(
+                            "The ID of an object",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [NonNull],
+                            name: "ID",
+                        },
+                        deprecated: No,
+                    },
+                ],
+                interfaces: [
+                    "Node",
+                ],
+            },
+        ),
+        Scalar(
+            ScalarType {
+                name: "Float",
+                description: Some(
+                    "The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](https://en.wikipedia.org/wiki/IEEE_floating_point).",
+                ),
+            },
+        ),
+        Object(
+            ObjectType {
+                name: "Planet",
+                description: Some(
+                    "A large mass, planet or planetoid in the Star Wars Universe, at the time of\n0 ABY.",
+                ),
+                fields: [
+                    Field {
+                        name: "name",
+                        description: Some(
+                            "The name of this planet.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "diameter",
+                        description: Some(
+                            "The diameter of this planet in kilometers.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "Int",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "rotationPeriod",
+                        description: Some(
+                            "The number of standard hours it takes for this planet to complete a single\nrotation on its axis.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "Int",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "orbitalPeriod",
+                        description: Some(
+                            "The number of standard days it takes for this planet to complete a single orbit\nof its local star.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "Int",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "gravity",
+                        description: Some(
+                            "A number denoting the gravity of this planet, where \"1\" is normal or 1 standard\nG. \"2\" is twice or 2 standard Gs. \"0.5\" is half or 0.5 standard Gs.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "population",
+                        description: Some(
+                            "The average population of sentient beings inhabiting this planet.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "Float",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "climates",
+                        description: Some(
+                            "The climates of this planet.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [List],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "terrains",
+                        description: Some(
+                            "The terrains of this planet.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [List],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "surfaceWater",
+                        description: Some(
+                            "The percentage of the planet surface that is naturally occurring water or bodies\nof water.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "Float",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "residentConnection",
+                        description: None,
+                        args: [
+                            InputValue {
+                                name: "after",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "String",
+                                },
+                                default_value: None,
+                            },
+                            InputValue {
+                                name: "first",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "Int",
+                                },
+                                default_value: None,
+                            },
+                            InputValue {
+                                name: "before",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "String",
+                                },
+                                default_value: None,
+                            },
+                            InputValue {
+                                name: "last",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "Int",
+                                },
+                                default_value: None,
+                            },
+                        ],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "PlanetResidentsConnection",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "filmConnection",
+                        description: None,
+                        args: [
+                            InputValue {
+                                name: "after",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "String",
+                                },
+                                default_value: None,
+                            },
+                            InputValue {
+                                name: "first",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "Int",
+                                },
+                                default_value: None,
+                            },
+                            InputValue {
+                                name: "before",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "String",
+                                },
+                                default_value: None,
+                            },
+                            InputValue {
+                                name: "last",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "Int",
+                                },
+                                default_value: None,
+                            },
+                        ],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "PlanetFilmsConnection",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "created",
+                        description: Some(
+                            "The ISO 8601 date format of the time that this resource was created.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "edited",
+                        description: Some(
+                            "The ISO 8601 date format of the time that this resource was edited.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "id",
+                        description: Some(
+                            "The ID of an object",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [NonNull],
+                            name: "ID",
+                        },
+                        deprecated: No,
+                    },
+                ],
+                interfaces: [
+                    "Node",
+                ],
+            },
+        ),
+        Object(
+            ObjectType {
+                name: "PlanetResidentsConnection",
+                description: Some(
+                    "A connection to a list of items.",
+                ),
+                fields: [
+                    Field {
+                        name: "pageInfo",
+                        description: Some(
+                            "Information to aid in pagination.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [NonNull],
+                            name: "PageInfo",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "edges",
+                        description: Some(
+                            "A list of edges.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [List],
+                            name: "PlanetResidentsEdge",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "totalCount",
+                        description: Some(
+                            "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "Int",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "residents",
+                        description: Some(
+                            "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [List],
+                            name: "Person",
+                        },
+                        deprecated: No,
+                    },
+                ],
+                interfaces: [],
+            },
+        ),
+        Object(
+            ObjectType {
+                name: "PlanetResidentsEdge",
+                description: Some(
+                    "An edge in a connection.",
+                ),
+                fields: [
+                    Field {
+                        name: "node",
+                        description: Some(
+                            "The item at the end of the edge",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "Person",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "cursor",
+                        description: Some(
+                            "A cursor for use in pagination",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [NonNull],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                ],
+                interfaces: [],
+            },
+        ),
+        Object(
+            ObjectType {
+                name: "Person",
+                description: Some(
+                    "An individual person or character within the Star Wars universe.",
+                ),
+                fields: [
+                    Field {
+                        name: "name",
+                        description: Some(
+                            "The name of this person.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "birthYear",
+                        description: Some(
+                            "The birth year of the person, using the in-universe standard of BBY or ABY -\nBefore the Battle of Yavin or After the Battle of Yavin. The Battle of Yavin is\na battle that occurs at the end of Star Wars episode IV: A New Hope.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "eyeColor",
+                        description: Some(
+                            "The eye color of this person. Will be \"unknown\" if not known or \"n/a\" if the\nperson does not have an eye.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "gender",
+                        description: Some(
+                            "The gender of this person. Either \"Male\", \"Female\" or \"unknown\",\n\"n/a\" if the person does not have a gender.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "hairColor",
+                        description: Some(
+                            "The hair color of this person. Will be \"unknown\" if not known or \"n/a\" if the\nperson does not have hair.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "height",
+                        description: Some(
+                            "The height of the person in centimeters.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "Int",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "mass",
+                        description: Some(
+                            "The mass of the person in kilograms.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "Float",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "skinColor",
+                        description: Some(
+                            "The skin color of this person.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "homeworld",
+                        description: Some(
+                            "A planet that this person was born on or inhabits.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "Planet",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "filmConnection",
+                        description: None,
+                        args: [
+                            InputValue {
+                                name: "after",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "String",
+                                },
+                                default_value: None,
+                            },
+                            InputValue {
+                                name: "first",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "Int",
+                                },
+                                default_value: None,
+                            },
+                            InputValue {
+                                name: "before",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "String",
+                                },
+                                default_value: None,
+                            },
+                            InputValue {
+                                name: "last",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "Int",
+                                },
+                                default_value: None,
+                            },
+                        ],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "PersonFilmsConnection",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "species",
+                        description: Some(
+                            "The species that this person belongs to, or null if unknown.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "Species",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "starshipConnection",
+                        description: None,
+                        args: [
+                            InputValue {
+                                name: "after",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "String",
+                                },
+                                default_value: None,
+                            },
+                            InputValue {
+                                name: "first",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "Int",
+                                },
+                                default_value: None,
+                            },
+                            InputValue {
+                                name: "before",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "String",
+                                },
+                                default_value: None,
+                            },
+                            InputValue {
+                                name: "last",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "Int",
+                                },
+                                default_value: None,
+                            },
+                        ],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "PersonStarshipsConnection",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "vehicleConnection",
+                        description: None,
+                        args: [
+                            InputValue {
+                                name: "after",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "String",
+                                },
+                                default_value: None,
+                            },
+                            InputValue {
+                                name: "first",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "Int",
+                                },
+                                default_value: None,
+                            },
+                            InputValue {
+                                name: "before",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "String",
+                                },
+                                default_value: None,
+                            },
+                            InputValue {
+                                name: "last",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "Int",
+                                },
+                                default_value: None,
+                            },
+                        ],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "PersonVehiclesConnection",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "created",
+                        description: Some(
+                            "The ISO 8601 date format of the time that this resource was created.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "edited",
+                        description: Some(
+                            "The ISO 8601 date format of the time that this resource was edited.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "id",
+                        description: Some(
+                            "The ID of an object",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [NonNull],
+                            name: "ID",
+                        },
+                        deprecated: No,
+                    },
+                ],
+                interfaces: [
+                    "Node",
+                ],
+            },
+        ),
+        Object(
+            ObjectType {
+                name: "PersonFilmsConnection",
+                description: Some(
+                    "A connection to a list of items.",
+                ),
+                fields: [
+                    Field {
+                        name: "pageInfo",
+                        description: Some(
+                            "Information to aid in pagination.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [NonNull],
+                            name: "PageInfo",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "edges",
+                        description: Some(
+                            "A list of edges.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [List],
+                            name: "PersonFilmsEdge",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "totalCount",
+                        description: Some(
+                            "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "Int",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "films",
+                        description: Some(
+                            "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [List],
+                            name: "Film",
+                        },
+                        deprecated: No,
+                    },
+                ],
+                interfaces: [],
+            },
+        ),
+        Object(
+            ObjectType {
+                name: "PersonFilmsEdge",
+                description: Some(
+                    "An edge in a connection.",
+                ),
+                fields: [
+                    Field {
+                        name: "node",
+                        description: Some(
+                            "The item at the end of the edge",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "Film",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "cursor",
+                        description: Some(
+                            "A cursor for use in pagination",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [NonNull],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                ],
+                interfaces: [],
+            },
+        ),
+        Object(
+            ObjectType {
+                name: "PersonStarshipsConnection",
+                description: Some(
+                    "A connection to a list of items.",
+                ),
+                fields: [
+                    Field {
+                        name: "pageInfo",
+                        description: Some(
+                            "Information to aid in pagination.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [NonNull],
+                            name: "PageInfo",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "edges",
+                        description: Some(
+                            "A list of edges.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [List],
+                            name: "PersonStarshipsEdge",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "totalCount",
+                        description: Some(
+                            "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "Int",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "starships",
+                        description: Some(
+                            "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [List],
+                            name: "Starship",
+                        },
+                        deprecated: No,
+                    },
+                ],
+                interfaces: [],
+            },
+        ),
+        Object(
+            ObjectType {
+                name: "PersonStarshipsEdge",
+                description: Some(
+                    "An edge in a connection.",
+                ),
+                fields: [
+                    Field {
+                        name: "node",
+                        description: Some(
+                            "The item at the end of the edge",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "Starship",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "cursor",
+                        description: Some(
+                            "A cursor for use in pagination",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [NonNull],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                ],
+                interfaces: [],
+            },
+        ),
+        Object(
+            ObjectType {
+                name: "Starship",
+                description: Some(
+                    "A single transport craft that has hyperdrive capability.",
+                ),
+                fields: [
+                    Field {
+                        name: "name",
+                        description: Some(
+                            "The name of this starship. The common name, such as \"Death Star\".",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "model",
+                        description: Some(
+                            "The model or official name of this starship. Such as \"T-65 X-wing\" or \"DS-1\nOrbital Battle Station\".",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "starshipClass",
+                        description: Some(
+                            "The class of this starship, such as \"Starfighter\" or \"Deep Space Mobile\nBattlestation\"",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "manufacturers",
+                        description: Some(
+                            "The manufacturers of this starship.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [List],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "costInCredits",
+                        description: Some(
+                            "The cost of this starship new, in galactic credits.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "Float",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "length",
+                        description: Some(
+                            "The length of this starship in meters.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "Float",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "crew",
+                        description: Some(
+                            "The number of personnel needed to run or pilot this starship.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "passengers",
+                        description: Some(
+                            "The number of non-essential people this starship can transport.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "maxAtmospheringSpeed",
+                        description: Some(
+                            "The maximum speed of this starship in atmosphere. null if this starship is\nincapable of atmosphering flight.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "Int",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "hyperdriveRating",
+                        description: Some(
+                            "The class of this starships hyperdrive.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "Float",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "MGLT",
+                        description: Some(
+                            "The Maximum number of Megalights this starship can travel in a standard hour.\nA \"Megalight\" is a standard unit of distance and has never been defined before\nwithin the Star Wars universe. This figure is only really useful for measuring\nthe difference in speed of starships. We can assume it is similar to AU, the\ndistance between our Sun (Sol) and Earth.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "Int",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "cargoCapacity",
+                        description: Some(
+                            "The maximum number of kilograms that this starship can transport.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "Float",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "consumables",
+                        description: Some(
+                            "The maximum length of time that this starship can provide consumables for its\nentire crew without having to resupply.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "pilotConnection",
+                        description: None,
+                        args: [
+                            InputValue {
+                                name: "after",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "String",
+                                },
+                                default_value: None,
+                            },
+                            InputValue {
+                                name: "first",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "Int",
+                                },
+                                default_value: None,
+                            },
+                            InputValue {
+                                name: "before",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "String",
+                                },
+                                default_value: None,
+                            },
+                            InputValue {
+                                name: "last",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "Int",
+                                },
+                                default_value: None,
+                            },
+                        ],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "StarshipPilotsConnection",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "filmConnection",
+                        description: None,
+                        args: [
+                            InputValue {
+                                name: "after",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "String",
+                                },
+                                default_value: None,
+                            },
+                            InputValue {
+                                name: "first",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "Int",
+                                },
+                                default_value: None,
+                            },
+                            InputValue {
+                                name: "before",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "String",
+                                },
+                                default_value: None,
+                            },
+                            InputValue {
+                                name: "last",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "Int",
+                                },
+                                default_value: None,
+                            },
+                        ],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "StarshipFilmsConnection",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "created",
+                        description: Some(
+                            "The ISO 8601 date format of the time that this resource was created.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "edited",
+                        description: Some(
+                            "The ISO 8601 date format of the time that this resource was edited.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "id",
+                        description: Some(
+                            "The ID of an object",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [NonNull],
+                            name: "ID",
+                        },
+                        deprecated: No,
+                    },
+                ],
+                interfaces: [
+                    "Node",
+                ],
+            },
+        ),
+        Object(
+            ObjectType {
+                name: "StarshipPilotsConnection",
+                description: Some(
+                    "A connection to a list of items.",
+                ),
+                fields: [
+                    Field {
+                        name: "pageInfo",
+                        description: Some(
+                            "Information to aid in pagination.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [NonNull],
+                            name: "PageInfo",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "edges",
+                        description: Some(
+                            "A list of edges.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [List],
+                            name: "StarshipPilotsEdge",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "totalCount",
+                        description: Some(
+                            "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "Int",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "pilots",
+                        description: Some(
+                            "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [List],
+                            name: "Person",
+                        },
+                        deprecated: No,
+                    },
+                ],
+                interfaces: [],
+            },
+        ),
+        Object(
+            ObjectType {
+                name: "StarshipPilotsEdge",
+                description: Some(
+                    "An edge in a connection.",
+                ),
+                fields: [
+                    Field {
+                        name: "node",
+                        description: Some(
+                            "The item at the end of the edge",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "Person",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "cursor",
+                        description: Some(
+                            "A cursor for use in pagination",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [NonNull],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                ],
+                interfaces: [],
+            },
+        ),
+        Object(
+            ObjectType {
+                name: "StarshipFilmsConnection",
+                description: Some(
+                    "A connection to a list of items.",
+                ),
+                fields: [
+                    Field {
+                        name: "pageInfo",
+                        description: Some(
+                            "Information to aid in pagination.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [NonNull],
+                            name: "PageInfo",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "edges",
+                        description: Some(
+                            "A list of edges.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [List],
+                            name: "StarshipFilmsEdge",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "totalCount",
+                        description: Some(
+                            "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "Int",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "films",
+                        description: Some(
+                            "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [List],
+                            name: "Film",
+                        },
+                        deprecated: No,
+                    },
+                ],
+                interfaces: [],
+            },
+        ),
+        Object(
+            ObjectType {
+                name: "StarshipFilmsEdge",
+                description: Some(
+                    "An edge in a connection.",
+                ),
+                fields: [
+                    Field {
+                        name: "node",
+                        description: Some(
+                            "The item at the end of the edge",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "Film",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "cursor",
+                        description: Some(
+                            "A cursor for use in pagination",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [NonNull],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                ],
+                interfaces: [],
+            },
+        ),
+        Object(
+            ObjectType {
+                name: "PersonVehiclesConnection",
+                description: Some(
+                    "A connection to a list of items.",
+                ),
+                fields: [
+                    Field {
+                        name: "pageInfo",
+                        description: Some(
+                            "Information to aid in pagination.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [NonNull],
+                            name: "PageInfo",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "edges",
+                        description: Some(
+                            "A list of edges.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [List],
+                            name: "PersonVehiclesEdge",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "totalCount",
+                        description: Some(
+                            "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "Int",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "vehicles",
+                        description: Some(
+                            "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [List],
+                            name: "Vehicle",
+                        },
+                        deprecated: No,
+                    },
+                ],
+                interfaces: [],
+            },
+        ),
+        Object(
+            ObjectType {
+                name: "PersonVehiclesEdge",
+                description: Some(
+                    "An edge in a connection.",
+                ),
+                fields: [
+                    Field {
+                        name: "node",
+                        description: Some(
+                            "The item at the end of the edge",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "Vehicle",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "cursor",
+                        description: Some(
+                            "A cursor for use in pagination",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [NonNull],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                ],
+                interfaces: [],
+            },
+        ),
+        Object(
+            ObjectType {
+                name: "Vehicle",
+                description: Some(
+                    "A single transport craft that does not have hyperdrive capability",
+                ),
+                fields: [
+                    Field {
+                        name: "name",
+                        description: Some(
+                            "The name of this vehicle. The common name, such as \"Sand Crawler\" or \"Speeder\nbike\".",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "model",
+                        description: Some(
+                            "The model or official name of this vehicle. Such as \"All-Terrain Attack\nTransport\".",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "vehicleClass",
+                        description: Some(
+                            "The class of this vehicle, such as \"Wheeled\" or \"Repulsorcraft\".",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "manufacturers",
+                        description: Some(
+                            "The manufacturers of this vehicle.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [List],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "costInCredits",
+                        description: Some(
+                            "The cost of this vehicle new, in Galactic Credits.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "Float",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "length",
+                        description: Some(
+                            "The length of this vehicle in meters.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "Float",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "crew",
+                        description: Some(
+                            "The number of personnel needed to run or pilot this vehicle.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "passengers",
+                        description: Some(
+                            "The number of non-essential people this vehicle can transport.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "maxAtmospheringSpeed",
+                        description: Some(
+                            "The maximum speed of this vehicle in atmosphere.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "Int",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "cargoCapacity",
+                        description: Some(
+                            "The maximum number of kilograms that this vehicle can transport.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "Float",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "consumables",
+                        description: Some(
+                            "The maximum length of time that this vehicle can provide consumables for its\nentire crew without having to resupply.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "pilotConnection",
+                        description: None,
+                        args: [
+                            InputValue {
+                                name: "after",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "String",
+                                },
+                                default_value: None,
+                            },
+                            InputValue {
+                                name: "first",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "Int",
+                                },
+                                default_value: None,
+                            },
+                            InputValue {
+                                name: "before",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "String",
+                                },
+                                default_value: None,
+                            },
+                            InputValue {
+                                name: "last",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "Int",
+                                },
+                                default_value: None,
+                            },
+                        ],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "VehiclePilotsConnection",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "filmConnection",
+                        description: None,
+                        args: [
+                            InputValue {
+                                name: "after",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "String",
+                                },
+                                default_value: None,
+                            },
+                            InputValue {
+                                name: "first",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "Int",
+                                },
+                                default_value: None,
+                            },
+                            InputValue {
+                                name: "before",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "String",
+                                },
+                                default_value: None,
+                            },
+                            InputValue {
+                                name: "last",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "Int",
+                                },
+                                default_value: None,
+                            },
+                        ],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "VehicleFilmsConnection",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "created",
+                        description: Some(
+                            "The ISO 8601 date format of the time that this resource was created.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "edited",
+                        description: Some(
+                            "The ISO 8601 date format of the time that this resource was edited.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "id",
+                        description: Some(
+                            "The ID of an object",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [NonNull],
+                            name: "ID",
+                        },
+                        deprecated: No,
+                    },
+                ],
+                interfaces: [
+                    "Node",
+                ],
+            },
+        ),
+        Object(
+            ObjectType {
+                name: "VehiclePilotsConnection",
+                description: Some(
+                    "A connection to a list of items.",
+                ),
+                fields: [
+                    Field {
+                        name: "pageInfo",
+                        description: Some(
+                            "Information to aid in pagination.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [NonNull],
+                            name: "PageInfo",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "edges",
+                        description: Some(
+                            "A list of edges.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [List],
+                            name: "VehiclePilotsEdge",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "totalCount",
+                        description: Some(
+                            "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "Int",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "pilots",
+                        description: Some(
+                            "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [List],
+                            name: "Person",
+                        },
+                        deprecated: No,
+                    },
+                ],
+                interfaces: [],
+            },
+        ),
+        Object(
+            ObjectType {
+                name: "VehiclePilotsEdge",
+                description: Some(
+                    "An edge in a connection.",
+                ),
+                fields: [
+                    Field {
+                        name: "node",
+                        description: Some(
+                            "The item at the end of the edge",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "Person",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "cursor",
+                        description: Some(
+                            "A cursor for use in pagination",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [NonNull],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                ],
+                interfaces: [],
+            },
+        ),
+        Object(
+            ObjectType {
+                name: "VehicleFilmsConnection",
+                description: Some(
+                    "A connection to a list of items.",
+                ),
+                fields: [
+                    Field {
+                        name: "pageInfo",
+                        description: Some(
+                            "Information to aid in pagination.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [NonNull],
+                            name: "PageInfo",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "edges",
+                        description: Some(
+                            "A list of edges.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [List],
+                            name: "VehicleFilmsEdge",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "totalCount",
+                        description: Some(
+                            "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "Int",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "films",
+                        description: Some(
+                            "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [List],
+                            name: "Film",
+                        },
+                        deprecated: No,
+                    },
+                ],
+                interfaces: [],
+            },
+        ),
+        Object(
+            ObjectType {
+                name: "VehicleFilmsEdge",
+                description: Some(
+                    "An edge in a connection.",
+                ),
+                fields: [
+                    Field {
+                        name: "node",
+                        description: Some(
+                            "The item at the end of the edge",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "Film",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "cursor",
+                        description: Some(
+                            "A cursor for use in pagination",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [NonNull],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                ],
+                interfaces: [],
+            },
+        ),
+        Object(
+            ObjectType {
+                name: "PlanetFilmsConnection",
+                description: Some(
+                    "A connection to a list of items.",
+                ),
+                fields: [
+                    Field {
+                        name: "pageInfo",
+                        description: Some(
+                            "Information to aid in pagination.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [NonNull],
+                            name: "PageInfo",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "edges",
+                        description: Some(
+                            "A list of edges.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [List],
+                            name: "PlanetFilmsEdge",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "totalCount",
+                        description: Some(
+                            "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "Int",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "films",
+                        description: Some(
+                            "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [List],
+                            name: "Film",
+                        },
+                        deprecated: No,
+                    },
+                ],
+                interfaces: [],
+            },
+        ),
+        Object(
+            ObjectType {
+                name: "PlanetFilmsEdge",
+                description: Some(
+                    "An edge in a connection.",
+                ),
+                fields: [
+                    Field {
+                        name: "node",
+                        description: Some(
+                            "The item at the end of the edge",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "Film",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "cursor",
+                        description: Some(
+                            "A cursor for use in pagination",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [NonNull],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                ],
+                interfaces: [],
+            },
+        ),
+        Object(
+            ObjectType {
+                name: "SpeciesPeopleConnection",
+                description: Some(
+                    "A connection to a list of items.",
+                ),
+                fields: [
+                    Field {
+                        name: "pageInfo",
+                        description: Some(
+                            "Information to aid in pagination.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [NonNull],
+                            name: "PageInfo",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "edges",
+                        description: Some(
+                            "A list of edges.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [List],
+                            name: "SpeciesPeopleEdge",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "totalCount",
+                        description: Some(
+                            "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "Int",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "people",
+                        description: Some(
+                            "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [List],
+                            name: "Person",
+                        },
+                        deprecated: No,
+                    },
+                ],
+                interfaces: [],
+            },
+        ),
+        Object(
+            ObjectType {
+                name: "SpeciesPeopleEdge",
+                description: Some(
+                    "An edge in a connection.",
+                ),
+                fields: [
+                    Field {
+                        name: "node",
+                        description: Some(
+                            "The item at the end of the edge",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "Person",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "cursor",
+                        description: Some(
+                            "A cursor for use in pagination",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [NonNull],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                ],
+                interfaces: [],
+            },
+        ),
+        Object(
+            ObjectType {
+                name: "SpeciesFilmsConnection",
+                description: Some(
+                    "A connection to a list of items.",
+                ),
+                fields: [
+                    Field {
+                        name: "pageInfo",
+                        description: Some(
+                            "Information to aid in pagination.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [NonNull],
+                            name: "PageInfo",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "edges",
+                        description: Some(
+                            "A list of edges.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [List],
+                            name: "SpeciesFilmsEdge",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "totalCount",
+                        description: Some(
+                            "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "Int",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "films",
+                        description: Some(
+                            "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [List],
+                            name: "Film",
+                        },
+                        deprecated: No,
+                    },
+                ],
+                interfaces: [],
+            },
+        ),
+        Object(
+            ObjectType {
+                name: "SpeciesFilmsEdge",
+                description: Some(
+                    "An edge in a connection.",
+                ),
+                fields: [
+                    Field {
+                        name: "node",
+                        description: Some(
+                            "The item at the end of the edge",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "Film",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "cursor",
+                        description: Some(
+                            "A cursor for use in pagination",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [NonNull],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                ],
+                interfaces: [],
+            },
+        ),
+        Object(
+            ObjectType {
+                name: "FilmStarshipsConnection",
+                description: Some(
+                    "A connection to a list of items.",
+                ),
+                fields: [
+                    Field {
+                        name: "pageInfo",
+                        description: Some(
+                            "Information to aid in pagination.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [NonNull],
+                            name: "PageInfo",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "edges",
+                        description: Some(
+                            "A list of edges.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [List],
+                            name: "FilmStarshipsEdge",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "totalCount",
+                        description: Some(
+                            "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "Int",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "starships",
+                        description: Some(
+                            "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [List],
+                            name: "Starship",
+                        },
+                        deprecated: No,
+                    },
+                ],
+                interfaces: [],
+            },
+        ),
+        Object(
+            ObjectType {
+                name: "FilmStarshipsEdge",
+                description: Some(
+                    "An edge in a connection.",
+                ),
+                fields: [
+                    Field {
+                        name: "node",
+                        description: Some(
+                            "The item at the end of the edge",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "Starship",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "cursor",
+                        description: Some(
+                            "A cursor for use in pagination",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [NonNull],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                ],
+                interfaces: [],
+            },
+        ),
+        Object(
+            ObjectType {
+                name: "FilmVehiclesConnection",
+                description: Some(
+                    "A connection to a list of items.",
+                ),
+                fields: [
+                    Field {
+                        name: "pageInfo",
+                        description: Some(
+                            "Information to aid in pagination.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [NonNull],
+                            name: "PageInfo",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "edges",
+                        description: Some(
+                            "A list of edges.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [List],
+                            name: "FilmVehiclesEdge",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "totalCount",
+                        description: Some(
+                            "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "Int",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "vehicles",
+                        description: Some(
+                            "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [List],
+                            name: "Vehicle",
+                        },
+                        deprecated: No,
+                    },
+                ],
+                interfaces: [],
+            },
+        ),
+        Object(
+            ObjectType {
+                name: "FilmVehiclesEdge",
+                description: Some(
+                    "An edge in a connection.",
+                ),
+                fields: [
+                    Field {
+                        name: "node",
+                        description: Some(
+                            "The item at the end of the edge",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "Vehicle",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "cursor",
+                        description: Some(
+                            "A cursor for use in pagination",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [NonNull],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                ],
+                interfaces: [],
+            },
+        ),
+        Object(
+            ObjectType {
+                name: "FilmCharactersConnection",
+                description: Some(
+                    "A connection to a list of items.",
+                ),
+                fields: [
+                    Field {
+                        name: "pageInfo",
+                        description: Some(
+                            "Information to aid in pagination.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [NonNull],
+                            name: "PageInfo",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "edges",
+                        description: Some(
+                            "A list of edges.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [List],
+                            name: "FilmCharactersEdge",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "totalCount",
+                        description: Some(
+                            "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "Int",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "characters",
+                        description: Some(
+                            "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [List],
+                            name: "Person",
+                        },
+                        deprecated: No,
+                    },
+                ],
+                interfaces: [],
+            },
+        ),
+        Object(
+            ObjectType {
+                name: "FilmCharactersEdge",
+                description: Some(
+                    "An edge in a connection.",
+                ),
+                fields: [
+                    Field {
+                        name: "node",
+                        description: Some(
+                            "The item at the end of the edge",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "Person",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "cursor",
+                        description: Some(
+                            "A cursor for use in pagination",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [NonNull],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                ],
+                interfaces: [],
+            },
+        ),
+        Object(
+            ObjectType {
+                name: "FilmPlanetsConnection",
+                description: Some(
+                    "A connection to a list of items.",
+                ),
+                fields: [
+                    Field {
+                        name: "pageInfo",
+                        description: Some(
+                            "Information to aid in pagination.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [NonNull],
+                            name: "PageInfo",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "edges",
+                        description: Some(
+                            "A list of edges.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [List],
+                            name: "FilmPlanetsEdge",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "totalCount",
+                        description: Some(
+                            "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "Int",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "planets",
+                        description: Some(
+                            "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [List],
+                            name: "Planet",
+                        },
+                        deprecated: No,
+                    },
+                ],
+                interfaces: [],
+            },
+        ),
+        Object(
+            ObjectType {
+                name: "FilmPlanetsEdge",
+                description: Some(
+                    "An edge in a connection.",
+                ),
+                fields: [
+                    Field {
+                        name: "node",
+                        description: Some(
+                            "The item at the end of the edge",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "Planet",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "cursor",
+                        description: Some(
+                            "A cursor for use in pagination",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [NonNull],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                ],
+                interfaces: [],
+            },
+        ),
+        Object(
+            ObjectType {
+                name: "PeopleConnection",
+                description: Some(
+                    "A connection to a list of items.",
+                ),
+                fields: [
+                    Field {
+                        name: "pageInfo",
+                        description: Some(
+                            "Information to aid in pagination.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [NonNull],
+                            name: "PageInfo",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "edges",
+                        description: Some(
+                            "A list of edges.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [List],
+                            name: "PeopleEdge",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "totalCount",
+                        description: Some(
+                            "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "Int",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "people",
+                        description: Some(
+                            "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [List],
+                            name: "Person",
+                        },
+                        deprecated: No,
+                    },
+                ],
+                interfaces: [],
+            },
+        ),
+        Object(
+            ObjectType {
+                name: "PeopleEdge",
+                description: Some(
+                    "An edge in a connection.",
+                ),
+                fields: [
+                    Field {
+                        name: "node",
+                        description: Some(
+                            "The item at the end of the edge",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "Person",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "cursor",
+                        description: Some(
+                            "A cursor for use in pagination",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [NonNull],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                ],
+                interfaces: [],
+            },
+        ),
+        Object(
+            ObjectType {
+                name: "PlanetsConnection",
+                description: Some(
+                    "A connection to a list of items.",
+                ),
+                fields: [
+                    Field {
+                        name: "pageInfo",
+                        description: Some(
+                            "Information to aid in pagination.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [NonNull],
+                            name: "PageInfo",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "edges",
+                        description: Some(
+                            "A list of edges.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [List],
+                            name: "PlanetsEdge",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "totalCount",
+                        description: Some(
+                            "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "Int",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "planets",
+                        description: Some(
+                            "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [List],
+                            name: "Planet",
+                        },
+                        deprecated: No,
+                    },
+                ],
+                interfaces: [],
+            },
+        ),
+        Object(
+            ObjectType {
+                name: "PlanetsEdge",
+                description: Some(
+                    "An edge in a connection.",
+                ),
+                fields: [
+                    Field {
+                        name: "node",
+                        description: Some(
+                            "The item at the end of the edge",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "Planet",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "cursor",
+                        description: Some(
+                            "A cursor for use in pagination",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [NonNull],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                ],
+                interfaces: [],
+            },
+        ),
+        Object(
+            ObjectType {
+                name: "SpeciesConnection",
+                description: Some(
+                    "A connection to a list of items.",
+                ),
+                fields: [
+                    Field {
+                        name: "pageInfo",
+                        description: Some(
+                            "Information to aid in pagination.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [NonNull],
+                            name: "PageInfo",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "edges",
+                        description: Some(
+                            "A list of edges.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [List],
+                            name: "SpeciesEdge",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "totalCount",
+                        description: Some(
+                            "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "Int",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "species",
+                        description: Some(
+                            "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [List],
+                            name: "Species",
+                        },
+                        deprecated: No,
+                    },
+                ],
+                interfaces: [],
+            },
+        ),
+        Object(
+            ObjectType {
+                name: "SpeciesEdge",
+                description: Some(
+                    "An edge in a connection.",
+                ),
+                fields: [
+                    Field {
+                        name: "node",
+                        description: Some(
+                            "The item at the end of the edge",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "Species",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "cursor",
+                        description: Some(
+                            "A cursor for use in pagination",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [NonNull],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                ],
+                interfaces: [],
+            },
+        ),
+        Object(
+            ObjectType {
+                name: "StarshipsConnection",
+                description: Some(
+                    "A connection to a list of items.",
+                ),
+                fields: [
+                    Field {
+                        name: "pageInfo",
+                        description: Some(
+                            "Information to aid in pagination.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [NonNull],
+                            name: "PageInfo",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "edges",
+                        description: Some(
+                            "A list of edges.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [List],
+                            name: "StarshipsEdge",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "totalCount",
+                        description: Some(
+                            "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "Int",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "starships",
+                        description: Some(
+                            "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [List],
+                            name: "Starship",
+                        },
+                        deprecated: No,
+                    },
+                ],
+                interfaces: [],
+            },
+        ),
+        Object(
+            ObjectType {
+                name: "StarshipsEdge",
+                description: Some(
+                    "An edge in a connection.",
+                ),
+                fields: [
+                    Field {
+                        name: "node",
+                        description: Some(
+                            "The item at the end of the edge",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "Starship",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "cursor",
+                        description: Some(
+                            "A cursor for use in pagination",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [NonNull],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                ],
+                interfaces: [],
+            },
+        ),
+        Object(
+            ObjectType {
+                name: "VehiclesConnection",
+                description: Some(
+                    "A connection to a list of items.",
+                ),
+                fields: [
+                    Field {
+                        name: "pageInfo",
+                        description: Some(
+                            "Information to aid in pagination.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [NonNull],
+                            name: "PageInfo",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "edges",
+                        description: Some(
+                            "A list of edges.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [List],
+                            name: "VehiclesEdge",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "totalCount",
+                        description: Some(
+                            "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "Int",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "vehicles",
+                        description: Some(
+                            "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [List],
+                            name: "Vehicle",
+                        },
+                        deprecated: No,
+                    },
+                ],
+                interfaces: [],
+            },
+        ),
+        Object(
+            ObjectType {
+                name: "VehiclesEdge",
+                description: Some(
+                    "An edge in a connection.",
+                ),
+                fields: [
+                    Field {
+                        name: "node",
+                        description: Some(
+                            "The item at the end of the edge",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "Vehicle",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "cursor",
+                        description: Some(
+                            "A cursor for use in pagination",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [NonNull],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                ],
+                interfaces: [],
+            },
+        ),
+        Object(
+            ObjectType {
+                name: "__Schema",
+                description: Some(
+                    "A GraphQL Schema defines the capabilities of a GraphQL server. It exposes all available types and directives on the server, as well as the entry points for query, mutation, and subscription operations.",
+                ),
+                fields: [
+                    Field {
+                        name: "types",
+                        description: Some(
+                            "A list of all types supported by this server.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [NonNull, List, NonNull],
+                            name: "__Type",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "queryType",
+                        description: Some(
+                            "The type that query operations will be rooted at.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [NonNull],
+                            name: "__Type",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "mutationType",
+                        description: Some(
+                            "If this server supports mutation, the type that mutation operations will be rooted at.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "__Type",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "subscriptionType",
+                        description: Some(
+                            "If this server support subscription, the type that subscription operations will be rooted at.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "__Type",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "directives",
+                        description: Some(
+                            "A list of all directives supported by this server.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [NonNull, List, NonNull],
+                            name: "__Directive",
+                        },
+                        deprecated: No,
+                    },
+                ],
+                interfaces: [],
+            },
+        ),
+        Object(
+            ObjectType {
+                name: "__Type",
+                description: Some(
+                    "The fundamental unit of any GraphQL Schema is the type. There are many kinds of types in GraphQL as represented by the `__TypeKind` enum.\n\nDepending on the kind of a type, certain fields describe information about that type. Scalar types provide no information beyond a name and description, while Enum types provide their values. Object and Interface types provide the fields they describe. Abstract types, Union and Interface, provide the Object types possible at runtime. List and NonNull types compose other types.",
+                ),
+                fields: [
+                    Field {
+                        name: "kind",
+                        description: None,
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [NonNull],
+                            name: "__TypeKind",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "name",
+                        description: None,
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "description",
+                        description: None,
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "fields",
+                        description: None,
+                        args: [
+                            InputValue {
+                                name: "includeDeprecated",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "Boolean",
+                                },
+                                default_value: Some(
+                                    "false",
+                                ),
+                            },
+                        ],
+                        ty: FieldType {
+                            wrapping: [List, NonNull],
+                            name: "__Field",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "interfaces",
+                        description: None,
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [List, NonNull],
+                            name: "__Type",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "possibleTypes",
+                        description: None,
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [List, NonNull],
+                            name: "__Type",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "enumValues",
+                        description: None,
+                        args: [
+                            InputValue {
+                                name: "includeDeprecated",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "Boolean",
+                                },
+                                default_value: Some(
+                                    "false",
+                                ),
+                            },
+                        ],
+                        ty: FieldType {
+                            wrapping: [List, NonNull],
+                            name: "__EnumValue",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "inputFields",
+                        description: None,
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [List, NonNull],
+                            name: "__InputValue",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "ofType",
+                        description: None,
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "__Type",
+                        },
+                        deprecated: No,
+                    },
+                ],
+                interfaces: [],
+            },
+        ),
+        Enum(
+            EnumType {
+                name: "__TypeKind",
+                description: Some(
+                    "An enum describing what kind of type a given `__Type` is.",
+                ),
+                values: [
+                    EnumValue {
+                        name: "SCALAR",
+                        description: Some(
+                            "Indicates this type is a scalar.",
+                        ),
+                        deprecated: No,
+                    },
+                    EnumValue {
+                        name: "OBJECT",
+                        description: Some(
+                            "Indicates this type is an object. `fields` and `interfaces` are valid fields.",
+                        ),
+                        deprecated: No,
+                    },
+                    EnumValue {
+                        name: "INTERFACE",
+                        description: Some(
+                            "Indicates this type is an interface. `fields` and `possibleTypes` are valid fields.",
+                        ),
+                        deprecated: No,
+                    },
+                    EnumValue {
+                        name: "UNION",
+                        description: Some(
+                            "Indicates this type is a union. `possibleTypes` is a valid field.",
+                        ),
+                        deprecated: No,
+                    },
+                    EnumValue {
+                        name: "ENUM",
+                        description: Some(
+                            "Indicates this type is an enum. `enumValues` is a valid field.",
+                        ),
+                        deprecated: No,
+                    },
+                    EnumValue {
+                        name: "INPUT_OBJECT",
+                        description: Some(
+                            "Indicates this type is an input object. `inputFields` is a valid field.",
+                        ),
+                        deprecated: No,
+                    },
+                    EnumValue {
+                        name: "LIST",
+                        description: Some(
+                            "Indicates this type is a list. `ofType` is a valid field.",
+                        ),
+                        deprecated: No,
+                    },
+                    EnumValue {
+                        name: "NON_NULL",
+                        description: Some(
+                            "Indicates this type is a non-null. `ofType` is a valid field.",
+                        ),
+                        deprecated: No,
+                    },
+                ],
+            },
+        ),
+        Object(
+            ObjectType {
+                name: "__Field",
+                description: Some(
+                    "Object and Interface types are described by a list of Fields, each of which has a name, potentially a list of arguments, and a return type.",
+                ),
+                fields: [
+                    Field {
+                        name: "name",
+                        description: None,
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [NonNull],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "description",
+                        description: None,
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "args",
+                        description: None,
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [NonNull, List, NonNull],
+                            name: "__InputValue",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "type",
+                        description: None,
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [NonNull],
+                            name: "__Type",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "isDeprecated",
+                        description: None,
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [NonNull],
+                            name: "Boolean",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "deprecationReason",
+                        description: None,
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                ],
+                interfaces: [],
+            },
+        ),
+        Object(
+            ObjectType {
+                name: "__InputValue",
+                description: Some(
+                    "Arguments provided to Fields or Directives and the input fields of an InputObject are represented as Input Values which describe their type and optionally a default value.",
+                ),
+                fields: [
+                    Field {
+                        name: "name",
+                        description: None,
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [NonNull],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "description",
+                        description: None,
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "type",
+                        description: None,
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [NonNull],
+                            name: "__Type",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "defaultValue",
+                        description: Some(
+                            "A GraphQL-formatted string representing the default value for this input value.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                ],
+                interfaces: [],
+            },
+        ),
+        Object(
+            ObjectType {
+                name: "__EnumValue",
+                description: Some(
+                    "One possible value for a given Enum. Enum values are unique values, not a placeholder for a string or numeric value. However an Enum value is returned in a JSON response as a string.",
+                ),
+                fields: [
+                    Field {
+                        name: "name",
+                        description: None,
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [NonNull],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "description",
+                        description: None,
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "isDeprecated",
+                        description: None,
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [NonNull],
+                            name: "Boolean",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "deprecationReason",
+                        description: None,
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                ],
+                interfaces: [],
+            },
+        ),
+        Object(
+            ObjectType {
+                name: "__Directive",
+                description: Some(
+                    "A Directive provides a way to describe alternate runtime execution and type validation behavior in a GraphQL document.\n\nIn some cases, you need to provide options to alter GraphQL's execution behavior in ways field arguments will not suffice, such as conditionally including or skipping a field. Directives provide this by describing additional information to the executor.",
+                ),
+                fields: [
+                    Field {
+                        name: "name",
+                        description: None,
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [NonNull],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "description",
+                        description: None,
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "locations",
+                        description: None,
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [NonNull, List, NonNull],
+                            name: "__DirectiveLocation",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "args",
+                        description: None,
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [NonNull, List, NonNull],
+                            name: "__InputValue",
+                        },
+                        deprecated: No,
+                    },
+                ],
+                interfaces: [],
+            },
+        ),
+        Enum(
+            EnumType {
+                name: "__DirectiveLocation",
+                description: Some(
+                    "A Directive can be adjacent to many parts of the GraphQL language, a __DirectiveLocation describes one such possible adjacencies.",
+                ),
+                values: [
+                    EnumValue {
+                        name: "QUERY",
+                        description: Some(
+                            "Location adjacent to a query operation.",
+                        ),
+                        deprecated: No,
+                    },
+                    EnumValue {
+                        name: "MUTATION",
+                        description: Some(
+                            "Location adjacent to a mutation operation.",
+                        ),
+                        deprecated: No,
+                    },
+                    EnumValue {
+                        name: "SUBSCRIPTION",
+                        description: Some(
+                            "Location adjacent to a subscription operation.",
+                        ),
+                        deprecated: No,
+                    },
+                    EnumValue {
+                        name: "FIELD",
+                        description: Some(
+                            "Location adjacent to a field.",
+                        ),
+                        deprecated: No,
+                    },
+                    EnumValue {
+                        name: "FRAGMENT_DEFINITION",
+                        description: Some(
+                            "Location adjacent to a fragment definition.",
+                        ),
+                        deprecated: No,
+                    },
+                    EnumValue {
+                        name: "FRAGMENT_SPREAD",
+                        description: Some(
+                            "Location adjacent to a fragment spread.",
+                        ),
+                        deprecated: No,
+                    },
+                    EnumValue {
+                        name: "INLINE_FRAGMENT",
+                        description: Some(
+                            "Location adjacent to an inline fragment.",
+                        ),
+                        deprecated: No,
+                    },
+                    EnumValue {
+                        name: "VARIABLE_DEFINITION",
+                        description: Some(
+                            "Location adjacent to a variable definition.",
+                        ),
+                        deprecated: No,
+                    },
+                    EnumValue {
+                        name: "SCHEMA",
+                        description: Some(
+                            "Location adjacent to a schema definition.",
+                        ),
+                        deprecated: No,
+                    },
+                    EnumValue {
+                        name: "SCALAR",
+                        description: Some(
+                            "Location adjacent to a scalar definition.",
+                        ),
+                        deprecated: No,
+                    },
+                    EnumValue {
+                        name: "OBJECT",
+                        description: Some(
+                            "Location adjacent to an object type definition.",
+                        ),
+                        deprecated: No,
+                    },
+                    EnumValue {
+                        name: "FIELD_DEFINITION",
+                        description: Some(
+                            "Location adjacent to a field definition.",
+                        ),
+                        deprecated: No,
+                    },
+                    EnumValue {
+                        name: "ARGUMENT_DEFINITION",
+                        description: Some(
+                            "Location adjacent to an argument definition.",
+                        ),
+                        deprecated: No,
+                    },
+                    EnumValue {
+                        name: "INTERFACE",
+                        description: Some(
+                            "Location adjacent to an interface definition.",
+                        ),
+                        deprecated: No,
+                    },
+                    EnumValue {
+                        name: "UNION",
+                        description: Some(
+                            "Location adjacent to a union definition.",
+                        ),
+                        deprecated: No,
+                    },
+                    EnumValue {
+                        name: "ENUM",
+                        description: Some(
+                            "Location adjacent to an enum definition.",
+                        ),
+                        deprecated: No,
+                    },
+                    EnumValue {
+                        name: "ENUM_VALUE",
+                        description: Some(
+                            "Location adjacent to an enum value definition.",
+                        ),
+                        deprecated: No,
+                    },
+                    EnumValue {
+                        name: "INPUT_OBJECT",
+                        description: Some(
+                            "Location adjacent to an input object type definition.",
+                        ),
+                        deprecated: No,
+                    },
+                    EnumValue {
+                        name: "INPUT_FIELD_DEFINITION",
+                        description: Some(
+                            "Location adjacent to an input object field definition.",
+                        ),
+                        deprecated: No,
+                    },
+                ],
+            },
+        ),
+    ],
+    directives: [
+        Directive {
+            name: "include",
+            description: Some(
+                "Directs the executor to include this field or fragment only when the `if` argument is true.",
+            ),
+            args: [
+                InputValue {
+                    name: "if",
+                    description: Some(
+                        "Included when true.",
+                    ),
+                    ty: FieldType {
+                        wrapping: [NonNull],
+                        name: "Boolean",
+                    },
+                    default_value: None,
+                },
+            ],
+            locations: [
+                Field,
+                FragmentSpread,
+                InlineFragment,
+            ],
+        },
+        Directive {
+            name: "skip",
+            description: Some(
+                "Directs the executor to skip this field or fragment when the `if` argument is true.",
+            ),
+            args: [
+                InputValue {
+                    name: "if",
+                    description: Some(
+                        "Skipped when true.",
+                    ),
+                    ty: FieldType {
+                        wrapping: [NonNull],
+                        name: "Boolean",
+                    },
+                    default_value: None,
+                },
+            ],
+            locations: [
+                Field,
+                FragmentSpread,
+                InlineFragment,
+            ],
+        },
+        Directive {
+            name: "deprecated",
+            description: Some(
+                "Marks an element of a GraphQL schema as no longer supported.",
+            ),
+            args: [
+                InputValue {
+                    name: "reason",
+                    description: Some(
+                        "Explains why this element was deprecated, usually also including a suggestion for how to access supported similar data. Formatted using the Markdown syntax (as specified by [CommonMark](https://commonmark.org/).",
+                    ),
+                    ty: FieldType {
+                        wrapping: [],
+                        name: "String",
+                    },
+                    default_value: Some(
+                        "\"No longer supported\"",
+                    ),
+                },
+            ],
+            locations: [
+                FieldDefinition,
+                EnumValue,
+            ],
+        },
+    ],
+}

--- a/cynic-introspection/tests/tests.rs
+++ b/cynic-introspection/tests/tests.rs
@@ -1,4 +1,4 @@
-use cynic_introspection::IntrospectionQuery;
+use cynic_introspection::{query::IntrospectionQuery, Schema};
 
 #[test]
 fn test_introspection_query() {
@@ -26,4 +26,21 @@ fn test_running_query() {
         assert_eq!(result.errors.unwrap().len(), 0);
     }
     insta::assert_debug_snapshot!(result.data);
+}
+
+#[test]
+fn test_schema_conversion() {
+    use cynic::http::ReqwestBlockingExt;
+
+    let query = build_query();
+
+    let result = reqwest::blocking::Client::new()
+        .post("https://swapi-graphql.netlify.app/.netlify/functions/index")
+        .run_graphql(query)
+        .unwrap();
+
+    if result.errors.is_some() {
+        assert_eq!(result.errors.unwrap().len(), 0);
+    }
+    insta::assert_debug_snapshot!(Schema::try_from(result.data.unwrap().schema).unwrap());
 }


### PR DESCRIPTION
#### Why are we making this change?

The raw introspection query output isn't very strongly typed - the same types
are used in various places to represent different things.  As such a lot of
fields that are optional are vice versa.

#### What effects does this change have?

This adds a `Schema` type to `cynic_introspection` that's a bit more usable,
taking all these rules into account, along with a `TryFrom` can convert between
the introspection output and a `Schema`