### PR TITLE
Fix issue with boxing `InlineFragment` variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ## Unreleased - xxxx-xx-xx
 
+### Bug Fixes
+
+- Inline fragment variants containing smart pointers should now decode
+  correctly.
+
 ## v3.1.0 - 2023-06-11
 
 ### New Features

--- a/cynic/src/core.rs
+++ b/cynic/src/core.rs
@@ -56,6 +56,8 @@ where
     type SchemaType = T::SchemaType;
     type VariablesFields = T::VariablesFields;
 
+    const TYPE: Option<&'static str> = T::TYPE;
+
     fn query(builder: SelectionBuilder<'_, Self::SchemaType, Self::VariablesFields>) {
         T::query(builder)
     }
@@ -68,6 +70,8 @@ where
     type SchemaType = T::SchemaType;
     type VariablesFields = T::VariablesFields;
 
+    const TYPE: Option<&'static str> = T::TYPE;
+
     fn query(builder: SelectionBuilder<'_, Self::SchemaType, Self::VariablesFields>) {
         T::query(builder)
     }
@@ -79,6 +83,8 @@ where
 {
     type SchemaType = T::SchemaType;
     type VariablesFields = T::VariablesFields;
+
+    const TYPE: Option<&'static str> = T::TYPE;
 
     fn query(builder: SelectionBuilder<'_, Self::SchemaType, Self::VariablesFields>) {
         T::query(builder)

--- a/cynic/tests/inline-fragments.rs
+++ b/cynic/tests/inline-fragments.rs
@@ -118,3 +118,27 @@ fn test_post_or_author_decoding(#[case] input: serde_json::Value, #[case] expect
 fn test_node_decoding(#[case] input: serde_json::Value, #[case] expected: Node) {
     assert_eq!(serde_json::from_value::<Node>(input).unwrap(), expected);
 }
+
+#[derive(InlineFragments, Serialize, PartialEq, Debug)]
+#[cynic(
+    schema_path = "tests/test-schema.graphql",
+    graphql_type = "PostOrAuthor"
+)]
+enum PostOrAuthorBox {
+    Post(Box<Post>),
+    Author(Author),
+    #[cynic(fallback)]
+    Other,
+}
+
+#[test]
+fn test_decoding_boxed_variant() {
+    let data = r#"{"__typename":"BlogPost","id":"4"}"#;
+
+    assert_eq!(
+        serde_json::from_str::<PostOrAuthorBox>(data).unwrap(),
+        PostOrAuthorBox::Post(Box::new(Post {
+            id: Some("4".into())
+        }))
+    );
+}


### PR DESCRIPTION
We weren't propagating `QueryFragment::TYPE` for smart pointers, which meant the `InlineFragments` derive would hit the `fallback` path even if you had a correct `__typename`.

Part of #724 