### PR TITLE
[Merged by Bors] - Allow cynic-codegen to use a preprocessed schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
   with cynic.
 - Added a `schema` attribute macro to declare the schema module for
   pre-registered schemas.
+- Added the `rkyv` feature flag which optimises the pre-registered schemas with
+  the `rkyv` library. This makes cynic much more efficient when working with
+  large schemas.
 
 ### Changes
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,6 +80,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "aliasable"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "250f629c0161ad8107cf89319e990051fae62832fd343083bea452d93e2205fd"
+
+[[package]]
 name = "anyhow"
 version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -672,6 +678,7 @@ dependencies = [
  "insta",
  "maplit",
  "once_cell",
+ "ouroboros",
  "proc-macro2",
  "quote",
  "rkyv",
@@ -1705,6 +1712,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "ouroboros"
+version = "0.15.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1358bd1558bd2a083fed428ffeda486fbfb323e698cdda7794259d592ca72db"
+dependencies = [
+ "aliasable",
+ "ouroboros_macro",
+]
+
+[[package]]
+name = "ouroboros_macro"
+version = "0.15.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f7d21ccd03305a674437ee1248f3ab5d4b1db095cf1caf49f1713ddf61956b7"
+dependencies = [
+ "Inflector",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.87",
+]
+
+[[package]]
 name = "parking"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1783,6 +1813,30 @@ name = "ppv-lite86"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.87",
+ "version_check 0.9.3",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check 0.9.3",
+]
 
 [[package]]
 name = "proc-macro-hack"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,6 +69,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
+dependencies = [
+ "getrandom 0.2.9",
+ "once_cell",
+ "version_check 0.9.3",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -333,6 +344,28 @@ name = "bumpalo"
 version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
+
+[[package]]
+name = "bytecheck"
+version = "0.6.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13fe11640a23eb24562225322cd3e452b93a3d4091d62fab69c70542fcd17d1f"
+dependencies = [
+ "bytecheck_derive",
+ "ptr_meta",
+ "simdutf8",
+]
+
+[[package]]
+name = "bytecheck_derive"
+version = "0.6.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31225543cb46f81a7e224762764f4a6a0f097b1db0b175f69e8065efaa42de5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.87",
+]
 
 [[package]]
 name = "byteorder"
@@ -641,6 +674,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
+ "rkyv",
  "rstest 0.11.0",
  "strsim",
  "syn",
@@ -1032,14 +1066,14 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.2"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9495705279e7140bf035dde1f6e750c162df8b625267cd52cc44e0b156732c8"
+checksum = "c85e1d9ab2eadba7e5040d4e09cbd6d072b76a557ad64e797c2cb9d4da21d7e4"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
  "libc",
- "wasi 0.10.2+wasi-snapshot-preview1",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "wasm-bindgen",
 ]
 
@@ -1137,6 +1171,9 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash",
+]
 
 [[package]]
 name = "hermit-abi"
@@ -1416,9 +1453,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.92"
+version = "0.2.143"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56d855069fafbb9b344c0f962150cd2c1187975cb1c22c1522c240d8c4986714"
+checksum = "edc207893e85c5d6be840e969b496b53d94cec8be2d501b214f50daa97fa8024"
 
 [[package]]
 name = "libnghttp2-sys"
@@ -1769,6 +1806,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ptr_meta"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0738ccf7ea06b608c10564b31debd4f5bc5e197fc8bfe088f68ae5ce81e7a4f1"
+dependencies = [
+ "ptr_meta_derive",
+]
+
+[[package]]
+name = "ptr_meta_derive"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.87",
+]
+
+[[package]]
 name = "pulldown-cmark"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1861,7 +1918,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34cf66eb183df1c5876e2dcf6b13d57340741e8dc255b48e40a26de954d06ae7"
 dependencies = [
- "getrandom 0.2.2",
+ "getrandom 0.2.9",
 ]
 
 [[package]]
@@ -1907,6 +1964,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "rend"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581008d2099240d37fb08d77ad713bcaec2c4d89d50b5b21a8bb1996bbab68ab"
+dependencies = [
+ "bytecheck",
 ]
 
 [[package]]
@@ -1958,6 +2024,31 @@ dependencies = [
  "untrusted",
  "web-sys",
  "winapi",
+]
+
+[[package]]
+name = "rkyv"
+version = "0.7.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21499ed91807f07ae081880aabb2ccc0235e9d88011867d984525e9a4c3cfa3e"
+dependencies = [
+ "bytecheck",
+ "hashbrown",
+ "ptr_meta",
+ "rend",
+ "rkyv_derive",
+ "seahash",
+]
+
+[[package]]
+name = "rkyv_derive"
+version = "0.7.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac1c672430eb41556291981f45ca900a0239ad007242d1cb4b4167af842db666"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.87",
 ]
 
 [[package]]
@@ -2087,6 +2178,12 @@ dependencies = [
  "ring",
  "untrusted",
 ]
+
+[[package]]
+name = "seahash"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "security-framework"
@@ -2245,6 +2342,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simdutf8"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f27f6278552951f1f2b8cf9da965d10969b2efdea95a6ec47987ab46edfe263a"
+
+[[package]]
 name = "similar"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2399,7 +2502,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "encoding_rs",
  "futures-util",
- "getrandom 0.2.2",
+ "getrandom 0.2.9",
  "http-client",
  "http-types",
  "log",
@@ -2777,7 +2880,7 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 dependencies = [
- "getrandom 0.2.2",
+ "getrandom 0.2.9",
 ]
 
 [[package]]
@@ -2843,9 +2946,9 @@ checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"
-version = "0.10.2+wasi-snapshot-preview1"
+version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3098,9 +3098,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.50"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a905d57e488fec8861446d3393670fb50d27a262344013181c2cdf9fff5481be"
+checksum = "38eb105f1c59d9eaa6b5cdc92b859d85b926e82cb2e0945cd0c9259faa6fe9fb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -370,7 +370,7 @@ checksum = "e31225543cb46f81a7e224762764f4a6a0f097b1db0b175f69e8065efaa42de5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.87",
+ "syn",
 ]
 
 [[package]]
@@ -1731,7 +1731,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 1.0.87",
+ "syn",
 ]
 
 [[package]]
@@ -1823,7 +1823,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
  "quote",
- "syn 1.0.87",
+ "syn",
  "version_check 0.9.3",
 ]
 
@@ -1876,7 +1876,7 @@ checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.87",
+ "syn",
 ]
 
 [[package]]
@@ -2102,7 +2102,7 @@ checksum = "ac1c672430eb41556291981f45ca900a0239ad007242d1cb4b4167af842db666"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.87",
+ "syn",
 ]
 
 [[package]]

--- a/cynic-codegen/Cargo.toml
+++ b/cynic-codegen/Cargo.toml
@@ -26,6 +26,8 @@ darling = "0.13"
 strsim = "0.10.0"
 once_cell = "1.9.0"
 
+rkyv = { version = "0.7.41", features = ["validation"] }
+
 [dev-dependencies]
 assert_matches = "1.4.0"
 insta = "1.17"

--- a/cynic-codegen/Cargo.toml
+++ b/cynic-codegen/Cargo.toml
@@ -14,6 +14,7 @@ documentation = "https://docs.rs/cynic-codegen"
 [features]
 default = ["rustfmt"]
 rustfmt = []
+rkyv = ["dep:rkyv"]
 
 [dependencies]
 counter = "0.5"
@@ -27,7 +28,7 @@ strsim = "0.10.0"
 syn = { version = "1.0", features = ["visit-mut"] }
 thiserror = "1"
 
-rkyv = { version = "0.7.41", features = ["validation"] }
+rkyv = { version = "0.7.41", features = ["validation"], optional = true }
 
 [dev-dependencies]
 assert_matches = "1.4.0"

--- a/cynic-codegen/Cargo.toml
+++ b/cynic-codegen/Cargo.toml
@@ -19,12 +19,9 @@ rustfmt = []
 counter = "0.5"
 darling = "0.13"
 graphql-parser = "0.4.0"
-graphql-parser = "0.4.0"
 once_cell = "1.9.0"
 ouroboros = "0.15"
 proc-macro2 = "1.0"
-proc-macro2 = "1.0"
-quote = "1.0"
 quote = "1.0"
 strsim = "0.10.0"
 syn = { version = "1.0", features = ["visit-mut"] }

--- a/cynic-codegen/Cargo.toml
+++ b/cynic-codegen/Cargo.toml
@@ -17,14 +17,18 @@ rustfmt = []
 
 [dependencies]
 counter = "0.5"
+darling = "0.13"
 graphql-parser = "0.4.0"
+graphql-parser = "0.4.0"
+once_cell = "1.9.0"
+ouroboros = "0.15"
 proc-macro2 = "1.0"
+proc-macro2 = "1.0"
+quote = "1.0"
+quote = "1.0"
+strsim = "0.10.0"
 syn = { version = "1.0", features = ["visit-mut"] }
 thiserror = "1"
-quote = "1.0"
-darling = "0.13"
-strsim = "0.10.0"
-once_cell = "1.9.0"
 
 rkyv = { version = "0.7.41", features = ["validation"] }
 

--- a/cynic-codegen/src/enum_derive/mod.rs
+++ b/cynic-codegen/src/enum_derive/mod.rs
@@ -63,7 +63,7 @@ pub fn enum_derive_impl(
         };
 
         let graphql_type_name = proc_macro2::Literal::string(&input.graphql_type_name());
-        let enum_marker_ident = proc_macro2::Ident::from(enum_def.marker_ident());
+        let enum_marker_ident = enum_def.marker_ident().to_rust_ident();
 
         let string_literals: Vec<_> = pairs
             .iter()
@@ -246,17 +246,14 @@ mod tests {
             },
         ];
         let mut gql_enum = EnumType {
-            description: None,
-            name: "Desserts",
+            name: "Desserts".into(),
             values: vec![],
         };
         gql_enum.values.push(EnumValue {
             name: FieldName::new(enum_value_1),
-            description: None,
         });
         gql_enum.values.push(EnumValue {
             name: FieldName::new(enum_value_2),
-            description: None,
         });
 
         let result = join_variants(
@@ -296,17 +293,14 @@ mod tests {
             },
         ];
         let mut gql_enum = EnumType {
-            description: None,
-            name: "Desserts",
+            name: "Desserts".into(),
             values: vec![],
         };
         gql_enum.values.push(EnumValue {
             name: FieldName::new("CHEESECAKE"),
-            description: None,
         });
         gql_enum.values.push(EnumValue {
             name: FieldName::new("iced-goodness"),
-            description: None,
         });
 
         let result = join_variants(
@@ -340,17 +334,14 @@ mod tests {
             rename: None,
         }];
         let mut gql_enum = EnumType {
-            description: None,
-            name: "Desserts",
+            name: "Desserts".into(),
             values: vec![],
         };
         gql_enum.values.push(EnumValue {
             name: FieldName::new("CHEESECAKE"),
-            description: None,
         });
         gql_enum.values.push(EnumValue {
             name: FieldName::new("ICE_CREAM"),
-            description: None,
         });
 
         let result = join_variants(
@@ -371,13 +362,11 @@ mod tests {
             rename: None,
         }];
         let mut gql_enum = EnumType {
-            description: None,
-            name: "Desserts",
+            name: "Desserts".into(),
             values: vec![],
         };
         gql_enum.values.push(EnumValue {
             name: FieldName::new("ICE_CREAM"),
-            description: None,
         });
 
         let result = join_variants(

--- a/cynic-codegen/src/enum_derive/mod.rs
+++ b/cynic-codegen/src/enum_derive/mod.rs
@@ -25,7 +25,7 @@ pub fn enum_derive(ast: &syn::DeriveInput) -> Result<TokenStream, syn::Error> {
 
     match EnumDeriveInput::from_derive_input(ast) {
         Ok(input) => {
-            let schema_input = SchemaInput::from_macro_attr_string(&*input.schema_path)
+            let schema_input = SchemaInput::from_schema_path(&*input.schema_path)
                 .map_err(|e| e.into_syn_error(input.schema_path.span()))?;
 
             let schema = Schema::new(schema_input);

--- a/cynic-codegen/src/enum_derive/mod.rs
+++ b/cynic-codegen/src/enum_derive/mod.rs
@@ -5,10 +5,9 @@ use {
 
 use crate::{
     idents::RenameAll,
-    load_schema,
     schema::{
         types::{EnumType, EnumValue},
-        Schema, Unvalidated,
+        Schema, SchemaInput, Unvalidated,
     },
 };
 
@@ -26,10 +25,10 @@ pub fn enum_derive(ast: &syn::DeriveInput) -> Result<TokenStream, syn::Error> {
 
     match EnumDeriveInput::from_derive_input(ast) {
         Ok(input) => {
-            let schema_doc = load_schema(&*input.schema_path)
+            let schema_input = SchemaInput::from_macro_attr_string(&*input.schema_path)
                 .map_err(|e| e.into_syn_error(input.schema_path.span()))?;
 
-            let schema = Schema::new(&schema_doc);
+            let schema = Schema::new(schema_input);
 
             enum_derive_impl(input, &schema, enum_span).or_else(|e| Ok(e.to_compile_error()))
         }

--- a/cynic-codegen/src/fragment_derive/arguments/analyse.rs
+++ b/cynic-codegen/src/fragment_derive/arguments/analyse.rs
@@ -59,18 +59,18 @@ pub struct VariantDetails<'a> {
 }
 
 pub fn analyse<'a>(
-    schema: &Schema<'a, Unvalidated>,
+    schema: &'a Schema<'a, Unvalidated>,
     literals: Vec<parsing::FieldArgument>,
     field: &schema::Field<'a>,
     variables_fields: Option<&syn::Path>,
     span: Span,
 ) -> Result<AnalysedArguments<'a>, Errors> {
     let mut analysis = Analysis {
-        schema,
         variables_fields,
         variants: HashSet::new(),
     };
-    let arguments = analyse_fields(&mut analysis, literals, &field.arguments, span)?;
+
+    let arguments = analyse_fields(&mut analysis, literals, &field.arguments, span, schema)?;
 
     let mut variants = analysis.variants.into_iter().collect::<Vec<_>>();
     variants.sort_by_key(|v| (v.en.name.clone(), v.variant.clone()));
@@ -83,7 +83,6 @@ pub fn analyse<'a>(
 }
 
 struct Analysis<'schema, 'a> {
-    schema: &'a Schema<'schema, Unvalidated>,
     variables_fields: Option<&'a syn::Path>,
     variants: HashSet<Rc<VariantDetails<'schema>>>,
 }
@@ -122,6 +121,7 @@ fn analyse_fields<'a>(
     literals: Vec<parsing::FieldArgument>,
     arguments: &[InputValue<'a>],
     span: Span,
+    schema: &'a Schema<'a, Unvalidated>,
 ) -> Result<Vec<Field<'a>>, Errors> {
     validate(&literals, arguments, span)?;
 
@@ -134,7 +134,7 @@ fn analyse_fields<'a>(
             .find(|a| a.name == arg.argument_name)
             .unwrap();
 
-        match analyse_argument(analysis, arg, schema_field) {
+        match analyse_argument(analysis, arg, schema_field, schema) {
             Ok(value) => fields.push(Field {
                 schema_field: schema_field.clone(),
                 value,
@@ -154,10 +154,11 @@ fn analyse_argument<'a>(
     analysis: &mut Analysis<'a, '_>,
     parsed_arg: parsing::FieldArgument,
     argument: &InputValue<'a>,
+    schema: &'a Schema<'a, Unvalidated>,
 ) -> Result<ArgumentValue<'a>, Errors> {
     match parsed_arg.value {
         parsing::FieldArgumentValue::Literal(lit) => {
-            analyse_value_type(analysis, lit, &argument.value_type)
+            analyse_value_type(analysis, lit, &argument.value_type, schema)
         }
         parsing::FieldArgumentValue::Expression(e) => Ok(ArgumentValue::Expression(*e)),
     }
@@ -167,6 +168,7 @@ fn analyse_value_type<'a>(
     analysis: &mut Analysis<'a, '_>,
     literal: parsing::ArgumentLiteral,
     value_type: &TypeRef<'a, InputType<'a>>,
+    schema: &'a Schema<'a, Unvalidated>,
 ) -> Result<ArgumentValue<'a>, Errors> {
     use parsing::ArgumentLiteral;
 
@@ -188,7 +190,7 @@ fn analyse_value_type<'a>(
     }
 
     match &value_type {
-        TypeRef::Named(_, _) => match (value_type.inner_type(analysis.schema), literal) {
+        TypeRef::Named(_, _) => match (value_type.inner_type(schema), literal) {
             (_, ArgumentLiteral::Variable(_, _)) => {
                 // Variable is handled above.
                 panic!("This should not happen");
@@ -224,7 +226,7 @@ fn analyse_value_type<'a>(
 
             (InputType::InputObject(def), ArgumentLiteral::Object(fields, span)) => {
                 let literals = fields.into_iter().collect::<Vec<_>>();
-                let fields = analyse_fields(analysis, literals, &def.fields, span)?;
+                let fields = analyse_fields(analysis, literals, &def.fields, span, schema)?;
 
                 Ok(ArgumentValue::Object(Object {
                     schema_obj: def,
@@ -240,7 +242,7 @@ fn analyse_value_type<'a>(
                 let mut output_values = Vec::new();
                 let mut errors = Vec::new();
                 for value in values {
-                    match analyse_value_type(analysis, value, element_type.as_ref()) {
+                    match analyse_value_type(analysis, value, element_type.as_ref(), schema) {
                         Ok(v) => output_values.push(v),
                         Err(e) => errors.push(e),
                     }
@@ -257,6 +259,7 @@ fn analyse_value_type<'a>(
                     analysis,
                     other,
                     element_type.as_ref(),
+                    schema,
                 )?]))
             }
         },
@@ -266,6 +269,7 @@ fn analyse_value_type<'a>(
                 analysis,
                 other,
                 inner_typeref.as_ref(),
+                schema,
             )?))),
         },
     }

--- a/cynic-codegen/src/fragment_derive/arguments/analyse.rs
+++ b/cynic-codegen/src/fragment_derive/arguments/analyse.rs
@@ -69,7 +69,7 @@ pub fn analyse<'a>(
     let arguments = analyse_fields(&mut analysis, literals, &field.arguments, span)?;
 
     let mut variants = analysis.variants.into_iter().collect::<Vec<_>>();
-    variants.sort_by_key(|v| (v.en.name, v.variant.clone()));
+    variants.sort_by_key(|v| (v.en.name.clone(), v.variant.clone()));
 
     Ok(AnalysedArguments {
         schema_field: field.clone(),

--- a/cynic-codegen/src/fragment_derive/arguments/mod.rs
+++ b/cynic-codegen/src/fragment_derive/arguments/mod.rs
@@ -4,7 +4,10 @@ mod parsing;
 
 use proc_macro2::Span;
 
-use crate::error::Errors;
+use crate::{
+    error::Errors,
+    schema::{Schema, Unvalidated},
+};
 
 pub use self::{
     output::Output,
@@ -12,13 +15,14 @@ pub use self::{
 };
 
 pub fn process_arguments<'a>(
+    schema: &Schema<'a, Unvalidated>,
     literals: Vec<parsing::FieldArgument>,
     field: &crate::schema::types::Field<'a>,
     schema_module: syn::Path,
     variables_fields: Option<&syn::Path>,
     span: Span,
 ) -> Result<Output<'a>, Errors> {
-    let analysed = analyse::analyse(literals, field, variables_fields, span)?;
+    let analysed = analyse::analyse(schema, literals, field, variables_fields, span)?;
 
     Ok(Output {
         analysed,

--- a/cynic-codegen/src/fragment_derive/arguments/mod.rs
+++ b/cynic-codegen/src/fragment_derive/arguments/mod.rs
@@ -15,7 +15,7 @@ pub use self::{
 };
 
 pub fn process_arguments<'a>(
-    schema: &Schema<'a, Unvalidated>,
+    schema: &'a Schema<'a, Unvalidated>,
     literals: Vec<parsing::FieldArgument>,
     field: &crate::schema::types::Field<'a>,
     schema_module: syn::Path,

--- a/cynic-codegen/src/fragment_derive/arguments/output.rs
+++ b/cynic-codegen/src/fragment_derive/arguments/output.rs
@@ -36,7 +36,7 @@ impl ToTokens for Output<'_> {
             .analysed
             .arguments
             .iter()
-            .map(|arg| proc_macro2::Ident::from(arg.schema_field.marker_ident()));
+            .map(|arg| arg.schema_field.marker_ident().to_rust_ident());
 
         let arg_values = self
             .analysed

--- a/cynic-codegen/src/fragment_derive/arguments/snapshots/cynic_codegen__fragment_derive__arguments__tests__a_list_of_strings.snap
+++ b/cynic-codegen/src/fragment_derive/arguments/snapshots/cynic_codegen__fragment_derive__arguments__tests__a_list_of_strings.snap
@@ -1,13 +1,11 @@
 ---
 source: cynic-codegen/src/fragment_derive/arguments/tests.rs
-assertion_line: 36
 expression: "analyse(literals, field, Some(&format_ident!(\"MyArguments\").into()),\n        Span::call_site()).map(|o| o.arguments)"
 ---
 Ok(
     [
         Field {
             schema_field: InputValue {
-                description: None,
                 name: FieldName {
                     graphql_name: "filters",
                 },
@@ -19,11 +17,9 @@ Ok(
             value: Object(
                 Object {
                     schema_obj: InputObjectType {
-                        description: None,
                         name: "BookFilters",
                         fields: [
                             InputValue {
-                                description: None,
                                 name: FieldName {
                                     graphql_name: "authors",
                                 },
@@ -37,7 +33,6 @@ Ok(
                                 has_default: false,
                             },
                             InputValue {
-                                description: None,
                                 name: FieldName {
                                     graphql_name: "state",
                                 },
@@ -53,7 +48,6 @@ Ok(
                     fields: [
                         Field {
                             schema_field: InputValue {
-                                description: None,
                                 name: FieldName {
                                     graphql_name: "authors",
                                 },

--- a/cynic-codegen/src/fragment_derive/arguments/snapshots/cynic_codegen__fragment_derive__arguments__tests__an_enum.snap
+++ b/cynic-codegen/src/fragment_derive/arguments/snapshots/cynic_codegen__fragment_derive__arguments__tests__an_enum.snap
@@ -6,7 +6,6 @@ Ok(
     [
         Field {
             schema_field: InputValue {
-                description: None,
                 name: FieldName {
                     graphql_name: "filters",
                 },
@@ -18,11 +17,9 @@ Ok(
             value: Object(
                 Object {
                     schema_obj: InputObjectType {
-                        description: None,
                         name: "BookFilters",
                         fields: [
                             InputValue {
-                                description: None,
                                 name: FieldName {
                                     graphql_name: "authors",
                                 },
@@ -36,7 +33,6 @@ Ok(
                                 has_default: false,
                             },
                             InputValue {
-                                description: None,
                                 name: FieldName {
                                     graphql_name: "state",
                                 },
@@ -52,7 +48,6 @@ Ok(
                     fields: [
                         Field {
                             schema_field: InputValue {
-                                description: None,
                                 name: FieldName {
                                     graphql_name: "state",
                                 },
@@ -67,17 +62,14 @@ Ok(
                                 Variant(
                                     VariantDetails {
                                         en: EnumType {
-                                            description: None,
                                             name: "BookState",
                                             values: [
                                                 EnumValue {
-                                                    description: None,
                                                     name: FieldName {
                                                         graphql_name: "PUBLISHED",
                                                     },
                                                 },
                                                 EnumValue {
-                                                    description: None,
                                                     name: FieldName {
                                                         graphql_name: "OUT_OF_PRINT",
                                                     },

--- a/cynic-codegen/src/fragment_derive/arguments/snapshots/cynic_codegen__fragment_derive__arguments__tests__boolean_scalar.snap
+++ b/cynic-codegen/src/fragment_derive/arguments/snapshots/cynic_codegen__fragment_derive__arguments__tests__boolean_scalar.snap
@@ -1,13 +1,11 @@
 ---
 source: cynic-codegen/src/fragment_derive/arguments/tests.rs
-assertion_line: 36
 expression: "analyse(literals, field, Some(&format_ident!(\"MyArguments\").into()),\n        Span::call_site()).map(|o| o.arguments)"
 ---
 Ok(
     [
         Field {
             schema_field: InputValue {
-                description: None,
                 name: FieldName {
                     graphql_name: "aBool",
                 },

--- a/cynic-codegen/src/fragment_derive/arguments/snapshots/cynic_codegen__fragment_derive__arguments__tests__list_wrapping.snap
+++ b/cynic-codegen/src/fragment_derive/arguments/snapshots/cynic_codegen__fragment_derive__arguments__tests__list_wrapping.snap
@@ -1,13 +1,11 @@
 ---
 source: cynic-codegen/src/fragment_derive/arguments/tests.rs
-assertion_line: 36
 expression: "analyse(literals, field, Some(&format_ident!(\"MyArguments\").into()),\n        Span::call_site()).map(|o| o.arguments)"
 ---
 Ok(
     [
         Field {
             schema_field: InputValue {
-                description: None,
                 name: FieldName {
                     graphql_name: "filters",
                 },
@@ -19,11 +17,9 @@ Ok(
             value: Object(
                 Object {
                     schema_obj: InputObjectType {
-                        description: None,
                         name: "BookFilters",
                         fields: [
                             InputValue {
-                                description: None,
                                 name: FieldName {
                                     graphql_name: "authors",
                                 },
@@ -37,7 +33,6 @@ Ok(
                                 has_default: false,
                             },
                             InputValue {
-                                description: None,
                                 name: FieldName {
                                     graphql_name: "state",
                                 },
@@ -53,7 +48,6 @@ Ok(
                     fields: [
                         Field {
                             schema_field: InputValue {
-                                description: None,
                                 name: FieldName {
                                     graphql_name: "authors",
                                 },

--- a/cynic-codegen/src/fragment_derive/arguments/snapshots/cynic_codegen__fragment_derive__arguments__tests__missing_nullable_scalars.snap
+++ b/cynic-codegen/src/fragment_derive/arguments/snapshots/cynic_codegen__fragment_derive__arguments__tests__missing_nullable_scalars.snap
@@ -1,13 +1,11 @@
 ---
 source: cynic-codegen/src/fragment_derive/arguments/tests.rs
-assertion_line: 36
 expression: "analyse(literals, field, Some(&format_ident!(\"MyArguments\").into()),\n        Span::call_site()).map(|o| o.arguments)"
 ---
 Ok(
     [
         Field {
             schema_field: InputValue {
-                description: None,
                 name: FieldName {
                     graphql_name: "anInt",
                 },

--- a/cynic-codegen/src/fragment_derive/arguments/snapshots/cynic_codegen__fragment_derive__arguments__tests__scalars.snap
+++ b/cynic-codegen/src/fragment_derive/arguments/snapshots/cynic_codegen__fragment_derive__arguments__tests__scalars.snap
@@ -1,13 +1,11 @@
 ---
 source: cynic-codegen/src/fragment_derive/arguments/tests.rs
-assertion_line: 36
 expression: "analyse(literals, field, Some(&format_ident!(\"MyArguments\").into()),\n        Span::call_site()).map(|o| o.arguments)"
 ---
 Ok(
     [
         Field {
             schema_field: InputValue {
-                description: None,
                 name: FieldName {
                     graphql_name: "anInt",
                 },
@@ -26,7 +24,6 @@ Ok(
         },
         Field {
             schema_field: InputValue {
-                description: None,
                 name: FieldName {
                     graphql_name: "aFloat",
                 },
@@ -45,7 +42,6 @@ Ok(
         },
         Field {
             schema_field: InputValue {
-                description: None,
                 name: FieldName {
                     graphql_name: "anId",
                 },

--- a/cynic-codegen/src/fragment_derive/arguments/snapshots/cynic_codegen__fragment_derive__arguments__tests__top_level_variable.snap
+++ b/cynic-codegen/src/fragment_derive/arguments/snapshots/cynic_codegen__fragment_derive__arguments__tests__top_level_variable.snap
@@ -6,7 +6,6 @@ Ok(
     [
         Field {
             schema_field: InputValue {
-                description: None,
                 name: FieldName {
                     graphql_name: "filters",
                 },

--- a/cynic-codegen/src/fragment_derive/arguments/snapshots/cynic_codegen__fragment_derive__arguments__tests__top_level_variables.snap
+++ b/cynic-codegen/src/fragment_derive/arguments/snapshots/cynic_codegen__fragment_derive__arguments__tests__top_level_variables.snap
@@ -6,7 +6,6 @@ Ok(
     [
         Field {
             schema_field: InputValue {
-                description: None,
                 name: FieldName {
                     graphql_name: "filters",
                 },
@@ -39,7 +38,6 @@ Ok(
         },
         Field {
             schema_field: InputValue {
-                description: None,
                 name: FieldName {
                     graphql_name: "optionalFilters",
                 },

--- a/cynic-codegen/src/fragment_derive/arguments/snapshots/cynic_codegen__fragment_derive__arguments__tests__variable_in_object.snap
+++ b/cynic-codegen/src/fragment_derive/arguments/snapshots/cynic_codegen__fragment_derive__arguments__tests__variable_in_object.snap
@@ -6,7 +6,6 @@ Ok(
     [
         Field {
             schema_field: InputValue {
-                description: None,
                 name: FieldName {
                     graphql_name: "filters",
                 },
@@ -18,11 +17,9 @@ Ok(
             value: Object(
                 Object {
                     schema_obj: InputObjectType {
-                        description: None,
                         name: "BookFilters",
                         fields: [
                             InputValue {
-                                description: None,
                                 name: FieldName {
                                     graphql_name: "authors",
                                 },
@@ -36,7 +33,6 @@ Ok(
                                 has_default: false,
                             },
                             InputValue {
-                                description: None,
                                 name: FieldName {
                                     graphql_name: "state",
                                 },
@@ -52,7 +48,6 @@ Ok(
                     fields: [
                         Field {
                             schema_field: InputValue {
-                                description: None,
                                 name: FieldName {
                                     graphql_name: "state",
                                 },

--- a/cynic-codegen/src/fragment_derive/arguments/tests.rs
+++ b/cynic-codegen/src/fragment_derive/arguments/tests.rs
@@ -2,7 +2,7 @@ use proc_macro2::Span;
 use rstest::rstest;
 use syn::parse_quote;
 
-use crate::schema::{parse_schema, types::Type, Schema};
+use crate::schema::{types::Type, Schema, SchemaInput};
 
 use super::{analyse::analyse, parsing::CynicArguments};
 
@@ -26,8 +26,7 @@ fn test_analyse(
 ) {
     use quote::format_ident;
 
-    let schema_doc = parse_schema(SCHEMA).unwrap();
-    let schema = Schema::new(&schema_doc);
+    let schema = Schema::new(SchemaInput::from_sdl(SCHEMA).unwrap());
     let ty = schema.lookup::<Type<'_>>("Query").ok().unwrap();
     let field = &ty.object().unwrap().field(field).unwrap();
 
@@ -48,8 +47,7 @@ fn test_analyse(
 
 #[test]
 fn test_analyse_errors_without_argument_struct() {
-    let schema_doc = parse_schema(SCHEMA).unwrap();
-    let schema = Schema::new(&schema_doc);
+    let schema = Schema::new(SchemaInput::from_sdl(SCHEMA).unwrap());
     let ty = schema.lookup::<Type<'_>>("Query").ok().unwrap();
     let field = &ty.object().unwrap().field("filteredBooks").unwrap();
 

--- a/cynic-codegen/src/fragment_derive/arguments/tests.rs
+++ b/cynic-codegen/src/fragment_derive/arguments/tests.rs
@@ -27,7 +27,7 @@ fn test_analyse(
     use quote::format_ident;
 
     let schema_doc = parse_schema(SCHEMA).unwrap();
-    let schema = Schema::new(&schema_doc).validate().unwrap();
+    let schema = Schema::new(&schema_doc);
     let ty = schema.lookup::<Type<'_>>("Query").ok().unwrap();
     let field = &ty.object().unwrap().field(field).unwrap();
 
@@ -36,6 +36,7 @@ fn test_analyse(
     insta::assert_debug_snapshot!(
         snapshot_name,
         analyse(
+            &schema,
             literals,
             field,
             Some(&format_ident!("MyArguments").into()),
@@ -48,7 +49,7 @@ fn test_analyse(
 #[test]
 fn test_analyse_errors_without_argument_struct() {
     let schema_doc = parse_schema(SCHEMA).unwrap();
-    let schema = Schema::new(&schema_doc).validate().unwrap();
+    let schema = Schema::new(&schema_doc);
     let ty = schema.lookup::<Type<'_>>("Query").ok().unwrap();
     let field = &ty.object().unwrap().field("filteredBooks").unwrap();
 
@@ -57,7 +58,7 @@ fn test_analyse_errors_without_argument_struct() {
     let literals = literals.arguments.into_iter().collect::<Vec<_>>();
 
     insta::assert_debug_snapshot!(
-        analyse(literals, field, None, Span::call_site()).map(|o| o.arguments)
+        analyse(&schema, literals, field, None, Span::call_site()).map(|o| o.arguments)
     )
 }
 

--- a/cynic-codegen/src/fragment_derive/deserialize_impl.rs
+++ b/cynic-codegen/src/fragment_derive/deserialize_impl.rs
@@ -34,7 +34,7 @@ struct Field {
 
 impl<'a> DeserializeImpl<'a> {
     pub fn new(
-        fields: &[(&FragmentDeriveField, Option<&schema::Field<'_>>)],
+        fields: &[(FragmentDeriveField, Option<schema::Field<'_>>)],
         name: &'a syn::Ident,
         generics: &'a syn::Generics,
     ) -> Self {
@@ -43,7 +43,7 @@ impl<'a> DeserializeImpl<'a> {
         let target_struct = name;
         let fields = fields
             .iter()
-            .map(|(field, schema_field)| process_field(field, *schema_field))
+            .map(|(field, schema_field)| process_field(field, schema_field.as_ref()))
             .collect();
 
         match spreading {

--- a/cynic-codegen/src/fragment_derive/fragment_derive_type.rs
+++ b/cynic-codegen/src/fragment_derive/fragment_derive_type.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use crate::schema::{
     markers::{FieldMarkerModule, TypeMarkerIdent},
     types::{Field, Kind, Type},
@@ -6,7 +8,7 @@ use crate::schema::{
 
 pub struct FragmentDeriveType<'a> {
     pub fields: Vec<Field<'a>>,
-    pub name: &'a str,
+    pub name: Cow<'a, str>,
     pub marker_ident: TypeMarkerIdent<'a>,
     pub field_module: FieldMarkerModule<'a>,
 }

--- a/cynic-codegen/src/fragment_derive/fragment_impl.rs
+++ b/cynic-codegen/src/fragment_derive/fragment_impl.rs
@@ -21,10 +21,10 @@ use super::{
 
 use super::input::FragmentDeriveField;
 
-pub struct FragmentImpl<'a> {
+pub struct FragmentImpl<'schema, 'a> {
     target_struct: &'a proc_macro2::Ident,
     generics: &'a syn::Generics,
-    selections: Vec<Selection<'a>>,
+    selections: Vec<Selection<'schema>>,
     variables_fields: syn::Type,
     graphql_type_name: String,
     schema_type_path: syn::Path,
@@ -61,13 +61,13 @@ enum FieldKind {
     Union,
 }
 
-impl<'a> FragmentImpl<'a> {
+impl<'schema, 'a: 'schema> FragmentImpl<'schema, 'a> {
     pub fn new_for(
-        schema: &Schema<'a, Unvalidated>,
-        fields: &[(&FragmentDeriveField, Option<&'a Field<'a>>)],
+        schema: &'a Schema<'schema, Unvalidated>,
+        fields: &'a [(FragmentDeriveField, Option<Field<'schema>>)],
         name: &'a syn::Ident,
         generics: &'a syn::Generics,
-        schema_type: &FragmentDeriveType<'_>,
+        schema_type: &FragmentDeriveType<'schema>,
         schema_module_path: &syn::Path,
         graphql_type_name: &str,
         variables: Option<&syn::Path>,
@@ -87,7 +87,7 @@ impl<'a> FragmentImpl<'a> {
                 process_field(
                     schema,
                     field,
-                    *schema_field,
+                    schema_field.as_ref(),
                     &field_module_path,
                     schema_module_path,
                     variables_fields,
@@ -114,7 +114,7 @@ impl<'a> FragmentImpl<'a> {
 }
 
 fn process_field<'a>(
-    schema: &Schema<'a, Unvalidated>,
+    schema: &'a Schema<'a, Unvalidated>,
     field: &FragmentDeriveField,
     schema_field: Option<&'a Field<'a>>,
     field_module_path: &syn::Path,
@@ -161,7 +161,7 @@ fn process_field<'a>(
     }))
 }
 
-impl quote::ToTokens for FragmentImpl<'_> {
+impl quote::ToTokens for FragmentImpl<'_, '_> {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         use quote::TokenStreamExt;
 

--- a/cynic-codegen/src/fragment_derive/fragment_impl.rs
+++ b/cynic-codegen/src/fragment_derive/fragment_impl.rs
@@ -62,6 +62,7 @@ enum FieldKind {
 }
 
 impl<'schema, 'a: 'schema> FragmentImpl<'schema, 'a> {
+    #[allow(clippy::too_many_arguments)]
     pub fn new_for(
         schema: &'a Schema<'schema, Unvalidated>,
         fields: &'a [(FragmentDeriveField, Option<Field<'schema>>)],

--- a/cynic-codegen/src/fragment_derive/mod.rs
+++ b/cynic-codegen/src/fragment_derive/mod.rs
@@ -2,8 +2,8 @@ use proc_macro2::{Span, TokenStream};
 
 use crate::{
     schema::{
-        load_schema,
         types::{self as schema},
+        Schema, SchemaInput,
     },
     suggestions::FieldSuggestionError,
     Errors,
@@ -40,10 +40,10 @@ pub fn fragment_derive_impl(input: FragmentDeriveInput) -> Result<TokenStream, E
     input.validate()?;
     input.detect_aliases();
 
-    let schema_doc =
-        load_schema(&*input.schema_path).map_err(|e| e.into_syn_error(input.schema_path.span()))?;
+    let schema_input = SchemaInput::from_macro_attr_string(&*input.schema_path)
+        .map_err(|e| e.into_syn_error(input.schema_path.span()))?;
 
-    let schema = crate::schema::Schema::new(&schema_doc);
+    let schema = Schema::new(schema_input);
 
     let schema_type = schema
         .lookup::<FragmentDeriveType<'_>>(&input.graphql_type_name())

--- a/cynic-codegen/src/fragment_derive/mod.rs
+++ b/cynic-codegen/src/fragment_derive/mod.rs
@@ -40,7 +40,7 @@ pub fn fragment_derive_impl(input: FragmentDeriveInput) -> Result<TokenStream, E
     input.validate()?;
     input.detect_aliases();
 
-    let schema_input = SchemaInput::from_macro_attr_string(&*input.schema_path)
+    let schema_input = SchemaInput::from_schema_path(&*input.schema_path)
         .map_err(|e| e.into_syn_error(input.schema_path.span()))?;
 
     let schema = Schema::new(schema_input);

--- a/cynic-codegen/src/fragment_derive/mod.rs
+++ b/cynic-codegen/src/fragment_derive/mod.rs
@@ -63,6 +63,7 @@ pub fn fragment_derive_impl(
         let fields = pair_fields(fields.iter(), &schema_type)?;
 
         let fragment_impl = FragmentImpl::new_for(
+            &schema,
             &fields,
             &input.ident,
             &input.generics,

--- a/cynic-codegen/src/fragment_derive/mod.rs
+++ b/cynic-codegen/src/fragment_derive/mod.rs
@@ -122,7 +122,7 @@ fn pair_fields<'a, 'b>(
                 field.span(),
                 FieldSuggestionError {
                     expected_field,
-                    graphql_type_name: schema_type.name,
+                    graphql_type_name: schema_type.name.as_ref(),
                     suggested_field,
                 },
             )

--- a/cynic-codegen/src/inline_fragments_derive/mod.rs
+++ b/cynic-codegen/src/inline_fragments_derive/mod.rs
@@ -5,11 +5,10 @@ use {
 
 use crate::{
     inline_fragments_derive::input::ValidationMode,
-    load_schema,
     schema::{
         markers::TypeMarkerIdent,
         types::{InterfaceType, Kind, Type, UnionType},
-        Schema, SchemaError,
+        Schema, SchemaError, SchemaInput,
     },
     variables_fields_path, Errors,
 };
@@ -41,10 +40,10 @@ pub(crate) fn inline_fragments_derive_impl(
 ) -> Result<TokenStream, Errors> {
     use quote::quote;
 
-    let schema =
-        load_schema(&*input.schema_path).map_err(|e| e.into_syn_error(input.schema_path.span()))?;
+    let schema_input = SchemaInput::from_macro_attr_string(&*input.schema_path)
+        .map_err(|e| e.into_syn_error(input.schema_path.span()))?;
 
-    let schema = Schema::new(&schema);
+    let schema = Schema::new(schema_input);
 
     let target_type = schema.lookup::<InlineFragmentType<'_>>(&input.graphql_type_name())?;
 

--- a/cynic-codegen/src/inline_fragments_derive/mod.rs
+++ b/cynic-codegen/src/inline_fragments_derive/mod.rs
@@ -40,7 +40,7 @@ pub(crate) fn inline_fragments_derive_impl(
 ) -> Result<TokenStream, Errors> {
     use quote::quote;
 
-    let schema_input = SchemaInput::from_macro_attr_string(&*input.schema_path)
+    let schema_input = SchemaInput::from_schema_path(&*input.schema_path)
         .map_err(|e| e.into_syn_error(input.schema_path.span()))?;
 
     let schema = Schema::new(schema_input);

--- a/cynic-codegen/src/input_object_derive/field_serializer.rs
+++ b/cynic-codegen/src/input_object_derive/field_serializer.rs
@@ -1,3 +1,5 @@
+use crate::schema::{Schema, Unvalidated};
+
 use {
     proc_macro2::TokenStream,
     quote::{quote, quote_spanned},
@@ -53,6 +55,7 @@ impl<'a> FieldSerializer<'a> {
         &self,
         impl_generics: &syn::ImplGenerics<'_>,
         where_clause: Option<&syn::WhereClause>,
+        schema: &Schema<'a, Unvalidated>,
     ) -> TokenStream {
         let marker_type = self
             .graphql_field
@@ -60,7 +63,7 @@ impl<'a> FieldSerializer<'a> {
             .marker_type()
             .to_path(self.schema_module);
 
-        let trait_bound = match self.graphql_field.value_type.inner_type() {
+        let trait_bound = match self.graphql_field.value_type.inner_type(schema) {
             InputType::Scalar(_) => quote! { cynic::schema::IsScalar<#marker_type> },
             InputType::Enum(_) => quote! { cynic::Enum<SchemaType = #marker_type> },
             InputType::InputObject(_) => {

--- a/cynic-codegen/src/input_object_derive/field_serializer.rs
+++ b/cynic-codegen/src/input_object_derive/field_serializer.rs
@@ -16,14 +16,14 @@ use {
 
 pub struct FieldSerializer<'a> {
     rust_field: &'a InputObjectDeriveField,
-    graphql_field: &'a InputValue<'a>,
+    graphql_field: InputValue<'a>,
     schema_module: &'a syn::Path,
 }
 
 impl<'a> FieldSerializer<'a> {
     pub fn new(
         rust_field: &'a InputObjectDeriveField,
-        graphql_field: &'a InputValue<'_>,
+        graphql_field: InputValue<'a>,
         schema_module: &'a syn::Path,
     ) -> FieldSerializer<'a> {
         FieldSerializer {
@@ -37,7 +37,7 @@ impl<'a> FieldSerializer<'a> {
     /// any.
     pub fn validate(&self) -> Option<syn::Error> {
         // First, check for type errors
-        if let Err(e) = check_input_types_are_compatible(self.graphql_field, &self.rust_field.ty) {
+        if let Err(e) = check_input_types_are_compatible(&self.graphql_field, &self.rust_field.ty) {
             return Some(e);
         }
 

--- a/cynic-codegen/src/input_object_derive/mod.rs
+++ b/cynic-codegen/src/input_object_derive/mod.rs
@@ -306,9 +306,6 @@ mod test {
 
         let (rust_field_ref, input_field_ref) = result.unwrap().into_iter().next().unwrap();
         assert!(std::ptr::eq(rust_field_ref, fields.first().unwrap()));
-        assert!(std::ptr::eq(
-            &input_field_ref,
-            input_object.fields.first().unwrap()
-        ));
+        assert_eq!(&input_field_ref, input_object.fields.first().unwrap());
     }
 }

--- a/cynic-codegen/src/input_object_derive/mod.rs
+++ b/cynic-codegen/src/input_object_derive/mod.rs
@@ -44,7 +44,7 @@ pub fn input_object_derive_impl(
 ) -> Result<TokenStream, Errors> {
     use quote::quote;
 
-    let schema_input = SchemaInput::from_macro_attr_string(&*input.schema_path)
+    let schema_input = SchemaInput::from_schema_path(&*input.schema_path)
         .map_err(|e| e.into_syn_error(input.schema_path.span()))?;
 
     let schema = Schema::new(schema_input);

--- a/cynic-codegen/src/input_object_derive/mod.rs
+++ b/cynic-codegen/src/input_object_derive/mod.rs
@@ -92,7 +92,7 @@ pub fn input_object_derive_impl(
 
         let typechecks = field_serializers
             .iter()
-            .map(|fs| fs.type_check(&impl_generics, where_clause));
+            .map(|fs| fs.type_check(&impl_generics, where_clause, schema));
         let map_serializer_ident = proc_macro2::Ident::new("map_serializer", Span::call_site());
         let field_inserts = field_serializers
             .iter()

--- a/cynic-codegen/src/input_object_derive/mod.rs
+++ b/cynic-codegen/src/input_object_derive/mod.rs
@@ -63,7 +63,7 @@ pub fn input_object_derive_impl(
         let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
         let generics_with_ser = generics_for_serde::with_serialize_bounds(&input.generics);
         let (impl_generics_with_ser, _, where_clause_with_ser) = generics_with_ser.split_for_impl();
-        let input_marker_ident = proc_macro2::Ident::from(input_object.marker_ident());
+        let input_marker_ident = input_object.marker_ident().to_rust_ident();
         let schema_module = input.schema_module();
 
         let pairs = pair_fields(
@@ -100,7 +100,7 @@ pub fn input_object_derive_impl(
 
         let map_len = field_serializers.len();
 
-        let graphql_type_name = proc_macro2::Literal::string(input_object.name);
+        let graphql_type_name = proc_macro2::Literal::string(input_object.name.as_ref());
 
         Ok(quote! {
             #[automatically_derived]
@@ -200,7 +200,7 @@ fn pair_fields<'a>(
                 field_name.span(),
                 FieldSuggestionError {
                     expected_field,
-                    graphql_type_name: input_object_def.name,
+                    graphql_type_name: input_object_def.name.as_ref(),
                     suggested_field,
                 },
             )

--- a/cynic-codegen/src/lib.rs
+++ b/cynic-codegen/src/lib.rs
@@ -19,7 +19,7 @@ mod types;
 
 pub use self::{idents::RenameAll, registration::register_schema};
 
-use {error::Errors, schema::load_schema};
+use error::Errors;
 
 #[deprecated(
     since = "3.0.0",

--- a/cynic-codegen/src/registration.rs
+++ b/cynic-codegen/src/registration.rs
@@ -100,11 +100,11 @@ impl SchemaRegistration<'_> {
             .map_err(|error| SchemaRegistrationError::SchemaErrors(error.to_string()))?
             .into_static();
 
-        let schema = Schema::new(SchemaInput::Document(document.clone()))
+        let schema = Schema::new(SchemaInput::Document(document))
             .validate()
             .map_err(|errors| SchemaRegistrationError::SchemaErrors(errors.to_string()))?;
 
-        let tokens = use_schema_impl(&document, schema)
+        let tokens = use_schema_impl(schema)
             .map_err(|errors| SchemaRegistrationError::SchemaErrors(errors.to_string()))?;
 
         let schema_module_filename = schema_module_filename(self.name, &out_dir()?);

--- a/cynic-codegen/src/registration.rs
+++ b/cynic-codegen/src/registration.rs
@@ -3,7 +3,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use crate::schema::Schema;
+use crate::schema::{Schema, SchemaInput};
 
 /// Registers a schema with cynic-codegen with the given name
 ///
@@ -96,11 +96,11 @@ impl SchemaRegistration<'_> {
         use crate::use_schema::use_schema_impl;
 
         let document_string = String::from_utf8(self.data.clone()).expect("schema to be utf8");
-        let document = crate::schema::schema_from_string(document_string)
+        let document = crate::schema::load_schema(&document_string)
             .map_err(|error| SchemaRegistrationError::SchemaErrors(error.to_string()))?
             .into_static();
 
-        let schema = Schema::new(&document)
+        let schema = Schema::new(SchemaInput::Document(document.clone()))
             .validate()
             .map_err(|errors| SchemaRegistrationError::SchemaErrors(errors.to_string()))?;
 

--- a/cynic-codegen/src/schema/input.rs
+++ b/cynic-codegen/src/schema/input.rs
@@ -26,7 +26,9 @@ impl SchemaInput {
         load_schema(sdl).map(SchemaInput::Document)
     }
 
+    #[cfg(feature = "rkyv")]
     pub fn from_rkyv_bytes(bytes: Vec<u8>) -> Result<SchemaInput, SchemaLoadError> {
+        use crate::schema::type_index::optimised::OptimisedTypes;
         // Typecheck here so we can be sure it's safe later on
         rkyv::check_archived_root::<OptimisedTypes<'_>>(&bytes)
             .map_err(|e| SchemaLoadError::ParseError(e.to_string()))?;

--- a/cynic-codegen/src/schema/input.rs
+++ b/cynic-codegen/src/schema/input.rs
@@ -1,0 +1,104 @@
+use crate::schema::load_schema;
+
+use super::{parser::SchemaLoadError, type_index::optimised::OptimisedTypes, Document};
+
+pub enum SchemaInput {
+    Document(Document),
+    Archive(Vec<u8>),
+}
+
+// Public API
+impl SchemaInput {
+    /// Parses a SchemaInput from a filename passed to a macro
+    ///
+    /// This will look for either:
+    /// - An rkyv file relative to OUT_DIR/cynic/ if set
+    /// - SDL relative to CARGO_MANIFEST_DIR if set (or CWD if not)
+    pub(crate) fn from_macro_attr_string(
+        filename: impl AsRef<std::path::Path>,
+    ) -> Result<SchemaInput, SchemaLoadError> {
+        let filename = filename.as_ref();
+        if let Ok(out_dir) = std::env::var("OUT_DIR") {
+            if let Some(bytes) = rkyv_from_outdir(filename, out_dir)? {
+                return Ok(SchemaInput::Archive(bytes));
+            }
+        }
+        if let Some(document) = document_from_path(filename)? {
+            return Ok(SchemaInput::Document(document));
+        }
+        return Err(SchemaLoadError::FileNotFound(
+            filename.to_string_lossy().to_string(),
+        ));
+    }
+
+    pub fn from_sdl(sdl: &str) -> Result<SchemaInput, SchemaLoadError> {
+        load_schema(sdl).map(SchemaInput::Document)
+    }
+
+    pub fn from_rkyv_bytes(bytes: Vec<u8>) -> Result<SchemaInput, SchemaLoadError> {
+        // Typecheck here so we can be sure it's safe later on
+        rkyv::check_archived_root::<OptimisedTypes<'_>>(&bytes)
+            .map_err(|e| SchemaLoadError::ParseError(e.to_string()))?;
+
+        Ok(SchemaInput::Archive(bytes))
+    }
+}
+
+// Private API
+fn rkyv_from_outdir(
+    filename: &std::path::Path,
+    outdir: String,
+) -> Result<Option<Vec<u8>>, SchemaLoadError> {
+    if filename.components().count() != 1 {
+        // We take a schema name for arkyvs, not a path
+        return Ok(None);
+    }
+    let mut path = std::path::PathBuf::from(outdir);
+    path.push("cynic");
+    path.push(format!("{}.rkyv", filename.to_string_lossy()));
+    if !path.exists() {
+        return Ok(None);
+    }
+    let bytes = std::fs::read(path)?;
+
+    Ok(Some(bytes))
+}
+
+fn document_from_path(
+    filename: impl AsRef<std::path::Path>,
+) -> Result<Option<Document>, SchemaLoadError> {
+    use std::path::PathBuf;
+    let mut pathbuf = PathBuf::new();
+
+    if let Ok(manifest_dir) = std::env::var("CARGO_MANIFEST_DIR") {
+        pathbuf.push(manifest_dir);
+    } else {
+        pathbuf.push(std::env::current_dir()?);
+    }
+    pathbuf.push(filename);
+
+    if pathbuf.exists() {
+        load_schema(&std::fs::read_to_string(pathbuf)?).map(Some)
+    } else {
+        Ok(None)
+    }
+}
+
+/// Loads a schema from a filename, relative to CARGO_MANIFEST_DIR if it's set.
+#[cfg(nope)]
+pub fn load_schema(filename: impl AsRef<std::path::Path>) -> Result<Document, SchemaLoadError> {
+    use std::path::PathBuf;
+    let mut pathbuf = PathBuf::new();
+
+    if let Ok(manifest_dir) = std::env::var("CARGO_MANIFEST_DIR") {
+        pathbuf.push(manifest_dir);
+    } else {
+        pathbuf.push(std::env::current_dir()?);
+    }
+    pathbuf.push(filename);
+
+    let schema = std::fs::read_to_string(&pathbuf)
+        .map_err(|_| SchemaLoadError::FileNotFound(pathbuf.to_str().unwrap().to_string()))?;
+
+    Ok(add_typenames(parse_schema(&schema)?))
+}

--- a/cynic-codegen/src/schema/input.rs
+++ b/cynic-codegen/src/schema/input.rs
@@ -1,9 +1,10 @@
 use crate::schema::load_schema;
 
-use super::{parser::SchemaLoadError, type_index::optimised::OptimisedTypes, Document};
+use super::{parser::SchemaLoadError, Document};
 
 pub enum SchemaInput {
     Document(Document),
+    #[cfg(feature = "rkyv")]
     Archive(Vec<u8>),
 }
 

--- a/cynic-codegen/src/schema/input.rs
+++ b/cynic-codegen/src/schema/input.rs
@@ -38,26 +38,6 @@ impl SchemaInput {
     }
 }
 
-// Private API
-// fn rkyv_from_outdir(
-//     filename: &std::path::Path,
-//     outdir: String,
-// ) -> Result<Option<Vec<u8>>, SchemaLoadError> {
-//     if filename.components().count() != 1 {
-//         // We take a schema name for arkyvs, not a path
-//         return Ok(None);
-//     }
-//     let mut path = std::path::PathBuf::from(outdir);
-//     path.push("cynic");
-//     path.push(format!("{}.rkyv", filename.to_string_lossy()));
-//     if !path.exists() {
-//         return Ok(None);
-//     }
-//     let bytes = std::fs::read(path)?;
-
-//     Ok(Some(bytes))
-// }
-
 fn document_from_path(
     filename: impl AsRef<std::path::Path>,
 ) -> Result<Option<Document>, SchemaLoadError> {
@@ -76,23 +56,4 @@ fn document_from_path(
     } else {
         Ok(None)
     }
-}
-
-/// Loads a schema from a filename, relative to CARGO_MANIFEST_DIR if it's set.
-#[cfg(nope)]
-pub fn load_schema(filename: impl AsRef<std::path::Path>) -> Result<Document, SchemaLoadError> {
-    use std::path::PathBuf;
-    let mut pathbuf = PathBuf::new();
-
-    if let Ok(manifest_dir) = std::env::var("CARGO_MANIFEST_DIR") {
-        pathbuf.push(manifest_dir);
-    } else {
-        pathbuf.push(std::env::current_dir()?);
-    }
-    pathbuf.push(filename);
-
-    let schema = std::fs::read_to_string(&pathbuf)
-        .map_err(|_| SchemaLoadError::FileNotFound(pathbuf.to_str().unwrap().to_string()))?;
-
-    Ok(add_typenames(parse_schema(&schema)?))
 }

--- a/cynic-codegen/src/schema/input.rs
+++ b/cynic-codegen/src/schema/input.rs
@@ -10,24 +10,15 @@ pub enum SchemaInput {
 // Public API
 impl SchemaInput {
     /// Parses a SchemaInput from a filename passed to a macro
-    ///
-    /// This will look for either:
-    /// - An rkyv file relative to OUT_DIR/cynic/ if set
-    /// - SDL relative to CARGO_MANIFEST_DIR if set (or CWD if not)
-    pub(crate) fn from_macro_attr_string(
-        filename: impl AsRef<std::path::Path>,
+    pub(crate) fn from_schema_path(
+        path: impl AsRef<std::path::Path>,
     ) -> Result<SchemaInput, SchemaLoadError> {
-        let filename = filename.as_ref();
-        if let Ok(out_dir) = std::env::var("OUT_DIR") {
-            if let Some(bytes) = rkyv_from_outdir(filename, out_dir)? {
-                return Ok(SchemaInput::Archive(bytes));
-            }
-        }
-        if let Some(document) = document_from_path(filename)? {
+        let path = path.as_ref();
+        if let Some(document) = document_from_path(path)? {
             return Ok(SchemaInput::Document(document));
         }
         return Err(SchemaLoadError::FileNotFound(
-            filename.to_string_lossy().to_string(),
+            path.to_string_lossy().to_string(),
         ));
     }
 
@@ -45,24 +36,24 @@ impl SchemaInput {
 }
 
 // Private API
-fn rkyv_from_outdir(
-    filename: &std::path::Path,
-    outdir: String,
-) -> Result<Option<Vec<u8>>, SchemaLoadError> {
-    if filename.components().count() != 1 {
-        // We take a schema name for arkyvs, not a path
-        return Ok(None);
-    }
-    let mut path = std::path::PathBuf::from(outdir);
-    path.push("cynic");
-    path.push(format!("{}.rkyv", filename.to_string_lossy()));
-    if !path.exists() {
-        return Ok(None);
-    }
-    let bytes = std::fs::read(path)?;
+// fn rkyv_from_outdir(
+//     filename: &std::path::Path,
+//     outdir: String,
+// ) -> Result<Option<Vec<u8>>, SchemaLoadError> {
+//     if filename.components().count() != 1 {
+//         // We take a schema name for arkyvs, not a path
+//         return Ok(None);
+//     }
+//     let mut path = std::path::PathBuf::from(outdir);
+//     path.push("cynic");
+//     path.push(format!("{}.rkyv", filename.to_string_lossy()));
+//     if !path.exists() {
+//         return Ok(None);
+//     }
+//     let bytes = std::fs::read(path)?;
 
-    Ok(Some(bytes))
-}
+//     Ok(Some(bytes))
+// }
 
 fn document_from_path(
     filename: impl AsRef<std::path::Path>,

--- a/cynic-codegen/src/schema/markers.rs
+++ b/cynic-codegen/src/schema/markers.rs
@@ -1,4 +1,4 @@
-use std::borrow::Borrow;
+use std::borrow::{Borrow, Cow};
 
 use quote::format_ident;
 use syn::spanned::Spanned;
@@ -10,28 +10,28 @@ use crate::idents::to_snake_case;
 use super::keywords::transform_keywords;
 
 /// Ident for a type
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Debug)]
 pub struct TypeMarkerIdent<'a> {
-    graphql_name: &'a str,
+    graphql_name: Cow<'a, str>,
 }
 
 /// Ident for a field of a type
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Debug)]
 pub struct FieldMarkerIdent<'a> {
     graphql_name: &'a str,
 }
 
 /// A module that contains everything associated with a field.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Debug)]
 pub struct FieldMarkerModule<'a> {
-    type_name: &'a str,
+    type_name: Cow<'a, str>,
 }
 
 /// A module that contains everything associated with an argument to a field
-#[derive(Clone, Copy, Debug)]
+#[derive(Debug)]
 pub struct ArgumentMarkerModule<'a> {
-    type_name: &'a str,
-    field_name: &'a str,
+    type_name: Cow<'a, str>,
+    field_name: Cow<'a, str>,
 }
 
 /// Marker to the type of a field - handles options & vecs and whatever the inner
@@ -46,9 +46,10 @@ impl<T> TypeRefMarker<'_, T> {
         use syn::parse_quote;
 
         match &self.type_ref {
-            TypeRef::Named(name, _, _) => {
-                TypeMarkerIdent { graphql_name: name }.to_path(schema_module_path)
+            TypeRef::Named(name, _, _) => TypeMarkerIdent {
+                graphql_name: name.clone(),
             }
+            .to_path(schema_module_path),
             TypeRef::List(inner) => {
                 let inner_path = TypeRefMarker {
                     type_ref: inner.as_ref(),
@@ -75,28 +76,28 @@ impl<T> TypeRefMarker<'_, T> {
 
 impl<'a> TypeMarkerIdent<'a> {
     pub fn with_graphql_name(graphql_name: &'a str) -> Self {
-        TypeMarkerIdent { graphql_name }
+        TypeMarkerIdent {
+            graphql_name: Cow::Borrowed(graphql_name),
+        }
     }
 
-    pub fn to_path(self, schema_module_path: &syn::Path) -> syn::Path {
+    pub fn to_path(&self, schema_module_path: &syn::Path) -> syn::Path {
         let mut path = schema_module_path.clone();
-        path.push(proc_macro2::Ident::from(self));
+        path.push(self.to_rust_ident());
         path
     }
-}
 
-impl From<TypeMarkerIdent<'_>> for proc_macro2::Ident {
-    fn from(val: TypeMarkerIdent<'_>) -> Self {
-        format_ident!("{}", transform_keywords(val.graphql_name))
+    pub fn to_rust_ident(&self) -> proc_macro2::Ident {
+        format_ident!("{}", transform_keywords(self.graphql_name.as_ref()))
     }
 }
 
 impl<'a> FieldMarkerModule<'a> {
     pub fn ident(&self) -> proc_macro2::Ident {
-        format_ident!("{}", transform_keywords(self.type_name))
+        format_ident!("{}", transform_keywords(self.type_name.as_ref()))
     }
 
-    pub fn to_path(self, schema_module_path: &syn::Path) -> syn::Path {
+    pub fn to_path(&self, schema_module_path: &syn::Path) -> syn::Path {
         let mut path = schema_module_path.clone();
         path.push(proc_macro2::Ident::new(
             "__fields",
@@ -108,31 +109,29 @@ impl<'a> FieldMarkerModule<'a> {
 }
 
 impl<'a> FieldMarkerIdent<'a> {
-    pub fn to_path(self, schema_module_path: &syn::Path) -> syn::Path {
+    pub fn to_path(&self, schema_module_path: &syn::Path) -> syn::Path {
         let mut path = schema_module_path.clone();
-        path.push(proc_macro2::Ident::from(self));
+        path.push(self.to_rust_ident());
         path
     }
-}
 
-impl From<FieldMarkerIdent<'_>> for proc_macro2::Ident {
-    fn from(val: FieldMarkerIdent<'_>) -> Self {
-        if val.graphql_name == "_" {
+    pub fn to_rust_ident(&self) -> proc_macro2::Ident {
+        if self.graphql_name == "_" {
             return format_ident!("_Underscore");
         }
 
-        format_ident!("{}", transform_keywords(val.graphql_name))
+        format_ident!("{}", transform_keywords(self.graphql_name))
     }
 }
 
 impl ArgumentMarkerModule<'_> {
     pub fn ident(&self) -> proc_macro2::Ident {
-        format_ident!("_{}_arguments", to_snake_case(self.field_name))
+        format_ident!("_{}_arguments", to_snake_case(self.field_name.as_ref()))
     }
 
-    pub fn to_path(self, schema_module_path: &syn::Path) -> syn::Path {
+    pub fn to_path(&self, schema_module_path: &syn::Path) -> syn::Path {
         let mut path = FieldMarkerModule {
-            type_name: self.type_name,
+            type_name: self.type_name.clone(),
         }
         .to_path(schema_module_path);
         path.push(self.ident());
@@ -146,7 +145,7 @@ macro_rules! marker_ident_for_named {
         impl<'a> $kind<'a> {
             pub fn marker_ident(&self) -> TypeMarkerIdent<'a> {
                 TypeMarkerIdent {
-                    graphql_name: self.name
+                    graphql_name: self.name.clone()
                 }
             }
         }
@@ -167,7 +166,7 @@ marker_ident_for_named!(
 );
 
 impl<'a> Field<'a> {
-    pub fn marker_ident(&self) -> FieldMarkerIdent<'a> {
+    pub fn marker_ident(&'a self) -> FieldMarkerIdent<'a> {
         FieldMarkerIdent {
             graphql_name: self.name.as_str(),
         }
@@ -175,7 +174,7 @@ impl<'a> Field<'a> {
 }
 
 impl<'a> InputValue<'a> {
-    pub fn marker_ident(&self) -> FieldMarkerIdent<'a> {
+    pub fn marker_ident(&'a self) -> FieldMarkerIdent<'a> {
         FieldMarkerIdent {
             graphql_name: self.name.as_str(),
         }
@@ -185,7 +184,7 @@ impl<'a> InputValue<'a> {
 impl<'a> ObjectType<'a> {
     pub fn field_module(&self) -> FieldMarkerModule<'a> {
         FieldMarkerModule {
-            type_name: self.name,
+            type_name: self.name.clone(),
         }
     }
 }
@@ -193,15 +192,15 @@ impl<'a> ObjectType<'a> {
 impl<'a> InterfaceType<'a> {
     pub fn field_module(&self) -> FieldMarkerModule<'a> {
         FieldMarkerModule {
-            type_name: self.name,
+            type_name: self.name.clone(),
         }
     }
 }
 
 impl<'a> InputObjectType<'a> {
-    pub fn field_module(&self) -> FieldMarkerModule<'a> {
+    pub fn field_module(&'a self) -> FieldMarkerModule<'a> {
         FieldMarkerModule {
-            type_name: self.name,
+            type_name: self.name.clone(),
         }
     }
 }
@@ -209,8 +208,8 @@ impl<'a> InputObjectType<'a> {
 impl<'a> Field<'a> {
     pub fn argument_module(&self) -> ArgumentMarkerModule<'a> {
         ArgumentMarkerModule {
-            type_name: self.parent_type_name,
-            field_name: self.name.graphql_name,
+            type_name: self.parent_type_name.clone(),
+            field_name: self.name.graphql_name.clone(),
         }
     }
 }
@@ -218,7 +217,7 @@ impl<'a> Field<'a> {
 impl<'a> ObjectRef<'a> {
     pub fn marker_ident(&self) -> TypeMarkerIdent<'a> {
         TypeMarkerIdent {
-            graphql_name: self.0,
+            graphql_name: self.0.clone(),
         }
     }
 }
@@ -226,7 +225,7 @@ impl<'a> ObjectRef<'a> {
 impl<'a> InterfaceRef<'a> {
     pub fn marker_ident(&self) -> TypeMarkerIdent<'a> {
         TypeMarkerIdent {
-            graphql_name: self.0,
+            graphql_name: self.0.clone(),
         }
     }
 }

--- a/cynic-codegen/src/schema/markers.rs
+++ b/cynic-codegen/src/schema/markers.rs
@@ -46,7 +46,7 @@ impl<T> TypeRefMarker<'_, T> {
         use syn::parse_quote;
 
         match &self.type_ref {
-            TypeRef::Named(name, _, _) => TypeMarkerIdent {
+            TypeRef::Named(name, _) => TypeMarkerIdent {
                 graphql_name: name.clone(),
             }
             .to_path(schema_module_path),

--- a/cynic-codegen/src/schema/mod.rs
+++ b/cynic-codegen/src/schema/mod.rs
@@ -18,9 +18,6 @@ pub use self::{
 };
 use self::{type_index::TypeIndex, types::SchemaRoots};
 
-#[cfg(test)]
-pub(crate) use self::parser::parse_schema;
-
 // TODO: Uncomment this
 // pub use self::{types::*},
 
@@ -72,7 +69,7 @@ impl<'a> Schema<'a, Unvalidated> {
 }
 
 impl<'a> Schema<'a, Validated> {
-    pub fn root_types<'b>(&'b self) -> Result<SchemaRoots<'b>, SchemaError> {
+    pub fn root_types(&self) -> Result<SchemaRoots<'_>, SchemaError> {
         self.type_index.root_types()
     }
 

--- a/cynic-codegen/src/schema/mod.rs
+++ b/cynic-codegen/src/schema/mod.rs
@@ -35,6 +35,7 @@ impl<'a> Schema<'a, Unvalidated> {
             SchemaInput::Document(document) => {
                 Box::new(type_index::SchemaBackedTypeIndex::for_schema(document))
             }
+            #[cfg(feature = "rkyv")]
             SchemaInput::Archive(data) => Box::new(
                 type_index::optimised::ArchiveBacked::from_checked_data(data),
             ),

--- a/cynic-codegen/src/schema/mod.rs
+++ b/cynic-codegen/src/schema/mod.rs
@@ -17,7 +17,7 @@ pub use self::{
 };
 
 #[cfg(test)]
-pub(crate) use self::{parser::parse_schema, type_index::TypeIndex};
+pub(crate) use self::parser::parse_schema;
 
 // TODO: Uncomment this
 // pub use self::{types::*},
@@ -56,9 +56,10 @@ impl<'a> Schema<'a, Unvalidated> {
 
     pub fn lookup<Kind>(&self, name: &str) -> Result<Kind, SchemaError>
     where
-        Kind: TryFrom<types::Type<'a>, Error = SchemaError> + 'a,
+        Kind: TryFrom<types::Type<'a>> + 'a,
+        Kind::Error: Into<SchemaError>,
     {
-        Kind::try_from(self.type_index.lookup_valid_type(name)?)
+        Kind::try_from(self.type_index.lookup_valid_type(name)?).map_err(Into::into)
         // TODO: Suggestion logic should probably be implemented here (or in type_index)
     }
 }

--- a/cynic-codegen/src/schema/names.rs
+++ b/cynic-codegen/src/schema/names.rs
@@ -2,10 +2,14 @@ use std::borrow::Cow;
 
 use crate::idents::RenamableFieldIdent;
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
-#[archive(check_bytes)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize),
+    archive(check_bytes)
+)]
 pub struct FieldName<'a> {
-    #[with(rkyv::with::AsOwned)]
+    #[cfg_attr(feature = "rkyv", with(rkyv::with::AsOwned))]
     pub(super) graphql_name: Cow<'a, str>,
 }
 

--- a/cynic-codegen/src/schema/names.rs
+++ b/cynic-codegen/src/schema/names.rs
@@ -1,27 +1,31 @@
+use std::borrow::Cow;
+
 use crate::idents::RenamableFieldIdent;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct FieldName<'a> {
-    pub(super) graphql_name: &'a str,
+    pub(super) graphql_name: Cow<'a, str>,
 }
 
 impl<'a> FieldName<'a> {
     pub fn new(graphql_name: &'a str) -> Self {
-        FieldName { graphql_name }
+        FieldName {
+            graphql_name: Cow::Borrowed(graphql_name),
+        }
     }
 
-    pub fn as_str(&self) -> &'a str {
-        self.graphql_name
+    pub fn as_str(&'a self) -> &'a str {
+        self.graphql_name.as_ref()
     }
 
     pub fn to_literal(&self) -> proc_macro2::Literal {
-        proc_macro2::Literal::string(self.graphql_name)
+        proc_macro2::Literal::string(self.graphql_name.as_ref())
     }
 }
 
 impl<'a> PartialEq<proc_macro2::Ident> for FieldName<'a> {
     fn eq(&self, other: &proc_macro2::Ident) -> bool {
-        other == self.graphql_name
+        other == self.graphql_name.as_ref()
     }
 }
 
@@ -33,7 +37,7 @@ impl<'a> PartialEq<str> for FieldName<'a> {
 
 impl<'a> PartialEq<String> for FieldName<'a> {
     fn eq(&self, other: &String) -> bool {
-        self.graphql_name == other
+        self.graphql_name.as_ref() == other
     }
 }
 

--- a/cynic-codegen/src/schema/names.rs
+++ b/cynic-codegen/src/schema/names.rs
@@ -2,8 +2,10 @@ use std::borrow::Cow;
 
 use crate::idents::RenamableFieldIdent;
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
+#[archive(check_bytes)]
 pub struct FieldName<'a> {
+    #[with(rkyv::with::AsOwned)]
     pub(super) graphql_name: Cow<'a, str>,
 }
 

--- a/cynic-codegen/src/schema/parser.rs
+++ b/cynic-codegen/src/schema/parser.rs
@@ -14,26 +14,9 @@ pub type TypeDefinition = graphql_parser::schema::TypeDefinition<'static, String
 pub type ScalarType = graphql_parser::schema::ScalarType<'static, String>;
 pub type InputValue = graphql_parser::schema::InputValue<'static, String>;
 
-/// Loads a schema from a filename, relative to CARGO_MANIFEST_DIR if it's set.
-pub fn load_schema(filename: impl AsRef<std::path::Path>) -> Result<Document, SchemaLoadError> {
-    use std::path::PathBuf;
-    let mut pathbuf = PathBuf::new();
-
-    if let Ok(manifest_dir) = std::env::var("CARGO_MANIFEST_DIR") {
-        pathbuf.push(manifest_dir);
-    } else {
-        pathbuf.push(std::env::current_dir()?);
-    }
-    pathbuf.push(filename);
-
-    let schema = std::fs::read_to_string(&pathbuf)
-        .map_err(|_| SchemaLoadError::FileNotFound(pathbuf.to_str().unwrap().to_string()))?;
-
-    schema_from_string(schema)
-}
-
-pub fn schema_from_string(schema: String) -> Result<Document, SchemaLoadError> {
-    Ok(add_typenames(parse_schema(&schema)?))
+/// Loads a schema from a string
+pub fn load_schema(sdl: &str) -> Result<Document, SchemaLoadError> {
+    Ok(add_typenames(parse_schema(&sdl)?))
 }
 
 fn add_typenames(mut schema: Document) -> Document {

--- a/cynic-codegen/src/schema/parser.rs
+++ b/cynic-codegen/src/schema/parser.rs
@@ -43,6 +43,8 @@ pub enum SchemaLoadError {
     IoError(String),
     ParseError(String),
     FileNotFound(String),
+    NamedSchemaNotFound(String),
+    DefaultSchemaNotFound,
 }
 
 impl SchemaLoadError {
@@ -57,6 +59,14 @@ impl std::fmt::Display for SchemaLoadError {
             SchemaLoadError::IoError(e) => write!(f, "Could not load schema file: {}", e),
             SchemaLoadError::ParseError(e) => write!(f, "Could not parse schema file: {}", e),
             SchemaLoadError::FileNotFound(e) => write!(f, "Could not find file: {}", e),
+            SchemaLoadError::NamedSchemaNotFound(e) => write!(
+                f,
+                "Could not find a schema named {}\n\n Have you registered it in build.rs?",
+                e
+            ),
+            SchemaLoadError::DefaultSchemaNotFound => {
+                write!(f, "Couldn't determine which schema to use.  Please provide the `schema` argument or set a default schema in build.rs")
+            }
         }
     }
 }

--- a/cynic-codegen/src/schema/parser.rs
+++ b/cynic-codegen/src/schema/parser.rs
@@ -16,7 +16,7 @@ pub type InputValue = graphql_parser::schema::InputValue<'static, String>;
 
 /// Loads a schema from a string
 pub fn load_schema(sdl: &str) -> Result<Document, SchemaLoadError> {
-    Ok(add_typenames(parse_schema(&sdl)?))
+    Ok(add_typenames(parse_schema(sdl)?))
 }
 
 fn add_typenames(mut schema: Document) -> Document {

--- a/cynic-codegen/src/schema/type_index/mod.rs
+++ b/cynic-codegen/src/schema/type_index/mod.rs
@@ -1,13 +1,17 @@
-use super::{types::Type, SchemaError};
+use super::{
+    types::{SchemaRoots, Type},
+    SchemaError,
+};
 
-mod optimised;
+pub mod optimised;
 mod schema_backed;
 
-pub use schema_backed::SchemaBackedTypeIndex;
+pub use self::schema_backed::SchemaBackedTypeIndex;
 
 pub trait TypeIndex {
     fn validate_all(&self) -> Result<(), SchemaError>;
     fn lookup_valid_type<'a>(&'a self, name: &str) -> Result<Type<'a>, SchemaError>;
+    fn root_types<'a>(&'a self) -> Result<SchemaRoots<'a>, SchemaError>;
 
     // These are only safe to call if the TypeIndex has been validated.
     // The Schema should make sure that's the case...

--- a/cynic-codegen/src/schema/type_index/mod.rs
+++ b/cynic-codegen/src/schema/type_index/mod.rs
@@ -1,5 +1,6 @@
 use super::{types::Type, SchemaError};
 
+mod optimised;
 mod schema_backed;
 
 pub use schema_backed::SchemaBackedTypeIndex;

--- a/cynic-codegen/src/schema/type_index/mod.rs
+++ b/cynic-codegen/src/schema/type_index/mod.rs
@@ -1,0 +1,15 @@
+use super::{types::Type, SchemaError};
+
+mod schema_backed;
+
+pub use schema_backed::SchemaBackedTypeIndex;
+
+pub trait TypeIndex {
+    fn validate_all(&self) -> Result<(), SchemaError>;
+    fn lookup_valid_type<'a>(&'a self, name: &str) -> Result<Type<'a>, SchemaError>;
+
+    // These are only safe to call if the TypeIndex has been validated.
+    // The Schema should make sure that's the case...
+    fn unsafe_lookup<'a>(&'a self, name: &str) -> Option<Type<'a>>;
+    fn unsafe_iter<'a>(&'a self) -> Box<dyn Iterator<Item = Type<'a>> + 'a>;
+}

--- a/cynic-codegen/src/schema/type_index/mod.rs
+++ b/cynic-codegen/src/schema/type_index/mod.rs
@@ -11,7 +11,7 @@ pub use self::schema_backed::SchemaBackedTypeIndex;
 pub trait TypeIndex {
     fn validate_all(&self) -> Result<(), SchemaError>;
     fn lookup_valid_type<'a>(&'a self, name: &str) -> Result<Type<'a>, SchemaError>;
-    fn root_types<'a>(&'a self) -> Result<SchemaRoots<'a>, SchemaError>;
+    fn root_types(&self) -> Result<SchemaRoots<'_>, SchemaError>;
 
     // These are only safe to call if the TypeIndex has been validated.
     // The Schema should make sure that's the case...

--- a/cynic-codegen/src/schema/type_index/mod.rs
+++ b/cynic-codegen/src/schema/type_index/mod.rs
@@ -3,7 +3,9 @@ use super::{
     SchemaError,
 };
 
+#[cfg(feature = "rkyv")]
 pub mod optimised;
+
 mod schema_backed;
 
 pub use self::schema_backed::SchemaBackedTypeIndex;

--- a/cynic-codegen/src/schema/type_index/optimised.rs
+++ b/cynic-codegen/src/schema/type_index/optimised.rs
@@ -11,7 +11,8 @@ use crate::schema::{
 
 #[derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize, PartialEq, Eq, Debug)]
 #[archive(check_bytes)]
-/// TODO: Doc string
+/// A collection of types that can be saved in an optimised rkyv format
+/// for quicker re-loading.
 pub struct OptimisedTypes<'a> {
     types: HashMap<String, Type<'a>>,
     schema_roots: SchemaRoots<'a>,

--- a/cynic-codegen/src/schema/type_index/optimised.rs
+++ b/cynic-codegen/src/schema/type_index/optimised.rs
@@ -1,18 +1,16 @@
+//! TODO: Docstring
 use std::collections::HashMap;
 
 use crate::schema::{self, types::Type, Schema};
 
 #[derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize, PartialEq, Eq, Debug)]
 #[archive(check_bytes)]
-// TODO: Convert into this somehow,
-// then serialize
-// then write code to load an ArchivedTypes and deserialize
-// on appropriate calls...
-struct Types<'a>(HashMap<String, Type<'a>>);
+/// TODO: Doc string
+pub struct OptimisedTypes<'a>(HashMap<String, Type<'a>>);
 
 impl Schema<'_, schema::Validated> {
-    fn optimise<'a>(&'a self) -> Types<'a> {
-        Types(
+    fn optimise<'a>(&'a self) -> OptimisedTypes<'a> {
+        OptimisedTypes(
             self.type_index
                 .unsafe_iter()
                 .map(|ty| (ty.name().to_string(), ty))
@@ -41,12 +39,12 @@ mod tests {
         optimised
             .0
             .iter()
-            .for_each(|(name, ty)| assert_eq!(schema.lookup::<Type<'_>>(&name).unwrap(), *ty));
+            .for_each(|(name, ty)| assert_eq!(schema.lookup::<Type<'_>>(name).unwrap(), *ty));
 
         let bytes = rkyv::to_bytes::<_, 1024>(&optimised).unwrap();
-        let archived = rkyv::check_archived_root::<Types<'_>>(&bytes[..]).unwrap();
+        let archived = rkyv::check_archived_root::<OptimisedTypes<'_>>(&bytes[..]).unwrap();
 
-        let deserialized: Types<'_> = archived.deserialize(&mut rkyv::Infallible).unwrap();
+        let deserialized: OptimisedTypes<'_> = archived.deserialize(&mut rkyv::Infallible).unwrap();
 
         assert_eq!(deserialized, optimised);
     }

--- a/cynic-codegen/src/schema/type_index/optimised.rs
+++ b/cynic-codegen/src/schema/type_index/optimised.rs
@@ -1,29 +1,104 @@
 //! TODO: Docstring
 use std::collections::HashMap;
 
-use crate::schema::{self, types::Type, Schema};
+use rkyv::Deserialize;
+
+use crate::schema::{
+    self,
+    types::{SchemaRoots, Type},
+    Schema, SchemaError,
+};
 
 #[derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize, PartialEq, Eq, Debug)]
 #[archive(check_bytes)]
 /// TODO: Doc string
-pub struct OptimisedTypes<'a>(HashMap<String, Type<'a>>);
+pub struct OptimisedTypes<'a> {
+    types: HashMap<String, Type<'a>>,
+    schema_roots: SchemaRoots<'a>,
+}
 
 impl Schema<'_, schema::Validated> {
     fn optimise<'a>(&'a self) -> OptimisedTypes<'a> {
-        OptimisedTypes(
-            self.type_index
+        OptimisedTypes {
+            types: self
+                .type_index
                 .unsafe_iter()
                 .map(|ty| (ty.name().to_string(), ty))
                 .collect(),
+            schema_roots: self.type_index.root_types().expect("valid root types"),
+        }
+    }
+}
+
+#[ouroboros::self_referencing]
+pub struct ArchiveBacked {
+    data: Vec<u8>,
+    #[borrows(data)]
+    archived: &'this ArchivedOptimisedTypes<'static>,
+}
+
+impl ArchiveBacked {
+    pub fn from_checked_data(data: Vec<u8>) -> Self {
+        ArchiveBacked::new(data, |data| unsafe {
+            // This is safe so long as we've already verified data
+            rkyv::archived_root::<OptimisedTypes<'_>>(&data[..])
+        })
+    }
+}
+
+impl super::TypeIndex for ArchiveBacked {
+    fn validate_all(&self) -> Result<(), SchemaError> {
+        // An ArchiveBacked can only be created from already validated types.
+        Ok(())
+    }
+
+    fn lookup_valid_type<'a>(&'a self, name: &str) -> Result<Type<'a>, SchemaError> {
+        Ok(self
+            .borrow_archived()
+            .types
+            .get(name)
+            .ok_or_else(|| SchemaError::CouldNotFindType {
+                name: name.to_string(),
+            })?
+            .deserialize(&mut rkyv::Infallible)
+            .expect("infalliable"))
+    }
+
+    fn root_types(&self) -> Result<schema::types::SchemaRoots<'_>, SchemaError> {
+        Ok(self
+            .borrow_archived()
+            .schema_roots
+            .deserialize(&mut rkyv::Infallible)
+            .expect("infallible"))
+    }
+
+    fn unsafe_lookup<'a>(&'a self, name: &str) -> Option<Type<'a>> {
+        Some(
+            self.borrow_archived()
+                .types
+                .get(name)
+                .unwrap()
+                .deserialize(&mut rkyv::Infallible)
+                .expect("infallible"),
         )
+    }
+
+    fn unsafe_iter<'a>(&'a self) -> Box<dyn Iterator<Item = Type<'a>> + 'a> {
+        Box::new(self.borrow_archived().types.values().map(|archived_type| {
+            archived_type
+                .deserialize(&mut rkyv::Infallible)
+                .expect("infallible")
+        }))
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashSet;
+
     use rkyv::Deserialize;
 
-    use crate::schema::SchemaInput;
+    use crate::schema::{type_index::TypeIndex, SchemaInput};
 
     use super::*;
 
@@ -38,7 +113,7 @@ mod tests {
 
         // Make sure optimising hasn't broken anything
         optimised
-            .0
+            .types
             .iter()
             .for_each(|(name, ty)| assert_eq!(schema.lookup::<Type<'_>>(name).unwrap(), *ty));
 
@@ -48,5 +123,34 @@ mod tests {
         let deserialized: OptimisedTypes<'_> = archived.deserialize(&mut rkyv::Infallible).unwrap();
 
         assert_eq!(deserialized, optimised);
+    }
+
+    #[test]
+    fn test_type_index_impl() {
+        let schema_string = std::fs::read_to_string("../schemas/github.graphql").unwrap();
+        let schema = Schema::new(SchemaInput::from_sdl(&schema_string).unwrap())
+            .validate()
+            .unwrap();
+
+        let optimised = schema.optimise();
+
+        let bytes = rkyv::to_bytes::<_, 1024>(&optimised).unwrap();
+
+        let schema_backed = schema.type_index;
+        let archive_backed = ArchiveBacked::from_checked_data(bytes.to_vec());
+
+        assert_eq!(
+            archive_backed.root_types().unwrap(),
+            schema_backed.root_types().unwrap()
+        );
+
+        for ty in schema_backed.unsafe_iter() {
+            assert_eq!(archive_backed.lookup_valid_type(ty.name()).unwrap(), ty);
+            assert_eq!(archive_backed.unsafe_lookup(ty.name()).unwrap(), ty);
+        }
+
+        let all_schema_backed = schema_backed.unsafe_iter().collect::<HashSet<_>>();
+        let all_archive_backed = archive_backed.unsafe_iter().collect::<HashSet<_>>();
+        assert_eq!(all_archive_backed, all_schema_backed);
     }
 }

--- a/cynic-codegen/src/schema/type_index/optimised.rs
+++ b/cynic-codegen/src/schema/type_index/optimised.rs
@@ -1,0 +1,53 @@
+use std::collections::HashMap;
+
+use crate::schema::{self, types::Type, Schema};
+
+#[derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize, PartialEq, Eq, Debug)]
+#[archive(check_bytes)]
+// TODO: Convert into this somehow,
+// then serialize
+// then write code to load an ArchivedTypes and deserialize
+// on appropriate calls...
+struct Types<'a>(HashMap<String, Type<'a>>);
+
+impl Schema<'_, schema::Validated> {
+    fn optimise<'a>(&'a self) -> Types<'a> {
+        Types(
+            self.type_index
+                .unsafe_iter()
+                .map(|ty| (ty.name().to_string(), ty))
+                .collect(),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rkyv::Deserialize;
+
+    use super::*;
+
+    #[test]
+    fn test_rkyv_roundtrip() {
+        let schema_string = std::fs::read_to_string("../schemas/github.graphql").unwrap();
+        let document = graphql_parser::parse_schema(&schema_string)
+            .unwrap()
+            .into_static();
+        let schema = Schema::new(&document).validate().unwrap();
+
+        let optimised = schema.optimise();
+
+        // Make sure optimising hasn't broken anything
+        optimised
+            .0
+            .iter()
+            .for_each(|(name, ty)| assert_eq!(schema.lookup::<Type<'_>>(&name).unwrap(), *ty));
+
+        let bytes = rkyv::to_bytes::<_, 1024>(&optimised).unwrap();
+        let archived = rkyv::check_archived_root::<Types<'_>>(&bytes[..]).unwrap();
+
+        let deserialized: Types<'_> = archived.deserialize(&mut rkyv::Infallible).unwrap();
+
+        assert_eq!(deserialized, optimised);
+    }
+}

--- a/cynic-codegen/src/schema/type_index/optimised.rs
+++ b/cynic-codegen/src/schema/type_index/optimised.rs
@@ -18,7 +18,7 @@ pub struct OptimisedTypes<'a> {
 }
 
 impl Schema<'_, schema::Validated> {
-    fn optimise(&self) -> OptimisedTypes<'_> {
+    pub(crate) fn optimise(&self) -> OptimisedTypes<'_> {
         OptimisedTypes {
             types: self
                 .type_index

--- a/cynic-codegen/src/schema/type_index/optimised.rs
+++ b/cynic-codegen/src/schema/type_index/optimised.rs
@@ -23,15 +23,16 @@ impl Schema<'_, schema::Validated> {
 mod tests {
     use rkyv::Deserialize;
 
+    use crate::schema::SchemaInput;
+
     use super::*;
 
     #[test]
     fn test_rkyv_roundtrip() {
         let schema_string = std::fs::read_to_string("../schemas/github.graphql").unwrap();
-        let document = graphql_parser::parse_schema(&schema_string)
-            .unwrap()
-            .into_static();
-        let schema = Schema::new(&document).validate().unwrap();
+        let schema = Schema::new(SchemaInput::from_sdl(&schema_string).unwrap())
+            .validate()
+            .unwrap();
 
         let optimised = schema.optimise();
 

--- a/cynic-codegen/src/schema/type_index/optimised.rs
+++ b/cynic-codegen/src/schema/type_index/optimised.rs
@@ -18,7 +18,7 @@ pub struct OptimisedTypes<'a> {
 }
 
 impl Schema<'_, schema::Validated> {
-    fn optimise<'a>(&'a self) -> OptimisedTypes<'a> {
+    fn optimise(&self) -> OptimisedTypes<'_> {
         OptimisedTypes {
             types: self
                 .type_index

--- a/cynic-codegen/src/schema/type_index/schema_backed.rs
+++ b/cynic-codegen/src/schema/type_index/schema_backed.rs
@@ -19,8 +19,6 @@ pub struct SchemaBackedTypeIndex {
     query_root: String,
     mutation_root: Option<String>,
     subscription_root: Option<String>,
-    // TODO: this should maybe just own the type defs?
-    // might be easier...
     #[borrows(document)]
     #[covariant]
     types: HashMap<&'this str, &'this TypeDefinition>,

--- a/cynic-codegen/src/schema/type_index/schema_backed.rs
+++ b/cynic-codegen/src/schema/type_index/schema_backed.rs
@@ -16,6 +16,8 @@ use crate::schema::{
 
 #[derive(Clone)]
 pub struct SchemaBackedTypeIndex<'a> {
+    // TODO: this should maybe just own the type defs?
+    // might be easier...
     pub(super) types: Rc<HashMap<&'a str, &'a TypeDefinition>>,
 }
 

--- a/cynic-codegen/src/schema/type_index/schema_backed.rs
+++ b/cynic-codegen/src/schema/type_index/schema_backed.rs
@@ -352,8 +352,8 @@ fn convert_input_value(val: &parser::InputValue) -> InputValue<'_> {
     }
 }
 
-fn build_type_ref<'a, T>(ty: &'a parser::Type) -> TypeRef<'a, T> {
-    fn inner_fn<'a, T>(ty: &'a parser::Type, nullable: bool) -> TypeRef<'a, T> {
+fn build_type_ref<T>(ty: &parser::Type) -> TypeRef<'_, T> {
+    fn inner_fn<T>(ty: &parser::Type, nullable: bool) -> TypeRef<'_, T> {
         if let parser::Type::NonNullType(inner) = ty {
             return inner_fn::<T>(inner, false);
         }
@@ -378,11 +378,7 @@ fn build_field<'a>(field: &'a parser::Field, parent_type_name: &'a str) -> Field
         name: FieldName {
             graphql_name: Cow::Borrowed(&field.name),
         },
-        arguments: field
-            .arguments
-            .iter()
-            .map(|arg| convert_input_value(arg))
-            .collect(),
+        arguments: field.arguments.iter().map(convert_input_value).collect(),
         field_type: build_type_ref::<OutputType<'_>>(&field.field_type),
         parent_type_name: Cow::Borrowed(parent_type_name),
     }

--- a/cynic-codegen/src/schema/type_index/schema_backed.rs
+++ b/cynic-codegen/src/schema/type_index/schema_backed.rs
@@ -27,13 +27,6 @@ pub struct SchemaBackedTypeIndex {
 }
 
 impl SchemaBackedTypeIndex {
-    #[cfg(test)]
-    pub fn empty() -> Self {
-        SchemaBackedTypeIndex::new(Document::default(), "Query".into(), None, None, |_| {
-            HashMap::new()
-        })
-    }
-
     pub fn for_schema(document: Document) -> Self {
         let mut query_root = "Query".to_string();
         let mut mutation_root = None;
@@ -405,7 +398,6 @@ mod tests {
 
     #[test]
     fn test_build_type_ref_non_null_type() {
-        let index = &SchemaBackedTypeIndex::empty();
         let non_null_type =
             parser::Type::NonNullType(Box::new(parser::Type::NamedType("User".to_string())));
 

--- a/cynic-codegen/src/schema/types.rs
+++ b/cynic-codegen/src/schema/types.rs
@@ -2,16 +2,24 @@ use std::{borrow::Cow, marker::PhantomData};
 
 use super::{names::FieldName, SchemaError};
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
-#[archive(check_bytes)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize),
+    archive(check_bytes)
+)]
 pub struct SchemaRoots<'a> {
     pub query: ObjectType<'a>,
     pub mutation: Option<ObjectType<'a>>,
     pub subscription: Option<ObjectType<'a>>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
-#[archive(check_bytes)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize),
+    archive(check_bytes)
+)]
 pub enum Type<'a> {
     Scalar(ScalarType<'a>),
     Object(ObjectType<'a>),
@@ -21,16 +29,24 @@ pub enum Type<'a> {
     InputObject(InputObjectType<'a>),
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
-#[archive(check_bytes)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize),
+    archive(check_bytes)
+)]
 pub enum InputType<'a> {
     Scalar(ScalarType<'a>),
     Enum(EnumType<'a>),
     InputObject(InputObjectType<'a>),
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
-#[archive(check_bytes)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize),
+    archive(check_bytes)
+)]
 pub enum OutputType<'a> {
     Scalar(ScalarType<'a>),
     Object(ObjectType<'a>),
@@ -39,35 +55,51 @@ pub enum OutputType<'a> {
     Enum(EnumType<'a>),
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
-#[archive(check_bytes)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize),
+    archive(check_bytes)
+)]
 pub struct ScalarType<'a> {
-    #[with(rkyv::with::AsOwned)]
+    #[cfg_attr(feature = "rkyv", with(rkyv::with::AsOwned))]
     pub name: Cow<'a, str>,
     pub builtin: bool,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
-#[archive(check_bytes)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize),
+    archive(check_bytes)
+)]
 pub struct ObjectType<'a> {
-    #[with(rkyv::with::AsOwned)]
+    #[cfg_attr(feature = "rkyv", with(rkyv::with::AsOwned))]
     pub name: Cow<'a, str>,
     pub implements_interfaces: Vec<InterfaceRef<'a>>,
     pub fields: Vec<Field<'a>>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
-#[archive(check_bytes)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize),
+    archive(check_bytes)
+)]
 pub struct Field<'a> {
     pub name: FieldName<'a>,
     pub arguments: Vec<InputValue<'a>>,
     pub field_type: TypeRef<'a, OutputType<'a>>,
-    #[with(rkyv::with::AsOwned)]
+    #[cfg_attr(feature = "rkyv", with(rkyv::with::AsOwned))]
     pub(super) parent_type_name: Cow<'a, str>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
-#[archive(check_bytes)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize),
+    archive(check_bytes)
+)]
 pub struct InputValue<'a> {
     pub name: FieldName<'a>,
     pub value_type: TypeRef<'a, InputType<'a>>,
@@ -84,46 +116,70 @@ impl InputValue<'_> {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
-#[archive(check_bytes)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize),
+    archive(check_bytes)
+)]
 pub struct InterfaceType<'a> {
-    #[with(rkyv::with::AsOwned)]
+    #[cfg_attr(feature = "rkyv", with(rkyv::with::AsOwned))]
     pub name: Cow<'a, str>,
     pub fields: Vec<Field<'a>>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
-#[archive(check_bytes)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize),
+    archive(check_bytes)
+)]
 pub struct UnionType<'a> {
-    #[with(rkyv::with::AsOwned)]
+    #[cfg_attr(feature = "rkyv", with(rkyv::with::AsOwned))]
     pub name: Cow<'a, str>,
     pub types: Vec<ObjectRef<'a>>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
-#[archive(check_bytes)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize),
+    archive(check_bytes)
+)]
 pub struct EnumType<'a> {
-    #[with(rkyv::with::AsOwned)]
+    #[cfg_attr(feature = "rkyv", with(rkyv::with::AsOwned))]
     pub name: Cow<'a, str>,
     pub values: Vec<EnumValue<'a>>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
-#[archive(check_bytes)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize),
+    archive(check_bytes)
+)]
 pub struct EnumValue<'a> {
     pub name: FieldName<'a>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
-#[archive(check_bytes)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize),
+    archive(check_bytes)
+)]
 pub struct InputObjectType<'a> {
-    #[with(rkyv::with::AsOwned)]
+    #[cfg_attr(feature = "rkyv", with(rkyv::with::AsOwned))]
     pub name: Cow<'a, str>,
     pub fields: Vec<InputValue<'a>>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
-#[archive(check_bytes)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize),
+    archive(check_bytes)
+)]
 pub enum Kind {
     InputType,
     OutputType,
@@ -175,9 +231,15 @@ impl<'a> EnumType<'a> {
     }
 }
 
-#[derive(Clone, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
-#[archive(check_bytes)]
-pub struct ObjectRef<'a>(#[with(rkyv::with::AsOwned)] pub(super) Cow<'a, str>);
+#[derive(Clone)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize),
+    archive(check_bytes)
+)]
+pub struct ObjectRef<'a>(
+    #[cfg_attr(feature = "rkyv", with(rkyv::with::AsOwned))] pub(super) Cow<'a, str>,
+);
 
 impl std::fmt::Debug for ObjectRef<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -199,9 +261,15 @@ impl<'a> std::hash::Hash for ObjectRef<'a> {
     }
 }
 
-#[derive(Clone, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
-#[archive(check_bytes)]
-pub struct InterfaceRef<'a>(#[with(rkyv::with::AsOwned)] pub(super) Cow<'a, str>);
+#[derive(Clone)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize),
+    archive(check_bytes)
+)]
+pub struct InterfaceRef<'a>(
+    #[cfg_attr(feature = "rkyv", with(rkyv::with::AsOwned))] pub(super) Cow<'a, str>,
+);
 
 impl std::fmt::Debug for InterfaceRef<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -223,26 +291,24 @@ impl<'a> std::hash::Hash for InterfaceRef<'a> {
     }
 }
 
-#[derive(Clone, PartialEq, Eq, Hash, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
-#[archive(check_bytes, bound(serialize = "__S: rkyv::ser::Serializer"))]
-#[archive_attr(check_bytes(
-    bound = "__C: rkyv::validation::ArchiveContext, <__C as rkyv::Fallible>::Error: rkyv::bytecheck::Error"
-))]
+#[derive(Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize),
+    archive(check_bytes, bound(serialize = "__S: rkyv::ser::Serializer")),
+    archive_attr(check_bytes(
+        bound = "__C: rkyv::validation::ArchiveContext, <__C as rkyv::Fallible>::Error: rkyv::bytecheck::Error"
+    ))
+)]
 pub enum TypeRef<'a, T> {
     Named(
-        #[with(rkyv::with::AsOwned)] Cow<'a, str>,
+        #[cfg_attr(feature = "rkyv", with(rkyv::with::AsOwned))] Cow<'a, str>,
         PhantomData<fn() -> T>,
     ),
 
-    List(
-        #[omit_bounds]
-        #[archive_attr(omit_bounds)]
-        Box<TypeRef<'a, T>>,
-    ),
+    List(#[cfg_attr(feature = "rkyv", omit_bounds, archive_attr(omit_bounds))] Box<TypeRef<'a, T>>),
     Nullable(
-        #[omit_bounds]
-        #[archive_attr(omit_bounds)]
-        Box<TypeRef<'a, T>>,
+        #[cfg_attr(feature = "rkyv", omit_bounds, archive_attr(omit_bounds))] Box<TypeRef<'a, T>>,
     ),
 }
 

--- a/cynic-codegen/src/schema/types.rs
+++ b/cynic-codegen/src/schema/types.rs
@@ -206,15 +206,15 @@ where
     Type<'a>: TryInto<T>,
     <Type<'a> as TryInto<T>>::Error: std::fmt::Debug,
 {
-    pub fn inner_type<SchemaState>(&self, schema: &super::Schema<'a, SchemaState>) -> T {
+    pub fn inner_type<SchemaState>(&self, schema: &'a super::Schema<'a, SchemaState>) -> T {
         match self {
             TypeRef::Named(name, _) => {
-                // Note: we assume that TypeRef is only constructed after validation,
-                // which makes this unwrap ok.
-                // Probably want to enforce this via module hierarchy.
+                // Note: We validate types prior to constructing a TypeRef
+                // for them so the unsafe_lookup and unwrap here should
+                // be safe.
                 schema
                     .type_index
-                    .private_lookup(name)
+                    .unsafe_lookup(name)
                     .unwrap()
                     .try_into()
                     .unwrap()

--- a/cynic-codegen/src/schema/types.rs
+++ b/cynic-codegen/src/schema/types.rs
@@ -2,7 +2,8 @@ use std::{borrow::Cow, marker::PhantomData};
 
 use super::{names::FieldName, type_index::TypeIndex, SchemaError};
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
+#[archive(check_bytes)]
 pub enum Type<'a> {
     Scalar(ScalarType<'a>),
     Object(ObjectType<'a>),
@@ -12,14 +13,16 @@ pub enum Type<'a> {
     InputObject(InputObjectType<'a>),
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
+#[archive(check_bytes)]
 pub enum InputType<'a> {
     Scalar(ScalarType<'a>),
     Enum(EnumType<'a>),
     InputObject(InputObjectType<'a>),
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
+#[archive(check_bytes)]
 pub enum OutputType<'a> {
     Scalar(ScalarType<'a>),
     Object(ObjectType<'a>),
@@ -28,29 +31,35 @@ pub enum OutputType<'a> {
     Enum(EnumType<'a>),
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
+#[archive(check_bytes)]
 pub struct ScalarType<'a> {
+    #[with(rkyv::with::AsOwned)]
     pub name: Cow<'a, str>,
     pub builtin: bool,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
+#[archive(check_bytes)]
 pub struct ObjectType<'a> {
-    pub description: Option<&'a str>,
+    #[with(rkyv::with::AsOwned)]
     pub name: Cow<'a, str>,
     pub implements_interfaces: Vec<InterfaceRef<'a>>,
     pub fields: Vec<Field<'a>>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
+#[archive(check_bytes)]
 pub struct Field<'a> {
     pub name: FieldName<'a>,
     pub arguments: Vec<InputValue<'a>>,
     pub field_type: TypeRef<'a, OutputType<'a>>,
+    #[with(rkyv::with::AsOwned)]
     pub(super) parent_type_name: Cow<'a, str>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
+#[archive(check_bytes)]
 pub struct InputValue<'a> {
     pub name: FieldName<'a>,
     pub value_type: TypeRef<'a, InputType<'a>>,
@@ -67,36 +76,46 @@ impl InputValue<'_> {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
+#[archive(check_bytes)]
 pub struct InterfaceType<'a> {
+    #[with(rkyv::with::AsOwned)]
     pub name: Cow<'a, str>,
     pub fields: Vec<Field<'a>>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
+#[archive(check_bytes)]
 pub struct UnionType<'a> {
+    #[with(rkyv::with::AsOwned)]
     pub name: Cow<'a, str>,
     pub types: Vec<ObjectRef<'a>>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
+#[archive(check_bytes)]
 pub struct EnumType<'a> {
+    #[with(rkyv::with::AsOwned)]
     pub name: Cow<'a, str>,
     pub values: Vec<EnumValue<'a>>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
+#[archive(check_bytes)]
 pub struct EnumValue<'a> {
     pub name: FieldName<'a>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
+#[archive(check_bytes)]
 pub struct InputObjectType<'a> {
+    #[with(rkyv::with::AsOwned)]
     pub name: Cow<'a, str>,
     pub fields: Vec<InputValue<'a>>,
 }
 
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
+#[archive(check_bytes)]
 pub enum Kind {
     InputType,
     OutputType,
@@ -148,8 +167,9 @@ impl<'a> EnumType<'a> {
     }
 }
 
-#[derive(Clone)]
-pub struct ObjectRef<'a>(pub(super) Cow<'a, str>);
+#[derive(Clone, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
+#[archive(check_bytes)]
+pub struct ObjectRef<'a>(#[with(rkyv::with::AsOwned)] pub(super) Cow<'a, str>);
 
 impl std::fmt::Debug for ObjectRef<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -171,8 +191,9 @@ impl<'a> std::hash::Hash for ObjectRef<'a> {
     }
 }
 
-#[derive(Clone)]
-pub struct InterfaceRef<'a>(pub(super) Cow<'a, str>);
+#[derive(Clone, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
+#[archive(check_bytes)]
+pub struct InterfaceRef<'a>(#[with(rkyv::with::AsOwned)] pub(super) Cow<'a, str>);
 
 impl std::fmt::Debug for InterfaceRef<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -194,11 +215,27 @@ impl<'a> std::hash::Hash for InterfaceRef<'a> {
     }
 }
 
-#[derive(Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
+#[archive(check_bytes, bound(serialize = "__S: rkyv::ser::Serializer"))]
+#[archive_attr(check_bytes(
+    bound = "__C: rkyv::validation::ArchiveContext, <__C as rkyv::Fallible>::Error: rkyv::bytecheck::Error"
+))]
 pub enum TypeRef<'a, T> {
-    Named(Cow<'a, str>, PhantomData<fn() -> T>),
-    List(Box<TypeRef<'a, T>>),
-    Nullable(Box<TypeRef<'a, T>>),
+    Named(
+        #[with(rkyv::with::AsOwned)] Cow<'a, str>,
+        PhantomData<fn() -> T>,
+    ),
+
+    List(
+        #[omit_bounds]
+        #[archive_attr(omit_bounds)]
+        Box<TypeRef<'a, T>>,
+    ),
+    Nullable(
+        #[omit_bounds]
+        #[archive_attr(omit_bounds)]
+        Box<TypeRef<'a, T>>,
+    ),
 }
 
 impl<'a, T> TypeRef<'a, T>

--- a/cynic-codegen/src/schema/types.rs
+++ b/cynic-codegen/src/schema/types.rs
@@ -1,6 +1,14 @@
 use std::{borrow::Cow, marker::PhantomData};
 
-use super::{names::FieldName, type_index::TypeIndex, SchemaError};
+use super::{names::FieldName, SchemaError};
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
+#[archive(check_bytes)]
+pub struct SchemaRoots<'a> {
+    pub query: ObjectType<'a>,
+    pub mutation: Option<ObjectType<'a>>,
+    pub subscription: Option<ObjectType<'a>>,
+}
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
 #[archive(check_bytes)]

--- a/cynic-codegen/src/types/alignment.rs
+++ b/cynic-codegen/src/types/alignment.rs
@@ -348,7 +348,7 @@ mod tests {
     }
 
     fn integer<'a, Kind>() -> TypeRef<'a, Kind> {
-        TypeRef::Named("Int", TypeIndex::empty(), PhantomData)
+        TypeRef::Named("Int".into(), TypeIndex::empty(), PhantomData)
     }
 
     fn list<Kind>(inner: TypeRef<'_, Kind>) -> TypeRef<'_, Kind> {

--- a/cynic-codegen/src/types/alignment.rs
+++ b/cynic-codegen/src/types/alignment.rs
@@ -21,7 +21,7 @@ fn align_output_type_impl<'a>(
 ) -> RustType<'a> {
     match (&ty, &gql_ty) {
         (RustType::Unknown { .. } | RustType::SimpleType { .. }, _) => ty.clone(),
-        (RustType::Optional { inner, .. }, TypeRef::Named(_, _, _) | TypeRef::List(_)) => {
+        (RustType::Optional { inner, .. }, TypeRef::Named(_, _) | TypeRef::List(_)) => {
             // If the rust type is optional but the schema type isn't
             // then we just ignore the `Option<_>` and recurse
             align_output_type_impl(inner.as_ref(), gql_ty)
@@ -108,7 +108,7 @@ mod tests {
 
     use {proc_macro2::TokenStream, quote::quote, rstest::rstest, syn::parse2};
 
-    use crate::schema::{types::TypeRef, TypeIndex};
+    use crate::schema::types::TypeRef;
 
     use super::*;
 
@@ -348,7 +348,7 @@ mod tests {
     }
 
     fn integer<'a, Kind>() -> TypeRef<'a, Kind> {
-        TypeRef::Named("Int".into(), TypeIndex::empty(), PhantomData)
+        TypeRef::Named("Int".into(), PhantomData)
     }
 
     fn list<Kind>(inner: TypeRef<'_, Kind>) -> TypeRef<'_, Kind> {

--- a/cynic-codegen/src/types/validation.rs
+++ b/cynic-codegen/src/types/validation.rs
@@ -136,8 +136,8 @@ fn output_type_check<'a>(
             provided_type: inner.to_syn().to_string(),
             span: rust_type.span(),
         }),
-        (TypeRef::Named(_, _, _), RustType::SimpleType { .. }) => Ok(()),
-        (TypeRef::Named(_, _, _), RustType::Unknown { .. }) => {
+        (TypeRef::Named(_, _), RustType::SimpleType { .. }) => Ok(()),
+        (TypeRef::Named(_, _), RustType::Unknown { .. }) => {
             // This is probably some type with generic params.
             // But we've satisfied any list/nullable requirements by here
             // so should probably just allow it
@@ -189,8 +189,8 @@ fn input_type_check<'a>(
             provided_type: inner.to_syn().to_string(),
             span: rust_type.span(),
         }),
-        (TypeRef::Named(_, _, _), RustType::SimpleType { .. }) => Ok(()),
-        (TypeRef::Named(_, _, _), RustType::Unknown { .. }) => {
+        (TypeRef::Named(_, _), RustType::SimpleType { .. }) => Ok(()),
+        (TypeRef::Named(_, _), RustType::Unknown { .. }) => {
             // This is probably some type with generic params.
             // But we've satisfied any list/nullable requirements by here
             // so should probably just allow it
@@ -301,10 +301,7 @@ mod tests {
 
     use {
         super::*,
-        crate::schema::{
-            types::{InputType, OutputType},
-            TypeIndex,
-        },
+        crate::schema::types::{InputType, OutputType},
     };
 
     use {assert_matches::assert_matches, quote::quote, rstest::rstest, syn::parse_quote};
@@ -322,7 +319,7 @@ mod tests {
 
     #[test]
     fn test_output_type_check() {
-        let required_field = TypeRef::Named("test".into(), TypeIndex::empty(), PhantomData);
+        let required_field = TypeRef::Named("test".into(), PhantomData);
         let optional_field = TypeRef::Nullable(Box::new(required_field.clone()));
 
         assert_matches!(
@@ -374,7 +371,7 @@ mod tests {
 
     #[test]
     fn test_output_type_list_validation() {
-        let named = TypeRef::Named("test".into(), TypeIndex::empty(), PhantomData);
+        let named = TypeRef::Named("test".into(), PhantomData);
         let list = TypeRef::List(Box::new(named.clone()));
         let optional_list = TypeRef::Nullable(Box::new(TypeRef::List(Box::new(named.clone()))));
         let option_list_option = TypeRef::Nullable(Box::new(TypeRef::List(Box::new(
@@ -471,7 +468,7 @@ mod tests {
 
     #[test]
     fn test_validation_when_flattening() {
-        let named = TypeRef::Named("test".into(), TypeIndex::empty(), PhantomData);
+        let named = TypeRef::Named("test".into(), PhantomData);
         let list = TypeRef::List(Box::new(named.clone()));
         let optional_list = TypeRef::Nullable(Box::new(TypeRef::List(Box::new(named.clone()))));
         let option_list_option = TypeRef::Nullable(Box::new(TypeRef::List(Box::new(
@@ -544,7 +541,7 @@ mod tests {
 
     #[test]
     fn test_input_type_validation() {
-        let required_field = TypeRef::Named("test".into(), TypeIndex::empty(), PhantomData);
+        let required_field = TypeRef::Named("test".into(), PhantomData);
         let optional_field = TypeRef::Nullable(Box::new(required_field.clone()));
 
         assert_matches!(
@@ -593,7 +590,7 @@ mod tests {
 
     #[test]
     fn test_input_type_validation_with_default() {
-        let required_field = TypeRef::Named("test".into(), TypeIndex::empty(), PhantomData);
+        let required_field = TypeRef::Named("test".into(), PhantomData);
         let optional_field = TypeRef::Nullable(Box::new(required_field.clone()));
 
         assert_matches!(
@@ -632,7 +629,7 @@ mod tests {
 
     #[test]
     fn test_input_type_list_validation() {
-        let named = TypeRef::Named("test".into(), TypeIndex::empty(), PhantomData);
+        let named = TypeRef::Named("test".into(), PhantomData);
         let list = TypeRef::List(Box::new(named.clone()));
         let optional_list = TypeRef::Nullable(Box::new(TypeRef::List(Box::new(named.clone()))));
         let option_list_option = TypeRef::Nullable(Box::new(TypeRef::List(Box::new(
@@ -719,24 +716,24 @@ mod tests {
 
     #[rstest(graphql_field, rust_field,
         case::required_t(
-            TypeRef::Named("T".into(), TypeIndex::empty(), PhantomData),
+            TypeRef::Named("T".into(), PhantomData),
             parse_quote! { Option<Box<T>> }
         ),
 
         case::optional_t(
-            TypeRef::Nullable(Box::new(TypeRef::Named("T".into(), TypeIndex::empty(), PhantomData))),
+            TypeRef::Nullable(Box::new(TypeRef::Named("T".into(), PhantomData))),
             parse_quote! { Option<T> }
         ),
 
         case::option_vec_required_t(
             TypeRef::Nullable(Box::new(
-                TypeRef::List(Box::new(TypeRef::Named("T".into(), TypeIndex::empty(), PhantomData)))
+                TypeRef::List(Box::new(TypeRef::Named("T".into(), PhantomData)))
             )),
             parse_quote! { Option<Vec<T>> }
         ),
 
         case::required_vec_required_t(
-            TypeRef::List(Box::new(TypeRef::Named("T".into(), TypeIndex::empty(), PhantomData))),
+            TypeRef::List(Box::new(TypeRef::Named("T".into(), PhantomData))),
             parse_quote! { Option<Vec<T>> }
         ),
     )]
@@ -749,54 +746,54 @@ mod tests {
 
     #[rstest(graphql_field, rust_field,
         case::required_t_box(
-            TypeRef::Named("T".into(), TypeIndex::empty(), PhantomData),
+            TypeRef::Named("T".into(), PhantomData),
             parse_quote! { Box<T> }
         ),
         case::required_t_standalone(
-            TypeRef::Named("T".into(), TypeIndex::empty(), PhantomData),
+            TypeRef::Named("T".into(), PhantomData),
             parse_quote! { T }
         ),
 
         case::optional_t_standalone(
-            TypeRef::Nullable(Box::new(TypeRef::Named("T".into(), TypeIndex::empty(), PhantomData))),
+            TypeRef::Nullable(Box::new(TypeRef::Named("T".into(), PhantomData))),
             parse_quote! { T }
         ),
         case::optional_t_box(
-            TypeRef::Nullable(Box::new(TypeRef::Named("T".into(), TypeIndex::empty(), PhantomData))),
+            TypeRef::Nullable(Box::new(TypeRef::Named("T".into(), PhantomData))),
             parse_quote! { Box<T> }
         ),
 
         case::option_vec_required_t(
             TypeRef::Nullable(Box::new(
-                TypeRef::List(Box::new(TypeRef::Named("T".into(), TypeIndex::empty(), PhantomData)))
+                TypeRef::List(Box::new(TypeRef::Named("T".into(), PhantomData)))
             )),
             parse_quote! { Vec<T> }
         ),
         case::option_vec_required_t(
             TypeRef::Nullable(Box::new(
-                TypeRef::List(Box::new(TypeRef::Named("T".into(), TypeIndex::empty(), PhantomData)))
+                TypeRef::List(Box::new(TypeRef::Named("T".into(), PhantomData)))
             )),
             parse_quote! { Vec<Option<T>> }
         ),
 
         case::required_vec_required_t(
-            TypeRef::List(Box::new(TypeRef::Named("T".into(), TypeIndex::empty(), PhantomData))),
+            TypeRef::List(Box::new(TypeRef::Named("T".into(), PhantomData))),
             parse_quote! { Vec<T> }
         ),
         case::required_vec_required_t_no_vec(
-            TypeRef::List(Box::new(TypeRef::Named("T".into(), TypeIndex::empty(), PhantomData))),
+            TypeRef::List(Box::new(TypeRef::Named("T".into(), PhantomData))),
             parse_quote! { T }
         ),
 
         case::required_vec_optional_t_no_vec(
             TypeRef::List(Box::new(
-                TypeRef::Nullable(Box::new(TypeRef::Named("T".into(), TypeIndex::empty(), PhantomData)))
+                TypeRef::Nullable(Box::new(TypeRef::Named("T".into(), PhantomData)))
             )),
             parse_quote! { Option<T> }
         ),
         case::required_vec_optional_t_wrong_nesting(
             TypeRef::List(Box::new(
-                TypeRef::Nullable(Box::new(TypeRef::Named("T".into(), TypeIndex::empty(), PhantomData)))
+                TypeRef::Nullable(Box::new(TypeRef::Named("T".into(), PhantomData)))
             )),
             parse_quote! { Option<Vec<T>> }
         ),

--- a/cynic-codegen/src/types/validation.rs
+++ b/cynic-codegen/src/types/validation.rs
@@ -322,7 +322,7 @@ mod tests {
 
     #[test]
     fn test_output_type_check() {
-        let required_field = TypeRef::Named("test", TypeIndex::empty(), PhantomData);
+        let required_field = TypeRef::Named("test".into(), TypeIndex::empty(), PhantomData);
         let optional_field = TypeRef::Nullable(Box::new(required_field.clone()));
 
         assert_matches!(
@@ -374,7 +374,7 @@ mod tests {
 
     #[test]
     fn test_output_type_list_validation() {
-        let named = TypeRef::Named("test", TypeIndex::empty(), PhantomData);
+        let named = TypeRef::Named("test".into(), TypeIndex::empty(), PhantomData);
         let list = TypeRef::List(Box::new(named.clone()));
         let optional_list = TypeRef::Nullable(Box::new(TypeRef::List(Box::new(named.clone()))));
         let option_list_option = TypeRef::Nullable(Box::new(TypeRef::List(Box::new(
@@ -471,7 +471,7 @@ mod tests {
 
     #[test]
     fn test_validation_when_flattening() {
-        let named = TypeRef::Named("test", TypeIndex::empty(), PhantomData);
+        let named = TypeRef::Named("test".into(), TypeIndex::empty(), PhantomData);
         let list = TypeRef::List(Box::new(named.clone()));
         let optional_list = TypeRef::Nullable(Box::new(TypeRef::List(Box::new(named.clone()))));
         let option_list_option = TypeRef::Nullable(Box::new(TypeRef::List(Box::new(
@@ -544,7 +544,7 @@ mod tests {
 
     #[test]
     fn test_input_type_validation() {
-        let required_field = TypeRef::Named("test", TypeIndex::empty(), PhantomData);
+        let required_field = TypeRef::Named("test".into(), TypeIndex::empty(), PhantomData);
         let optional_field = TypeRef::Nullable(Box::new(required_field.clone()));
 
         assert_matches!(
@@ -593,7 +593,7 @@ mod tests {
 
     #[test]
     fn test_input_type_validation_with_default() {
-        let required_field = TypeRef::Named("test", TypeIndex::empty(), PhantomData);
+        let required_field = TypeRef::Named("test".into(), TypeIndex::empty(), PhantomData);
         let optional_field = TypeRef::Nullable(Box::new(required_field.clone()));
 
         assert_matches!(
@@ -632,7 +632,7 @@ mod tests {
 
     #[test]
     fn test_input_type_list_validation() {
-        let named = TypeRef::Named("test", TypeIndex::empty(), PhantomData);
+        let named = TypeRef::Named("test".into(), TypeIndex::empty(), PhantomData);
         let list = TypeRef::List(Box::new(named.clone()));
         let optional_list = TypeRef::Nullable(Box::new(TypeRef::List(Box::new(named.clone()))));
         let option_list_option = TypeRef::Nullable(Box::new(TypeRef::List(Box::new(
@@ -719,24 +719,24 @@ mod tests {
 
     #[rstest(graphql_field, rust_field,
         case::required_t(
-            TypeRef::Named("T", TypeIndex::empty(), PhantomData),
+            TypeRef::Named("T".into(), TypeIndex::empty(), PhantomData),
             parse_quote! { Option<Box<T>> }
         ),
 
         case::optional_t(
-            TypeRef::Nullable(Box::new(TypeRef::Named("T", TypeIndex::empty(), PhantomData))),
+            TypeRef::Nullable(Box::new(TypeRef::Named("T".into(), TypeIndex::empty(), PhantomData))),
             parse_quote! { Option<T> }
         ),
 
         case::option_vec_required_t(
             TypeRef::Nullable(Box::new(
-                TypeRef::List(Box::new(TypeRef::Named("T", TypeIndex::empty(), PhantomData)))
+                TypeRef::List(Box::new(TypeRef::Named("T".into(), TypeIndex::empty(), PhantomData)))
             )),
             parse_quote! { Option<Vec<T>> }
         ),
 
         case::required_vec_required_t(
-            TypeRef::List(Box::new(TypeRef::Named("T", TypeIndex::empty(), PhantomData))),
+            TypeRef::List(Box::new(TypeRef::Named("T".into(), TypeIndex::empty(), PhantomData))),
             parse_quote! { Option<Vec<T>> }
         ),
     )]
@@ -749,54 +749,54 @@ mod tests {
 
     #[rstest(graphql_field, rust_field,
         case::required_t_box(
-            TypeRef::Named("T", TypeIndex::empty(), PhantomData),
+            TypeRef::Named("T".into(), TypeIndex::empty(), PhantomData),
             parse_quote! { Box<T> }
         ),
         case::required_t_standalone(
-            TypeRef::Named("T", TypeIndex::empty(), PhantomData),
+            TypeRef::Named("T".into(), TypeIndex::empty(), PhantomData),
             parse_quote! { T }
         ),
 
         case::optional_t_standalone(
-            TypeRef::Nullable(Box::new(TypeRef::Named("T", TypeIndex::empty(), PhantomData))),
+            TypeRef::Nullable(Box::new(TypeRef::Named("T".into(), TypeIndex::empty(), PhantomData))),
             parse_quote! { T }
         ),
         case::optional_t_box(
-            TypeRef::Nullable(Box::new(TypeRef::Named("T", TypeIndex::empty(), PhantomData))),
+            TypeRef::Nullable(Box::new(TypeRef::Named("T".into(), TypeIndex::empty(), PhantomData))),
             parse_quote! { Box<T> }
         ),
 
         case::option_vec_required_t(
             TypeRef::Nullable(Box::new(
-                TypeRef::List(Box::new(TypeRef::Named("T", TypeIndex::empty(), PhantomData)))
+                TypeRef::List(Box::new(TypeRef::Named("T".into(), TypeIndex::empty(), PhantomData)))
             )),
             parse_quote! { Vec<T> }
         ),
         case::option_vec_required_t(
             TypeRef::Nullable(Box::new(
-                TypeRef::List(Box::new(TypeRef::Named("T", TypeIndex::empty(), PhantomData)))
+                TypeRef::List(Box::new(TypeRef::Named("T".into(), TypeIndex::empty(), PhantomData)))
             )),
             parse_quote! { Vec<Option<T>> }
         ),
 
         case::required_vec_required_t(
-            TypeRef::List(Box::new(TypeRef::Named("T", TypeIndex::empty(), PhantomData))),
+            TypeRef::List(Box::new(TypeRef::Named("T".into(), TypeIndex::empty(), PhantomData))),
             parse_quote! { Vec<T> }
         ),
         case::required_vec_required_t_no_vec(
-            TypeRef::List(Box::new(TypeRef::Named("T", TypeIndex::empty(), PhantomData))),
+            TypeRef::List(Box::new(TypeRef::Named("T".into(), TypeIndex::empty(), PhantomData))),
             parse_quote! { T }
         ),
 
         case::required_vec_optional_t_no_vec(
             TypeRef::List(Box::new(
-                TypeRef::Nullable(Box::new(TypeRef::Named("T", TypeIndex::empty(), PhantomData)))
+                TypeRef::Nullable(Box::new(TypeRef::Named("T".into(), TypeIndex::empty(), PhantomData)))
             )),
             parse_quote! { Option<T> }
         ),
         case::required_vec_optional_t_wrong_nesting(
             TypeRef::List(Box::new(
-                TypeRef::Nullable(Box::new(TypeRef::Named("T", TypeIndex::empty(), PhantomData)))
+                TypeRef::Nullable(Box::new(TypeRef::Named("T".into(), TypeIndex::empty(), PhantomData)))
             )),
             parse_quote! { Option<Vec<T>> }
         ),

--- a/cynic-codegen/src/use_schema/fields.rs
+++ b/cynic-codegen/src/use_schema/fields.rs
@@ -18,7 +18,7 @@ struct ArgumentOutput<'a> {
 impl ToTokens for FieldOutput<'_> {
     fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
         let parent_marker = self.parent_marker;
-        let field_marker = &proc_macro2::Ident::from(self.field.marker_ident());
+        let field_marker = &self.field.marker_ident().to_rust_ident();
         let field_name_literal = proc_macro2::Literal::string(self.field.name.as_str());
 
         let field_type_marker = self
@@ -60,7 +60,7 @@ impl ToTokens for FieldOutput<'_> {
 impl ToTokens for ArgumentOutput<'_> {
     fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
         let name = proc_macro2::Literal::string(self.argument.name.as_str());
-        let argument_ident = proc_macro2::Ident::from(self.argument.marker_ident());
+        let argument_ident = self.argument.marker_ident().to_rust_ident();
         let field_marker = self.field_marker;
 
         let schema_type = self

--- a/cynic-codegen/src/use_schema/input_object.rs
+++ b/cynic-codegen/src/use_schema/input_object.rs
@@ -18,7 +18,7 @@ struct FieldOutput<'a> {
 impl<'a> InputObjectOutput<'a> {
     pub fn new(object: InputObjectType<'a>) -> Self {
         InputObjectOutput {
-            object_marker: proc_macro2::Ident::from(object.marker_ident()),
+            object_marker: object.marker_ident().to_rust_ident(),
             object,
         }
     }
@@ -53,7 +53,7 @@ impl ToTokens for InputObjectOutput<'_> {
 impl ToTokens for FieldOutput<'_> {
     fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
         let object_marker = self.object_marker;
-        let field_marker = &proc_macro2::Ident::from(self.field.marker_ident());
+        let field_marker = &self.field.marker_ident().to_rust_ident();
         let field_name_literal = proc_macro2::Literal::string(self.field.name.as_str());
 
         let field_type_marker = self

--- a/cynic-codegen/src/use_schema/interface.rs
+++ b/cynic-codegen/src/use_schema/interface.rs
@@ -12,7 +12,7 @@ pub struct InterfaceOutput<'a> {
 impl<'a> InterfaceOutput<'a> {
     pub fn new(iface: InterfaceType<'a>) -> Self {
         InterfaceOutput {
-            marker_ident: proc_macro2::Ident::from(iface.marker_ident()),
+            marker_ident: iface.marker_ident().to_rust_ident(),
             iface,
         }
     }

--- a/cynic-codegen/src/use_schema/mod.rs
+++ b/cynic-codegen/src/use_schema/mod.rs
@@ -53,8 +53,8 @@ pub(crate) fn use_schema_impl(
 
         match definition {
             Type::Scalar(def) if !def.builtin => {
-                let name = proc_macro2::Literal::string(def.name);
-                let ident = proc_macro2::Ident::from(def.marker_ident());
+                let name = proc_macro2::Literal::string(def.name.as_ref());
+                let ident = def.marker_ident().to_rust_ident();
                 output.append_all(quote! {
                     pub struct #ident {}
                     impl cynic::schema::NamedType for #ident {
@@ -80,13 +80,13 @@ pub(crate) fn use_schema_impl(
             Type::Union(def) => {
                 subtype_markers.extend(SubtypeMarkers::from_union(&def));
 
-                let ident = proc_macro2::Ident::from(def.marker_ident());
+                let ident = def.marker_ident().to_rust_ident();
                 output.append_all(quote! {
                     pub struct #ident {}
                 });
             }
             Type::Enum(def) => {
-                let ident = proc_macro2::Ident::from(def.marker_ident());
+                let ident = def.marker_ident().to_rust_ident();
                 output.append_all(quote! {
                     pub struct #ident {}
                 });

--- a/cynic-codegen/src/use_schema/mod.rs
+++ b/cynic-codegen/src/use_schema/mod.rs
@@ -16,7 +16,7 @@ use {
 
 use crate::{
     error::Errors,
-    schema::{types::Type, Document, Schema, SchemaInput, Validated},
+    schema::{types::Type, Schema, SchemaInput, Validated},
 };
 
 use self::{
@@ -25,16 +25,14 @@ use self::{
 };
 
 pub fn use_schema(input: UseSchemaParams) -> Result<TokenStream, Errors> {
-    let document = crate::schema::load_schema(&input.schema_filename)
+    let input = SchemaInput::from_schema_path(input.schema_filename)
         .map_err(|e| e.into_syn_error(proc_macro2::Span::call_site()))?;
-    let schema = Schema::new(SchemaInput::Document(document.clone())).validate()?;
-    use_schema_impl(&document, schema)
+
+    let schema = Schema::new(input).validate()?;
+    use_schema_impl(schema)
 }
 
-pub(crate) fn use_schema_impl(
-    document: &Document,
-    schema: Schema<'_, Validated>,
-) -> Result<TokenStream, Errors> {
+pub(crate) fn use_schema_impl(schema: Schema<'_, Validated>) -> Result<TokenStream, Errors> {
     use quote::TokenStreamExt;
 
     let mut output = TokenStream::new();

--- a/cynic-codegen/src/use_schema/mod.rs
+++ b/cynic-codegen/src/use_schema/mod.rs
@@ -16,7 +16,7 @@ use {
 
 use crate::{
     error::Errors,
-    schema::{types::Type, Document, Schema, Validated},
+    schema::{types::Type, Document, Schema, SchemaInput, Validated},
 };
 
 use self::{
@@ -25,9 +25,9 @@ use self::{
 };
 
 pub fn use_schema(input: UseSchemaParams) -> Result<TokenStream, Errors> {
-    let document = crate::schema::load_schema(input.schema_filename)
+    let document = crate::schema::load_schema(&input.schema_filename)
         .map_err(|e| e.into_syn_error(proc_macro2::Span::call_site()))?;
-    let schema = Schema::new(&document).validate()?;
+    let schema = Schema::new(SchemaInput::Document(document.clone())).validate()?;
     use_schema_impl(&document, schema)
 }
 
@@ -40,7 +40,7 @@ pub(crate) fn use_schema_impl(
     let mut output = TokenStream::new();
     let mut field_module = TokenStream::new();
 
-    let root_types = schema_roots::RootTypes::from_definitions(&document.definitions, &schema)?;
+    let root_types = schema.root_types()?;
     output.append_all(quote! {
         #root_types
     });

--- a/cynic-codegen/src/use_schema/named_type.rs
+++ b/cynic-codegen/src/use_schema/named_type.rs
@@ -1,9 +1,11 @@
+use std::borrow::Cow;
+
 use proc_macro2::TokenStream;
 
 use crate::schema::{markers::TypeMarkerIdent, types::Type};
 
 pub struct NamedType<'a> {
-    graphql_name: &'a str,
+    graphql_name: Cow<'a, str>,
     marker_ident: TypeMarkerIdent<'a>,
 }
 
@@ -18,15 +20,15 @@ impl<'a> NamedType<'a> {
             Type::Enum(_) => None,
 
             Type::Object(def) => Some(NamedType {
-                graphql_name: def.name,
+                graphql_name: def.name.clone(),
                 marker_ident: def.marker_ident(),
             }),
             Type::Interface(def) => Some(NamedType {
-                graphql_name: def.name,
+                graphql_name: def.name.clone(),
                 marker_ident: def.marker_ident(),
             }),
             Type::Union(def) => Some(NamedType {
-                graphql_name: def.name,
+                graphql_name: def.name.clone(),
                 marker_ident: def.marker_ident(),
             }),
         }
@@ -37,8 +39,8 @@ impl quote::ToTokens for NamedType<'_> {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         use quote::{quote, TokenStreamExt};
 
-        let target_struct = proc_macro2::Ident::from(self.marker_ident);
-        let graphql_name = proc_macro2::Literal::string(self.graphql_name);
+        let target_struct = self.marker_ident.to_rust_ident();
+        let graphql_name = proc_macro2::Literal::string(self.graphql_name.as_ref());
 
         tokens.append_all(quote! {
             impl cynic::schema::NamedType for #target_struct {

--- a/cynic-codegen/src/use_schema/object.rs
+++ b/cynic-codegen/src/use_schema/object.rs
@@ -15,7 +15,7 @@ impl<'a> ObjectOutput<'a> {
 
     pub fn append_fields(&self, field_module: &mut proc_macro2::TokenStream) {
         if !self.object.fields.is_empty() {
-            let object_marker = proc_macro2::Ident::from(self.object.marker_ident());
+            let object_marker = self.object.marker_ident().to_rust_ident();
             let field_module_ident = self.object.field_module().ident();
             let fields = self.object.fields.iter().map(|f| FieldOutput {
                 field: f,
@@ -32,7 +32,7 @@ impl<'a> ObjectOutput<'a> {
 
 impl ToTokens for ObjectOutput<'_> {
     fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
-        let object_marker = proc_macro2::Ident::from(self.object.marker_ident());
+        let object_marker = self.object.marker_ident().to_rust_ident();
         tokens.append_all(quote! {
             pub struct #object_marker;
         });

--- a/cynic-codegen/src/use_schema/schema_roots.rs
+++ b/cynic-codegen/src/use_schema/schema_roots.rs
@@ -1,44 +1,8 @@
 use proc_macro2::TokenStream;
 
-use crate::schema::{parser::Definition, types::ObjectType, Schema, SchemaError, Validated};
+use crate::schema::types::SchemaRoots;
 
-pub struct RootTypes<'a> {
-    query: ObjectType<'a>,
-    mutation: Option<ObjectType<'a>>,
-    subscription: Option<ObjectType<'a>>,
-}
-
-impl<'a> RootTypes<'a> {
-    pub fn from_definitions(
-        definitions: &[Definition],
-        schema: &'a Schema<'a, Validated>,
-    ) -> Result<RootTypes<'a>, SchemaError> {
-        let mut query_name = "Query".to_owned();
-        let mut mutation_name = Some("Mutation".to_owned());
-        let mut subscription_name = Some("Subscription".to_owned());
-
-        for definition in definitions {
-            if let Definition::SchemaDefinition(schema) = definition {
-                if let Some(query_type) = &schema.query {
-                    query_name = query_type.clone();
-                }
-                mutation_name = schema.mutation.clone();
-                subscription_name = schema.subscription.clone();
-                break;
-            }
-        }
-
-        Ok(RootTypes {
-            query: schema.lookup::<ObjectType<'_>>(&query_name)?,
-            mutation: mutation_name
-                .and_then(|name| schema.try_lookup::<ObjectType<'_>>(&name).ok()),
-            subscription: subscription_name
-                .and_then(|name| schema.try_lookup::<ObjectType<'_>>(&name).ok()),
-        })
-    }
-}
-
-impl quote::ToTokens for RootTypes<'_> {
+impl quote::ToTokens for SchemaRoots<'_> {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         use quote::{quote, TokenStreamExt};
 

--- a/cynic-codegen/src/use_schema/schema_roots.rs
+++ b/cynic-codegen/src/use_schema/schema_roots.rs
@@ -42,21 +42,21 @@ impl quote::ToTokens for RootTypes<'_> {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         use quote::{quote, TokenStreamExt};
 
-        let name = proc_macro2::Ident::from(self.query.marker_ident());
+        let name = self.query.marker_ident().to_rust_ident();
 
         tokens.append_all(quote! {
             impl cynic::schema::QueryRoot for #name {}
         });
 
         if let Some(mutation) = &self.mutation {
-            let name = proc_macro2::Ident::from(mutation.marker_ident());
+            let name = mutation.marker_ident().to_rust_ident();
             tokens.append_all(quote! {
                 impl cynic::schema::MutationRoot for #name {}
             });
         }
 
         if let Some(subscription) = &self.subscription {
-            let name = proc_macro2::Ident::from(subscription.marker_ident());
+            let name = subscription.marker_ident().to_rust_ident();
             tokens.append_all(quote! {
                 impl cynic::schema::SubscriptionRoot for #name {}
             });

--- a/cynic-codegen/src/use_schema/schema_roots.rs
+++ b/cynic-codegen/src/use_schema/schema_roots.rs
@@ -11,7 +11,7 @@ pub struct RootTypes<'a> {
 impl<'a> RootTypes<'a> {
     pub fn from_definitions(
         definitions: &[Definition],
-        schema: &Schema<'a, Validated>,
+        schema: &'a Schema<'a, Validated>,
     ) -> Result<RootTypes<'a>, SchemaError> {
         let mut query_name = "Query".to_owned();
         let mut mutation_name = Some("Mutation".to_owned());

--- a/cynic-codegen/src/use_schema/subtype_markers.rs
+++ b/cynic-codegen/src/use_schema/subtype_markers.rs
@@ -14,7 +14,7 @@ impl<'a> SubtypeMarkers<'a> {
         let marker = iface.marker_ident();
 
         Self {
-            subtype: marker,
+            subtype: marker.clone(),
             supertypes: vec![marker],
         }
     }
@@ -26,7 +26,7 @@ impl<'a> SubtypeMarkers<'a> {
             .iter()
             .map(|ty| SubtypeMarkers {
                 subtype: ty.marker_ident(),
-                supertypes: vec![supertype],
+                supertypes: vec![supertype.clone()],
             })
             .collect()
     }
@@ -51,12 +51,8 @@ impl quote::ToTokens for SubtypeMarkers<'_> {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         use quote::{quote, TokenStreamExt};
 
-        let subtype = proc_macro2::Ident::from(self.subtype);
-        let supertypes = self
-            .supertypes
-            .iter()
-            .copied()
-            .map(proc_macro2::Ident::from);
+        let subtype = self.subtype.to_rust_ident();
+        let supertypes = self.supertypes.iter().map(|marker| marker.to_rust_ident());
 
         tokens.append_all(quote! {
             #(

--- a/cynic/src/queries/builders.rs
+++ b/cynic/src/queries/builders.rs
@@ -188,16 +188,6 @@ impl<'a, Field, FieldSchemaType, VariablesFields>
     where
         VariablesFields: VariableMatch<InnerVariables>,
     {
-        // Ok, so theoretically this could be the point that does fragment
-        // magic?
-        //
-        // Or we could be explicit about it and move it to the QueryFragment
-        // HMM?
-        //
-        // Or a hybrid approach?  Add a way to name particular selection
-        // sets to the builder, _and then_ add an optimisation phase
-        // that detects identical selection sets and extracts them as
-        // fragments?
         SelectionBuilder {
             recurse_depth: self.recurse_depth,
             ..SelectionBuilder::new(&mut self.field.children)

--- a/cynic/src/queries/builders.rs
+++ b/cynic/src/queries/builders.rs
@@ -188,6 +188,16 @@ impl<'a, Field, FieldSchemaType, VariablesFields>
     where
         VariablesFields: VariableMatch<InnerVariables>,
     {
+        // Ok, so theoretically this could be the point that does fragment
+        // magic?
+        //
+        // Or we could be explicit about it and move it to the QueryFragment
+        // HMM?
+        //
+        // Or a hybrid approach?  Add a way to name particular selection
+        // sets to the builder, _and then_ add an optimisation phase
+        // that detects identical selection sets and extracts them as
+        // fragments?
         SelectionBuilder {
             recurse_depth: self.recurse_depth,
             ..SelectionBuilder::new(&mut self.field.children)


### PR DESCRIPTION
#### Why are we making this change?

Certain schemas (GitHub in particular but I'm sure there's others) are massive.
If you build a cynic project with these it can take a while to compile, and
rust-analyzer sometimes goes a bit unresponsive.

As far as I can tell _some_ of this is down to the astronomical quantity of
code `use_schema` puts out.  But each of the derives also has to parse the
entire schema - which is a lot of parses if you're doing anything more than the
simplest query.

`graphql_parser` is relatively fast - it can parse the GH schema in 9ms in a
release build and 50ms in a debug build.  But particularly for debug builds,
this adds up - even just 10 parses of the schema is half a second wasted on
repeat work.

#### What effects does this change have?

This PR adds `rkyv` into `cynic-codegen` and offers functionality to pre-parse
the schema into an rkyv format in your `build.rs`, which the derives can then
load rather than parsing the SDL every time.

In my initial testing (using triagebot as a test case) this shaves somewhere
between 30-50% off the compile time of the crate that uses cynic.  It does also
add compile time to build rkyv, but that should be an infrequent cost on
developers machines, so this should be an overall win.

Part of #150 (need to see if this + other optimisations are finally enough)