### PR TITLE
[Merged by Bors] - Add schema registration functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 - The derive macros now support fields that are references.
 - Added `cynic_codegen::register_schema`, a mechanism for pre-registering schemas
   with cynic.
+- Added a `schema` attribute macro to declare the schema module for
+  pre-registered schemas.
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,9 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 - Added `cynic-introspection::Schema` which converts the introspection output
   into a friendlier format for working with.
 - The derive macros now support structs that are generic on lifetimes _and_ types.
-- The derive macros now fields that are references.
+- The derive macros now support fields that are references.
+- Added `cynic_codegen::register_schema`, a mechanism for pre-registering schemas
+  with cynic.
 
 ### Changes
 
@@ -37,6 +39,10 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 - Response deserialization will no longer work on random blobs of JSON that
   aren't in GraphQLResponse format.
 
+### Deprecations
+
+- `cynic_codegen::output_schema_module` is now deprecated in favour of `register_schema`.
+
 ## v2.2.8 - 2023-03-01
 
 ### Bug Fixes
@@ -45,7 +51,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ## v2.2.7 - 2023-02-27
 
-### Bug Fixes 
+### Bug Fixes
 
 - You no longer have to specify the `Extensions` parameter on `GraphQLError` if
   you don't have any extensions.
@@ -99,7 +105,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 ### Changes
 
 - The `use_schema` output has been re-organised to reduce the chances of
-  clashes.  This is technically a breaking change, but only if you're writing
+  clashes. This is technically a breaking change, but only if you're writing
   queries by hand rather than using the derives.
 
 ## v2.1.0 - 2022-11-09
@@ -121,7 +127,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 - Some of the derives weren't recasing GraphQL types/fields correctly, leading
   to weird errors.
-- Scalars defined using `impl_scalar!` couldn't be used as variables.  Now they
+- Scalars defined using `impl_scalar!` couldn't be used as variables. Now they
   can.
 
 ## v2.0.0 - 2022-11-07

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -291,6 +291,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
+name = "basic-toml"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c0de75129aa8d0cceaf750b89013f0e08804d6ec61416da787b35ad0d7cddf1"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2151,18 +2160,18 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.136"
+version = "1.0.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789"
+checksum = "d193d69bae983fc11a79df82342761dfbf28a99fc8d203dca4c3c1b590948965"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.136"
+version = "1.0.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08597e7152fcd306f41838ed3e37be9eaeed2b61c42e2117266a554fab4662f9"
+checksum = "4f1d362ca8fc9c3e3a7484440752472d68a6caa98f1ab81d99b5dfe517cec852"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2405,9 +2414,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.87"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e59d925cf59d8151f25a3bedf97c9c157597c9df7324d32d68991cc399ed08b"
+checksum = "a07e33e919ebcd69113d5be0e4d70c5707004ff45188910106854f38b960df4a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2582,15 +2591,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml"
-version = "0.5.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "tower-service"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2647,17 +2647,17 @@ checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
 name = "trybuild"
-version = "1.0.63"
+version = "1.0.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "764b9e244b482a9b81bde596aa37aa6f1347bf8007adab25e59f901b32b4e0a0"
+checksum = "501dbdbb99861e4ab6b60eb6a7493956a9defb644fd034bc4a5ef27c693c8a3a"
 dependencies = [
+ "basic-toml",
  "glob",
  "once_cell",
  "serde",
  "serde_derive",
  "serde_json",
  "termcolor",
- "toml",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -635,6 +635,7 @@ dependencies = [
  "rstest 0.11.0",
  "strsim",
  "syn",
+ "thiserror",
 ]
 
 [[package]]

--- a/cynic-codegen/Cargo.toml
+++ b/cynic-codegen/Cargo.toml
@@ -20,6 +20,7 @@ counter = "0.5"
 graphql-parser = "0.4.0"
 proc-macro2 = "1.0"
 syn = { version = "1.0", features = ["visit-mut"] }
+thiserror = "1"
 quote = "1.0"
 darling = "0.13"
 strsim = "0.10.0"

--- a/cynic-codegen/src/error.rs
+++ b/cynic-codegen/src/error.rs
@@ -67,7 +67,6 @@ impl From<syn::Error> for Errors {
     }
 }
 
-#[cfg(test)]
 impl std::fmt::Display for Errors {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         for err in &self.errors {

--- a/cynic-codegen/src/lib.rs
+++ b/cynic-codegen/src/lib.rs
@@ -8,6 +8,7 @@ pub mod query_variables_derive;
 pub mod registration;
 pub mod scalar_derive;
 pub mod schema_for_derives;
+pub mod schema_module_attr;
 pub mod use_schema;
 
 mod error;

--- a/cynic-codegen/src/lib.rs
+++ b/cynic-codegen/src/lib.rs
@@ -5,6 +5,7 @@ pub mod generics_for_serde;
 pub mod inline_fragments_derive;
 pub mod input_object_derive;
 pub mod query_variables_derive;
+pub mod registration;
 pub mod scalar_derive;
 pub mod schema_for_derives;
 pub mod use_schema;
@@ -15,10 +16,14 @@ mod schema;
 mod suggestions;
 mod types;
 
-pub use idents::RenameAll;
+pub use self::{idents::RenameAll, registration::register_schema};
 
 use {error::Errors, schema::load_schema};
 
+#[deprecated(
+    since = "3.0.0",
+    note = "output_schema_module is deprecated.  See `register_schema` instead"
+)]
 pub fn output_schema_module(
     schema: impl AsRef<std::path::Path>,
     output_path: impl AsRef<std::path::Path>,
@@ -34,20 +39,20 @@ pub fn output_schema_module(
         write!(&mut out, "{}", tokens).unwrap();
     }
 
-    format_code(output_path.as_ref());
+    format_code(output_path.as_ref()).ok();
 
     Ok(())
 }
 
 #[allow(unused_variables)]
-fn format_code(filename: &std::path::Path) {
+fn format_code(filename: &std::path::Path) -> std::io::Result<()> {
     #[cfg(feature = "rustfmt")]
     {
         std::process::Command::new("cargo")
             .args(["fmt", "--", filename.to_str().unwrap()])
-            .spawn()
-            .expect("failed to execute process");
+            .spawn()?;
     }
+    Ok(())
 }
 
 fn variables_fields_path(variables: Option<&syn::Path>) -> Option<syn::Path> {

--- a/cynic-codegen/src/registration.rs
+++ b/cynic-codegen/src/registration.rs
@@ -1,0 +1,163 @@
+use std::{
+    io::Write,
+    path::{Path, PathBuf},
+};
+
+use crate::schema::Schema;
+
+/// Registers a schema with cynic-codegen with the given name
+///
+/// This will prepare the schema for use and write intermediate files
+/// into the current crates target directory.  You can then refer to
+/// the schema by name when working with cynics macros.
+///
+/// This is designed to be called from `build.rs`
+pub fn register_schema(name: &str) -> SchemaRegistrationBuilder<'_> {
+    SchemaRegistrationBuilder { name }
+}
+
+#[derive(thiserror::Error, Debug)]
+#[error("Could not register schema with cynic")]
+pub enum SchemaRegistrationError {
+    #[error("IOError: {0}")]
+    IoError(#[from] std::io::Error),
+    #[error("Could not find the OUT_DIR environment variable, which should be set by cargo")]
+    OutDirNotSet,
+    #[error("Errors when parsing schema: {0}")]
+    SchemaErrors(String),
+}
+
+#[must_use]
+/// An incomplete schema registration.
+///
+/// Call one of the methods on this type to provide the schema details
+pub struct SchemaRegistrationBuilder<'a> {
+    name: &'a str,
+}
+
+impl<'a> SchemaRegistrationBuilder<'a> {
+    /// Pulls schema information from the SDL file at `path`
+    pub fn from_sdl_file(
+        self,
+        path: impl AsRef<std::path::Path>,
+    ) -> Result<SchemaRegistration<'a>, SchemaRegistrationError> {
+        let SchemaRegistrationBuilder { name } = self;
+        fn inner<'a>(
+            name: &'a str,
+            path: &Path,
+        ) -> Result<SchemaRegistration<'a>, SchemaRegistrationError> {
+            let data = std::fs::read(path)?;
+            let registration = SchemaRegistration {
+                name,
+                data,
+                format: Format::Sdl,
+            };
+            registration.write(&registration.filename()?)?;
+            registration.write_schema_module()?;
+            cargo_rerun_if_changed(path.as_os_str().to_str().expect("utf8 paths"));
+            Ok(registration)
+        }
+        inner(name, path.as_ref())
+    }
+}
+
+/// A complete schema registration.
+///
+/// Additional methods can be called on this to
+pub struct SchemaRegistration<'a> {
+    name: &'a str,
+    format: Format,
+    data: Vec<u8>,
+}
+
+// Public API
+impl SchemaRegistration<'_> {
+    /// Registers this schema as the default.
+    ///
+    /// The default schema (if any) will be used when you don't provide a schema
+    /// name to any of the cynic macros.
+    ///
+    /// You should only call this once per crate - any subsequent calls will overwrite
+    /// the default.
+    pub fn as_default(self) -> Result<Self, SchemaRegistrationError> {
+        self.write(&default_filename(self.format, &out_dir()?))?;
+        Ok(self)
+    }
+}
+
+// Private API
+impl SchemaRegistration<'_> {
+    fn write(&self, filename: &Path) -> Result<(), SchemaRegistrationError> {
+        Ok(std::fs::write(filename, &self.data)?)
+    }
+
+    fn write_schema_module(&self) -> Result<(), SchemaRegistrationError> {
+        use crate::use_schema::use_schema_impl;
+
+        let document_string = String::from_utf8(self.data.clone()).expect("schema to be utf8");
+        let document = graphql_parser::parse_schema(&document_string)
+            .map_err(|error| SchemaRegistrationError::SchemaErrors(error.to_string()))?
+            .into_static();
+
+        let schema = Schema::new(&document)
+            .validate()
+            .map_err(|errors| SchemaRegistrationError::SchemaErrors(errors.to_string()))?;
+
+        let tokens = use_schema_impl(&document, schema)
+            .map_err(|errors| SchemaRegistrationError::SchemaErrors(errors.to_string()))?;
+
+        let mut out = std::fs::File::create(schema_module_filename(self.name, &out_dir()?))?;
+        write!(&mut out, "{}", tokens)?;
+
+        Ok(())
+    }
+
+    fn filename(&self) -> Result<PathBuf, SchemaRegistrationError> {
+        let out_dir = out_dir()?;
+        Ok(registration_filename(self.name, self.format, &out_dir))
+    }
+}
+
+fn cargo_rerun_if_changed(name: &str) {
+    println!("cargo:rerun-if-changed={name}");
+}
+
+fn out_dir() -> Result<String, SchemaRegistrationError> {
+    let out_dir = std::env::var("OUT_DIR").map_err(|_| SchemaRegistrationError::OutDirNotSet)?;
+    Ok(out_dir)
+}
+
+fn schema_module_filename(name: &str, out_dir: &str) -> PathBuf {
+    let mut path = PathBuf::from(out_dir);
+    path.push("cynic-schemas");
+    path.push(format!("{name}.rs",));
+
+    path
+}
+
+fn registration_filename(name: &str, format: Format, out_dir: &str) -> PathBuf {
+    let extension = match format {
+        Format::Sdl => "graphql",
+    };
+    let mut path = PathBuf::from(out_dir);
+    path.push("cynic-schemas");
+    path.push(format!("{name}.{extension}",));
+
+    path
+}
+
+fn default_filename(format: Format, out_dir: &str) -> PathBuf {
+    let extension = match format {
+        Format::Sdl => "graphql",
+    };
+    let mut path = PathBuf::from(out_dir);
+    path.push("cynic-schemas");
+    path.push(format!("default.{extension}",));
+
+    path
+}
+
+#[derive(Clone, Copy)]
+enum Format {
+    Sdl,
+}

--- a/cynic-codegen/src/registration.rs
+++ b/cynic-codegen/src/registration.rs
@@ -96,7 +96,7 @@ impl SchemaRegistration<'_> {
         use crate::use_schema::use_schema_impl;
 
         let document_string = String::from_utf8(self.data.clone()).expect("schema to be utf8");
-        let document = graphql_parser::parse_schema(&document_string)
+        let document = crate::schema::schema_from_string(document_string)
             .map_err(|error| SchemaRegistrationError::SchemaErrors(error.to_string()))?
             .into_static();
 

--- a/cynic-codegen/src/schema/mod.rs
+++ b/cynic-codegen/src/schema/mod.rs
@@ -13,7 +13,7 @@ use std::marker::PhantomData;
 
 pub use self::{
     names::FieldName,
-    parser::{load_schema, Document},
+    parser::{load_schema, schema_from_string, Document},
 };
 
 #[cfg(test)]

--- a/cynic-codegen/src/schema_module_attr.rs
+++ b/cynic-codegen/src/schema_module_attr.rs
@@ -31,6 +31,11 @@ pub fn attribute_impl(
         }
     }
 
+    // Silence a bunch of warnings inside this module
+    module.attrs.push(parse_quote! {
+        #[allow(clippy::all, non_snake_case, non_camel_case_types)]
+    });
+
     let include: Item = parse_quote! {
         include!(concat!(env!("OUT_DIR"), #filename_str));
     };

--- a/cynic-codegen/src/schema_module_attr.rs
+++ b/cynic-codegen/src/schema_module_attr.rs
@@ -1,0 +1,42 @@
+//! The implementation of the schema attribute for modules.
+
+use std::path::PathBuf;
+
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::{self, parse_quote, Item, LitStr};
+
+use crate::error::Errors;
+
+pub fn attribute_impl(
+    schema_literal: LitStr,
+    mut module: syn::ItemMod,
+) -> Result<TokenStream, Errors> {
+    let schema_name = schema_literal.value();
+
+    let filename_str = LitStr::new(
+        &format!("/cynic-schemas/{schema_name}.rs"),
+        schema_literal.span(),
+    );
+
+    if let Ok(out_dir) = std::env::var("OUT_DIR") {
+        let mut path = PathBuf::from(&out_dir);
+        path.push("cynic-schemas");
+        path.push(format!("{schema_name}.rs"));
+        if !path.exists() {
+            return Err(syn::Error::new(
+                schema_literal.span(),
+                format!("Couldn't find a schema named {schema_name} in {out_dir}\n\nHave you registered it in your build.rs?")
+            ).into());
+        }
+    }
+
+    let include: Item = parse_quote! {
+        include!(concat!(env!("OUT_DIR"), #filename_str));
+    };
+    if let Some((_, items)) = &mut module.content {
+        items.push(include);
+    }
+
+    Ok(quote! { #module })
+}

--- a/cynic-codegen/src/use_schema/mod.rs
+++ b/cynic-codegen/src/use_schema/mod.rs
@@ -16,7 +16,7 @@ use {
 
 use crate::{
     error::Errors,
-    schema::{types::Type, Schema},
+    schema::{types::Type, Document, Schema, Validated},
 };
 
 use self::{
@@ -25,11 +25,17 @@ use self::{
 };
 
 pub fn use_schema(input: UseSchemaParams) -> Result<TokenStream, Errors> {
-    use quote::TokenStreamExt;
-
     let document = crate::schema::load_schema(input.schema_filename)
         .map_err(|e| e.into_syn_error(proc_macro2::Span::call_site()))?;
     let schema = Schema::new(&document).validate()?;
+    use_schema_impl(&document, schema)
+}
+
+pub(crate) fn use_schema_impl(
+    document: &Document,
+    schema: Schema<'_, Validated>,
+) -> Result<TokenStream, Errors> {
+    use quote::TokenStreamExt;
 
     let mut output = TokenStream::new();
     let mut field_module = TokenStream::new();

--- a/cynic-proc-macros/src/lib.rs
+++ b/cynic-proc-macros/src/lib.rs
@@ -9,7 +9,7 @@ use proc_macro::TokenStream;
 
 use cynic_codegen::{
     enum_derive, fragment_derive, inline_fragments_derive, input_object_derive,
-    query_variables_derive, scalar_derive, schema_for_derives, use_schema,
+    query_variables_derive, scalar_derive, schema_for_derives, schema_module_attr, use_schema,
 };
 
 /// Imports a schema for use by cynic.
@@ -168,6 +168,21 @@ pub fn schema_for_derives(attrs: TokenStream, input: TokenStream) -> TokenStream
     let rv: TokenStream = match schema_for_derives::add_schema_attrs_to_derives(attrs, module) {
         Ok(tokens) => tokens.into(),
         Err(e) => e.to_compile_error().into(),
+    };
+
+    // eprintln!("{}", rv);
+
+    rv
+}
+
+#[proc_macro_attribute]
+pub fn schema(attrs: TokenStream, input: TokenStream) -> TokenStream {
+    let schema_name = syn::parse_macro_input!(attrs as syn::LitStr);
+    let module = syn::parse_macro_input!(input as syn::ItemMod);
+
+    let rv: TokenStream = match schema_module_attr::attribute_impl(schema_name, module) {
+        Ok(tokens) => tokens.into(),
+        Err(e) => e.to_compile_errors().into(),
     };
 
     // eprintln!("{}", rv);

--- a/cynic-proc-macros/src/lib.rs
+++ b/cynic-proc-macros/src/lib.rs
@@ -176,6 +176,15 @@ pub fn schema_for_derives(attrs: TokenStream, input: TokenStream) -> TokenStream
 }
 
 #[proc_macro_attribute]
+/// Imports a registered schema into a schema module.
+///
+/// If you have registered a schema in your build.rs, then you can apply
+/// this attribute to a module to import that schema:
+///
+/// ```rust,ignore
+/// #[cynic::schema("starwars")]
+/// mod schema {}
+/// ```
 pub fn schema(attrs: TokenStream, input: TokenStream) -> TokenStream {
     let schema_name = syn::parse_macro_input!(attrs as syn::LitStr);
     let module = syn::parse_macro_input!(input as syn::ItemMod);

--- a/cynic/src/lib.rs
+++ b/cynic/src/lib.rs
@@ -194,7 +194,7 @@ pub use {
 };
 
 pub use cynic_proc_macros::{
-    schema_for_derives, use_schema, Enum, FragmentArguments, InlineFragments, InputObject,
+    schema, schema_for_derives, use_schema, Enum, FragmentArguments, InlineFragments, InputObject,
     QueryFragment, QueryVariables, Scalar,
 };
 

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -27,3 +27,6 @@ github-schema = { path = "../schemas/github" }
 
 [dev-dependencies]
 insta = "1.17"
+
+[build-dependencies]
+cynic-codegen = { path = "../cynic-codegen" }

--- a/examples/build.rs
+++ b/examples/build.rs
@@ -1,0 +1,7 @@
+fn main() {
+    cynic_codegen::register_schema("starwars")
+        .from_sdl_file("../schemas/starwars.schema.graphql")
+        .unwrap()
+        .as_default()
+        .unwrap();
+}

--- a/examples/examples/chrono-scalars.rs
+++ b/examples/examples/chrono-scalars.rs
@@ -1,6 +1,8 @@
 //! An example of querying the starwars API using the reqwest-blocking feature
 
 mod schema {
+    // We didn't register the graphql.jobs schema in our build.rs
+    // so we bring it in here with `use_schema!`
     cynic::use_schema!("../schemas/graphql.jobs.graphql");
 }
 

--- a/examples/examples/manual-reqwest.rs
+++ b/examples/examples/manual-reqwest.rs
@@ -1,9 +1,9 @@
 //! An example that shows how to send a GraphQL operation and deserialize
 //! a GraphQL response using reqwest directly (i.e. without the cynic integration code)
 
-mod schema {
-    cynic::use_schema!("../schemas/starwars.schema.graphql");
-}
+// Pull in the Star Wars schema we registered in build.rs
+#[cynic::schema("starwars")]
+mod schema {}
 
 #[derive(cynic::QueryFragment, Debug)]
 #[cynic(schema_path = "../schemas/starwars.schema.graphql")]

--- a/examples/examples/querying-interfaces.rs
+++ b/examples/examples/querying-interfaces.rs
@@ -1,8 +1,8 @@
 //! An example of querying for interfaces with an InlineFragment
 
-mod schema {
-    cynic::use_schema!("../schemas/starwars.schema.graphql");
-}
+// Pull in the Star Wars schema we registered in build.rs
+#[cynic::schema("starwars")]
+mod schema {}
 
 #[derive(cynic::InlineFragments, Debug)]
 #[cynic(schema_path = "../schemas/starwars.schema.graphql")]

--- a/examples/examples/reqwest-async.rs
+++ b/examples/examples/reqwest-async.rs
@@ -3,9 +3,9 @@
 //!
 //! This example requires the `http-reqwest` feature to be active
 
-mod schema {
-    cynic::use_schema!("../schemas/starwars.schema.graphql");
-}
+// Pull in the Star Wars schema we registered in build.rs
+#[cynic::schema("starwars")]
+mod schema {}
 
 #[derive(cynic::QueryFragment, Debug)]
 #[cynic(schema_path = "../schemas/starwars.schema.graphql")]

--- a/examples/examples/spread.rs
+++ b/examples/examples/spread.rs
@@ -1,8 +1,8 @@
 //! An example of querying the starwars API using the reqwest-blocking feature
 
-mod schema {
-    cynic::use_schema!("../schemas/starwars.schema.graphql");
-}
+// Pull in the Star Wars schema we registered in build.rs
+#[cynic::schema("starwars")]
+mod schema {}
 
 #[derive(cynic::QueryFragment, Debug)]
 #[cynic(

--- a/examples/examples/starwars.rs
+++ b/examples/examples/starwars.rs
@@ -1,8 +1,8 @@
 //! An example of querying the starwars API using the reqwest-blocking feature
 
-mod schema {
-    cynic::use_schema!("../schemas/starwars.schema.graphql");
-}
+// Pull in the Star Wars schema we registered in build.rs
+#[cynic::schema("starwars")]
+mod schema {}
 
 #[derive(cynic::QueryFragment, Debug)]
 #[cynic(schema_path = "../schemas/starwars.schema.graphql")]

--- a/examples/examples/surf-client.rs
+++ b/examples/examples/surf-client.rs
@@ -3,9 +3,9 @@
 //!
 //! This example requires the `surf` feature to be active.
 
-mod schema {
-    cynic::use_schema!("../schemas/starwars.schema.graphql");
-}
+// Pull in the Star Wars schema we registered in build.rs
+#[cynic::schema("starwars")]
+mod schema {}
 
 #[derive(cynic::QueryFragment, Debug)]
 #[cynic(schema_path = "../schemas/starwars.schema.graphql")]

--- a/tests/querygen-compile-run/Cargo.toml
+++ b/tests/querygen-compile-run/Cargo.toml
@@ -13,7 +13,7 @@ serde_json = "1.0"
 ureq = { version = "2.4", features = ["json"] }
 
 [dev-dependencies]
-trybuild = "1.0"
+trybuild = "1.0.80"
 
 [build-dependencies]
 cynic-querygen = { path = "../../cynic-querygen" }

--- a/tests/querygen-compile-run/build.rs
+++ b/tests/querygen-compile-run/build.rs
@@ -333,12 +333,12 @@ struct Schema {
 impl Schema {
     /// Constructs a SchemaPath from the examples package
     fn from_repo_schemas(query_url: impl Into<String>, path: impl Into<PathBuf>) -> Schema {
-        let example_path = PathBuf::from("../../schemas/");
-        let path = example_path.join(path.into());
+        let schema_dir = PathBuf::from("../../schemas/");
+        let path = schema_dir.join(path.into());
         Schema {
             query_url: query_url.into(),
             path_for_loading: path.clone(),
-            path_for_generated_code: PathBuf::from("./..").join(path),
+            path_for_generated_code: PathBuf::from("./../..").join(path),
         }
     }
 }

--- a/tests/ui-tests/Cargo.toml
+++ b/tests/ui-tests/Cargo.toml
@@ -10,4 +10,4 @@ publish = false
 [dev-dependencies]
 cynic = { path = "../../cynic" }
 serde_json = "1.0"
-trybuild = "1.0"
+trybuild = "1.0.80"

--- a/tests/ui-tests/tests/cases/argument-missing-fields.rs
+++ b/tests/ui-tests/tests/cases/argument-missing-fields.rs
@@ -2,7 +2,7 @@
 
 fn main() {}
 
-#[cynic::schema_for_derives(file = r#"./../../../schemas/github.graphql"#, module = "schema")]
+#[cynic::schema_for_derives(file = r#"./../../../../schemas/github.graphql"#, module = "schema")]
 mod queries {
     use super::schema;
 
@@ -26,5 +26,5 @@ mod queries {
 }
 
 mod schema {
-    cynic::use_schema!(r#"./../../../schemas/github.graphql"#);
+    cynic::use_schema!(r#"./../../../../schemas/github.graphql"#);
 }

--- a/tests/ui-tests/tests/cases/enum-guess-validation.rs
+++ b/tests/ui-tests/tests/cases/enum-guess-validation.rs
@@ -1,12 +1,12 @@
 fn main() {}
 
 mod schema {
-    cynic::use_schema!("../../../cynic/src/bin/simple.graphql");
+    cynic::use_schema!("../../../../cynic/src/bin/simple.graphql");
 }
 
 #[derive(cynic::Enum, Clone, Copy, Debug)]
 #[cynic(
-    schema_path = "../../../cynic/src/bin/simple.graphql",
+    schema_path = "../../../../cynic/src/bin/simple.graphql",
     graphql_type = "Desseqt"
 )]
 enum Dessert {

--- a/tests/ui-tests/tests/cases/fragment-guess-validation.rs
+++ b/tests/ui-tests/tests/cases/fragment-guess-validation.rs
@@ -1,7 +1,7 @@
 fn main() {}
 
 #[cynic::schema_for_derives(
-    file = r#"./../../../schemas/starwars.schema.graphql"#,
+    file = r#"./../../../../schemas/starwars.schema.graphql"#,
     module = "schema"
 )]
 mod queries {
@@ -28,5 +28,5 @@ mod queries {
 }
 
 mod schema {
-    cynic::use_schema!(r#"./../../../schemas/starwars.schema.graphql"#);
+    cynic::use_schema!(r#"./../../../../schemas/starwars.schema.graphql"#);
 }

--- a/tests/ui-tests/tests/cases/inline-fragment-fallback-validation.rs
+++ b/tests/ui-tests/tests/cases/inline-fragment-fallback-validation.rs
@@ -1,12 +1,12 @@
 fn main() {}
 
 mod schema {
-    cynic::use_schema!("../../../cynic/src/bin/simple.graphql");
+    cynic::use_schema!("../../../../cynic/src/bin/simple.graphql");
 }
 
 #[derive(cynic::InlineFragments)]
 #[cynic(
-    schema_path = "../../../cynic/src/bin/simple.graphql",
+    schema_path = "../../../../cynic/src/bin/simple.graphql",
     graphql_type = "MyUnionType"
 )]
 enum MyFailingUnionType {
@@ -18,7 +18,7 @@ enum MyFailingUnionType {
 }
 
 #[derive(cynic::QueryFragment)]
-#[cynic(schema_path = "../../../cynic/src/bin/simple.graphql")]
+#[cynic(schema_path = "../../../../cynic/src/bin/simple.graphql")]
 struct Nested {
     pub a_string: String,
     pub opt_string: Option<String>,
@@ -26,7 +26,7 @@ struct Nested {
 
 #[derive(cynic::InlineFragments)]
 #[cynic(
-    schema_path = "../../../cynic/src/bin/simple.graphql",
+    schema_path = "../../../../cynic/src/bin/simple.graphql",
     graphql_type = "MyUnionType"
 )]
 enum MyOkUnionTYpe {
@@ -38,7 +38,7 @@ enum MyOkUnionTYpe {
 
 #[derive(cynic::InlineFragments)]
 #[cynic(
-    schema_path = "../../../cynic/src/bin/simple.graphql",
+    schema_path = "../../../../cynic/src/bin/simple.graphql",
     graphql_type = "MyUnionType"
 )]
 enum UnionTypeWithStringFallback {

--- a/tests/ui-tests/tests/cases/input-fragment-no-graphql-type.rs
+++ b/tests/ui-tests/tests/cases/input-fragment-no-graphql-type.rs
@@ -1,6 +1,6 @@
 fn main() {}
 #[cynic::schema_for_derives(
-    file = r#"./../../../schemas/starwars.schema.graphql"#,
+    file = r#"./../../../../schemas/starwars.schema.graphql"#,
     module = "schema"
 )]
 mod queries {
@@ -46,5 +46,5 @@ mod queries {
 }
 
 mod schema {
-    cynic::use_schema!("./../../../schemas/starwars.schema.graphql");
+    cynic::use_schema!("./../../../../schemas/starwars.schema.graphql");
 }

--- a/tests/ui-tests/tests/cases/inputobject-guess-validation.rs
+++ b/tests/ui-tests/tests/cases/inputobject-guess-validation.rs
@@ -2,7 +2,7 @@
 
 fn main() {}
 
-#[cynic::schema_for_derives(file = r#"./../../../schemas/github.graphql"#, module = "schema")]
+#[cynic::schema_for_derives(file = r#"./../../../../schemas/github.graphql"#, module = "schema")]
 mod queries {
     use super::schema;
 
@@ -27,5 +27,5 @@ mod queries {
 }
 
 mod schema {
-    cynic::use_schema!(r#"./../../../schemas/github.graphql"#);
+    cynic::use_schema!(r#"./../../../../schemas/github.graphql"#);
 }

--- a/tests/ui-tests/tests/cases/missing-variable.rs
+++ b/tests/ui-tests/tests/cases/missing-variable.rs
@@ -1,7 +1,7 @@
 fn main() {}
 
 #[cynic::schema_for_derives(
-    file = r#"./../../../schemas/starwars.schema.graphql"#,
+    file = r#"./../../../../schemas/starwars.schema.graphql"#,
     module = "schema"
 )]
 mod queries {
@@ -29,5 +29,5 @@ mod queries {
 }
 
 mod schema {
-    cynic::use_schema!(r#"./../../../schemas/starwars.schema.graphql"#);
+    cynic::use_schema!(r#"./../../../../schemas/starwars.schema.graphql"#);
 }

--- a/tests/ui-tests/tests/cases/rename-failures.rs
+++ b/tests/ui-tests/tests/cases/rename-failures.rs
@@ -1,18 +1,18 @@
 fn main() {}
 
 mod schema {
-    cynic::use_schema!("../../../schemas/starwars.schema.graphql");
+    cynic::use_schema!("../../../../schemas/starwars.schema.graphql");
 }
 
 #[derive(cynic::QueryFragment, Debug)]
-#[cynic(schema_path = "../../../schemas/starwars.schema.graphql")]
+#[cynic(schema_path = "../../../../schemas/starwars.schema.graphql")]
 struct Film {
     #[cynic(rename = "episode")]
     episode_id: Option<i32>,
 }
 
 #[derive(cynic::QueryFragment, Debug)]
-#[cynic(schema_path = "../../../schemas/starwars.schema.graphql")]
+#[cynic(schema_path = "../../../../schemas/starwars.schema.graphql")]
 struct AliasWithoutRename {
     #[cynic(alias)]
     episode_id: Option<i32>,

--- a/tests/ui-tests/tests/cases/wrong-enum-type.rs
+++ b/tests/ui-tests/tests/cases/wrong-enum-type.rs
@@ -2,7 +2,7 @@
 
 fn main() {}
 
-#[cynic::schema_for_derives(file = r#"./../../../schemas/github.graphql"#, module = "schema")]
+#[cynic::schema_for_derives(file = r#"./../../../../schemas/github.graphql"#, module = "schema")]
 mod queries {
     use super::schema;
 
@@ -29,5 +29,5 @@ mod queries {
 }
 
 mod schema {
-    cynic::use_schema!(r#"./../../../schemas/github.graphql"#);
+    cynic::use_schema!(r#"./../../../../schemas/github.graphql"#);
 }

--- a/tests/ui-tests/tests/cases/wrong-scalar-type.rs
+++ b/tests/ui-tests/tests/cases/wrong-scalar-type.rs
@@ -3,7 +3,7 @@
 fn main() {}
 
 #[cynic::schema_for_derives(
-    file = r#"./../../../schemas/starwars.schema.graphql"#,
+    file = r#"./../../../../schemas/starwars.schema.graphql"#,
     module = "schema"
 )]
 mod queries {
@@ -17,5 +17,5 @@ mod queries {
 }
 
 mod schema {
-    cynic::use_schema!(r#"./../../../schemas/starwars.schema.graphql"#);
+    cynic::use_schema!(r#"./../../../../schemas/starwars.schema.graphql"#);
 }

--- a/tests/ui-tests/tests/cases/wrong-variable-type.rs
+++ b/tests/ui-tests/tests/cases/wrong-variable-type.rs
@@ -1,7 +1,7 @@
 fn main() {}
 
 #[cynic::schema_for_derives(
-    file = r#"./../../../schemas/starwars.schema.graphql"#,
+    file = r#"./../../../../schemas/starwars.schema.graphql"#,
     module = "schema"
 )]
 mod queries {
@@ -27,5 +27,5 @@ mod queries {
 }
 
 mod schema {
-    cynic::use_schema!(r#"./../../../schemas/starwars.schema.graphql"#);
+    cynic::use_schema!(r#"./../../../../schemas/starwars.schema.graphql"#);
 }


### PR DESCRIPTION
#### Why are we making this change?

Currently all the cynic macros require access to the schema SDL.  This is a bit
annoying, because it means you need to provide the path to the schema whenever
you call one of these macros.

I added the `schema_for_derives` attribute macro to help alleviate this pain,
but it's also quite annoying.  It forces you to put things in a module when you
otherwise might not have to _and_ it often obscures the true source of macro
errors that occur within the module.

#### What effects does this change have?

This PR adds:

1. A `register_schema` macro that allows you to name a schema and provide it's
   SDL.  This will be moved into a known location inside the current builds
   `OUT_DIR`, allowing the other macros in `cynic` to refer to the schema by
   its name instead of it's path.
2. The above also lets you specify a schema as a "default".  I intend to update
   the macros to use this schema when no alternative is provided to them.  This
   should allow the user to omit schema information entirely in the common case
   where they're only working with one remote schema.
3. Added a `schema` attribute macro, intended to replace `use_schema` when
   paired with registered schemas.  This can be used on a schema module and
   will pull in pre-generated schema output from `OUT_DIR`.

This functionality replaces the older `output_schema_module` functionality, 
which I have marked as deprecated.