### PR TITLE
fix syntax errors in generated code for spread

### DIFF
--- a/cynic-codegen/src/fragment_derive/deserialize_impl.rs
+++ b/cynic-codegen/src/fragment_derive/deserialize_impl.rs
@@ -220,7 +220,7 @@ impl quote::ToTokens for SpreadingDeserializeImpl<'_> {
                 quote! {
                     #field_name: <#field_ty as cynic::serde::Deserialize<'de>>::deserialize(
                         spreadable.spread_deserializer()
-                    )?,
+                    )?
                 }
             } else if f.is_flattened {
                 let serialized_name = proc_macro2::Literal::string(
@@ -259,7 +259,7 @@ impl quote::ToTokens for SpreadingDeserializeImpl<'_> {
                     let spreadable = cynic::__private::Spreadable::<__D::Error>::deserialize(deserializer)?;
 
                     Ok(#target_struct {
-                        #(#field_inserts)*
+                        #(#field_inserts,)*
                     })
                 }
             }

--- a/cynic-codegen/src/fragment_derive/fragment_impl.rs
+++ b/cynic-codegen/src/fragment_derive/fragment_impl.rs
@@ -372,6 +372,8 @@ impl quote::ToTokens for SpreadSelection {
         tokens.append_all(quote_spanned! { self.span =>
             <#field_type as cynic::QueryFragment>::query(
                 builder
+                    .inline_fragment()
+                    .select_children::<<#field_type as cynic::QueryFragment>::VariablesFields>()
             );
         })
     }

--- a/cynic-codegen/src/fragment_derive/fragment_impl.rs
+++ b/cynic-codegen/src/fragment_derive/fragment_impl.rs
@@ -372,7 +372,7 @@ impl quote::ToTokens for SpreadSelection {
         tokens.append_all(quote_spanned! { self.span =>
             <#field_type as cynic::QueryFragment>::query(
                 builder
-            )
+            );
         })
     }
 }

--- a/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__spread_attr.snap
+++ b/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__spread_attr.snap
@@ -11,7 +11,11 @@ impl cynic::QueryFragment for Film {
         mut builder: cynic::queries::SelectionBuilder<'_, Self::SchemaType, Self::VariablesFields>,
     ) {
         #![allow(unused_mut)]
-        <FilmDetails as cynic::QueryFragment>::query(builder);
+        <FilmDetails as cynic::QueryFragment>::query(
+            builder
+                .inline_fragment()
+                .select_children::<<FilmDetails as cynic::QueryFragment>::VariablesFields>(),
+        );
     }
     fn name() -> Option<std::borrow::Cow<'static, str>> {
         Some(std::borrow::Cow::Borrowed("Film"))

--- a/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__spread_attr_multi_field1.snap
+++ b/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__spread_attr_multi_field1.snap
@@ -12,7 +12,11 @@ impl cynic::QueryFragment for Film {
     ) {
         #![allow(unused_mut)]
         let mut field_builder = builder . select_field :: < schema :: __fields :: Film :: releaseDate , < Option < String > as cynic :: schema :: IsScalar < < schema :: __fields :: Film :: releaseDate as cynic :: schema :: Field > :: Type >> :: SchemaType > () ;
-        <FilmDetails as cynic::QueryFragment>::query(builder);
+        <FilmDetails as cynic::QueryFragment>::query(
+            builder
+                .inline_fragment()
+                .select_children::<<FilmDetails as cynic::QueryFragment>::VariablesFields>(),
+        );
     }
     fn name() -> Option<std::borrow::Cow<'static, str>> {
         Some(std::borrow::Cow::Borrowed("Film"))

--- a/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__spread_attr_multi_field1.snap
+++ b/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__spread_attr_multi_field1.snap
@@ -11,6 +11,7 @@ impl cynic::QueryFragment for Film {
         mut builder: cynic::queries::SelectionBuilder<'_, Self::SchemaType, Self::VariablesFields>,
     ) {
         #![allow(unused_mut)]
+        let mut field_builder = builder . select_field :: < schema :: __fields :: Film :: releaseDate , < Option < String > as cynic :: schema :: IsScalar < < schema :: __fields :: Film :: releaseDate as cynic :: schema :: Field > :: Type >> :: SchemaType > () ;
         <FilmDetails as cynic::QueryFragment>::query(builder);
     }
     fn name() -> Option<std::borrow::Cow<'static, str>> {
@@ -25,6 +26,7 @@ impl<'de> cynic::serde::Deserialize<'de> for Film {
     {
         let spreadable = cynic::__private::Spreadable::<__D::Error>::deserialize(deserializer)?;
         Ok(Film {
+            release_date: spreadable.deserialize_field("releaseDate")?,
             details: <FilmDetails as cynic::serde::Deserialize<'de>>::deserialize(
                 spreadable.spread_deserializer(),
             )?,

--- a/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__spread_attr_multi_field2.snap
+++ b/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__spread_attr_multi_field2.snap
@@ -11,7 +11,11 @@ impl cynic::QueryFragment for Film {
         mut builder: cynic::queries::SelectionBuilder<'_, Self::SchemaType, Self::VariablesFields>,
     ) {
         #![allow(unused_mut)]
-        <FilmDetails as cynic::QueryFragment>::query(builder);
+        <FilmDetails as cynic::QueryFragment>::query(
+            builder
+                .inline_fragment()
+                .select_children::<<FilmDetails as cynic::QueryFragment>::VariablesFields>(),
+        );
         let mut field_builder = builder . select_field :: < schema :: __fields :: Film :: releaseDate , < Option < String > as cynic :: schema :: IsScalar < < schema :: __fields :: Film :: releaseDate as cynic :: schema :: Field > :: Type >> :: SchemaType > () ;
     }
     fn name() -> Option<std::borrow::Cow<'static, str>> {

--- a/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__spread_attr_multi_field2.snap
+++ b/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__spread_attr_multi_field2.snap
@@ -12,6 +12,7 @@ impl cynic::QueryFragment for Film {
     ) {
         #![allow(unused_mut)]
         <FilmDetails as cynic::QueryFragment>::query(builder);
+        let mut field_builder = builder . select_field :: < schema :: __fields :: Film :: releaseDate , < Option < String > as cynic :: schema :: IsScalar < < schema :: __fields :: Film :: releaseDate as cynic :: schema :: Field > :: Type >> :: SchemaType > () ;
     }
     fn name() -> Option<std::borrow::Cow<'static, str>> {
         Some(std::borrow::Cow::Borrowed("Film"))
@@ -28,6 +29,7 @@ impl<'de> cynic::serde::Deserialize<'de> for Film {
             details: <FilmDetails as cynic::serde::Deserialize<'de>>::deserialize(
                 spreadable.spread_deserializer(),
             )?,
+            release_date: spreadable.deserialize_field("releaseDate")?,
         })
     }
 }

--- a/cynic-codegen/src/fragment_derive/tests.rs
+++ b/cynic-codegen/src/fragment_derive/tests.rs
@@ -80,6 +80,36 @@ use super::fragment_derive;
         }
     )
 )]
+#[case::spread_attr_multi_field1(
+    "spread_attr_multi_field1",
+    parse_quote!(
+        #[derive(cynic::QueryFragment, Debug)]
+        #[cynic(
+            schema_path = "../schemas/starwars.schema.graphql",
+            schema_module = "schema"
+        )]
+        struct Film {
+            release_date: Option<String>,
+            #[cynic(spread)]
+            details: FilmDetails,
+        }
+    )
+)]
+#[case::spread_attr_multi_field2(
+    "spread_attr_multi_field2",
+    parse_quote!(
+        #[derive(cynic::QueryFragment, Debug)]
+        #[cynic(
+            schema_path = "../schemas/starwars.schema.graphql",
+            schema_module = "schema"
+        )]
+        struct Film {
+            #[cynic(spread)]
+            details: FilmDetails,
+            release_date: Option<String>,
+        }
+    )
+)]
 #[case::flatten_attr(
     "flatten_attr",
     parse_quote!(

--- a/examples/examples/snapshots/spread__test__running_query.snap
+++ b/examples/examples/snapshots/spread__test__running_query.snap
@@ -1,12 +1,14 @@
 ---
 source: examples/examples/spread.rs
-assertion_line: 94
 expression: result.data
 ---
 Some(
     FilmDirectorQuery {
         film: Some(
             Film {
+                release_date: Some(
+                    "1977-05-25",
+                ),
                 details: FilmDetails {
                     title: Some(
                         "A New Hope",

--- a/examples/examples/snapshots/spread__test__running_query.snap
+++ b/examples/examples/snapshots/spread__test__running_query.snap
@@ -6,8 +6,8 @@ Some(
     FilmDirectorQuery {
         film: Some(
             Film {
-                release_date: Some(
-                    "1977-05-25",
+                id: Id(
+                    "ZmlsbXM6MQ==",
                 ),
                 details: FilmDetails {
                     title: Some(
@@ -17,6 +17,21 @@ Some(
                         "George Lucas",
                     ),
                 },
+                more_details: FilmMoreDetails {
+                    release_date: Some(
+                        "1977-05-25",
+                    ),
+                },
+                producers: Some(
+                    [
+                        Some(
+                            "Gary Kurtz",
+                        ),
+                        Some(
+                            "Rick McCallum",
+                        ),
+                    ],
+                ),
             },
         ),
     },

--- a/examples/examples/snapshots/spread__test__snapshot_test_query.snap
+++ b/examples/examples/snapshots/spread__test__snapshot_test_query.snap
@@ -4,9 +4,16 @@ expression: query.query
 ---
 query FilmDirectorQuery($id: ID) {
   film(id: $id) {
-    releaseDate
-    title
-    director
+    id
+    __typename
+    ... {
+      title
+      director
+    }
+    ... {
+      releaseDate
+    }
+    producers
   }
 }
 

--- a/examples/examples/snapshots/spread__test__snapshot_test_query.snap
+++ b/examples/examples/snapshots/spread__test__snapshot_test_query.snap
@@ -4,6 +4,7 @@ expression: query.query
 ---
 query FilmDirectorQuery($id: ID) {
   film(id: $id) {
+    releaseDate
     title
     director
   }

--- a/examples/examples/spread.rs
+++ b/examples/examples/spread.rs
@@ -12,10 +12,19 @@ struct FilmDetails {
 }
 
 #[derive(cynic::QueryFragment, Debug)]
-struct Film {
+#[cynic(graphql_type = "Film")]
+struct FilmMoreDetails {
     release_date: Option<String>,
+}
+
+#[derive(cynic::QueryFragment, Debug)]
+struct Film {
+    id: cynic::Id,
     #[cynic(spread)]
     details: FilmDetails,
+    #[cynic(spread)]
+    more_details: FilmMoreDetails,
+    producers: Option<Vec<Option<String>>>,
 }
 
 #[derive(cynic::QueryVariables)]
@@ -33,10 +42,13 @@ struct FilmDirectorQuery {
 fn main() {
     match run_query().data {
         Some(FilmDirectorQuery { film: Some(film) }) => {
+            println!("Id: {:?}", film.id);
             println!(
-                "{:?} was directed by {:?} and released on {:?}",
-                film.details.title, film.details.director, film.release_date
-            )
+                "{:?} was directed by {:?}",
+                film.details.title, film.details.director
+            );
+            println!("Released on: {:?}", film.more_details.release_date);
+            println!("Producers: {:?}", film.producers);
         }
         _ => {
             println!("No film found");

--- a/examples/examples/spread.rs
+++ b/examples/examples/spread.rs
@@ -13,6 +13,7 @@ struct FilmDetails {
 
 #[derive(cynic::QueryFragment, Debug)]
 struct Film {
+    release_date: Option<String>,
     #[cynic(spread)]
     details: FilmDetails,
 }
@@ -33,8 +34,8 @@ fn main() {
     match run_query().data {
         Some(FilmDirectorQuery { film: Some(film) }) => {
             println!(
-                "{:?} was directed by {:?}",
-                film.details.title, film.details.director
+                "{:?} was directed by {:?} and released on {:?}",
+                film.details.title, film.details.director, film.release_date
             )
         }
         _ => {


### PR DESCRIPTION
#### Why are we making this change?

Fix #772 

#### What effects does this change have?

* Fixed syntax error in generated code as a first step.
* However, deeper issue is that the `query` method in `QueryFragment` takes ownership of `builder`, which means `spread` can only be used once and it must appear in the last place. I'm not sure if taking `&mut builder` is feasible, and it will be a breaking change that requires major version change. The best thing we can do is clearly document this limitation. 
