### PR TITLE
[Merged by Bors] - Make the GraphQLResponse deserialization stricter.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 ### Bug Fixes
 
 - Fixed an issue deserializing recursive fields that hit their recurse depth.
+- Response deserialization will no longer work on random blobs of JSON that
+  aren't in GraphQLResponse format.
 
 ## v2.2.8 - 2023-03-01
 


### PR DESCRIPTION
Currently both `data` & `errors` are Options, so you can throw completely invalid JSON at it and the parse will succed.  This makes it difficult to debug issues where there's some non-graphql error JSON in the response.

I've added a custom Deserialize impl that validates at least one of them is present and errors if not