### PR TITLE
Fixed an issue with input type validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 - Fixed some more corner cases in string literal escaping
 - Schema registration no longer parses schemas twice when rkyv is enabled.
+- Fixed input type validation to better support skipping `Option` wrapping
 
 ## v3.0.0 - 2023-06-04
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -777,7 +777,6 @@ name = "cynic-proc-macros"
 version = "3.0.0"
 dependencies = [
  "cynic-codegen",
- "proc-macro2",
  "quote",
  "syn 1.0.109",
 ]

--- a/cynic-codegen/src/types/validation.rs
+++ b/cynic-codegen/src/types/validation.rs
@@ -160,9 +160,6 @@ fn input_type_check<'a>(
         (TypeRef::Nullable(inner_gql), RustType::Optional { inner, .. }) => {
             input_type_check(inner_gql, false, inner.as_ref())
         }
-        (TypeRef::Nullable(_), RustType::Unknown { .. }) => Err(TypeValidationError::UnknownType {
-            span: rust_type.span(),
-        }),
         (TypeRef::Nullable(inner_gql), _) => {
             // For input types its fine if a field isn't actually optional.
             // We just need to check that the inner types line up.
@@ -708,9 +705,9 @@ mod tests {
             call_input_type_check(
                 &option_list_option,
                 false,
-                &syn::parse2(quote! { Option<DateTime<Vec<Option<i32>>>> }).unwrap(),
+                &syn::parse2(quote! { Option<Vec<Inner<'a>>> }).unwrap(),
             ),
-            Err(TypeValidationError::UnknownType { .. })
+            Ok(())
         );
     }
 

--- a/cynic-proc-macros/Cargo.toml
+++ b/cynic-proc-macros/Cargo.toml
@@ -23,4 +23,3 @@ proc-macro = true
 cynic-codegen = { path = "../cynic-codegen", version = "3.0.0" }
 quote = "1"
 syn = "1.0.87"
-proc-macro2 = "1"


### PR DESCRIPTION
#### Why are we making this change?

If an input type expects an `Option<Vec<Option<i32>>>` the GraphQL input coercion rules allow a user to pass in a `Vec<i32>`, or even an `i32`.  But, there was a bug in the cynic input validation that prevented you from doing this.

#### What effects does this change have?

Fixes the bug described above.

Also removed an un-used dep.

Fixes #700 
