### PR TITLE
cynic-book: Adding missing '`'

### DIFF
--- a/cynic-book/src/derives/query-fragments.md
+++ b/cynic-book/src/derives/query-fragments.md
@@ -111,7 +111,7 @@ for arguments in GraphQL itself][gql-arguments]. Some examples:
 | `values: ["Hello"]`            | `values: ["Hello"]`            |
 | `values: ["Hello"]`            | `values: ["Hello"]`            |
 | `arg1: "Foo", arg2: "Bar"`     | `arg1: "Foo", arg2: "Bar"`     |
-| `arg1: null                    | `arg1: null`                   |
+| `arg1: null`                   | `arg1: null`                   |
 
 ### Variables
 


### PR DESCRIPTION
Normally I don't bother contributing typo fixes, but in this case the rendering looks quite odd, so I thought it was worth a contribution. Before the fix, the docs looks like this:

![image](https://github.com/obmarg/cynic/assets/115040/c12e04da-16cd-4bf2-b228-3988e8691e1f)
