### PR TITLE
Expose pre-registered schema functionality on derives.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -749,9 +749,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.13.1"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0d720b8683f8dd83c65155f0530560cba68cd2bf395f6513a483caee57ff7f4"
+checksum = "7b750cb3417fd1b327431a470f388520309479ab0bf5e323505daf0290cd3850"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -759,9 +759,9 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.13.1"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a340f241d2ceed1deb47ae36c4144b2707ec7dd0b649f894cb39bb595986324"
+checksum = "109c1ca6e6b7f82cc233a97004ea8ed7ca123a9af07a8230878fcfda9b158bf0"
 dependencies = [
  "fnv",
  "ident_case",
@@ -773,9 +773,9 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.13.1"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72c41b3b7352feb3211a0d743dc5700a4e3b60f51bd2b368892d1e0f9a95f44b"
+checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
 dependencies = [
  "darling_core",
  "quote",
@@ -1852,11 +1852,11 @@ checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.36"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
+checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
 dependencies = [
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -1904,9 +1904,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.14"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47aa80447ce4daf1717500037052af176af5d38cc3e571d9ec1c7353fc10c87d"
+checksum = "8f4f29d145265ec1c483c7c654450edde0bfe043d3938d6972630663356d9500"
 dependencies = [
  "proc-macro2",
 ]
@@ -2849,6 +2849,12 @@ checksum = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
 dependencies = [
  "matches",
 ]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
 
 [[package]]
 name = "unicode-normalization"

--- a/cynic-codegen/Cargo.toml
+++ b/cynic-codegen/Cargo.toml
@@ -18,7 +18,7 @@ rkyv = ["dep:rkyv"]
 
 [dependencies]
 counter = "0.5"
-darling = "0.13"
+darling = "0.14"
 graphql-parser = "0.4.0"
 once_cell = "1.9.0"
 ouroboros = "0.15"

--- a/cynic-codegen/src/enum_derive/mod.rs
+++ b/cynic-codegen/src/enum_derive/mod.rs
@@ -7,7 +7,7 @@ use crate::{
     idents::RenameAll,
     schema::{
         types::{EnumType, EnumValue},
-        Schema, SchemaInput, Unvalidated,
+        Schema, Unvalidated,
     },
 };
 
@@ -25,10 +25,7 @@ pub fn enum_derive(ast: &syn::DeriveInput) -> Result<TokenStream, syn::Error> {
 
     match EnumDeriveInput::from_derive_input(ast) {
         Ok(input) => {
-            let schema_input = SchemaInput::from_schema_path(&*input.schema_path)
-                .map_err(|e| e.into_syn_error(input.schema_path.span()))?;
-
-            let schema = Schema::new(schema_input);
+            let schema = Schema::new(input.schema_input()?);
 
             enum_derive_impl(input, &schema, enum_span).or_else(|e| Ok(e.to_compile_error()))
         }

--- a/cynic-codegen/src/fragment_derive/mod.rs
+++ b/cynic-codegen/src/fragment_derive/mod.rs
@@ -3,7 +3,7 @@ use proc_macro2::{Span, TokenStream};
 use crate::{
     schema::{
         types::{self as schema},
-        Schema, SchemaInput,
+        Schema,
     },
     suggestions::FieldSuggestionError,
     Errors,
@@ -40,10 +40,7 @@ pub fn fragment_derive_impl(input: FragmentDeriveInput) -> Result<TokenStream, E
     input.validate()?;
     input.detect_aliases();
 
-    let schema_input = SchemaInput::from_schema_path(&*input.schema_path)
-        .map_err(|e| e.into_syn_error(input.schema_path.span()))?;
-
-    let schema = Schema::new(schema_input);
+    let schema = Schema::new(input.schema_input()?);
 
     let schema_type = schema
         .lookup::<FragmentDeriveType<'_>>(&input.graphql_type_name())

--- a/cynic-codegen/src/inline_fragments_derive/input.rs
+++ b/cynic-codegen/src/inline_fragments_derive/input.rs
@@ -1,6 +1,7 @@
+#![allow(deprecated)] // Until we remove deprecated stuff...
 use {darling::util::SpannedValue, proc_macro2::Span, quote::quote_spanned};
 
-use crate::error::Errors;
+use crate::{error::Errors, schema::SchemaInput};
 
 #[derive(darling::FromDeriveInput)]
 #[darling(attributes(cynic), supports(enum_newtype, enum_unit))]
@@ -9,7 +10,10 @@ pub struct InlineFragmentsDeriveInput {
     pub(super) data: darling::ast::Data<SpannedValue<InlineFragmentsDeriveVariant>, ()>,
     pub(super) generics: syn::Generics,
 
-    pub schema_path: SpannedValue<String>,
+    #[darling(default)]
+    schema: Option<SpannedValue<String>>,
+    #[darling(default)]
+    schema_path: Option<SpannedValue<String>>,
 
     #[darling(default, rename = "schema_module")]
     schema_module_: Option<syn::Path>,
@@ -106,6 +110,20 @@ impl InlineFragmentsDeriveInput {
         }
 
         rv
+    }
+
+    pub fn schema_input(&self) -> Result<SchemaInput, syn::Error> {
+        match (&self.schema, &self.schema_path) {
+            (None, None) => SchemaInput::default().map_err(|e| e.into_syn_error(Span::call_site())),
+            (None, Some(path)) => SchemaInput::from_schema_path(path.as_ref())
+                .map_err(|e| e.into_syn_error(path.span())),
+            (Some(name), None) => SchemaInput::from_schema_name(name.as_ref())
+                .map_err(|e| e.into_syn_error(name.span())),
+            (Some(_), Some(path)) => Err(syn::Error::new(
+                path.span(),
+                "Only one of schema_path & schema can be provided",
+            )),
+        }
     }
 }
 

--- a/cynic-codegen/src/inline_fragments_derive/mod.rs
+++ b/cynic-codegen/src/inline_fragments_derive/mod.rs
@@ -8,7 +8,7 @@ use crate::{
     schema::{
         markers::TypeMarkerIdent,
         types::{InterfaceType, Kind, Type, UnionType},
-        Schema, SchemaError, SchemaInput,
+        Schema, SchemaError,
     },
     variables_fields_path, Errors,
 };
@@ -40,10 +40,7 @@ pub(crate) fn inline_fragments_derive_impl(
 ) -> Result<TokenStream, Errors> {
     use quote::quote;
 
-    let schema_input = SchemaInput::from_schema_path(&*input.schema_path)
-        .map_err(|e| e.into_syn_error(input.schema_path.span()))?;
-
-    let schema = Schema::new(schema_input);
+    let schema = Schema::new(input.schema_input()?);
 
     let target_type = schema.lookup::<InlineFragmentType<'_>>(&input.graphql_type_name())?;
 

--- a/cynic-codegen/src/input_object_derive/mod.rs
+++ b/cynic-codegen/src/input_object_derive/mod.rs
@@ -9,7 +9,7 @@ use crate::{
     idents::RenameAll,
     schema::{
         types::{InputObjectType, InputValue},
-        Schema, SchemaInput,
+        Schema,
     },
     suggestions::FieldSuggestionError,
 };
@@ -44,10 +44,7 @@ pub fn input_object_derive_impl(
 ) -> Result<TokenStream, Errors> {
     use quote::quote;
 
-    let schema_input = SchemaInput::from_schema_path(&*input.schema_path)
-        .map_err(|e| e.into_syn_error(input.schema_path.span()))?;
-
-    let schema = Schema::new(schema_input);
+    let schema = Schema::new(input.schema_input()?);
 
     let input_object = schema
         .lookup::<InputObjectType<'_>>(&input.graphql_type_name())
@@ -226,6 +223,8 @@ fn pair_fields<'a>(
 #[cfg(test)]
 mod test {
     use assert_matches::assert_matches;
+
+    use crate::schema::SchemaInput;
 
     use super::*;
 

--- a/cynic-codegen/src/registration.rs
+++ b/cynic-codegen/src/registration.rs
@@ -96,7 +96,7 @@ impl SchemaRegistration<'_> {
                 .map_err(|errors| SchemaRegistrationError::SchemaErrors(errors.to_string()))?;
             let optimised = schema.optimise();
             let bytes = rkyv::to_bytes::<_, 4096>(&optimised).unwrap();
-            Ok(std::fs::write(filename, &self.data)?)
+            Ok(std::fs::write(filename, &bytes)?)
         }
         #[cfg(not(feature = "rkyv"))]
         {

--- a/cynic-codegen/src/registration.rs
+++ b/cynic-codegen/src/registration.rs
@@ -86,7 +86,7 @@ impl SchemaRegistration<'_> {
         std::fs::create_dir_all(filename.parent().expect("filename to have a parent"))?;
         #[cfg(feature = "rkyv")]
         {
-            filename.set_extension("graphql");
+            filename.set_extension("rkyv");
             let document_string = String::from_utf8(self.data.clone()).expect("schema to be utf8");
             let document = crate::schema::load_schema(&document_string)
                 .map_err(|error| SchemaRegistrationError::SchemaErrors(error.to_string()))?
@@ -100,7 +100,7 @@ impl SchemaRegistration<'_> {
         }
         #[cfg(not(feature = "rkyv"))]
         {
-            filename.set_extension("rkyv");
+            filename.set_extension("graphql");
             Ok(std::fs::write(filename, &self.data)?)
         }
     }

--- a/cynic-codegen/src/schema/parser.rs
+++ b/cynic-codegen/src/schema/parser.rs
@@ -45,6 +45,7 @@ pub enum SchemaLoadError {
     FileNotFound(String),
     NamedSchemaNotFound(String),
     DefaultSchemaNotFound,
+    UnknownOutDir,
 }
 
 impl SchemaLoadError {
@@ -59,13 +60,18 @@ impl std::fmt::Display for SchemaLoadError {
             SchemaLoadError::IoError(e) => write!(f, "Could not load schema file: {}", e),
             SchemaLoadError::ParseError(e) => write!(f, "Could not parse schema file: {}", e),
             SchemaLoadError::FileNotFound(e) => write!(f, "Could not find file: {}", e),
-            SchemaLoadError::NamedSchemaNotFound(e) => write!(
+            SchemaLoadError::NamedSchemaNotFound(_) => write!(
                 f,
-                "Could not find a schema named {}\n\n Have you registered it in build.rs?",
-                e
+                "Could not find a schema with this name.  Have you registered it in build.rs?",
             ),
             SchemaLoadError::DefaultSchemaNotFound => {
                 write!(f, "Couldn't determine which schema to use.  Please provide the `schema` argument or set a default schema in build.rs")
+            }
+            SchemaLoadError::UnknownOutDir => {
+                write!(
+                    f,
+                    "OUT_DIR was not defined.  Have you set up your build.rs correctly?"
+                )
             }
         }
     }

--- a/examples/build.rs
+++ b/examples/build.rs
@@ -4,4 +4,7 @@ fn main() {
         .unwrap()
         .as_default()
         .unwrap();
+    cynic_codegen::register_schema("github")
+        .from_sdl_file("../schemas/github.graphql")
+        .unwrap();
 }

--- a/examples/examples/github-mutation.rs
+++ b/examples/examples/github-mutation.rs
@@ -16,7 +16,7 @@ fn main() {
     println!("{:?}", result);
 }
 
-fn run_query() -> cynic::GraphQlResponse<queries::CommentOnMutationSupportIssue> {
+fn run_query() -> cynic::GraphQlResponse<CommentOnMutationSupportIssue> {
     use cynic::http::ReqwestBlockingExt;
 
     let query = build_query();
@@ -31,63 +31,61 @@ fn run_query() -> cynic::GraphQlResponse<queries::CommentOnMutationSupportIssue>
         .unwrap()
 }
 
-fn build_query() -> cynic::Operation<
-    queries::CommentOnMutationSupportIssue,
-    queries::CommentOnMutationSupportIssueArguments,
-> {
+fn build_query(
+) -> cynic::Operation<CommentOnMutationSupportIssue, CommentOnMutationSupportIssueArguments> {
     use cynic::MutationBuilder;
-    use queries::{CommentOnMutationSupportIssue, CommentOnMutationSupportIssueArguments};
 
     CommentOnMutationSupportIssue::build(CommentOnMutationSupportIssueArguments {
         comment_body: "Testing".into(),
     })
 }
 
-#[cynic::schema_for_derives(file = "../schemas/github.graphql", module = "schema")]
-mod queries {
-    use github_schema as schema;
+use github_schema as schema;
 
-    #[derive(cynic::QueryVariables, Debug)]
-    pub struct CommentOnMutationSupportIssueArguments {
-        pub comment_body: String,
-    }
+#[derive(cynic::QueryVariables, Debug)]
+pub struct CommentOnMutationSupportIssueArguments {
+    pub comment_body: String,
+}
 
-    #[derive(cynic::QueryFragment, Debug)]
-    #[cynic(
-        graphql_type = "Mutation",
-        variables = "CommentOnMutationSupportIssueArguments"
-    )]
-    pub struct CommentOnMutationSupportIssue {
-        #[arguments(input: {
+#[derive(cynic::QueryFragment, Debug)]
+#[cynic(
+    schema = "github",
+    graphql_type = "Mutation",
+    variables = "CommentOnMutationSupportIssueArguments"
+)]
+pub struct CommentOnMutationSupportIssue {
+    #[arguments(input: {
             body: $comment_body,
             subjectId: "MDU6SXNzdWU2ODU4NzUxMzQ=",
             clientMutationId: null,
         })]
-        pub add_comment: Option<AddCommentPayload>,
-    }
+    pub add_comment: Option<AddCommentPayload>,
+}
 
-    #[derive(cynic::QueryFragment, Debug)]
-    pub struct AddCommentPayload {
-        pub comment_edge: Option<IssueCommentEdge>,
-    }
+#[derive(cynic::QueryFragment, Debug)]
+#[cynic(schema = "github")]
+pub struct AddCommentPayload {
+    pub comment_edge: Option<IssueCommentEdge>,
+}
 
-    #[derive(cynic::QueryFragment, Debug)]
-    pub struct IssueCommentEdge {
-        pub node: Option<IssueComment>,
-    }
+#[derive(cynic::QueryFragment, Debug)]
+#[cynic(schema = "github")]
+pub struct IssueCommentEdge {
+    pub node: Option<IssueComment>,
+}
 
-    #[derive(cynic::QueryFragment, Debug)]
-    pub struct IssueComment {
-        pub id: cynic::Id,
-    }
+#[derive(cynic::QueryFragment, Debug)]
+#[cynic(schema = "github")]
+pub struct IssueComment {
+    pub id: cynic::Id,
+}
 
-    #[derive(cynic::InputObject, Clone, Debug)]
-    #[cynic(rename_all = "camelCase")]
-    pub struct AddCommentInput {
-        pub body: String,
-        pub client_mutation_id: Option<String>,
-        pub subject_id: cynic::Id,
-    }
+#[derive(cynic::InputObject, Clone, Debug)]
+#[cynic(schema = "github", rename_all = "camelCase")]
+pub struct AddCommentInput {
+    pub body: String,
+    pub client_mutation_id: Option<String>,
+    pub subject_id: cynic::Id,
 }
 
 #[cfg(test)]

--- a/examples/examples/github.rs
+++ b/examples/examples/github.rs
@@ -16,7 +16,7 @@ fn main() {
     println!("{:?}", result);
 }
 
-fn run_query() -> cynic::GraphQlResponse<queries::PullRequestTitles> {
+fn run_query() -> cynic::GraphQlResponse<PullRequestTitles> {
     use cynic::http::ReqwestBlockingExt;
 
     let query = build_query();
@@ -31,12 +31,8 @@ fn run_query() -> cynic::GraphQlResponse<queries::PullRequestTitles> {
         .unwrap()
 }
 
-fn build_query() -> cynic::Operation<queries::PullRequestTitles, queries::PullRequestTitlesArguments>
-{
+fn build_query() -> cynic::Operation<PullRequestTitles, PullRequestTitlesArguments> {
     use cynic::QueryBuilder;
-    use queries::{
-        IssueOrder, IssueOrderField, OrderDirection, PullRequestTitles, PullRequestTitlesArguments,
-    };
 
     PullRequestTitles::build(PullRequestTitlesArguments {
         pr_order: IssueOrder {
@@ -46,64 +42,67 @@ fn build_query() -> cynic::Operation<queries::PullRequestTitles, queries::PullRe
     })
 }
 
-#[cynic::schema_for_derives(file = "../schemas/github.graphql", module = "schema")]
-mod queries {
-    use github_schema as schema;
+use github_schema as schema;
 
-    pub type DateTime = chrono::DateTime<chrono::Utc>;
+pub type DateTime = chrono::DateTime<chrono::Utc>;
 
-    #[derive(cynic::QueryVariables, Debug)]
-    pub struct PullRequestTitlesArguments {
-        pub pr_order: IssueOrder,
-    }
+#[derive(cynic::QueryVariables, Debug)]
+pub struct PullRequestTitlesArguments {
+    pub pr_order: IssueOrder,
+}
 
-    #[derive(cynic::InputObject, Clone, Debug)]
-    #[cynic(rename_all = "camelCase")]
-    pub struct IssueOrder {
-        pub direction: OrderDirection,
-        pub field: IssueOrderField,
-    }
+#[derive(cynic::InputObject, Clone, Debug)]
+#[cynic(schema = "github", rename_all = "camelCase")]
+pub struct IssueOrder {
+    pub direction: OrderDirection,
+    pub field: IssueOrderField,
+}
 
-    #[derive(cynic::Enum, Clone, Copy, Debug)]
-    #[cynic(rename_all = "SCREAMING_SNAKE_CASE")]
-    pub enum OrderDirection {
-        Asc,
-        Desc,
-    }
+#[derive(cynic::Enum, Clone, Copy, Debug)]
+#[cynic(schema = "github", rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum OrderDirection {
+    Asc,
+    Desc,
+}
 
-    #[derive(cynic::Enum, Clone, Copy, Debug)]
-    #[cynic(rename_all = "SCREAMING_SNAKE_CASE")]
-    pub enum IssueOrderField {
-        Comments,
-        CreatedAt,
-        UpdatedAt,
-    }
+#[derive(cynic::Enum, Clone, Copy, Debug)]
+#[cynic(schema = "github", rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum IssueOrderField {
+    Comments,
+    CreatedAt,
+    UpdatedAt,
+}
 
-    #[derive(cynic::QueryFragment, Debug)]
-    #[cynic(graphql_type = "Query", variables = "PullRequestTitlesArguments")]
-    pub struct PullRequestTitles {
-        #[arguments(name = "cynic".to_string(), owner = "obmarg".to_string())]
-        pub repository: Option<Repository>,
-    }
+#[derive(cynic::QueryFragment, Debug)]
+#[cynic(
+    graphql_type = "Query",
+    schema = "github",
+    variables = "PullRequestTitlesArguments"
+)]
+pub struct PullRequestTitles {
+    #[arguments(name = "cynic".to_string(), owner = "obmarg".to_string())]
+    pub repository: Option<Repository>,
+}
 
-    #[derive(cynic::QueryFragment, Debug)]
-    #[cynic(variables = "PullRequestTitlesArguments")]
-    pub struct Repository {
-        #[arguments(orderBy: $pr_order, first: 10)]
-        pub pull_requests: PullRequestConnection,
-    }
+#[derive(cynic::QueryFragment, Debug)]
+#[cynic(schema = "github", variables = "PullRequestTitlesArguments")]
+pub struct Repository {
+    #[arguments(orderBy: $pr_order, first: 10)]
+    pub pull_requests: PullRequestConnection,
+}
 
-    #[derive(cynic::QueryFragment, Debug)]
-    pub struct PullRequestConnection {
-        #[cynic(flatten)]
-        pub nodes: Vec<PullRequest>,
-    }
+#[derive(cynic::QueryFragment, Debug)]
+#[cynic(schema = "github")]
+pub struct PullRequestConnection {
+    #[cynic(flatten)]
+    pub nodes: Vec<PullRequest>,
+}
 
-    #[derive(cynic::QueryFragment, Debug)]
-    pub struct PullRequest {
-        pub title: String,
-        pub created_at: DateTime,
-    }
+#[derive(cynic::QueryFragment, Debug)]
+#[cynic(schema = "github")]
+pub struct PullRequest {
+    pub title: String,
+    pub created_at: DateTime,
 }
 
 #[cfg(test)]

--- a/examples/examples/manual-reqwest.rs
+++ b/examples/examples/manual-reqwest.rs
@@ -6,7 +6,6 @@
 mod schema {}
 
 #[derive(cynic::QueryFragment, Debug)]
-#[cynic(schema_path = "../schemas/starwars.schema.graphql")]
 struct Film {
     title: Option<String>,
     director: Option<String>,
@@ -18,11 +17,7 @@ struct FilmArguments {
 }
 
 #[derive(cynic::QueryFragment, Debug)]
-#[cynic(
-    schema_path = "../schemas/starwars.schema.graphql",
-    graphql_type = "Root",
-    variables = "FilmArguments"
-)]
+#[cynic(graphql_type = "Root", variables = "FilmArguments")]
 struct FilmDirectorQuery {
     #[arguments(id: $id)]
     film: Option<Film>,

--- a/examples/examples/querying-interfaces.rs
+++ b/examples/examples/querying-interfaces.rs
@@ -5,7 +5,6 @@
 mod schema {}
 
 #[derive(cynic::InlineFragments, Debug)]
-#[cynic(schema_path = "../schemas/starwars.schema.graphql")]
 enum Node {
     Film(Film),
     Planet(Planet),
@@ -15,23 +14,18 @@ enum Node {
 }
 
 #[derive(cynic::QueryFragment, Debug)]
-#[cynic(schema_path = "../schemas/starwars.schema.graphql")]
 struct Film {
     __typename: String,
     title: Option<String>,
 }
 
 #[derive(cynic::QueryFragment, Debug)]
-#[cynic(schema_path = "../schemas/starwars.schema.graphql")]
 struct Planet {
     name: Option<String>,
 }
 
 #[derive(cynic::QueryFragment, Debug)]
-#[cynic(
-    schema_path = "../schemas/starwars.schema.graphql",
-    graphql_type = "Node"
-)]
+#[cynic(graphql_type = "Node")]
 struct OtherNode {
     id: cynic::Id,
 }
@@ -42,11 +36,7 @@ struct Arguments {
 }
 
 #[derive(cynic::QueryFragment, Debug)]
-#[cynic(
-    schema_path = "../schemas/starwars.schema.graphql",
-    graphql_type = "Root",
-    variables = "Arguments"
-)]
+#[cynic(graphql_type = "Root", variables = "Arguments")]
 struct Query {
     #[arguments(id: $id)]
     node: Option<Node>,

--- a/examples/examples/reqwest-async.rs
+++ b/examples/examples/reqwest-async.rs
@@ -8,7 +8,6 @@
 mod schema {}
 
 #[derive(cynic::QueryFragment, Debug)]
-#[cynic(schema_path = "../schemas/starwars.schema.graphql")]
 struct Film {
     title: Option<String>,
     director: Option<String>,
@@ -20,11 +19,7 @@ struct FilmArguments {
 }
 
 #[derive(cynic::QueryFragment, Debug)]
-#[cynic(
-    schema_path = "../schemas/starwars.schema.graphql",
-    graphql_type = "Root",
-    variables = "FilmArguments"
-)]
+#[cynic(graphql_type = "Root", variables = "FilmArguments")]
 struct FilmDirectorQuery {
     #[arguments(id: $id)]
     film: Option<Film>,

--- a/examples/examples/spread.rs
+++ b/examples/examples/spread.rs
@@ -5,17 +5,13 @@
 mod schema {}
 
 #[derive(cynic::QueryFragment, Debug)]
-#[cynic(
-    schema_path = "../schemas/starwars.schema.graphql",
-    graphql_type = "Film"
-)]
+#[cynic(graphql_type = "Film")]
 struct FilmDetails {
     title: Option<String>,
     director: Option<String>,
 }
 
 #[derive(cynic::QueryFragment, Debug)]
-#[cynic(schema_path = "../schemas/starwars.schema.graphql")]
 struct Film {
     #[cynic(spread)]
     details: FilmDetails,
@@ -27,11 +23,7 @@ struct FilmArguments {
 }
 
 #[derive(cynic::QueryFragment, Debug)]
-#[cynic(
-    schema_path = "../schemas/starwars.schema.graphql",
-    graphql_type = "Root",
-    variables = "FilmArguments"
-)]
+#[cynic(graphql_type = "Root", variables = "FilmArguments")]
 struct FilmDirectorQuery {
     #[arguments(id: $id)]
     film: Option<Film>,

--- a/examples/examples/starwars.rs
+++ b/examples/examples/starwars.rs
@@ -5,7 +5,6 @@
 mod schema {}
 
 #[derive(cynic::QueryFragment, Debug)]
-#[cynic(schema_path = "../schemas/starwars.schema.graphql")]
 struct Film {
     title: Option<String>,
     director: Option<String>,
@@ -17,11 +16,7 @@ struct FilmArguments {
 }
 
 #[derive(cynic::QueryFragment, Debug)]
-#[cynic(
-    schema_path = "../schemas/starwars.schema.graphql",
-    graphql_type = "Root",
-    variables = "FilmArguments"
-)]
+#[cynic(graphql_type = "Root", variables = "FilmArguments")]
 struct FilmDirectorQuery {
     #[arguments(id: $id)]
     film: Option<Film>,

--- a/examples/examples/surf-client.rs
+++ b/examples/examples/surf-client.rs
@@ -8,7 +8,6 @@
 mod schema {}
 
 #[derive(cynic::QueryFragment, Debug)]
-#[cynic(schema_path = "../schemas/starwars.schema.graphql")]
 struct Film {
     title: Option<String>,
     director: Option<String>,
@@ -20,11 +19,7 @@ struct FilmArguments {
 }
 
 #[derive(cynic::QueryFragment, Debug)]
-#[cynic(
-    schema_path = "../schemas/starwars.schema.graphql",
-    graphql_type = "Root",
-    variables = "FilmArguments"
-)]
+#[cynic(graphql_type = "Root", variables = "FilmArguments")]
 struct FilmDirectorQuery {
     #[arguments(id: $id)]
     film: Option<Film>,

--- a/tests/ui-tests/tests/cases/enum-guess-validation.stderr
+++ b/tests/ui-tests/tests/cases/enum-guess-validation.stderr
@@ -1,8 +1,8 @@
 error: Could not find a type named `Desseqt` in the schema
-  --> tests/cases/enum-guess-validation.rs:10:5
+  --> tests/cases/enum-guess-validation.rs:10:20
    |
 10 |     graphql_type = "Desseqt"
-   |     ^^^^^^^^^^^^
+   |                    ^^^^^^^^^
 
 warning: variant `ICE_CREAM` should have an upper camel case name
   --> tests/cases/enum-guess-validation.rs:14:5

--- a/tests/ui-tests/tests/cases/rename-failures.stderr
+++ b/tests/ui-tests/tests/cases/rename-failures.stderr
@@ -1,8 +1,8 @@
 error: no field `episode` on the GraphQL type `Film`.  Did you mean `created`?
-  --> tests/cases/rename-failures.rs:10:13
+  --> tests/cases/rename-failures.rs:10:22
    |
 10 |     #[cynic(rename = "episode")]
-   |             ^^^^^^
+   |                      ^^^^^^^^^
 
 error: You can only alias a renamed field.  Try removing `alias` or adding a rename
   --> tests/cases/rename-failures.rs:17:13


### PR DESCRIPTION
PRs #668 & #660 exposed functionality for registering schemas in your build.rs

This PR updates the various derive macros to accept the schema name instead of the path, which vastly simplifies the API for these.  They also support _not_ specifying a schema, in which case they'll attempt to use the one that was registered as the default (or error if no default was registered).

I've not updated the schema_for_derives attribute macro as part of this, as I believe it might be more trouble than its worth with this new approach.  I'll try it out and see - either update that macro or possibly deprecate it if it's no longer any use.

Fixes #669
