### PR TITLE
Improve string escaping in querygen & query output.

### DIFF
--- a/cynic-codegen/src/schema_module_attr.rs
+++ b/cynic-codegen/src/schema_module_attr.rs
@@ -33,7 +33,7 @@ pub fn attribute_impl(
 
     // Silence a bunch of warnings inside this module
     module.attrs.push(parse_quote! {
-        #[allow(clippy::all, non_snake_case, non_camel_case_types)]
+        #[allow(clippy::all, non_snake_case, non_camel_case_types, dead_code)]
     });
 
     let include: Item = parse_quote! {

--- a/cynic-codegen/tests/snapshots/use_schema__test_cases.graphql.snap
+++ b/cynic-codegen/tests/snapshots/use_schema__test_cases.graphql.snap
@@ -141,6 +141,21 @@ pub mod __fields {
                 const NAME: &'static str = "recursive2";
             }
         }
+        pub struct fieldWithStringArg;
+        impl cynic::schema::Field for fieldWithStringArg {
+            type Type = Option<super::super::Int>;
+            const NAME: &'static str = "fieldWithStringArg";
+        }
+        impl cynic::schema::HasField<fieldWithStringArg> for super::super::Foo {
+            type Type = Option<super::super::Int>;
+        }
+        pub mod _field_with_string_arg_arguments {
+            pub struct input;
+            impl cynic::schema::HasArgument<input> for super::fieldWithStringArg {
+                type ArgumentType = super::super::super::String;
+                const NAME: &'static str = "input";
+            }
+        }
         pub struct __typename;
         impl cynic::schema::Field for __typename {
             type Type = super::super::String;

--- a/cynic-querygen/src/query_parsing/value.rs
+++ b/cynic-querygen/src/query_parsing/value.rs
@@ -153,7 +153,11 @@ impl<'query, 'schema> TypedValue<'query, 'schema> {
                 .map(|d| d.to_string())
                 .unwrap_or_else(|| "null".to_string()),
             TypedValue::String(s, _) => {
-                format!("\"{s}\"")
+                if string_needs_raw_literal(s) {
+                    format!("r#\"{s}\"#")
+                } else {
+                    format!("\"{s}\"")
+                }
             }
             TypedValue::Boolean(b, _) => b.to_string(),
             TypedValue::Null(_) => "null".into(),
@@ -195,6 +199,10 @@ impl<'query, 'schema> TypedValue<'query, 'schema> {
             }
         })
     }
+}
+
+fn string_needs_raw_literal(s: &str) -> bool {
+    s.chars().any(|c| c.is_ascii_control() || c == '"')
 }
 
 /// The contexts in which a Value literal can appear in generated code.

--- a/cynic-querygen/tests/misc-tests.rs
+++ b/cynic-querygen/tests/misc-tests.rs
@@ -60,3 +60,19 @@ fn test_recursive_inputs() {
             .expect("QueryGen Failed")
     )
 }
+
+#[test]
+fn test_string_escaping() {
+    let schema = include_str!("../../schemas/test_cases.graphql");
+    let query = r#"
+      query {
+        one: fieldWithStringArg(input: "Hello\n There")
+        two: fieldWithStringArg(input: "Hello \" I am a string with quotes")
+      }
+    "#;
+
+    assert_snapshot!(
+        document_to_fragment_structs(query, schema, &QueryGenOptions::default())
+            .expect("QueryGen Failed")
+    )
+}

--- a/cynic-querygen/tests/snapshots/misc_tests__string_escaping.snap
+++ b/cynic-querygen/tests/snapshots/misc_tests__string_escaping.snap
@@ -1,0 +1,31 @@
+---
+source: cynic-querygen/tests/misc-tests.rs
+expression: "document_to_fragment_structs(query, schema,\n        &QueryGenOptions::default()).expect(\"QueryGen Failed\")"
+---
+#[cynic::schema_for_derives(
+    file = r#"schema.graphql"#,
+    module = "schema",
+)]
+mod queries {
+    use super::schema;
+
+    #[derive(cynic::QueryFragment, Debug)]
+    #[cynic(graphql_type = "Foo")]
+    pub struct UnnamedQuery {
+        #[arguments(input: r#"Hello
+         There"#)]
+        #[cynic(rename = "fieldWithStringArg")]
+        pub one: Option<i32>,
+        #[arguments(input: r#"Hello " I am a string with quotes"#)]
+        #[cynic(rename = "fieldWithStringArg")]
+        pub two: Option<i32>,
+    }
+
+}
+
+#[allow(non_snake_case, non_camel_case_types)]
+mod schema {
+    cynic::use_schema!(r#"schema.graphql"#);
+}
+
+

--- a/cynic/src/queries/ast.rs
+++ b/cynic/src/queries/ast.rs
@@ -154,7 +154,14 @@ impl std::fmt::Display for InputLiteral {
             InputLiteral::Int(val) => write!(f, "{}", val),
             InputLiteral::Float(val) => write!(f, "{}", val),
             InputLiteral::Bool(val) => write!(f, "{}", val),
-            InputLiteral::String(val) => write!(f, "\"{}\"", val),
+            InputLiteral::String(val) if requires_block_string(val) => {
+                write!(f, "\"\"\"")?;
+                write!(f, "{val}")?;
+                write!(f, "\"\"\"")
+            }
+            InputLiteral::String(val) => {
+                write!(f, "\"{val}\"")
+            }
             InputLiteral::Id(val) => write!(f, "\"{}\"", val),
             InputLiteral::Object(fields) => {
                 write!(f, "{{")?;
@@ -181,4 +188,10 @@ impl std::fmt::Display for InputLiteral {
             }
         }
     }
+}
+
+fn requires_block_string(string: &str) -> bool {
+    string
+        .chars()
+        .any(|c| !c.is_ascii() || c.is_ascii_control() || c == '"')
 }

--- a/cynic/tests/escaping-strings.rs
+++ b/cynic/tests/escaping-strings.rs
@@ -1,0 +1,74 @@
+//! Tests of string escaping in queries
+//! Tests of the generated serialization code for InputObjects
+
+mod schema {
+    cynic::use_schema!("tests/test-schema.graphql");
+}
+
+#[test]
+fn test_quotes_in_string() {
+    use cynic::QueryBuilder;
+
+    #[derive(cynic::QueryFragment)]
+    #[cynic(schema_path = "tests/test-schema.graphql")]
+    struct Query {
+        #[allow(dead_code)]
+        #[arguments(input: "Hello \"Graeme\"")]
+        field_with_string: i32,
+    }
+
+    let query = Query::build(());
+
+    insta::assert_display_snapshot!(query.query, @r###"
+    query Query {
+      fieldWithString(input: """Hello "Graeme"""")
+    }
+
+    "###);
+}
+
+#[test]
+fn test_newlines_in_string() {
+    use cynic::QueryBuilder;
+
+    #[derive(cynic::QueryFragment)]
+    #[cynic(schema_path = "tests/test-schema.graphql")]
+    struct Query {
+        #[allow(dead_code)]
+        #[arguments(input: "I am a string with \nnew\nlines")]
+        field_with_string: i32,
+    }
+
+    let query = Query::build(());
+
+    insta::assert_display_snapshot!(query.query, @r###"
+    query Query {
+      fieldWithString(input: """I am a string with 
+      new
+      lines""")
+    }
+
+    "###);
+}
+
+#[test]
+fn test_unicode_in_string() {
+    use cynic::QueryBuilder;
+
+    #[derive(cynic::QueryFragment)]
+    #[cynic(schema_path = "tests/test-schema.graphql")]
+    struct Query {
+        #[allow(dead_code)]
+        #[arguments(input: "I am a 😎 string")]
+        field_with_string: i32,
+    }
+
+    let query = Query::build(());
+
+    insta::assert_display_snapshot!(query.query, @r###"
+    query Query {
+      fieldWithString(input: """I am a 😎 string""")
+    }
+
+    "###);
+}

--- a/cynic/tests/test-schema.graphql
+++ b/cynic/tests/test-schema.graphql
@@ -56,6 +56,8 @@ type Query {
     anOptionalInt: Int = 1
     input: InputWithDefaults
   ): Int!
+
+  fieldWithString(input: String!): Int!
 }
 
 union PostOrAuthor = BlogPost | Author

--- a/schemas/test_cases.graphql
+++ b/schemas/test_cases.graphql
@@ -16,6 +16,8 @@ type Foo {
     recursive: SelfRecursiveInput
     recursive2: RecursiveInputParent
   ): Boolean
+
+  fieldWithStringArg(input: String!): Int
 }
 
 type Bar {


### PR DESCRIPTION
Improve string escaping in querygen & query output.

We weren't handling string escaping very well.

1. Querygen wouldn't bother escaping strings in the rust it generated.
   I've updated this to output a raw string when it looks like it needs
   it.
2. Our generated queries wouldn't escape strings either.  I've updated
   this to put out a block string if it looks like it needs escaping.

I'm pretty certain this doesn't handle all cases - it'll likely need
some more work.  But it seems like an improvement if nothing else.

Fixes #648