### PR TITLE
Add fallback support to enum derive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ## Unreleased - xxxx-xx-xx
 
+### New Features 
+
+- The `Enum` derive now supports fallback variants
+
 ## v3.0.0-beta.3 - 2023-05-13
 
 ### New Features

--- a/cynic-book/src/derives/enums.md
+++ b/cynic-book/src/derives/enums.md
@@ -2,7 +2,7 @@
 
 Much like with query structs cynic expects you to own any enums you want to
 query for, or provide as arguments. The `cynic::Enum` trait is used to define
-an enum, and the easiest way to define that trait is to derive it:
+an enum. The easiest way to define that trait is to derive it:
 
 ```rust
 #[derive(cynic::Enum, Clone, Copy, Debug)]
@@ -34,12 +34,12 @@ An Enum can be configured with several attributes on the enum itself:
   a particular rule to match their GraphQL counterparts. If not provided this
   defaults to `SCREAMING_SNAKE_CASE` to be consistent with GraphQL conventions.
 - `schema` tells cynic which schema to use to validate this Enum.
-  The schema you provide should have been registered in your `build.rs`.  This
+  The schema you provide should have been registered in your `build.rs`. This
   is optional if you're using the schema that was registered as default, or if
   you're using `schema_path` instead.
 - `schema_path` provides a path to some GraphQL schema SDL. This is only
   required if you're using a schema that wasn't registered in `build.rs`.
-- `schema_module` tells cynic where to find your schema module.  This is
+- `schema_module` tells cynic where to find your schema module. This is
   optional and should only be needed if your schema module is not in scope or
   is named something other than `schema`.
 
@@ -51,6 +51,11 @@ Each variant can also have it's own attributes:
 
 - `rename="SOME_VARIANT"` can be used to map a variant to a completely
   different GraphQL variant name.
+- The `fallback` attribute can be provided on a single variant. This variant
+  will be used when we receive a value we didn't expect from the server - such
+  as when the server has added a new variant since we last pulled its schema.
+  This variant can optionally have a single string field, which will receive
+  the value we received from the server.
 
 <!-- TODO: example of the above?  Better wording -->
 

--- a/cynic-codegen/src/enum_derive/snapshots/cynic_codegen__enum_derive__tests__snapshot_enum_derive.snap
+++ b/cynic-codegen/src/enum_derive/snapshots/cynic_codegen__enum_derive__tests__snapshot_enum_derive.snap
@@ -25,7 +25,8 @@ impl<'de> cynic::serde::Deserialize<'de> for States {
     where
         __D: cynic::serde::Deserializer<'de>,
     {
-        match <String as cynic::serde::Deserialize>::deserialize(deserializer)?.as_ref() {
+        let desered_string = <String as cynic::serde::Deserialize>::deserialize(deserializer)?;
+        match desered_string.as_ref() {
             "CLOSED" => Ok(States::Closed),
             "DELETED" => Ok(States::Deleted),
             "OPEN" => Ok(States::Open),

--- a/cynic-codegen/src/inline_fragments_derive/input.rs
+++ b/cynic-codegen/src/inline_fragments_derive/input.rs
@@ -72,9 +72,9 @@ impl InlineFragmentsDeriveInput {
                     .into_iter()
                     .map(|f| {
                         syn::Error::new(
-                    f.span(),
-                    "InlineFragments only support a single fallback, but this enum has many",
-                )
+                            f.span(),
+                            "InlineFragments only support a single fallback, but this enum has many",
+                        )
                     })
                     .collect::<Vec<_>>(),
             );
@@ -162,8 +162,6 @@ impl InlineFragmentsDeriveVariant {
             darling::ast::Style::{Struct, Tuple, Unit},
             ValidationMode::{Interface, Union},
         };
-
-        if let Struct = self.fields.style {}
 
         if *self.fallback {
             match (mode, self.fields.style, self.fields.len()) {

--- a/cynic/tests/enum-fallbacks.rs
+++ b/cynic/tests/enum-fallbacks.rs
@@ -1,0 +1,48 @@
+use cynic::Enum;
+use serde::Deserialize;
+use serde_json::json;
+
+#[derive(Enum, Debug, PartialEq)]
+#[cynic(graphql_type = "PostState", schema_path = "tests/test-schema.graphql")]
+enum PostStateEmptyFallback {
+    Posted,
+    Draft,
+    #[cynic(fallback)]
+    Unknown,
+}
+
+#[derive(Enum, Debug, PartialEq)]
+#[cynic(graphql_type = "PostState", schema_path = "tests/test-schema.graphql")]
+enum PostStateStringFallback {
+    Posted,
+    Draft,
+    #[cynic(fallback)]
+    Unknown(String),
+}
+
+#[allow(non_snake_case, non_camel_case_types)]
+mod schema {
+    cynic::use_schema!("tests/test-schema.graphql");
+}
+
+#[test]
+fn test_empty_fallback() {
+    assert_eq!(
+        PostStateEmptyFallback::deserialize(json!("BLAH")).unwrap(),
+        PostStateEmptyFallback::Unknown
+    );
+
+    serde_json::to_value(PostStateEmptyFallback::Unknown).expect_err("should fail");
+}
+
+#[test]
+fn test_string_fallback() {
+    assert_eq!(
+        PostStateStringFallback::deserialize(json!("BLAH")).unwrap(),
+        PostStateStringFallback::Unknown("BLAH".to_string())
+    );
+
+    let val = serde_json::to_value(PostStateStringFallback::Unknown("BLAH".to_string())).unwrap();
+
+    assert_eq!(val, serde_json::Value::String("BLAH".into()));
+}

--- a/tests/querygen-compile-run/build.rs
+++ b/tests/querygen-compile-run/build.rs
@@ -107,8 +107,8 @@ fn main() {
             "tests/queries/github/nested-arguments.graphql",
             r#"PullRequestTitles::build(
                 PullRequestTitlesVariables {
-                    owner: "obmarg".into(),
-                    repo: "cynic".into(),
+                    owner: "obmarg",
+                    repo: "cynic",
                     pr_order: IssueOrder {
                         direction: OrderDirection::Asc,
                         field: IssueOrderField::CreatedAt,
@@ -140,7 +140,7 @@ fn main() {
             "tests/queries/github/scalar-inside-input-object.graphql",
             r#"AddPRComment::build(
                 AddPRCommentVariables {
-                    body: "hello!".into(),
+                    body: "hello!",
                     commit: GitObjectID("abcd".into())
                 }
             )"#,


### PR DESCRIPTION
#### Why are we making this change?

Some servers will add new enum variants without considering this a breaking change.  In this scenario we want to provide users with a way to keep their cynic clients working.
  
#### What effects does this change have?

Adds support for the `#[cynic(fallback)]` attribute on a single enum variant, similar to the one in `InlineFragments`.  When this is present it will be used for any enum variants we don't understand.  It can optionally have a single `String` field that will get the name of the variant.

Fixes #629 