### PR TITLE
Don't check variant exhaustiveness if a fallback variant is provided

### DIFF
--- a/cynic-codegen/src/enum_derive/input.rs
+++ b/cynic-codegen/src/enum_derive/input.rs
@@ -26,6 +26,9 @@ pub struct EnumDeriveInput {
 
     #[darling(default)]
     pub(super) rename_all: Option<RenameAll>,
+
+    #[darling(default)]
+    pub(super) non_exhaustive: bool,
 }
 
 impl EnumDeriveInput {

--- a/cynic/tests/enum-fallbacks.rs
+++ b/cynic/tests/enum-fallbacks.rs
@@ -20,6 +20,14 @@ enum PostStateStringFallback {
     Unknown(String),
 }
 
+#[derive(Enum, Debug, PartialEq)]
+#[cynic(graphql_type = "PostState", schema_path = "tests/test-schema.graphql")]
+enum PostStateNonexhaustiveFallback {
+    Posted,
+    #[cynic(fallback)]
+    Unknown(String),
+}
+
 #[allow(non_snake_case, non_camel_case_types)]
 mod schema {
     cynic::use_schema!("tests/test-schema.graphql");
@@ -45,4 +53,17 @@ fn test_string_fallback() {
     let val = serde_json::to_value(PostStateStringFallback::Unknown("BLAH".to_string())).unwrap();
 
     assert_eq!(val, serde_json::Value::String("BLAH".into()));
+}
+
+#[test]
+fn test_nonexhaustive_fallback() {
+    assert_eq!(
+        PostStateNonexhaustiveFallback::deserialize(json!("DRAFT")).unwrap(),
+        PostStateNonexhaustiveFallback::Unknown("DRAFT".to_string())
+    );
+
+    let val =
+        serde_json::to_value(PostStateNonexhaustiveFallback::Unknown("DRAFT".to_string())).unwrap();
+
+    assert_eq!(val, serde_json::Value::String("DRAFT".into()));
 }

--- a/cynic/tests/enum-fallbacks.rs
+++ b/cynic/tests/enum-fallbacks.rs
@@ -21,7 +21,11 @@ enum PostStateStringFallback {
 }
 
 #[derive(Enum, Debug, PartialEq)]
-#[cynic(graphql_type = "PostState", schema_path = "tests/test-schema.graphql")]
+#[cynic(
+    graphql_type = "PostState",
+    schema_path = "tests/test-schema.graphql",
+    non_exhaustive
+)]
 enum PostStateNonexhaustiveFallback {
     Posted,
     #[cynic(fallback)]


### PR DESCRIPTION
#### Why are we making this change?

Sometimes it is useful to capture the name of a variant of a GraphQL enum into cynic's fallback variant without enumerating all the existing variants in the cynic-mapped Rust enum. In such case one may want to opt out of exhaustiveness.

#### What effects does this change have?

Enums that contain a fallback variant are excluded from the exhaustiveness check.

I am not sure about this change – perhaps it should be controlled by another `cynic(non_exhaustive)` attribute.
