### PR TITLE
[Merged by Bors] - Provide operationName based on the QueryFragment name.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 - The derive macros now support structs that are generic on lifetimes _and_ types.
 - The derive macros now fields that are references.
 
+### Changes
+
+- Cynic now uses operationName when one is provided by the top-level QueryFragment
+- QueryFragments now provide the name of the struct to use as operationName
+
 ## v2.2.8 - 2023-03-01
 
 ### Bug Fixes

--- a/cynic-codegen/src/fragment_derive/fragment_impl.rs
+++ b/cynic-codegen/src/fragment_derive/fragment_impl.rs
@@ -163,6 +163,7 @@ impl quote::ToTokens for FragmentImpl<'_> {
         let selections = &self.selections;
         let graphql_type = proc_macro2::Literal::string(&self.graphql_type_name);
         let schema_type = &self.schema_type_path;
+        let fragment_name = proc_macro2::Literal::string(&target_struct.to_string());
         let (impl_generics, ty_generics, where_clause) = self.generics.split_for_impl();
 
         tokens.append_all(quote! {
@@ -179,6 +180,10 @@ impl quote::ToTokens for FragmentImpl<'_> {
                     #![allow(unused_mut)]
 
                     #(#selections)*
+                }
+
+                fn name() -> Option<std::borrow::Cow<'static, str>> {
+                    Some(std::borrow::Cow::Borrowed(#fragment_name))
                 }
             }
         })

--- a/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__argument_and_rename.snap
+++ b/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__argument_and_rename.snap
@@ -25,6 +25,9 @@ impl ::cynic::QueryFragment for MyQuery {
         let mut field_builder = builder . select_field :: < schema :: __fields :: Query :: allPosts , < Vec < BlogPostOutput > as :: cynic :: QueryFragment > :: SchemaType > () ;
         <Vec<BlogPostOutput> as ::cynic::QueryFragment>::query(field_builder.select_children());
     }
+    fn name() -> Option<std::borrow::Cow<'static, str>> {
+        Some(std::borrow::Cow::Borrowed("MyQuery"))
+    }
 }
 #[automatically_derived]
 impl<'de> ::cynic::serde::Deserialize<'de> for MyQuery {

--- a/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__argument_literals.snap
+++ b/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__argument_literals.snap
@@ -41,6 +41,9 @@ impl ::cynic::QueryFragment for MyQuery {
         }
         <Vec<BlogPostOutput> as ::cynic::QueryFragment>::query(field_builder.select_children());
     }
+    fn name() -> Option<std::borrow::Cow<'static, str>> {
+        Some(std::borrow::Cow::Borrowed("MyQuery"))
+    }
 }
 #[automatically_derived]
 impl<'de> ::cynic::serde::Deserialize<'de> for MyQuery {

--- a/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__flatten_attr.snap
+++ b/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__flatten_attr.snap
@@ -17,6 +17,9 @@ impl ::cynic::QueryFragment for Film {
         #![allow(unused_mut)]
         let mut field_builder = builder . select_flattened_field :: < schema :: __fields :: Film :: producers , < Vec < String > as :: cynic :: schema :: IsScalar < < schema :: __fields :: Film :: producers as :: cynic :: schema :: Field > :: Type >> :: SchemaType , < schema :: __fields :: Film :: producers as :: cynic :: schema :: Field > :: Type , > () ;
     }
+    fn name() -> Option<std::borrow::Cow<'static, str>> {
+        Some(std::borrow::Cow::Borrowed("Film"))
+    }
 }
 #[automatically_derived]
 impl<'de> ::cynic::serde::Deserialize<'de> for Film {

--- a/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__not_sure.snap
+++ b/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__not_sure.snap
@@ -51,6 +51,9 @@ impl ::cynic::QueryFragment for MyQuery {
         }
         <Vec<BlogPostOutput> as ::cynic::QueryFragment>::query(field_builder.select_children());
     }
+    fn name() -> Option<std::borrow::Cow<'static, str>> {
+        Some(std::borrow::Cow::Borrowed("MyQuery"))
+    }
 }
 #[automatically_derived]
 impl<'de> ::cynic::serde::Deserialize<'de> for MyQuery {

--- a/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__simple_struct.snap
+++ b/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__simple_struct.snap
@@ -19,6 +19,9 @@ impl ::cynic::QueryFragment for BlogPostOutput {
         let mut field_builder = builder . select_field :: < schema :: __fields :: BlogPost :: author , < AuthorOutput as :: cynic :: QueryFragment > :: SchemaType > () ;
         <AuthorOutput as ::cynic::QueryFragment>::query(field_builder.select_children());
     }
+    fn name() -> Option<std::borrow::Cow<'static, str>> {
+        Some(std::borrow::Cow::Borrowed("BlogPostOutput"))
+    }
 }
 #[automatically_derived]
 impl<'de> ::cynic::serde::Deserialize<'de> for BlogPostOutput {

--- a/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__spread_attr.snap
+++ b/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__spread_attr.snap
@@ -17,6 +17,9 @@ impl ::cynic::QueryFragment for Film {
         #![allow(unused_mut)]
         <FilmDetails as ::cynic::QueryFragment>::query(builder)
     }
+    fn name() -> Option<std::borrow::Cow<'static, str>> {
+        Some(std::borrow::Cow::Borrowed("Film"))
+    }
 }
 #[automatically_derived]
 impl<'de> ::cynic::serde::Deserialize<'de> for Film {

--- a/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__variable_in_argument.snap
+++ b/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__variable_in_argument.snap
@@ -23,6 +23,9 @@ impl ::cynic::QueryFragment for MyQuery {
         }
         <Vec<BlogPostOutput> as ::cynic::QueryFragment>::query(field_builder.select_children());
     }
+    fn name() -> Option<std::borrow::Cow<'static, str>> {
+        Some(std::borrow::Cow::Borrowed("MyQuery"))
+    }
 }
 #[automatically_derived]
 impl<'de> ::cynic::serde::Deserialize<'de> for MyQuery {

--- a/cynic-introspection/src/query.rs
+++ b/cynic-introspection/src/query.rs
@@ -82,7 +82,7 @@ mod queries {
     pub struct FieldType {
         pub kind: TypeKind,
         pub name: Option<String>,
-        #[cynic(recurse = 5)]
+        #[cynic(recurse = 4)]
         pub of_type: Option<Box<FieldType>>,
     }
 

--- a/cynic-introspection/tests/snapshots/tests__introspection_query.snap
+++ b/cynic-introspection/tests/snapshots/tests__introspection_query.snap
@@ -2,7 +2,7 @@
 source: cynic-introspection/tests/tests.rs
 expression: build_query().query
 ---
-query {
+query IntrospectionQuery {
   __schema {
     queryType {
       name
@@ -38,10 +38,6 @@ query {
                   ofType {
                     kind
                     name
-                    ofType {
-                      kind
-                      name
-                    }
                   }
                 }
               }
@@ -64,10 +60,6 @@ query {
                 ofType {
                   kind
                   name
-                  ofType {
-                    kind
-                    name
-                  }
                 }
               }
             }
@@ -94,10 +86,6 @@ query {
                 ofType {
                   kind
                   name
-                  ofType {
-                    kind
-                    name
-                  }
                 }
               }
             }
@@ -139,10 +127,6 @@ query {
                 ofType {
                   kind
                   name
-                  ofType {
-                    kind
-                    name
-                  }
                 }
               }
             }

--- a/cynic/src/core.rs
+++ b/cynic/src/core.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use crate::{queries::SelectionBuilder, QueryVariablesFields};
 
 /// Indicates that a type may be used as part of a graphql query.
@@ -15,6 +17,12 @@ pub trait QueryFragment: Sized {
 
     /// Adds this fragment to the query being built by `builder`
     fn query(builder: SelectionBuilder<'_, Self::SchemaType, Self::VariablesFields>);
+
+    /// The name of this fragment, useful for operations, maybe fragments if we ever support them...
+    fn name() -> Option<Cow<'static, str>> {
+        // Most QueryFragments don't need a name so return None
+        None
+    }
 }
 
 impl<T> QueryFragment for Option<T>

--- a/cynic/src/operation.rs
+++ b/cynic/src/operation.rs
@@ -1,4 +1,4 @@
-use std::marker::PhantomData;
+use std::{borrow::Cow, marker::PhantomData};
 
 use crate::{
     core::QueryFragment,
@@ -19,6 +19,9 @@ pub struct Operation<QueryFragment, Variables = ()> {
     /// The variables that will be sent to the server as part of this operation
     pub variables: Variables,
 
+    /// The name of the operation in query that we should run
+    pub operation_name: Option<Cow<'static, str>>,
+
     phantom: PhantomData<fn() -> QueryFragment>,
 }
 
@@ -35,6 +38,9 @@ where
         let mut map_serializer = serializer.serialize_map(Some(2))?;
         map_serializer.serialize_entry("query", &self.query)?;
         map_serializer.serialize_entry("variables", &self.variables)?;
+        if let Some(operation_name) = &self.operation_name {
+            map_serializer.serialize_entry("operationName", &operation_name)?;
+        }
         map_serializer.end()
     }
 }
@@ -57,12 +63,17 @@ where
 
         let vars = VariableDefinitions::new::<Variables>();
 
+        let operation_name = Fragment::name();
+        let name_str = operation_name.as_deref().unwrap_or("");
+
         let mut query = String::new();
-        writeln!(&mut query, "query{vars}{selection_set}").expect("Couldn't stringify query");
+        writeln!(&mut query, "query {name_str}{vars}{selection_set}")
+            .expect("Couldn't stringify query");
 
         Operation {
             query,
             variables,
+            operation_name,
             phantom: PhantomData,
         }
     }
@@ -80,12 +91,17 @@ where
 
         let vars = VariableDefinitions::new::<Variables>();
 
+        let operation_name = Fragment::name();
+        let name_str = operation_name.as_deref().unwrap_or("");
+
         let mut query = String::new();
-        writeln!(&mut query, "mutation{vars}{selection_set}").expect("Couldn't stringify query");
+        writeln!(&mut query, "mutation {name_str}{vars}{selection_set}")
+            .expect("Couldn't stringify query");
 
         Operation {
             query,
             variables,
+            operation_name,
             phantom: PhantomData,
         }
     }
@@ -116,14 +132,18 @@ where
 
         let vars = VariableDefinitions::new::<Variables>();
 
+        let operation_name = Fragment::name();
+        let name_str = operation_name.as_deref().unwrap_or("");
+
         let mut query = String::new();
-        writeln!(&mut query, "subscription{vars}{selection_set}")
+        writeln!(&mut query, "subscription {name_str}{vars}{selection_set}")
             .expect("Couldn't stringify query");
 
         StreamingOperation {
             inner: Operation {
                 query,
                 variables,
+                operation_name,
                 phantom: PhantomData,
             },
         }

--- a/cynic/tests/aliases.rs
+++ b/cynic/tests/aliases.rs
@@ -31,7 +31,7 @@ fn test_explicit_alias_query_output() {
     let operation = FilmQueryWithExplicitAlias::build(());
 
     insta::assert_display_snapshot!(operation.query, @r###"
-    query {
+    query FilmQueryWithExplicitAlias {
       a_new_hope: film(id: "ZmlsbXM6MQ==") {
         title
       }
@@ -82,7 +82,7 @@ fn test_implicit_alias_query_output() {
     let operation = FilmQueryWithImplicitAlias::build(());
 
     insta::assert_display_snapshot!(operation.query, @r###"
-    query {
+    query FilmQueryWithImplicitAlias {
       film(id: "ZmlsbXM6MQ==") {
         title
       }

--- a/cynic/tests/enum-arguments.rs
+++ b/cynic/tests/enum-arguments.rs
@@ -27,7 +27,7 @@ fn test_enum_argument_literal() {
     let query = Query::build(());
 
     insta::assert_display_snapshot!(query.query, @r###"
-    query {
+    query Query {
       filteredPosts(filters: {states: [DRAFT, ], }) {
         hasMetadata
       }
@@ -64,7 +64,7 @@ fn test_enum_argument() {
     let query = Query::build(());
 
     insta::assert_display_snapshot!(query.query, @r###"
-    query {
+    query Query {
       filteredPosts(filters: {states: [POSTED, ], }) {
         hasMetadata
       }

--- a/cynic/tests/inline-fragments.rs
+++ b/cynic/tests/inline-fragments.rs
@@ -63,7 +63,7 @@ fn test_inline_fragment_query_output() {
     let operation = AllPostsQuery::build(());
 
     insta::assert_display_snapshot!(operation.query, @r###"
-    query {
+    query AllPostsQuery {
       allData {
         __typename
         ... on BlogPost {

--- a/cynic/tests/snapshots/generics_simple__query_building.snap
+++ b/cynic/tests/snapshots/generics_simple__query_building.snap
@@ -1,9 +1,8 @@
 ---
-source: cynic/tests/generics.rs
-assertion_line: 33
+source: cynic/tests/generics_simple.rs
 expression: operation.query
 ---
-query($aStr: String) {
+query TestQuery($aStr: String) {
   testStruct {
     fieldOne(x: 1, y: $aStr)
   }

--- a/cynic/tests/snapshots/keyword_queries__query_output.snap
+++ b/cynic/tests/snapshots/keyword_queries__query_output.snap
@@ -1,9 +1,8 @@
 ---
 source: cynic/tests/keyword-queries.rs
-assertion_line: 11
 expression: query.query
 ---
-query {
+query KeywordQuery {
   _
   async
   crate

--- a/cynic/tests/snapshots/mutation_generics__query_building.snap
+++ b/cynic/tests/snapshots/mutation_generics__query_building.snap
@@ -1,9 +1,8 @@
 ---
 source: cynic/tests/mutation_generics.rs
-assertion_line: 40
 expression: operation.query
 ---
-mutation($input: SignInInput!) {
+mutation SignIn($input: SignInInput!) {
   signIn(input: $input)
 }
 

--- a/cynic/tests/snapshots/mutation_generics__query_building_more_generic.snap
+++ b/cynic/tests/snapshots/mutation_generics__query_building_more_generic.snap
@@ -1,9 +1,8 @@
 ---
 source: cynic/tests/mutation_generics.rs
-assertion_line: 75
 expression: operation.query
 ---
-mutation($input: SignInInput!) {
+mutation SignInMoreGeneric($input: SignInInput!) {
   signIn(input: $input)
 }
 

--- a/cynic/tests/snapshots/recursive_queries__optional_recursive_types__friends_query_output.snap
+++ b/cynic/tests/snapshots/recursive_queries__optional_recursive_types__friends_query_output.snap
@@ -1,9 +1,8 @@
 ---
 source: cynic/tests/recursive-queries.rs
-assertion_line: 90
 expression: operation.query
 ---
-query {
+query FriendsQuery {
   allAuthors {
     friends {
       friends

--- a/cynic/tests/snapshots/recursive_queries__recursive_lists__all_posts_query_output.snap
+++ b/cynic/tests/snapshots/recursive_queries__recursive_lists__all_posts_query_output.snap
@@ -1,9 +1,8 @@
 ---
 source: cynic/tests/recursive-queries.rs
-assertion_line: 42
 expression: operation.query
 ---
-query {
+query AllPostsQuery {
   allPosts {
     comments {
       author {

--- a/cynic/tests/snapshots/recursive_queries__required_recursive_types__friends_query_output.snap
+++ b/cynic/tests/snapshots/recursive_queries__required_recursive_types__friends_query_output.snap
@@ -1,9 +1,8 @@
 ---
 source: cynic/tests/recursive-queries.rs
-assertion_line: 158
 expression: operation.query
 ---
-query {
+query FriendsQuery {
   allAuthors {
     me {
       me

--- a/cynic/tests/snapshots/renames__all_posts_query_output.snap
+++ b/cynic/tests/snapshots/renames__all_posts_query_output.snap
@@ -1,9 +1,8 @@
 ---
 source: cynic/tests/renames.rs
-assertion_line: 53
 expression: operation.query
 ---
-query {
+query AllPostsQuery {
   allPosts {
     hasMetadata
     metadata {

--- a/cynic/tests/snapshots/simple_schema_tests__query_building.snap
+++ b/cynic/tests/snapshots/simple_schema_tests__query_building.snap
@@ -1,9 +1,8 @@
 ---
 source: cynic/tests/simple_schema_tests.rs
-assertion_line: 100
 expression: operation.query
 ---
-query($anInt: Int!) {
+query TestQuery($anInt: Int!) {
   testStruct {
     fieldOne(x: $anInt, y: "1")
     nested {

--- a/examples/examples/snapshots/chrono_scalars__test__snapshot_test_query.snap
+++ b/examples/examples/snapshots/chrono_scalars__test__snapshot_test_query.snap
@@ -1,9 +1,8 @@
 ---
 source: examples/examples/chrono-scalars.rs
-assertion_line: 62
 expression: query.query
 ---
-query {
+query JobsQuery {
   jobs {
     createdAt
   }

--- a/examples/examples/snapshots/github__test__snapshot_test_query.snap
+++ b/examples/examples/snapshots/github__test__snapshot_test_query.snap
@@ -1,9 +1,8 @@
 ---
 source: examples/examples/github.rs
-assertion_line: 121
 expression: query.query
 ---
-query($prOrder: IssueOrder!) {
+query PullRequestTitles($prOrder: IssueOrder!) {
   repository(name: "cynic", owner: "obmarg") {
     pullRequests(orderBy: $prOrder, first: 10) {
       nodes {

--- a/examples/examples/snapshots/github_mutation__test__snapshot_test_query.snap
+++ b/examples/examples/snapshots/github_mutation__test__snapshot_test_query.snap
@@ -1,9 +1,8 @@
 ---
 source: examples/examples/github-mutation.rs
-assertion_line: 105
 expression: query.query
 ---
-mutation($commentBody: String!) {
+mutation CommentOnMutationSupportIssue($commentBody: String!) {
   addComment(input: {body: $commentBody, subjectId: "MDU6SXNzdWU2ODU4NzUxMzQ=", clientMutationId: null, }) {
     commentEdge {
       node {

--- a/examples/examples/snapshots/manual_reqwest__test__snapshot_test_query.snap
+++ b/examples/examples/snapshots/manual_reqwest__test__snapshot_test_query.snap
@@ -1,9 +1,8 @@
 ---
 source: examples/examples/manual-reqwest.rs
-assertion_line: 74
 expression: query.query
 ---
-query($id: ID) {
+query FilmDirectorQuery($id: ID) {
   film(id: $id) {
     title
     director

--- a/examples/examples/snapshots/querying_interfaces__test__snapshot_test_query.snap
+++ b/examples/examples/snapshots/querying_interfaces__test__snapshot_test_query.snap
@@ -2,7 +2,7 @@
 source: examples/examples/querying-interfaces.rs
 expression: query.query
 ---
-query($id: ID!) {
+query Query($id: ID!) {
   node(id: $id) {
     __typename
     ... on Film {

--- a/examples/examples/snapshots/reqwest_async__test__snapshot_test_query.snap
+++ b/examples/examples/snapshots/reqwest_async__test__snapshot_test_query.snap
@@ -1,9 +1,8 @@
 ---
 source: examples/examples/reqwest-async.rs
-assertion_line: 77
 expression: query.query
 ---
-query($id: ID) {
+query FilmDirectorQuery($id: ID) {
   film(id: $id) {
     title
     director

--- a/examples/examples/snapshots/spread__test__snapshot_test_query.snap
+++ b/examples/examples/snapshots/spread__test__snapshot_test_query.snap
@@ -1,9 +1,8 @@
 ---
 source: examples/examples/spread.rs
-assertion_line: 85
 expression: query.query
 ---
-query($id: ID) {
+query FilmDirectorQuery($id: ID) {
   film(id: $id) {
     title
     director

--- a/examples/examples/snapshots/starwars__test__snapshot_test_query.snap
+++ b/examples/examples/snapshots/starwars__test__snapshot_test_query.snap
@@ -1,9 +1,8 @@
 ---
 source: examples/examples/starwars.rs
-assertion_line: 72
 expression: query.query
 ---
-query($id: ID) {
+query FilmDirectorQuery($id: ID) {
   film(id: $id) {
     title
     director

--- a/examples/examples/snapshots/surf_client__test__snapshot_test_query.snap
+++ b/examples/examples/snapshots/surf_client__test__snapshot_test_query.snap
@@ -1,9 +1,8 @@
 ---
 source: examples/examples/surf-client.rs
-assertion_line: 77
 expression: query.query
 ---
-query($id: ID) {
+query FilmDirectorQuery($id: ID) {
   film(id: $id) {
     title
     director


### PR DESCRIPTION
Cynic has never really bothered providing operationName in its payload as its query document never contains more than one operation.

However some bizzare GraphQL APIs have disabled introspection _unless_ you name the query `IntrospectionQuery`.  This seems rather pointless, but is easy to work around.

And that's what this commit does - updates cynic to allow a QueryFragment to provide a name, and updates `Operation` to use the name of the top-level `QueryFragment`
