### PR TITLE
Added CapabilityDetectionQuery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 - Added support for introspecting a scalars `@specifiedBy` field on servers
   supporting GraphQL 2021
 - `cynic-introspection` can now output SDL
+- Added `CapabilityDetectionQuery` to `cynic-introspection`, which can detect
+  which version of the GraphQL specification a server supports.
 
 ## v3.1.1 - 2023-06-22
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -912,6 +912,7 @@ dependencies = [
  "insta",
  "maplit",
  "reqwest",
+ "serde_json",
  "thiserror",
 ]
 

--- a/cynic-introspection/Cargo.toml
+++ b/cynic-introspection/Cargo.toml
@@ -32,6 +32,7 @@ assert_matches = "1.4"
 insta = "1.4"
 maplit = "1.0.2"
 reqwest = "0.11"
+serde_json = "1"
 
 [dev-dependencies.cynic]
 path = "../cynic"

--- a/cynic-introspection/src/detection.rs
+++ b/cynic-introspection/src/detection.rs
@@ -1,0 +1,93 @@
+//! Defines types for an introspection query that can tell what a GraphQL server
+//! supports.
+
+use super::query2018::schema;
+
+#[derive(cynic::QueryFragment, Debug)]
+#[cynic(graphql_type = "Query")]
+/// A query that detects what capabilities a remote GraphQL server has, which can be used
+/// to determine what introspection query should be made against that server.
+///
+/// Currently this just determines which version of the specification the server supports,
+/// but it may be extended in the future to detect other capabilities e.g. which RFCs a
+/// server has implemented support for.
+///
+/// ```rust
+/// use cynic::{QueryBuilder, http::ReqwestBlockingExt};
+/// use cynic_introspection::CapabilityDetectionQuery;
+///
+/// // We can run an introspection query and unwrap the data contained within
+/// let capabilities = reqwest::blocking::Client::new()
+///     .post("https://swapi-graphql.netlify.app/.netlify/functions/index")
+///     .run_graphql(CapabilityDetectionQuery::build(()))
+///     .unwrap()
+///     .data
+///     .unwrap();
+///
+/// let version_supported = capabilities.version_supported();
+/// println!("This server supports GraphQL {version_supported:?}");
+/// ```
+pub struct CapabilityDetectionQuery {
+    #[cynic(rename = "__type")]
+    #[arguments(name: "__Type")]
+    type_type: Option<Type>,
+}
+
+impl CapabilityDetectionQuery {
+    /// The version of the GraphQL specification this server supports
+    pub fn version_supported(&self) -> SpecificationVersion {
+        let Some(type_type) = &self.type_type else {
+            return SpecificationVersion::Unknown
+        };
+
+        let specified_by_field = type_type
+            .fields
+            .iter()
+            .find(|field| field.name == "specifiedByURL");
+
+        match specified_by_field {
+            Some(_) => SpecificationVersion::October2021,
+            None => SpecificationVersion::June2018,
+        }
+    }
+}
+
+/// Versions of the GraphQL specification that the CapabilityDetectionQuery can detect.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[non_exhaustive]
+pub enum SpecificationVersion {
+    /// We were unable to determine which version of the GraphQL specification
+    /// this server supports.
+    Unknown,
+    /// The GraphQL specification published in June 2018
+    June2018,
+    /// The GraphQL specification published in October 2021
+    October2021,
+}
+
+#[derive(cynic::QueryFragment, Debug)]
+#[cynic(graphql_type = "__Type")]
+/// Details about a type in the schema
+struct Type {
+    #[cynic(flatten)]
+    #[arguments(includeDeprecated: true)]
+    fields: Vec<Field>,
+}
+
+#[derive(cynic::QueryFragment, Debug)]
+#[cynic(graphql_type = "__Field")]
+/// Represents one of the fields of an object or interface type
+struct Field {
+    /// The name of the field
+    name: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_ordering_of_specification_version() {
+        assert!(SpecificationVersion::June2018 < SpecificationVersion::October2021);
+    }
+}

--- a/cynic-introspection/src/lib.rs
+++ b/cynic-introspection/src/lib.rs
@@ -27,13 +27,33 @@
 //! assert_eq!(schema.query_type, "Root");
 //! ```
 //!
+//! ### GraphQL Versions
+//!
+//! GraphQL servers currently commonly support two different versions of the GraphQL
+//! specification:
+//!
+//! - [The June 2018 Specification][3]
+//! - [The October 2021 Specification][4]
+//!
+//! The fields available for introspection differ between these two versions, so cynic
+//! provides two different introspection queries in the modules [query2018] and [query2021]
+//! respectively.
+//!
+//! It also provides [CapabilityDetectionQuery], a query which can determine which version
+//! of the specification a GraphQL server supports.
+//!
 //! [1]: http://spec.graphql.org/October2021/#sec-Introspection
 //! [2]: https://cynic-rs.dev
+//! [3]: http://spec.graphql.org/June2018
+//! [4]: http://spec.graphql.org/October2021
 
+mod detection;
 pub mod query2018;
 pub mod query2021;
 mod schema;
 
+#[doc(inline)]
+pub use detection::{CapabilityDetectionQuery, SpecificationVersion};
 pub use query2018 as query;
 #[doc(inline)]
 pub use query2018::{DirectiveLocation, IntrospectionQuery};

--- a/cynic-introspection/src/query2018.rs
+++ b/cynic-introspection/src/query2018.rs
@@ -92,7 +92,7 @@ pub struct EnumValue {
 #[cynic(graphql_type = "__Field")]
 /// Represents one of the fields of an object or interface type
 pub struct Field {
-    /// The name of the value
+    /// The name of the field
     pub name: String,
     /// A description of the field
     pub description: Option<String>,

--- a/cynic-introspection/tests/detection-responses/2018.json
+++ b/cynic-introspection/tests/detection-responses/2018.json
@@ -1,0 +1,35 @@
+{
+    "data": {
+      "__type": {
+        "fields": [
+          {
+            "name": "kind"
+          },
+          {
+            "name": "name"
+          },
+          {
+            "name": "description"
+          },
+          {
+            "name": "fields"
+          },
+          {
+            "name": "interfaces"
+          },
+          {
+            "name": "possibleTypes"
+          },
+          {
+            "name": "enumValues"
+          },
+          {
+            "name": "inputFields"
+          },
+          {
+            "name": "ofType"
+          }
+        ]
+      }
+    }
+  }

--- a/cynic-introspection/tests/detection-responses/2021.json
+++ b/cynic-introspection/tests/detection-responses/2021.json
@@ -1,0 +1,38 @@
+{
+    "data": {
+      "__type": {
+        "fields": [
+          {
+            "name": "kind"
+          },
+          {
+            "name": "name"
+          },
+          {
+            "name": "description"
+          },
+          {
+            "name": "specifiedByURL"
+          },
+          {
+            "name": "fields"
+          },
+          {
+            "name": "interfaces"
+          },
+          {
+            "name": "possibleTypes"
+          },
+          {
+            "name": "enumValues"
+          },
+          {
+            "name": "inputFields"
+          },
+          {
+            "name": "ofType"
+          }
+        ]
+      }
+    }
+  }

--- a/cynic-introspection/tests/detection-tests.rs
+++ b/cynic-introspection/tests/detection-tests.rs
@@ -1,0 +1,44 @@
+use cynic::GraphQlResponse;
+use cynic_introspection::{CapabilityDetectionQuery, SpecificationVersion};
+
+#[test]
+fn shapshot_test_detection_query() {
+    use cynic::QueryBuilder;
+
+    insta::assert_snapshot!(CapabilityDetectionQuery::build(()).query, @r###"
+    query CapabilityDetectionQuery {
+      __type(name: "__Type") {
+        fields(includeDeprecated: true) {
+          name
+        }
+      }
+    }
+
+    "###);
+}
+
+#[test]
+fn detection_query_with_2018_response() {
+    let capabilities = serde_json::from_str::<GraphQlResponse<CapabilityDetectionQuery>>(
+        include_str!("detection-responses/2018.json"),
+    )
+    .unwrap();
+
+    assert_eq!(
+        capabilities.data.unwrap().version_supported(),
+        SpecificationVersion::June2018
+    );
+}
+
+#[test]
+fn detection_query_with_2021_response() {
+    let response = serde_json::from_str::<GraphQlResponse<CapabilityDetectionQuery>>(include_str!(
+        "detection-responses/2021.json"
+    ))
+    .unwrap();
+
+    assert_eq!(
+        response.data.unwrap().version_supported(),
+        SpecificationVersion::October2021
+    );
+}


### PR DESCRIPTION
#### Why are we making this change?

I've been working on adding introspection support to cynic recently.  

The october 2021 version of the specification added new fields into introspection, to cover `@specifiedByUrl`.  This presents a challenge to introspection queries - if you request this field from a server that doesn't support it you'll get an error.  This is fine if you know which version of the spec you're targeting, or you don't care about this field.  But if you are querying arbitrary servers it's a problem.

#### What effects does this change have?

This adds a `CapabilityDetectionQuery` into `cynic-introspection` - a very cut down introspection query and some associated logic that can be used to determine what a server supports.  Currently this just detects which version of the specification is supported, but I intend to extend it to detect `@oneOf`, `@stream`, `@defer` and maybe others as and when the need arises.