### PR TITLE
Don't parse schema twice in registration.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 ### Bug Fixes
 
 - Fixed some more corner cases in string literal escaping
+- Schema registration no longer parses schemas twice when rkyv is enabled.
 
 ## v3.0.0 - 2023-06-04
 

--- a/cynic-codegen/src/use_schema/mod.rs
+++ b/cynic-codegen/src/use_schema/mod.rs
@@ -29,10 +29,10 @@ pub fn use_schema(input: UseSchemaParams) -> Result<TokenStream, Errors> {
         .map_err(|e| e.into_syn_error(proc_macro2::Span::call_site()))?;
 
     let schema = Schema::new(input).validate()?;
-    use_schema_impl(schema)
+    use_schema_impl(&schema)
 }
 
-pub(crate) fn use_schema_impl(schema: Schema<'_, Validated>) -> Result<TokenStream, Errors> {
+pub(crate) fn use_schema_impl(schema: &Schema<'_, Validated>) -> Result<TokenStream, Errors> {
     use quote::TokenStreamExt;
 
     let mut output = TokenStream::new();


### PR DESCRIPTION
#### Why are we making this change?

v3.0.0 added schema registration as an optimisation in cynic.  But under some circumstances that optimisation would parse the schema twice.  That was a bit silly since the optimisation was intended to avoid doing more work than necessary.

#### What effects does this change have?

Uses `once_cell` to memoize the validated schema and avoid duplicating work.