### PR TITLE
Fix cynic_codegen dep in quickstart.md

### DIFF
--- a/cynic-book/src/quickstart.md
+++ b/cynic-book/src/quickstart.md
@@ -37,7 +37,7 @@ You'll also want to add a `[build-dependency]`:
 
 ```toml
 [build-dependency]
-cynic_codegen = { version = "3" }
+cynic-codegen = { version = "3" }
 ```
 
 You may also optionally want to install `insta` - a snapshot testing library


### PR DESCRIPTION
#### Why are we making this change?

Because the code in tutorial doesn't work

#### What effects does this change have?

Just typo fix
