### PR TITLE
Disable clippy::pedantic as well as clippy::all

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ## Unreleased - xxxx-xx-xx
 
+### Bug Fixes
+
+- Schema file should no longer cause clippy warnings if `clippy::pedantic` is on.
+
 ## v3.0.0-beta.1 - 2023-04-27
 
 ### Breaking Changes

--- a/cynic-codegen/src/schema_module_attr.rs
+++ b/cynic-codegen/src/schema_module_attr.rs
@@ -33,7 +33,7 @@ pub fn attribute_impl(
 
     // Silence a bunch of warnings inside this module
     module.attrs.push(parse_quote! {
-        #[allow(clippy::all, non_snake_case, non_camel_case_types, dead_code)]
+        #[allow(clippy::all, clippy::pedantic, non_snake_case, non_camel_case_types, dead_code)]
     });
 
     let include: Item = parse_quote! {


### PR DESCRIPTION
Seems like clippy::all doesn't always disable pedantic?  Bit odd but whatever.