### PR TITLE
Improve errors for unregistered schemas.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -721,6 +721,8 @@ name = "cynic-proc-macros"
 version = "3.0.0-beta.3"
 dependencies = [
  "cynic-codegen",
+ "proc-macro2",
+ "quote",
  "syn",
 ]
 

--- a/cynic-codegen/src/schema/input.rs
+++ b/cynic-codegen/src/schema/input.rs
@@ -14,13 +14,17 @@ impl SchemaInput {
     pub(crate) fn default() -> Result<SchemaInput, SchemaLoadError> {
         Self::from_schema_name("default").map_err(|error| match error {
             SchemaLoadError::NamedSchemaNotFound(_) => SchemaLoadError::DefaultSchemaNotFound,
+            SchemaLoadError::UnknownOutDirWithNamedSchema(_) => {
+                SchemaLoadError::UnknownOutDirWithDefaultSchema
+            }
             _ => error,
         })
     }
 
     /// Parses a SchemaInput from a name passed to a macro
     pub(crate) fn from_schema_name(name: &str) -> Result<SchemaInput, SchemaLoadError> {
-        let out_dir = std::env::var("OUT_DIR").map_err(|_| SchemaLoadError::UnknownOutDir)?;
+        let out_dir = std::env::var("OUT_DIR")
+            .map_err(|_| SchemaLoadError::UnknownOutDirWithNamedSchema(name.to_string()))?;
 
         let mut path = std::path::PathBuf::from(out_dir);
         path.push("cynic-schemas");

--- a/cynic-codegen/src/schema/parser.rs
+++ b/cynic-codegen/src/schema/parser.rs
@@ -45,7 +45,8 @@ pub enum SchemaLoadError {
     FileNotFound(String),
     NamedSchemaNotFound(String),
     DefaultSchemaNotFound,
-    UnknownOutDir,
+    UnknownOutDirWithNamedSchema(String),
+    UnknownOutDirWithDefaultSchema,
 }
 
 impl SchemaLoadError {
@@ -62,20 +63,26 @@ impl std::fmt::Display for SchemaLoadError {
             SchemaLoadError::FileNotFound(e) => write!(f, "Could not find file: {}", e),
             SchemaLoadError::NamedSchemaNotFound(_) => write!(
                 f,
-                "Could not find a schema with this name.  Have you registered it in build.rs?",
+                "Could not find a schema with this name.  Have you registered it in build.rs?  {SCHEMA_DOCUMENTATION_TEXT}",
             ),
             SchemaLoadError::DefaultSchemaNotFound => {
-                write!(f, "Couldn't determine which schema to use.  Please provide the `schema` argument or set a default schema in build.rs")
+                write!(f, "This derive is trying to use the default schema but it doesn't look like you've registered a default.  Please provide the `schema` argument or set a default in your build.rs.  {SCHEMA_DOCUMENTATION_TEXT}")
             }
-            SchemaLoadError::UnknownOutDir => {
+            SchemaLoadError::UnknownOutDirWithNamedSchema(name) => {
+                write!(f, "You requested a schema named {name} but it doesn't look like you've registered any schemas.  {SCHEMA_DOCUMENTATION_TEXT}")
+            }
+            SchemaLoadError::UnknownOutDirWithDefaultSchema => {
                 write!(
                     f,
-                    "OUT_DIR was not defined.  Have you set up your build.rs correctly?"
+                    "This derive is trying to use the default schema, but it doesn't look like you've registered any schemas.  {SCHEMA_DOCUMENTATION_TEXT}"
                 )
             }
         }
     }
 }
+
+const SCHEMA_DOCUMENTATION_TEXT: &str =
+    "See the cynic documentation on regsistering schemas if you need help.";
 
 impl From<graphql_parser::schema::ParseError> for SchemaLoadError {
     fn from(e: graphql_parser::schema::ParseError) -> SchemaLoadError {

--- a/cynic-proc-macros/Cargo.toml
+++ b/cynic-proc-macros/Cargo.toml
@@ -20,4 +20,6 @@ proc-macro = true
 
 [dependencies]
 cynic-codegen = { path = "../cynic-codegen", version = "3.0.0-beta.3" }
+quote = "1"
 syn = "1.0.87"
+proc-macro2 = "1"

--- a/cynic-proc-macros/src/lib.rs
+++ b/cynic-proc-macros/src/lib.rs
@@ -187,11 +187,18 @@ pub fn schema_for_derives(attrs: TokenStream, input: TokenStream) -> TokenStream
 /// ```
 pub fn schema(attrs: TokenStream, input: TokenStream) -> TokenStream {
     let schema_name = syn::parse_macro_input!(attrs as syn::LitStr);
-    let module = syn::parse_macro_input!(input as syn::ItemMod);
+    let mut module = syn::parse_macro_input!(input as syn::ItemMod);
 
-    let rv: TokenStream = match schema_module_attr::attribute_impl(schema_name, module) {
+    let rv: TokenStream = match schema_module_attr::attribute_impl(schema_name, &mut module) {
         Ok(tokens) => tokens.into(),
-        Err(e) => e.to_compile_errors().into(),
+        Err(error) => {
+            let error = error.to_compile_error();
+            quote::quote! {
+                #error
+                #module
+            }
+            .into()
+        }
     };
 
     // eprintln!("{}", rv);

--- a/tests/ui-tests/tests/cases/unregistered-schema.rs
+++ b/tests/ui-tests/tests/cases/unregistered-schema.rs
@@ -1,0 +1,10 @@
+fn main() {}
+
+#[derive(cynic::QueryFragment, Debug)]
+#[cynic(graphql_type = "Root")]
+pub struct AllFilms {
+    pub __typename: String,
+}
+
+#[cynic::schema("other")]
+mod schema {}

--- a/tests/ui-tests/tests/cases/unregistered-schema.stderr
+++ b/tests/ui-tests/tests/cases/unregistered-schema.stderr
@@ -1,0 +1,13 @@
+error: This derive is trying to use the default schema, but it doesn't look like you've registered any schemas.  See the cynic documentation on regsistering schemas if you need help.
+ --> tests/cases/unregistered-schema.rs:3:10
+  |
+3 | #[derive(cynic::QueryFragment, Debug)]
+  |          ^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: this error originates in the derive macro `cynic::QueryFragment` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: You requested a schema named other but it doesn't look like you've registered any schemas.  See the cynic documentation on regsistering schemas if you need help.
+ --> tests/cases/unregistered-schema.rs:9:17
+  |
+9 | #[cynic::schema("other")]
+  |                 ^^^^^^^

--- a/tests/ui-tests/tests/ui-tests.rs
+++ b/tests/ui-tests/tests/ui-tests.rs
@@ -8,6 +8,7 @@ fn ui_test_inlinefragments() {
     t.compile_fail("tests/cases/inputobject-guess-validation.rs");
     t.compile_fail("tests/cases/missing-variable.rs");
     t.compile_fail("tests/cases/rename-failures.rs");
+    t.compile_fail("tests/cases/unregistered-schema.rs");
     t.compile_fail("tests/cases/wrong-enum-type.rs");
     t.compile_fail("tests/cases/wrong-scalar-type.rs");
     t.compile_fail("tests/cases/wrong-variable-type.rs");


### PR DESCRIPTION
I want to make registering schemas the recommended behaviour, and update querygen accordingly.  But if people don't know what they're doing they'll easily run into the various error cases for unregistered schemas.

This commit adds a ui-test for that case and improves the errors that appear for that test, as they were not really clear _at all_.