### PR TITLE
Allow `impl_scalar!` for built in scalars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 ### Bug Fixes
 
 - The generator no longer outputs a broken `#[cynic::schema]` module.
+- `impl_scalar!` and `derive(Scalar)` can now be used on built in scalars.
 
 ## v3.0.2 - 2023-06-07
 

--- a/cynic/src/schema.rs
+++ b/cynic/src/schema.rs
@@ -154,5 +154,25 @@ pub trait NamedType {
     const NAME: &'static str;
 }
 
+impl NamedType for i32 {
+    const NAME: &'static str = "Int";
+}
+
+impl NamedType for f64 {
+    const NAME: &'static str = "Float";
+}
+
+impl NamedType for String {
+    const NAME: &'static str = "String";
+}
+
+impl NamedType for bool {
+    const NAME: &'static str = "Boolean";
+}
+
+impl NamedType for crate::Id {
+    const NAME: &'static str = "ID";
+}
+
 /// Indicates that a type is an `InputObject`
 pub trait InputObjectMarker {}

--- a/cynic/tests/scalars.rs
+++ b/cynic/tests/scalars.rs
@@ -12,3 +12,41 @@ cynic::impl_scalar!(chrono::DateTime<chrono::Utc>, schema::DateTime);
 #[derive(cynic::Scalar)]
 #[cynic(graphql_type = "DateTime")]
 pub struct DateTimeInner<DT>(pub DT);
+
+// Make sure we can use impl scalar on built in types
+pub struct MyString(String);
+cynic::impl_scalar!(MyString, schema::String);
+
+pub struct MyInt(i64);
+cynic::impl_scalar!(MyInt, schema::Int);
+
+pub struct MyFloat(f64);
+cynic::impl_scalar!(MyFloat, schema::Float);
+
+pub struct MyBool(bool);
+cynic::impl_scalar!(MyBool, schema::Boolean);
+
+pub struct MyId(cynic::Id);
+cynic::impl_scalar!(MyId, schema::ID);
+
+// Also make sure we can derive built in scalars.
+
+#[derive(cynic::Scalar)]
+#[cynic(graphql_type = "String")]
+pub struct MyString2(String);
+
+#[derive(cynic::Scalar)]
+#[cynic(graphql_type = "Int")]
+pub struct MyInt2(i64);
+
+#[derive(cynic::Scalar)]
+#[cynic(graphql_type = "Float")]
+pub struct MyFloat2(f64);
+
+#[derive(cynic::Scalar)]
+#[cynic(graphql_type = "Boolean")]
+pub struct MyBool2(bool);
+
+#[derive(cynic::Scalar)]
+#[cynic(graphql_type = "ID")]
+pub struct MyId2(cynic::Id);


### PR DESCRIPTION
#### Why are we making this change?

#711 pointed out that Github doesn't always stick to the GraphQL spec - it returns integers larger than an i32.  Since this isn't spec complaint I don't want to support this by default, but I do want to provide users with a way to handle it, should they need to.

Currently the best way to handle it is with a new type, but there were some problems using both `derive(Scalar)` and `impl_scalar` on built in scalars.
  
#### What effects does this change have?

Provides `NamedType` impls for all the built in scalars, which makes them compatible with the `Variable` trait impls inside  `impl_scalar` and `derive(Scalar)`.

Fixes #714 