### PR TITLE
Fix issue with InlineFragments fallback decoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ### Bug Fixes
 
+- Fixed an issue where `InlineFragments` fallbacks would fail to decode if the
+  data contained anything other than just the `__typename`.
 - Inline fragment variants containing smart pointers should now decode
   correctly.
 

--- a/cynic-codegen/src/inline_fragments_derive/inline_fragments_impl.rs
+++ b/cynic-codegen/src/inline_fragments_derive/inline_fragments_impl.rs
@@ -34,13 +34,19 @@ impl quote::ToTokens for InlineFragmentsImpl<'_> {
 
         let fallback = match &self.fallback {
             Some(Fallback::UnionUnitVariant(variant)) => quote! {
-                Ok(#target_enum::#variant)
+                <cynic::serde::de::IgnoredAny as cynic::serde::Deserialize<'de>>
+                    ::deserialize(deserializer).map(|_|
+                        #target_enum::#variant
+                    )
             },
             Some(Fallback::UnionVariantWithTypename(variant, ty)) => {
                 let ty_span = ty.span();
                 quote_spanned! { ty_span => {
                         cynic::assert_type_eq_all!(#ty, String);
-                        Ok(#target_enum::#variant(typename.to_string()))
+                        <cynic::serde::de::IgnoredAny as cynic::serde::Deserialize<'de>>
+                            ::deserialize(deserializer).map(|_|
+                                #target_enum::#variant(typename.to_string())
+                            )
                     }
                 }
             }

--- a/cynic-codegen/src/inline_fragments_derive/snapshots/cynic_codegen__inline_fragments_derive__tests__interface.snap
+++ b/cynic-codegen/src/inline_fragments_derive/snapshots/cynic_codegen__inline_fragments_derive__tests__interface.snap
@@ -25,7 +25,8 @@ impl<'de> cynic::InlineFragments<'de> for Node {
             return <Author as cynic::serde::Deserialize<'de>>::deserialize(deserializer)
                 .map(Node::Author);
         }
-        Ok(Node::Other)
+        <cynic::serde::de::IgnoredAny as cynic::serde::Deserialize<'de>>::deserialize(deserializer)
+            .map(|_| Node::Other)
     }
 }
 #[automatically_derived]

--- a/cynic-codegen/src/inline_fragments_derive/snapshots/cynic_codegen__inline_fragments_derive__tests__union_type.snap
+++ b/cynic-codegen/src/inline_fragments_derive/snapshots/cynic_codegen__inline_fragments_derive__tests__union_type.snap
@@ -25,7 +25,8 @@ impl<'de> cynic::InlineFragments<'de> for PostOrAuthor {
             return <Author as cynic::serde::Deserialize<'de>>::deserialize(deserializer)
                 .map(PostOrAuthor::Author);
         }
-        Ok(PostOrAuthor::Other)
+        <cynic::serde::de::IgnoredAny as cynic::serde::Deserialize<'de>>::deserialize(deserializer)
+            .map(|_| PostOrAuthor::Other)
     }
 }
 #[automatically_derived]

--- a/cynic/tests/inline-fragments.rs
+++ b/cynic/tests/inline-fragments.rs
@@ -119,6 +119,42 @@ fn test_node_decoding(#[case] input: serde_json::Value, #[case] expected: Node) 
     assert_eq!(serde_json::from_value::<Node>(input).unwrap(), expected);
 }
 
+#[test]
+fn test_decoding_fallback_with_extra_data_and_unit_fallback() {
+    // This has a typename that doesn't exist _and_ some associated data.
+    // Make sure we decode succesfully
+    let data = r#"{"__typename":"Image","id":"4"}"#;
+
+    assert_eq!(
+        serde_json::from_str::<PostOrAuthor>(data).unwrap(),
+        PostOrAuthor::Other
+    );
+}
+
+#[derive(InlineFragments, Serialize, PartialEq, Debug)]
+#[cynic(
+    schema_path = "tests/test-schema.graphql",
+    graphql_type = "PostOrAuthor"
+)]
+enum PostOrAuthorStringFallback {
+    Post(Post),
+    Author(Author),
+    #[cynic(fallback)]
+    Other(String),
+}
+
+#[test]
+fn test_decoding_fallback_with_extra_data_and_string_fallback() {
+    // This has a typename that doesn't exist _and_ some associated data.
+    // Make sure we decode succesfully
+    let data = r#"{"__typename":"Image","id":"4"}"#;
+
+    assert_eq!(
+        serde_json::from_str::<PostOrAuthorStringFallback>(data).unwrap(),
+        PostOrAuthorStringFallback::Other("Image".into())
+    );
+}
+
 #[derive(InlineFragments, Serialize, PartialEq, Debug)]
 #[cynic(
     schema_path = "tests/test-schema.graphql",


### PR DESCRIPTION
`serde_json` requires you to decode an entire object or it'll throw an "unexpected comma" error.  The fallback impl for `InlineFragments` was not doing this correctly, leading to confusing errors.

This updates it to use `IgnoredAny` to just ignore the rest of the object.

Fixes #724 
