### PR TITLE
[Merged by Bors] - Fix recursive fields deserilization issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 - Cynic now uses operationName when one is provided by the top-level QueryFragment
 - QueryFragments now provide the name of the struct to use as operationName
 
+### Bug Fixes
+
+- Fixed an issue deserializing recursive fields that hit their recurse depth.
+
 ## v2.2.8 - 2023-03-01
 
 ### Bug Fixes

--- a/cynic/tests/recursive-queries.rs
+++ b/cynic/tests/recursive-queries.rs
@@ -96,13 +96,19 @@ mod optional_recursive_types {
         };
     }
 
+    macro_rules! empty_object {
+        () => {
+            json!(null)
+        };
+    }
+
     #[test]
     fn test_friends_decoding_with_matching_depth() {
         let data = json!({
             "allAuthors":
                 authors(
-                    authors(authors(null!(), null!()), author(null!(), null!())),
-                    author(authors(null!(), null!()), author(null!(), null!())),
+                    authors(authors(null!(), null!()), author(empty_object!(), empty_object!())),
+                    author(authors(null!(), null!()), author(empty_object!(), empty_object!())),
                 )
         });
         insta::assert_yaml_snapshot!(serde_json::from_value::<FriendsQuery>(data).unwrap());
@@ -155,7 +161,16 @@ mod required_recursive_types {
 
         let operation = FriendsQuery::build(());
 
-        insta::assert_display_snapshot!(operation.query);
+        insta::assert_display_snapshot!(operation.query, @r###"
+        query FriendsQuery {
+          allAuthors {
+            me {
+              me
+            }
+          }
+        }
+
+        "###);
     }
 
     macro_rules! null {
@@ -164,18 +179,22 @@ mod required_recursive_types {
         };
     }
 
+    macro_rules! empty_object {
+        () => {
+            json!(null)
+        };
+    }
+
     #[test]
     fn test_friends_decoding_with_matching_depth() {
-        let data = json!({ "allAuthors": authors(author(author(null!()))) });
+        let data = json!({ "allAuthors": [{"me": {"me": {}}}]});
 
         insta::assert_yaml_snapshot!(serde_json::from_value::<FriendsQuery>(data).unwrap());
     }
 
     #[test]
     fn test_friends_decoding_with_less_depth() {
-        // This is only a valid test for optional fields.
-
-        let data = json!({ "allAuthors": authors(author(null!())) });
+        let data = json!({ "allAuthors": [{"me": null}]});
 
         insta::assert_yaml_snapshot!(serde_json::from_value::<FriendsQuery>(data).unwrap());
     }

--- a/cynic/tests/snapshots/recursive_queries__required_recursive_types__friends_decoding_with_less_depth.snap
+++ b/cynic/tests/snapshots/recursive_queries__required_recursive_types__friends_decoding_with_less_depth.snap
@@ -1,9 +1,7 @@
 ---
 source: cynic/tests/recursive-queries.rs
-assertion_line: 180
 expression: "serde_json::from_value::<FriendsQuery>(data).unwrap()"
 ---
 all_authors:
-  - me:
-      me: ~
+  - me: ~
 


### PR DESCRIPTION
I'd written the recursive fields deserialization to expect nulls when you hit the recurse depth, but that's not actually the case - the field just isn't present.

This fixes the deserializtion to handle this case, and updates the tests of the feature to more accurately represent reality.