### PR TITLE
Don't output broken schema module in generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ## Unreleased - xxxx-xx-xx
 
+### Bug Fixes
+
+- The generator no longer outputs a broken `#[cynic::schema]` module.
+
 ## v3.0.2 - 2023-06-07
 
 ### Bug Fixes

--- a/cynic-querygen/src/lib.rs
+++ b/cynic-querygen/src/lib.rs
@@ -165,15 +165,6 @@ pub fn document_to_fragment_structs(
         writeln!(output, "{}", scalar).unwrap();
     }
 
-    let schema_module_name = &options.schema_module_name;
-
-    write!(output, "#[cynic::schema").unwrap();
-    if let Some(name) = &options.schema_name {
-        write!(output, r#"("{name}")"#).unwrap();
-    }
-    writeln!(output, "]").unwrap();
-    writeln!(output, "mod {schema_module_name} {{}}").unwrap();
-
     Ok(output)
 }
 

--- a/cynic-querygen/tests/snapshots/github_tests__add_comment_mutation.snap
+++ b/cynic-querygen/tests/snapshots/github_tests__add_comment_mutation.snap
@@ -29,6 +29,4 @@ pub struct IssueComment {
     pub id: cynic::Id,
 }
 
-#[cynic::schema]
-mod schema {}
 

--- a/cynic-querygen/tests/snapshots/github_tests__field_on_interface.snap
+++ b/cynic-querygen/tests/snapshots/github_tests__field_on_interface.snap
@@ -35,6 +35,4 @@ pub struct Actor {
     pub login: String,
 }
 
-#[cynic::schema]
-mod schema {}
 

--- a/cynic-querygen/tests/snapshots/github_tests__inline_fragment_on_union.snap
+++ b/cynic-querygen/tests/snapshots/github_tests__inline_fragment_on_union.snap
@@ -39,6 +39,4 @@ pub enum IssueOrPullRequest {
 #[derive(cynic::Scalar, Debug, Clone)]
 pub struct DateTime(pub String);
 
-#[cynic::schema]
-mod schema {}
 

--- a/cynic-querygen/tests/snapshots/github_tests__inline_fragment_with_arguments.snap
+++ b/cynic-querygen/tests/snapshots/github_tests__inline_fragment_with_arguments.snap
@@ -53,6 +53,4 @@ pub enum IssueOrPullRequest {
     Unknown
 }
 
-#[cynic::schema]
-mod schema {}
 

--- a/cynic-querygen/tests/snapshots/github_tests__input_object_arguments.snap
+++ b/cynic-querygen/tests/snapshots/github_tests__input_object_arguments.snap
@@ -50,6 +50,4 @@ pub struct IssueOrder {
     pub field: IssueOrderField,
 }
 
-#[cynic::schema]
-mod schema {}
 

--- a/cynic-querygen/tests/snapshots/github_tests__input_object_literals.snap
+++ b/cynic-querygen/tests/snapshots/github_tests__input_object_literals.snap
@@ -25,6 +25,4 @@ pub struct PullRequest {
     pub title: String,
 }
 
-#[cynic::schema]
-mod schema {}
 

--- a/cynic-querygen/tests/snapshots/github_tests__literal_enums.snap
+++ b/cynic-querygen/tests/snapshots/github_tests__literal_enums.snap
@@ -32,6 +32,4 @@ pub enum IssueState {
     Open,
 }
 
-#[cynic::schema]
-mod schema {}
 

--- a/cynic-querygen/tests/snapshots/github_tests__queries_with_typename.snap
+++ b/cynic-querygen/tests/snapshots/github_tests__queries_with_typename.snap
@@ -65,6 +65,4 @@ pub enum IssueOrPullRequest {
 #[derive(cynic::Scalar, Debug, Clone)]
 pub struct DateTime(pub String);
 
-#[cynic::schema]
-mod schema {}
 

--- a/cynic-querygen/tests/snapshots/misc_tests__book_subscription_test.snap
+++ b/cynic-querygen/tests/snapshots/misc_tests__book_subscription_test.snap
@@ -29,6 +29,4 @@ pub enum MutationType {
     Deleted,
 }
 
-#[cynic::schema]
-mod schema {}
 

--- a/cynic-querygen/tests/snapshots/misc_tests__keyword_renames.snap
+++ b/cynic-querygen/tests/snapshots/misc_tests__keyword_renames.snap
@@ -17,6 +17,4 @@ pub struct KeywordRenames {
     pub async_: Option<bool>,
 }
 
-#[cynic::schema]
-mod schema {}
 

--- a/cynic-querygen/tests/snapshots/misc_tests__mutation_with_scalar_result_and_input.snap
+++ b/cynic-querygen/tests/snapshots/misc_tests__mutation_with_scalar_result_and_input.snap
@@ -15,6 +15,4 @@ pub struct SignIn {
     pub sign_in: String,
 }
 
-#[cynic::schema]
-mod schema {}
 

--- a/cynic-querygen/tests/snapshots/misc_tests__pascal_type_renaming.snap
+++ b/cynic-querygen/tests/snapshots/misc_tests__pascal_type_renaming.snap
@@ -37,6 +37,4 @@ pub struct InputType {
 #[cynic(graphql_type = "my_scalar")]
 pub struct MyScalar(pub String);
 
-#[cynic::schema]
-mod schema {}
 

--- a/cynic-querygen/tests/snapshots/misc_tests__recursive_inputs.snap
+++ b/cynic-querygen/tests/snapshots/misc_tests__recursive_inputs.snap
@@ -30,6 +30,4 @@ pub struct RecursiveInputChild {
     pub recurse: Option<Box<RecursiveInputParent>>,
 }
 
-#[cynic::schema]
-mod schema {}
 

--- a/cynic-querygen/tests/snapshots/misc_tests__scalar_casing.snap
+++ b/cynic-querygen/tests/snapshots/misc_tests__scalar_casing.snap
@@ -24,6 +24,4 @@ pub struct Bar {
 #[cynic(graphql_type = "UUID")]
 pub struct Uuid(pub String);
 
-#[cynic::schema]
-mod schema {}
 

--- a/cynic-querygen/tests/snapshots/misc_tests__string_escaping.snap
+++ b/cynic-querygen/tests/snapshots/misc_tests__string_escaping.snap
@@ -14,6 +14,4 @@ pub struct UnnamedQuery {
     pub two: Option<i32>,
 }
 
-#[cynic::schema]
-mod schema {}
 

--- a/cynic-querygen/tests/snapshots/misc_tests__with_named_schema.snap
+++ b/cynic-querygen/tests/snapshots/misc_tests__with_named_schema.snap
@@ -62,6 +62,4 @@ pub enum IssueState {
     Open,
 }
 
-#[cynic::schema("my-schema")]
-mod schema {}
 

--- a/cynic-querygen/tests/snapshots/starwars_tests__aliases.snap
+++ b/cynic-querygen/tests/snapshots/starwars_tests__aliases.snap
@@ -18,6 +18,4 @@ pub struct Film {
     pub title: Option<String>,
 }
 
-#[cynic::schema]
-mod schema {}
 

--- a/cynic-querygen/tests/snapshots/starwars_tests__bare_selection_sets.snap
+++ b/cynic-querygen/tests/snapshots/starwars_tests__bare_selection_sets.snap
@@ -19,6 +19,4 @@ pub struct Film {
     pub title: Option<String>,
 }
 
-#[cynic::schema]
-mod schema {}
 

--- a/cynic-querygen/tests/snapshots/starwars_tests__float.snap
+++ b/cynic-querygen/tests/snapshots/starwars_tests__float.snap
@@ -18,6 +18,4 @@ pub struct Person {
     pub mass: Option<f64>,
 }
 
-#[cynic::schema]
-mod schema {}
 

--- a/cynic-querygen/tests/snapshots/starwars_tests__fragment_spreads.snap
+++ b/cynic-querygen/tests/snapshots/starwars_tests__fragment_spreads.snap
@@ -21,6 +21,4 @@ pub struct Film {
     pub title: Option<String>,
 }
 
-#[cynic::schema]
-mod schema {}
 

--- a/cynic-querygen/tests/snapshots/starwars_tests__multiple_queries.snap
+++ b/cynic-querygen/tests/snapshots/starwars_tests__multiple_queries.snap
@@ -83,6 +83,4 @@ pub struct Film {
     pub title: Option<String>,
 }
 
-#[cynic::schema]
-mod schema {}
 

--- a/cynic-querygen/tests/snapshots/starwars_tests__nested_arguments.snap
+++ b/cynic-querygen/tests/snapshots/starwars_tests__nested_arguments.snap
@@ -48,6 +48,4 @@ pub struct Person {
     pub name: Option<String>,
 }
 
-#[cynic::schema]
-mod schema {}
 

--- a/cynic-querygen/tests/snapshots/starwars_tests__sanity_test_starwars_query.snap
+++ b/cynic-querygen/tests/snapshots/starwars_tests__sanity_test_starwars_query.snap
@@ -20,6 +20,4 @@ pub struct Film {
     pub director: Option<String>,
 }
 
-#[cynic::schema]
-mod schema {}
 

--- a/tests/querygen-compile-run/build.rs
+++ b/tests/querygen-compile-run/build.rs
@@ -322,10 +322,14 @@ impl TestCase {
             }}
 
             {query_code}
+
+            #[cynic::schema("{schema_name}")]
+            mod schema {{}}
             "#,
             norun_code = norun_code,
             query_code = query_code,
-            run_code = run_code
+            run_code = run_code,
+            schema_name = self.schema.schema_name
         )
         .unwrap();
     }


### PR DESCRIPTION
#### Why are we making this change?

The generator outputs a broken schema module if you don't give it a correct schema name, which is the default in the web version.

#### What effects does this change have?

Removes the module altogether.  We already document creating it elsewhere, so seems redundant having it here.

Fixes #699 