### PR TITLE
Clean up some of the examples in the book

### DIFF
--- a/cynic-book/src/derives/inline-fragments.md
+++ b/cynic-book/src/derives/inline-fragments.md
@@ -78,7 +78,6 @@ received from the server.
 
 ```rust
 #[derive(cynic::InlineFragments)]
-#[cynic(schema_path = "github.graphql")]
 enum Assignee {
     Bot(Bot),
     User(User)

--- a/cynic-book/src/derives/query-fragments.md
+++ b/cynic-book/src/derives/query-fragments.md
@@ -9,10 +9,6 @@ Generally you'll use a derive to create query fragments, like this:
 
 ```rust
 #[derive(cynic::QueryFragment, Debug)]
-#[cynic(
-    schema_path = "examples/starwars.schema.graphql",
-    schema_module = "schema",
-)]
 struct Film {
     title: Option<String>,
     director: Option<String>,
@@ -25,11 +21,6 @@ be nested inside each other, like so:
 
 ```rust
 #[derive(cynic::QueryFragment, Debug)]
-#[cynic(
-    schema_path = "examples/starwars.schema.graphql",
-    schema_module = "schema",
-    graphql_type = "Root",
-)]
 struct FilmsConnection {
     films: Vec<Film>,
 }
@@ -63,11 +54,7 @@ API we need a QueryFragment like this:
 
 ```rust
 #[derive(cynic::QueryFragment, Debug)]
-#[cynic(
-    schema_path = "examples/starwars.schema.graphql",
-    schema_module = "schema",
-    graphql_type = "Root",
-)]
+#[cynic(graphql_type = "Root")]
 struct AllFilmsQuery {
     all_films: Option<FilmConnection>,
 }
@@ -97,11 +84,7 @@ Here, we define a query that fetches a film by a particular ID:
 
 ```rust
 #[derive(cynic::QueryFragment, Debug)]
-#[cynic(
-    schema_path = "examples/starwars.schema.graphql",
-    schema_module = "schema",
-    graphql_type = "Root",
-)]
+#[cynic(graphql_type = "Root")]
 struct FilmQuery {
     #[arguments(id: "ZmlsbXM6MQ==")]
     film: Option<Film>,
@@ -154,8 +137,6 @@ to provide the `id` argument.
 ```rust
 #[derive(cynic::QueryFragment, Debug)]
 #[cynic(
-    schema_path = "examples/starwars.schema.graphql",
-    schema_module = "schema",
     graphql_type = "Root",
     variables = "FilmQueryVariables"
 )]

--- a/cynic-book/src/derives/query-variables.md
+++ b/cynic-book/src/derives/query-variables.md
@@ -28,7 +28,6 @@ struct is in scope.  You do this by providing a a `variables` parameter to the
 ```rust
 #[derive(cynic::QueryFragment, Debug)]
 #[cynic(
-    schema_path = "examples/starwars.schema.graphql",
     graphql_type = "Root",
     variables = "FilmVariables"
 )]

--- a/cynic-book/src/derives/scalars.md
+++ b/cynic-book/src/derives/scalars.md
@@ -38,7 +38,6 @@ You can also derive `Scalar` on any newtype structs:
 
 ```rust
 #[derive(cynic::Scalar, serde::Serialize)]
-#[cynic(schema_module = "schema")]
 struct MyScalar(String);
 ```
 
@@ -58,6 +57,6 @@ A Scalar derive can be configured with several attributes on the struct itself:
 - `graphql_type = "AType"` can be provided if the type of the struct differs
   from the type of and tells cynic the name of the Scalar in the schema. This
   defaults to the name of the struct if not provided.
-- `schema_module` tells cynic where to find your schema module.  This is
+- `schema_module` tells cynic where to find your schema module. This is
   optional and should only be needed if your schema module is not in scope or
   named `schema`.


### PR DESCRIPTION
They still had a lot of attributes that usually users shouldn't need to use
