### PR TITLE
Simplify the schema module

### DIFF
--- a/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__feature_flagging.snap
+++ b/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__feature_flagging.snap
@@ -13,8 +13,8 @@ impl cynic::QueryFragment for MyQuery {
         #![allow(unused_mut)]
         let mut field_builder = builder
             .select_field::<schema::__fields::Query::__typename, <String as cynic::schema::IsScalar<
-                <schema::__fields::Query::__typename as cynic::schema::Field>::Type,
-            >>::SchemaType>();
+            <schema::Query as cynic::schema::HasField<schema::__fields::Query::__typename>>::Type,
+        >>::SchemaType>();
         if builder.is_feature_enabled("2018") {
             let mut field_builder = builder . select_field :: < schema :: __fields :: Query :: filteredPosts , < Vec < BlogPostOutput > as cynic :: QueryFragment > :: SchemaType > () ;
             <Vec<BlogPostOutput> as cynic::QueryFragment>::query(field_builder.select_children());

--- a/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__flatten_attr.snap
+++ b/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__flatten_attr.snap
@@ -11,7 +11,7 @@ impl cynic::QueryFragment for Film {
         mut builder: cynic::queries::SelectionBuilder<'_, Self::SchemaType, Self::VariablesFields>,
     ) {
         #![allow(unused_mut)]
-        let mut field_builder = builder . select_flattened_field :: < schema :: __fields :: Film :: producers , < Vec < String > as cynic :: schema :: IsScalar < < schema :: __fields :: Film :: producers as cynic :: schema :: Field > :: Type >> :: SchemaType , < schema :: __fields :: Film :: producers as cynic :: schema :: Field > :: Type , > () ;
+        let mut field_builder = builder . select_flattened_field :: < schema :: __fields :: Film :: producers , < Vec < String > as cynic :: schema :: IsScalar < < schema :: Film as cynic :: schema :: HasField < schema :: __fields :: Film :: producers >> :: Type >> :: SchemaType , < schema :: Film as cynic :: schema :: HasField < schema :: __fields :: Film :: producers >> :: Type > () ;
     }
     fn name() -> Option<std::borrow::Cow<'static, str>> {
         Some(std::borrow::Cow::Borrowed("Film"))

--- a/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__simple_struct.snap
+++ b/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__simple_struct.snap
@@ -11,7 +11,7 @@ impl cynic::QueryFragment for BlogPostOutput {
         mut builder: cynic::queries::SelectionBuilder<'_, Self::SchemaType, Self::VariablesFields>,
     ) {
         #![allow(unused_mut)]
-        let mut field_builder = builder . select_field :: < schema :: __fields :: BlogPost :: hasMetadata , < Option < bool > as cynic :: schema :: IsScalar < < schema :: __fields :: BlogPost :: hasMetadata as cynic :: schema :: Field > :: Type >> :: SchemaType > () ;
+        let mut field_builder = builder . select_field :: < schema :: __fields :: BlogPost :: hasMetadata , < Option < bool > as cynic :: schema :: IsScalar < < schema :: BlogPost as cynic :: schema :: HasField < schema :: __fields :: BlogPost :: hasMetadata >> :: Type >> :: SchemaType > () ;
         let mut field_builder = builder . select_field :: < schema :: __fields :: BlogPost :: author , < AuthorOutput as cynic :: QueryFragment > :: SchemaType > () ;
         <AuthorOutput as cynic::QueryFragment>::query(field_builder.select_children());
     }

--- a/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__spread_attr_multi_field1.snap
+++ b/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__spread_attr_multi_field1.snap
@@ -11,7 +11,7 @@ impl cynic::QueryFragment for Film {
         mut builder: cynic::queries::SelectionBuilder<'_, Self::SchemaType, Self::VariablesFields>,
     ) {
         #![allow(unused_mut)]
-        let mut field_builder = builder . select_field :: < schema :: __fields :: Film :: releaseDate , < Option < String > as cynic :: schema :: IsScalar < < schema :: __fields :: Film :: releaseDate as cynic :: schema :: Field > :: Type >> :: SchemaType > () ;
+        let mut field_builder = builder . select_field :: < schema :: __fields :: Film :: releaseDate , < Option < String > as cynic :: schema :: IsScalar < < schema :: Film as cynic :: schema :: HasField < schema :: __fields :: Film :: releaseDate >> :: Type >> :: SchemaType > () ;
         <FilmDetails as cynic::QueryFragment>::query(
             builder
                 .inline_fragment()

--- a/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__spread_attr_multi_field2.snap
+++ b/cynic-codegen/src/fragment_derive/snapshots/cynic_codegen__fragment_derive__tests__spread_attr_multi_field2.snap
@@ -16,7 +16,7 @@ impl cynic::QueryFragment for Film {
                 .inline_fragment()
                 .select_children::<<FilmDetails as cynic::QueryFragment>::VariablesFields>(),
         );
-        let mut field_builder = builder . select_field :: < schema :: __fields :: Film :: releaseDate , < Option < String > as cynic :: schema :: IsScalar < < schema :: __fields :: Film :: releaseDate as cynic :: schema :: Field > :: Type >> :: SchemaType > () ;
+        let mut field_builder = builder . select_field :: < schema :: __fields :: Film :: releaseDate , < Option < String > as cynic :: schema :: IsScalar < < schema :: Film as cynic :: schema :: HasField < schema :: __fields :: Film :: releaseDate >> :: Type >> :: SchemaType > () ;
     }
     fn name() -> Option<std::borrow::Cow<'static, str>> {
         Some(std::borrow::Cow::Borrowed("Film"))

--- a/cynic-codegen/src/use_schema/fields.rs
+++ b/cynic-codegen/src/use_schema/fields.rs
@@ -30,14 +30,10 @@ impl ToTokens for FieldOutput<'_> {
         tokens.append_all(quote! {
             pub struct #field_marker;
 
-            impl cynic::schema::Field for #field_marker{
+            impl cynic::schema::HasField<#field_marker> for super::super::#parent_marker {
                 type Type = #field_type_marker;
 
                 const NAME: &'static str = #field_name_literal;
-            }
-
-            impl cynic::schema::HasField<#field_marker> for super::super::#parent_marker {
-                type Type = #field_type_marker;
             }
         });
 

--- a/cynic-codegen/src/use_schema/input_object.rs
+++ b/cynic-codegen/src/use_schema/input_object.rs
@@ -65,13 +65,10 @@ impl ToTokens for FieldOutput<'_> {
         tokens.append_all(quote! {
             pub struct #field_marker;
 
-            impl cynic::schema::Field for #field_marker {
+            impl cynic::schema::HasInputField<#field_marker> for super::super::#object_marker {
                 type Type = #field_type_marker;
 
                 const NAME: &'static str = #field_name_literal;
-            }
-
-            impl cynic::schema::HasInputField<#field_marker, #field_type_marker> for super::super::#object_marker {
             }
         });
     }

--- a/cynic-codegen/tests/snapshots/use_schema__books.graphql.snap
+++ b/cynic-codegen/tests/snapshots/use_schema__books.graphql.snap
@@ -30,80 +30,53 @@ impl cynic::schema::NamedType for SubscriptionRoot {
 pub mod __fields {
     pub mod Book {
         pub struct id;
-        impl cynic::schema::Field for id {
+        impl cynic::schema::HasField<id> for super::super::Book {
             type Type = super::super::String;
             const NAME: &'static str = "id";
         }
-        impl cynic::schema::HasField<id> for super::super::Book {
-            type Type = super::super::String;
-        }
         pub struct name;
-        impl cynic::schema::Field for name {
+        impl cynic::schema::HasField<name> for super::super::Book {
             type Type = super::super::String;
             const NAME: &'static str = "name";
         }
-        impl cynic::schema::HasField<name> for super::super::Book {
-            type Type = super::super::String;
-        }
         pub struct author;
-        impl cynic::schema::Field for author {
+        impl cynic::schema::HasField<author> for super::super::Book {
             type Type = super::super::String;
             const NAME: &'static str = "author";
         }
-        impl cynic::schema::HasField<author> for super::super::Book {
-            type Type = super::super::String;
-        }
         pub struct __typename;
-        impl cynic::schema::Field for __typename {
-            type Type = super::super::String;
-            const NAME: &'static str = "__typename";
-        }
         impl cynic::schema::HasField<__typename> for super::super::Book {
             type Type = super::super::String;
+            const NAME: &'static str = "__typename";
         }
     }
     pub mod BookChanged {
         pub struct mutationType;
-        impl cynic::schema::Field for mutationType {
+        impl cynic::schema::HasField<mutationType> for super::super::BookChanged {
             type Type = super::super::MutationType;
             const NAME: &'static str = "mutationType";
         }
-        impl cynic::schema::HasField<mutationType> for super::super::BookChanged {
-            type Type = super::super::MutationType;
-        }
         pub struct id;
-        impl cynic::schema::Field for id {
+        impl cynic::schema::HasField<id> for super::super::BookChanged {
             type Type = super::super::ID;
             const NAME: &'static str = "id";
         }
-        impl cynic::schema::HasField<id> for super::super::BookChanged {
-            type Type = super::super::ID;
-        }
         pub struct book;
-        impl cynic::schema::Field for book {
+        impl cynic::schema::HasField<book> for super::super::BookChanged {
             type Type = Option<super::super::Book>;
             const NAME: &'static str = "book";
         }
-        impl cynic::schema::HasField<book> for super::super::BookChanged {
-            type Type = Option<super::super::Book>;
-        }
         pub struct __typename;
-        impl cynic::schema::Field for __typename {
-            type Type = super::super::String;
-            const NAME: &'static str = "__typename";
-        }
         impl cynic::schema::HasField<__typename> for super::super::BookChanged {
             type Type = super::super::String;
+            const NAME: &'static str = "__typename";
         }
     }
     pub mod MutationRoot {
         pub struct createBook;
-        impl cynic::schema::Field for createBook {
-            type Type = super::super::ID;
-            const NAME: &'static str = "createBook";
-        }
         impl cynic::schema::HasField<createBook> for super::super::MutationRoot {
             type Type = super::super::ID;
+            const NAME: &'static str = "createBook";
         }
         pub mod _create_book_arguments {
             pub struct name;
@@ -118,12 +91,9 @@ pub mod __fields {
             }
         }
         pub struct deleteBook;
-        impl cynic::schema::Field for deleteBook {
-            type Type = super::super::Boolean;
-            const NAME: &'static str = "deleteBook";
-        }
         impl cynic::schema::HasField<deleteBook> for super::super::MutationRoot {
             type Type = super::super::Boolean;
+            const NAME: &'static str = "deleteBook";
         }
         pub mod _delete_book_arguments {
             pub struct id;
@@ -133,40 +103,28 @@ pub mod __fields {
             }
         }
         pub struct __typename;
-        impl cynic::schema::Field for __typename {
-            type Type = super::super::String;
-            const NAME: &'static str = "__typename";
-        }
         impl cynic::schema::HasField<__typename> for super::super::MutationRoot {
             type Type = super::super::String;
+            const NAME: &'static str = "__typename";
         }
     }
     pub mod QueryRoot {
         pub struct books;
-        impl cynic::schema::Field for books {
+        impl cynic::schema::HasField<books> for super::super::QueryRoot {
             type Type = Vec<super::super::Book>;
             const NAME: &'static str = "books";
         }
-        impl cynic::schema::HasField<books> for super::super::QueryRoot {
-            type Type = Vec<super::super::Book>;
-        }
         pub struct __typename;
-        impl cynic::schema::Field for __typename {
-            type Type = super::super::String;
-            const NAME: &'static str = "__typename";
-        }
         impl cynic::schema::HasField<__typename> for super::super::QueryRoot {
             type Type = super::super::String;
+            const NAME: &'static str = "__typename";
         }
     }
     pub mod SubscriptionRoot {
         pub struct interval;
-        impl cynic::schema::Field for interval {
-            type Type = super::super::Int;
-            const NAME: &'static str = "interval";
-        }
         impl cynic::schema::HasField<interval> for super::super::SubscriptionRoot {
             type Type = super::super::Int;
+            const NAME: &'static str = "interval";
         }
         pub mod _interval_arguments {
             pub struct n;
@@ -176,12 +134,9 @@ pub mod __fields {
             }
         }
         pub struct books;
-        impl cynic::schema::Field for books {
-            type Type = super::super::BookChanged;
-            const NAME: &'static str = "books";
-        }
         impl cynic::schema::HasField<books> for super::super::SubscriptionRoot {
             type Type = super::super::BookChanged;
+            const NAME: &'static str = "books";
         }
         pub mod _books_arguments {
             pub struct mutationType;
@@ -191,12 +146,9 @@ pub mod __fields {
             }
         }
         pub struct __typename;
-        impl cynic::schema::Field for __typename {
-            type Type = super::super::String;
-            const NAME: &'static str = "__typename";
-        }
         impl cynic::schema::HasField<__typename> for super::super::SubscriptionRoot {
             type Type = super::super::String;
+            const NAME: &'static str = "__typename";
         }
     }
 }

--- a/cynic-codegen/tests/snapshots/use_schema__graphql.jobs.graphql.snap
+++ b/cynic-codegen/tests/snapshots/use_schema__graphql.jobs.graphql.snap
@@ -91,52 +91,34 @@ impl cynic::schema::NamedType for User {
 pub mod __fields {
     pub mod City {
         pub struct id;
-        impl cynic::schema::Field for id {
+        impl cynic::schema::HasField<id> for super::super::City {
             type Type = super::super::ID;
             const NAME: &'static str = "id";
         }
-        impl cynic::schema::HasField<id> for super::super::City {
-            type Type = super::super::ID;
-        }
         pub struct name;
-        impl cynic::schema::Field for name {
+        impl cynic::schema::HasField<name> for super::super::City {
             type Type = super::super::String;
             const NAME: &'static str = "name";
         }
-        impl cynic::schema::HasField<name> for super::super::City {
-            type Type = super::super::String;
-        }
         pub struct slug;
-        impl cynic::schema::Field for slug {
+        impl cynic::schema::HasField<slug> for super::super::City {
             type Type = super::super::String;
             const NAME: &'static str = "slug";
         }
-        impl cynic::schema::HasField<slug> for super::super::City {
-            type Type = super::super::String;
-        }
         pub struct country;
-        impl cynic::schema::Field for country {
+        impl cynic::schema::HasField<country> for super::super::City {
             type Type = super::super::Country;
             const NAME: &'static str = "country";
         }
-        impl cynic::schema::HasField<country> for super::super::City {
-            type Type = super::super::Country;
-        }
         pub struct r#type;
-        impl cynic::schema::Field for r#type {
+        impl cynic::schema::HasField<r#type> for super::super::City {
             type Type = super::super::String;
             const NAME: &'static str = "type";
         }
-        impl cynic::schema::HasField<r#type> for super::super::City {
-            type Type = super::super::String;
-        }
         pub struct jobs;
-        impl cynic::schema::Field for jobs {
-            type Type = Option<Vec<super::super::Job>>;
-            const NAME: &'static str = "jobs";
-        }
         impl cynic::schema::HasField<jobs> for super::super::City {
             type Type = Option<Vec<super::super::Job>>;
+            const NAME: &'static str = "jobs";
         }
         pub mod _jobs_arguments {
             pub struct r#where;
@@ -176,772 +158,438 @@ pub mod __fields {
             }
         }
         pub struct createdAt;
-        impl cynic::schema::Field for createdAt {
+        impl cynic::schema::HasField<createdAt> for super::super::City {
             type Type = super::super::DateTime;
             const NAME: &'static str = "createdAt";
         }
-        impl cynic::schema::HasField<createdAt> for super::super::City {
-            type Type = super::super::DateTime;
-        }
         pub struct updatedAt;
-        impl cynic::schema::Field for updatedAt {
+        impl cynic::schema::HasField<updatedAt> for super::super::City {
             type Type = super::super::DateTime;
             const NAME: &'static str = "updatedAt";
         }
-        impl cynic::schema::HasField<updatedAt> for super::super::City {
-            type Type = super::super::DateTime;
-        }
         pub struct __typename;
-        impl cynic::schema::Field for __typename {
-            type Type = super::super::String;
-            const NAME: &'static str = "__typename";
-        }
         impl cynic::schema::HasField<__typename> for super::super::City {
             type Type = super::super::String;
+            const NAME: &'static str = "__typename";
         }
     }
     pub mod CityWhereInput {
         pub struct id;
-        impl cynic::schema::Field for id {
+        impl cynic::schema::HasInputField<id> for super::super::CityWhereInput {
             type Type = Option<super::super::ID>;
             const NAME: &'static str = "id";
         }
-        impl cynic::schema::HasInputField<id, Option<super::super::ID>> for super::super::CityWhereInput {}
         pub struct id_not;
-        impl cynic::schema::Field for id_not {
+        impl cynic::schema::HasInputField<id_not> for super::super::CityWhereInput {
             type Type = Option<super::super::ID>;
             const NAME: &'static str = "id_not";
         }
-        impl cynic::schema::HasInputField<id_not, Option<super::super::ID>>
-            for super::super::CityWhereInput
-        {
-        }
         pub struct id_in;
-        impl cynic::schema::Field for id_in {
+        impl cynic::schema::HasInputField<id_in> for super::super::CityWhereInput {
             type Type = Option<Vec<super::super::ID>>;
             const NAME: &'static str = "id_in";
         }
-        impl cynic::schema::HasInputField<id_in, Option<Vec<super::super::ID>>>
-            for super::super::CityWhereInput
-        {
-        }
         pub struct id_not_in;
-        impl cynic::schema::Field for id_not_in {
+        impl cynic::schema::HasInputField<id_not_in> for super::super::CityWhereInput {
             type Type = Option<Vec<super::super::ID>>;
             const NAME: &'static str = "id_not_in";
         }
-        impl cynic::schema::HasInputField<id_not_in, Option<Vec<super::super::ID>>>
-            for super::super::CityWhereInput
-        {
-        }
         pub struct id_lt;
-        impl cynic::schema::Field for id_lt {
+        impl cynic::schema::HasInputField<id_lt> for super::super::CityWhereInput {
             type Type = Option<super::super::ID>;
             const NAME: &'static str = "id_lt";
         }
-        impl cynic::schema::HasInputField<id_lt, Option<super::super::ID>>
-            for super::super::CityWhereInput
-        {
-        }
         pub struct id_lte;
-        impl cynic::schema::Field for id_lte {
+        impl cynic::schema::HasInputField<id_lte> for super::super::CityWhereInput {
             type Type = Option<super::super::ID>;
             const NAME: &'static str = "id_lte";
         }
-        impl cynic::schema::HasInputField<id_lte, Option<super::super::ID>>
-            for super::super::CityWhereInput
-        {
-        }
         pub struct id_gt;
-        impl cynic::schema::Field for id_gt {
+        impl cynic::schema::HasInputField<id_gt> for super::super::CityWhereInput {
             type Type = Option<super::super::ID>;
             const NAME: &'static str = "id_gt";
         }
-        impl cynic::schema::HasInputField<id_gt, Option<super::super::ID>>
-            for super::super::CityWhereInput
-        {
-        }
         pub struct id_gte;
-        impl cynic::schema::Field for id_gte {
+        impl cynic::schema::HasInputField<id_gte> for super::super::CityWhereInput {
             type Type = Option<super::super::ID>;
             const NAME: &'static str = "id_gte";
         }
-        impl cynic::schema::HasInputField<id_gte, Option<super::super::ID>>
-            for super::super::CityWhereInput
-        {
-        }
         pub struct id_contains;
-        impl cynic::schema::Field for id_contains {
+        impl cynic::schema::HasInputField<id_contains> for super::super::CityWhereInput {
             type Type = Option<super::super::ID>;
             const NAME: &'static str = "id_contains";
         }
-        impl cynic::schema::HasInputField<id_contains, Option<super::super::ID>>
-            for super::super::CityWhereInput
-        {
-        }
         pub struct id_not_contains;
-        impl cynic::schema::Field for id_not_contains {
+        impl cynic::schema::HasInputField<id_not_contains> for super::super::CityWhereInput {
             type Type = Option<super::super::ID>;
             const NAME: &'static str = "id_not_contains";
         }
-        impl cynic::schema::HasInputField<id_not_contains, Option<super::super::ID>>
-            for super::super::CityWhereInput
-        {
-        }
         pub struct id_starts_with;
-        impl cynic::schema::Field for id_starts_with {
+        impl cynic::schema::HasInputField<id_starts_with> for super::super::CityWhereInput {
             type Type = Option<super::super::ID>;
             const NAME: &'static str = "id_starts_with";
         }
-        impl cynic::schema::HasInputField<id_starts_with, Option<super::super::ID>>
-            for super::super::CityWhereInput
-        {
-        }
         pub struct id_not_starts_with;
-        impl cynic::schema::Field for id_not_starts_with {
+        impl cynic::schema::HasInputField<id_not_starts_with> for super::super::CityWhereInput {
             type Type = Option<super::super::ID>;
             const NAME: &'static str = "id_not_starts_with";
         }
-        impl cynic::schema::HasInputField<id_not_starts_with, Option<super::super::ID>>
-            for super::super::CityWhereInput
-        {
-        }
         pub struct id_ends_with;
-        impl cynic::schema::Field for id_ends_with {
+        impl cynic::schema::HasInputField<id_ends_with> for super::super::CityWhereInput {
             type Type = Option<super::super::ID>;
             const NAME: &'static str = "id_ends_with";
         }
-        impl cynic::schema::HasInputField<id_ends_with, Option<super::super::ID>>
-            for super::super::CityWhereInput
-        {
-        }
         pub struct id_not_ends_with;
-        impl cynic::schema::Field for id_not_ends_with {
+        impl cynic::schema::HasInputField<id_not_ends_with> for super::super::CityWhereInput {
             type Type = Option<super::super::ID>;
             const NAME: &'static str = "id_not_ends_with";
         }
-        impl cynic::schema::HasInputField<id_not_ends_with, Option<super::super::ID>>
-            for super::super::CityWhereInput
-        {
-        }
         pub struct name;
-        impl cynic::schema::Field for name {
+        impl cynic::schema::HasInputField<name> for super::super::CityWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "name";
         }
-        impl cynic::schema::HasInputField<name, Option<super::super::String>>
-            for super::super::CityWhereInput
-        {
-        }
         pub struct name_not;
-        impl cynic::schema::Field for name_not {
+        impl cynic::schema::HasInputField<name_not> for super::super::CityWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "name_not";
         }
-        impl cynic::schema::HasInputField<name_not, Option<super::super::String>>
-            for super::super::CityWhereInput
-        {
-        }
         pub struct name_in;
-        impl cynic::schema::Field for name_in {
+        impl cynic::schema::HasInputField<name_in> for super::super::CityWhereInput {
             type Type = Option<Vec<super::super::String>>;
             const NAME: &'static str = "name_in";
         }
-        impl cynic::schema::HasInputField<name_in, Option<Vec<super::super::String>>>
-            for super::super::CityWhereInput
-        {
-        }
         pub struct name_not_in;
-        impl cynic::schema::Field for name_not_in {
+        impl cynic::schema::HasInputField<name_not_in> for super::super::CityWhereInput {
             type Type = Option<Vec<super::super::String>>;
             const NAME: &'static str = "name_not_in";
         }
-        impl cynic::schema::HasInputField<name_not_in, Option<Vec<super::super::String>>>
-            for super::super::CityWhereInput
-        {
-        }
         pub struct name_lt;
-        impl cynic::schema::Field for name_lt {
+        impl cynic::schema::HasInputField<name_lt> for super::super::CityWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "name_lt";
         }
-        impl cynic::schema::HasInputField<name_lt, Option<super::super::String>>
-            for super::super::CityWhereInput
-        {
-        }
         pub struct name_lte;
-        impl cynic::schema::Field for name_lte {
+        impl cynic::schema::HasInputField<name_lte> for super::super::CityWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "name_lte";
         }
-        impl cynic::schema::HasInputField<name_lte, Option<super::super::String>>
-            for super::super::CityWhereInput
-        {
-        }
         pub struct name_gt;
-        impl cynic::schema::Field for name_gt {
+        impl cynic::schema::HasInputField<name_gt> for super::super::CityWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "name_gt";
         }
-        impl cynic::schema::HasInputField<name_gt, Option<super::super::String>>
-            for super::super::CityWhereInput
-        {
-        }
         pub struct name_gte;
-        impl cynic::schema::Field for name_gte {
+        impl cynic::schema::HasInputField<name_gte> for super::super::CityWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "name_gte";
         }
-        impl cynic::schema::HasInputField<name_gte, Option<super::super::String>>
-            for super::super::CityWhereInput
-        {
-        }
         pub struct name_contains;
-        impl cynic::schema::Field for name_contains {
+        impl cynic::schema::HasInputField<name_contains> for super::super::CityWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "name_contains";
         }
-        impl cynic::schema::HasInputField<name_contains, Option<super::super::String>>
-            for super::super::CityWhereInput
-        {
-        }
         pub struct name_not_contains;
-        impl cynic::schema::Field for name_not_contains {
+        impl cynic::schema::HasInputField<name_not_contains> for super::super::CityWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "name_not_contains";
         }
-        impl cynic::schema::HasInputField<name_not_contains, Option<super::super::String>>
-            for super::super::CityWhereInput
-        {
-        }
         pub struct name_starts_with;
-        impl cynic::schema::Field for name_starts_with {
+        impl cynic::schema::HasInputField<name_starts_with> for super::super::CityWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "name_starts_with";
         }
-        impl cynic::schema::HasInputField<name_starts_with, Option<super::super::String>>
-            for super::super::CityWhereInput
-        {
-        }
         pub struct name_not_starts_with;
-        impl cynic::schema::Field for name_not_starts_with {
+        impl cynic::schema::HasInputField<name_not_starts_with> for super::super::CityWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "name_not_starts_with";
         }
-        impl cynic::schema::HasInputField<name_not_starts_with, Option<super::super::String>>
-            for super::super::CityWhereInput
-        {
-        }
         pub struct name_ends_with;
-        impl cynic::schema::Field for name_ends_with {
+        impl cynic::schema::HasInputField<name_ends_with> for super::super::CityWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "name_ends_with";
         }
-        impl cynic::schema::HasInputField<name_ends_with, Option<super::super::String>>
-            for super::super::CityWhereInput
-        {
-        }
         pub struct name_not_ends_with;
-        impl cynic::schema::Field for name_not_ends_with {
+        impl cynic::schema::HasInputField<name_not_ends_with> for super::super::CityWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "name_not_ends_with";
         }
-        impl cynic::schema::HasInputField<name_not_ends_with, Option<super::super::String>>
-            for super::super::CityWhereInput
-        {
-        }
         pub struct slug;
-        impl cynic::schema::Field for slug {
+        impl cynic::schema::HasInputField<slug> for super::super::CityWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "slug";
         }
-        impl cynic::schema::HasInputField<slug, Option<super::super::String>>
-            for super::super::CityWhereInput
-        {
-        }
         pub struct slug_not;
-        impl cynic::schema::Field for slug_not {
+        impl cynic::schema::HasInputField<slug_not> for super::super::CityWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "slug_not";
         }
-        impl cynic::schema::HasInputField<slug_not, Option<super::super::String>>
-            for super::super::CityWhereInput
-        {
-        }
         pub struct slug_in;
-        impl cynic::schema::Field for slug_in {
+        impl cynic::schema::HasInputField<slug_in> for super::super::CityWhereInput {
             type Type = Option<Vec<super::super::String>>;
             const NAME: &'static str = "slug_in";
         }
-        impl cynic::schema::HasInputField<slug_in, Option<Vec<super::super::String>>>
-            for super::super::CityWhereInput
-        {
-        }
         pub struct slug_not_in;
-        impl cynic::schema::Field for slug_not_in {
+        impl cynic::schema::HasInputField<slug_not_in> for super::super::CityWhereInput {
             type Type = Option<Vec<super::super::String>>;
             const NAME: &'static str = "slug_not_in";
         }
-        impl cynic::schema::HasInputField<slug_not_in, Option<Vec<super::super::String>>>
-            for super::super::CityWhereInput
-        {
-        }
         pub struct slug_lt;
-        impl cynic::schema::Field for slug_lt {
+        impl cynic::schema::HasInputField<slug_lt> for super::super::CityWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "slug_lt";
         }
-        impl cynic::schema::HasInputField<slug_lt, Option<super::super::String>>
-            for super::super::CityWhereInput
-        {
-        }
         pub struct slug_lte;
-        impl cynic::schema::Field for slug_lte {
+        impl cynic::schema::HasInputField<slug_lte> for super::super::CityWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "slug_lte";
         }
-        impl cynic::schema::HasInputField<slug_lte, Option<super::super::String>>
-            for super::super::CityWhereInput
-        {
-        }
         pub struct slug_gt;
-        impl cynic::schema::Field for slug_gt {
+        impl cynic::schema::HasInputField<slug_gt> for super::super::CityWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "slug_gt";
         }
-        impl cynic::schema::HasInputField<slug_gt, Option<super::super::String>>
-            for super::super::CityWhereInput
-        {
-        }
         pub struct slug_gte;
-        impl cynic::schema::Field for slug_gte {
+        impl cynic::schema::HasInputField<slug_gte> for super::super::CityWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "slug_gte";
         }
-        impl cynic::schema::HasInputField<slug_gte, Option<super::super::String>>
-            for super::super::CityWhereInput
-        {
-        }
         pub struct slug_contains;
-        impl cynic::schema::Field for slug_contains {
+        impl cynic::schema::HasInputField<slug_contains> for super::super::CityWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "slug_contains";
         }
-        impl cynic::schema::HasInputField<slug_contains, Option<super::super::String>>
-            for super::super::CityWhereInput
-        {
-        }
         pub struct slug_not_contains;
-        impl cynic::schema::Field for slug_not_contains {
+        impl cynic::schema::HasInputField<slug_not_contains> for super::super::CityWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "slug_not_contains";
         }
-        impl cynic::schema::HasInputField<slug_not_contains, Option<super::super::String>>
-            for super::super::CityWhereInput
-        {
-        }
         pub struct slug_starts_with;
-        impl cynic::schema::Field for slug_starts_with {
+        impl cynic::schema::HasInputField<slug_starts_with> for super::super::CityWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "slug_starts_with";
         }
-        impl cynic::schema::HasInputField<slug_starts_with, Option<super::super::String>>
-            for super::super::CityWhereInput
-        {
-        }
         pub struct slug_not_starts_with;
-        impl cynic::schema::Field for slug_not_starts_with {
+        impl cynic::schema::HasInputField<slug_not_starts_with> for super::super::CityWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "slug_not_starts_with";
         }
-        impl cynic::schema::HasInputField<slug_not_starts_with, Option<super::super::String>>
-            for super::super::CityWhereInput
-        {
-        }
         pub struct slug_ends_with;
-        impl cynic::schema::Field for slug_ends_with {
+        impl cynic::schema::HasInputField<slug_ends_with> for super::super::CityWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "slug_ends_with";
         }
-        impl cynic::schema::HasInputField<slug_ends_with, Option<super::super::String>>
-            for super::super::CityWhereInput
-        {
-        }
         pub struct slug_not_ends_with;
-        impl cynic::schema::Field for slug_not_ends_with {
+        impl cynic::schema::HasInputField<slug_not_ends_with> for super::super::CityWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "slug_not_ends_with";
         }
-        impl cynic::schema::HasInputField<slug_not_ends_with, Option<super::super::String>>
-            for super::super::CityWhereInput
-        {
-        }
         pub struct country;
-        impl cynic::schema::Field for country {
+        impl cynic::schema::HasInputField<country> for super::super::CityWhereInput {
             type Type = Option<super::super::CountryWhereInput>;
             const NAME: &'static str = "country";
         }
-        impl cynic::schema::HasInputField<country, Option<super::super::CountryWhereInput>>
-            for super::super::CityWhereInput
-        {
-        }
         pub struct r#type;
-        impl cynic::schema::Field for r#type {
+        impl cynic::schema::HasInputField<r#type> for super::super::CityWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "type";
         }
-        impl cynic::schema::HasInputField<r#type, Option<super::super::String>>
-            for super::super::CityWhereInput
-        {
-        }
         pub struct type_not;
-        impl cynic::schema::Field for type_not {
+        impl cynic::schema::HasInputField<type_not> for super::super::CityWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "type_not";
         }
-        impl cynic::schema::HasInputField<type_not, Option<super::super::String>>
-            for super::super::CityWhereInput
-        {
-        }
         pub struct type_in;
-        impl cynic::schema::Field for type_in {
+        impl cynic::schema::HasInputField<type_in> for super::super::CityWhereInput {
             type Type = Option<Vec<super::super::String>>;
             const NAME: &'static str = "type_in";
         }
-        impl cynic::schema::HasInputField<type_in, Option<Vec<super::super::String>>>
-            for super::super::CityWhereInput
-        {
-        }
         pub struct type_not_in;
-        impl cynic::schema::Field for type_not_in {
+        impl cynic::schema::HasInputField<type_not_in> for super::super::CityWhereInput {
             type Type = Option<Vec<super::super::String>>;
             const NAME: &'static str = "type_not_in";
         }
-        impl cynic::schema::HasInputField<type_not_in, Option<Vec<super::super::String>>>
-            for super::super::CityWhereInput
-        {
-        }
         pub struct type_lt;
-        impl cynic::schema::Field for type_lt {
+        impl cynic::schema::HasInputField<type_lt> for super::super::CityWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "type_lt";
         }
-        impl cynic::schema::HasInputField<type_lt, Option<super::super::String>>
-            for super::super::CityWhereInput
-        {
-        }
         pub struct type_lte;
-        impl cynic::schema::Field for type_lte {
+        impl cynic::schema::HasInputField<type_lte> for super::super::CityWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "type_lte";
         }
-        impl cynic::schema::HasInputField<type_lte, Option<super::super::String>>
-            for super::super::CityWhereInput
-        {
-        }
         pub struct type_gt;
-        impl cynic::schema::Field for type_gt {
+        impl cynic::schema::HasInputField<type_gt> for super::super::CityWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "type_gt";
         }
-        impl cynic::schema::HasInputField<type_gt, Option<super::super::String>>
-            for super::super::CityWhereInput
-        {
-        }
         pub struct type_gte;
-        impl cynic::schema::Field for type_gte {
+        impl cynic::schema::HasInputField<type_gte> for super::super::CityWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "type_gte";
         }
-        impl cynic::schema::HasInputField<type_gte, Option<super::super::String>>
-            for super::super::CityWhereInput
-        {
-        }
         pub struct type_contains;
-        impl cynic::schema::Field for type_contains {
+        impl cynic::schema::HasInputField<type_contains> for super::super::CityWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "type_contains";
         }
-        impl cynic::schema::HasInputField<type_contains, Option<super::super::String>>
-            for super::super::CityWhereInput
-        {
-        }
         pub struct type_not_contains;
-        impl cynic::schema::Field for type_not_contains {
+        impl cynic::schema::HasInputField<type_not_contains> for super::super::CityWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "type_not_contains";
         }
-        impl cynic::schema::HasInputField<type_not_contains, Option<super::super::String>>
-            for super::super::CityWhereInput
-        {
-        }
         pub struct type_starts_with;
-        impl cynic::schema::Field for type_starts_with {
+        impl cynic::schema::HasInputField<type_starts_with> for super::super::CityWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "type_starts_with";
         }
-        impl cynic::schema::HasInputField<type_starts_with, Option<super::super::String>>
-            for super::super::CityWhereInput
-        {
-        }
         pub struct type_not_starts_with;
-        impl cynic::schema::Field for type_not_starts_with {
+        impl cynic::schema::HasInputField<type_not_starts_with> for super::super::CityWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "type_not_starts_with";
         }
-        impl cynic::schema::HasInputField<type_not_starts_with, Option<super::super::String>>
-            for super::super::CityWhereInput
-        {
-        }
         pub struct type_ends_with;
-        impl cynic::schema::Field for type_ends_with {
+        impl cynic::schema::HasInputField<type_ends_with> for super::super::CityWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "type_ends_with";
         }
-        impl cynic::schema::HasInputField<type_ends_with, Option<super::super::String>>
-            for super::super::CityWhereInput
-        {
-        }
         pub struct type_not_ends_with;
-        impl cynic::schema::Field for type_not_ends_with {
+        impl cynic::schema::HasInputField<type_not_ends_with> for super::super::CityWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "type_not_ends_with";
         }
-        impl cynic::schema::HasInputField<type_not_ends_with, Option<super::super::String>>
-            for super::super::CityWhereInput
-        {
-        }
         pub struct jobs_every;
-        impl cynic::schema::Field for jobs_every {
+        impl cynic::schema::HasInputField<jobs_every> for super::super::CityWhereInput {
             type Type = Option<super::super::JobWhereInput>;
             const NAME: &'static str = "jobs_every";
         }
-        impl cynic::schema::HasInputField<jobs_every, Option<super::super::JobWhereInput>>
-            for super::super::CityWhereInput
-        {
-        }
         pub struct jobs_some;
-        impl cynic::schema::Field for jobs_some {
+        impl cynic::schema::HasInputField<jobs_some> for super::super::CityWhereInput {
             type Type = Option<super::super::JobWhereInput>;
             const NAME: &'static str = "jobs_some";
         }
-        impl cynic::schema::HasInputField<jobs_some, Option<super::super::JobWhereInput>>
-            for super::super::CityWhereInput
-        {
-        }
         pub struct jobs_none;
-        impl cynic::schema::Field for jobs_none {
+        impl cynic::schema::HasInputField<jobs_none> for super::super::CityWhereInput {
             type Type = Option<super::super::JobWhereInput>;
             const NAME: &'static str = "jobs_none";
         }
-        impl cynic::schema::HasInputField<jobs_none, Option<super::super::JobWhereInput>>
-            for super::super::CityWhereInput
-        {
-        }
         pub struct createdAt;
-        impl cynic::schema::Field for createdAt {
+        impl cynic::schema::HasInputField<createdAt> for super::super::CityWhereInput {
             type Type = Option<super::super::DateTime>;
             const NAME: &'static str = "createdAt";
         }
-        impl cynic::schema::HasInputField<createdAt, Option<super::super::DateTime>>
-            for super::super::CityWhereInput
-        {
-        }
         pub struct createdAt_not;
-        impl cynic::schema::Field for createdAt_not {
+        impl cynic::schema::HasInputField<createdAt_not> for super::super::CityWhereInput {
             type Type = Option<super::super::DateTime>;
             const NAME: &'static str = "createdAt_not";
         }
-        impl cynic::schema::HasInputField<createdAt_not, Option<super::super::DateTime>>
-            for super::super::CityWhereInput
-        {
-        }
         pub struct createdAt_in;
-        impl cynic::schema::Field for createdAt_in {
+        impl cynic::schema::HasInputField<createdAt_in> for super::super::CityWhereInput {
             type Type = Option<Vec<super::super::DateTime>>;
             const NAME: &'static str = "createdAt_in";
         }
-        impl cynic::schema::HasInputField<createdAt_in, Option<Vec<super::super::DateTime>>>
-            for super::super::CityWhereInput
-        {
-        }
         pub struct createdAt_not_in;
-        impl cynic::schema::Field for createdAt_not_in {
+        impl cynic::schema::HasInputField<createdAt_not_in> for super::super::CityWhereInput {
             type Type = Option<Vec<super::super::DateTime>>;
             const NAME: &'static str = "createdAt_not_in";
         }
-        impl cynic::schema::HasInputField<createdAt_not_in, Option<Vec<super::super::DateTime>>>
-            for super::super::CityWhereInput
-        {
-        }
         pub struct createdAt_lt;
-        impl cynic::schema::Field for createdAt_lt {
+        impl cynic::schema::HasInputField<createdAt_lt> for super::super::CityWhereInput {
             type Type = Option<super::super::DateTime>;
             const NAME: &'static str = "createdAt_lt";
         }
-        impl cynic::schema::HasInputField<createdAt_lt, Option<super::super::DateTime>>
-            for super::super::CityWhereInput
-        {
-        }
         pub struct createdAt_lte;
-        impl cynic::schema::Field for createdAt_lte {
+        impl cynic::schema::HasInputField<createdAt_lte> for super::super::CityWhereInput {
             type Type = Option<super::super::DateTime>;
             const NAME: &'static str = "createdAt_lte";
         }
-        impl cynic::schema::HasInputField<createdAt_lte, Option<super::super::DateTime>>
-            for super::super::CityWhereInput
-        {
-        }
         pub struct createdAt_gt;
-        impl cynic::schema::Field for createdAt_gt {
+        impl cynic::schema::HasInputField<createdAt_gt> for super::super::CityWhereInput {
             type Type = Option<super::super::DateTime>;
             const NAME: &'static str = "createdAt_gt";
         }
-        impl cynic::schema::HasInputField<createdAt_gt, Option<super::super::DateTime>>
-            for super::super::CityWhereInput
-        {
-        }
         pub struct createdAt_gte;
-        impl cynic::schema::Field for createdAt_gte {
+        impl cynic::schema::HasInputField<createdAt_gte> for super::super::CityWhereInput {
             type Type = Option<super::super::DateTime>;
             const NAME: &'static str = "createdAt_gte";
         }
-        impl cynic::schema::HasInputField<createdAt_gte, Option<super::super::DateTime>>
-            for super::super::CityWhereInput
-        {
-        }
         pub struct updatedAt;
-        impl cynic::schema::Field for updatedAt {
+        impl cynic::schema::HasInputField<updatedAt> for super::super::CityWhereInput {
             type Type = Option<super::super::DateTime>;
             const NAME: &'static str = "updatedAt";
         }
-        impl cynic::schema::HasInputField<updatedAt, Option<super::super::DateTime>>
-            for super::super::CityWhereInput
-        {
-        }
         pub struct updatedAt_not;
-        impl cynic::schema::Field for updatedAt_not {
+        impl cynic::schema::HasInputField<updatedAt_not> for super::super::CityWhereInput {
             type Type = Option<super::super::DateTime>;
             const NAME: &'static str = "updatedAt_not";
         }
-        impl cynic::schema::HasInputField<updatedAt_not, Option<super::super::DateTime>>
-            for super::super::CityWhereInput
-        {
-        }
         pub struct updatedAt_in;
-        impl cynic::schema::Field for updatedAt_in {
+        impl cynic::schema::HasInputField<updatedAt_in> for super::super::CityWhereInput {
             type Type = Option<Vec<super::super::DateTime>>;
             const NAME: &'static str = "updatedAt_in";
         }
-        impl cynic::schema::HasInputField<updatedAt_in, Option<Vec<super::super::DateTime>>>
-            for super::super::CityWhereInput
-        {
-        }
         pub struct updatedAt_not_in;
-        impl cynic::schema::Field for updatedAt_not_in {
+        impl cynic::schema::HasInputField<updatedAt_not_in> for super::super::CityWhereInput {
             type Type = Option<Vec<super::super::DateTime>>;
             const NAME: &'static str = "updatedAt_not_in";
         }
-        impl cynic::schema::HasInputField<updatedAt_not_in, Option<Vec<super::super::DateTime>>>
-            for super::super::CityWhereInput
-        {
-        }
         pub struct updatedAt_lt;
-        impl cynic::schema::Field for updatedAt_lt {
+        impl cynic::schema::HasInputField<updatedAt_lt> for super::super::CityWhereInput {
             type Type = Option<super::super::DateTime>;
             const NAME: &'static str = "updatedAt_lt";
         }
-        impl cynic::schema::HasInputField<updatedAt_lt, Option<super::super::DateTime>>
-            for super::super::CityWhereInput
-        {
-        }
         pub struct updatedAt_lte;
-        impl cynic::schema::Field for updatedAt_lte {
+        impl cynic::schema::HasInputField<updatedAt_lte> for super::super::CityWhereInput {
             type Type = Option<super::super::DateTime>;
             const NAME: &'static str = "updatedAt_lte";
         }
-        impl cynic::schema::HasInputField<updatedAt_lte, Option<super::super::DateTime>>
-            for super::super::CityWhereInput
-        {
-        }
         pub struct updatedAt_gt;
-        impl cynic::schema::Field for updatedAt_gt {
+        impl cynic::schema::HasInputField<updatedAt_gt> for super::super::CityWhereInput {
             type Type = Option<super::super::DateTime>;
             const NAME: &'static str = "updatedAt_gt";
         }
-        impl cynic::schema::HasInputField<updatedAt_gt, Option<super::super::DateTime>>
-            for super::super::CityWhereInput
-        {
-        }
         pub struct updatedAt_gte;
-        impl cynic::schema::Field for updatedAt_gte {
+        impl cynic::schema::HasInputField<updatedAt_gte> for super::super::CityWhereInput {
             type Type = Option<super::super::DateTime>;
             const NAME: &'static str = "updatedAt_gte";
         }
-        impl cynic::schema::HasInputField<updatedAt_gte, Option<super::super::DateTime>>
-            for super::super::CityWhereInput
-        {
-        }
         pub struct AND;
-        impl cynic::schema::Field for AND {
+        impl cynic::schema::HasInputField<AND> for super::super::CityWhereInput {
             type Type = Option<Vec<super::super::CityWhereInput>>;
             const NAME: &'static str = "AND";
         }
-        impl cynic::schema::HasInputField<AND, Option<Vec<super::super::CityWhereInput>>>
-            for super::super::CityWhereInput
-        {
-        }
         pub struct OR;
-        impl cynic::schema::Field for OR {
+        impl cynic::schema::HasInputField<OR> for super::super::CityWhereInput {
             type Type = Option<Vec<super::super::CityWhereInput>>;
             const NAME: &'static str = "OR";
         }
-        impl cynic::schema::HasInputField<OR, Option<Vec<super::super::CityWhereInput>>>
-            for super::super::CityWhereInput
-        {
-        }
         pub struct NOT;
-        impl cynic::schema::Field for NOT {
+        impl cynic::schema::HasInputField<NOT> for super::super::CityWhereInput {
             type Type = Option<Vec<super::super::CityWhereInput>>;
             const NAME: &'static str = "NOT";
-        }
-        impl cynic::schema::HasInputField<NOT, Option<Vec<super::super::CityWhereInput>>>
-            for super::super::CityWhereInput
-        {
         }
     }
     pub mod Commitment {
         pub struct id;
-        impl cynic::schema::Field for id {
+        impl cynic::schema::HasField<id> for super::super::Commitment {
             type Type = super::super::ID;
             const NAME: &'static str = "id";
         }
-        impl cynic::schema::HasField<id> for super::super::Commitment {
-            type Type = super::super::ID;
-        }
         pub struct title;
-        impl cynic::schema::Field for title {
+        impl cynic::schema::HasField<title> for super::super::Commitment {
             type Type = super::super::String;
             const NAME: &'static str = "title";
         }
-        impl cynic::schema::HasField<title> for super::super::Commitment {
-            type Type = super::super::String;
-        }
         pub struct slug;
-        impl cynic::schema::Field for slug {
+        impl cynic::schema::HasField<slug> for super::super::Commitment {
             type Type = super::super::String;
             const NAME: &'static str = "slug";
         }
-        impl cynic::schema::HasField<slug> for super::super::Commitment {
-            type Type = super::super::String;
-        }
         pub struct jobs;
-        impl cynic::schema::Field for jobs {
-            type Type = Option<Vec<super::super::Job>>;
-            const NAME: &'static str = "jobs";
-        }
         impl cynic::schema::HasField<jobs> for super::super::Commitment {
             type Type = Option<Vec<super::super::Job>>;
+            const NAME: &'static str = "jobs";
         }
         pub mod _jobs_arguments {
             pub struct r#where;
@@ -981,656 +629,373 @@ pub mod __fields {
             }
         }
         pub struct createdAt;
-        impl cynic::schema::Field for createdAt {
+        impl cynic::schema::HasField<createdAt> for super::super::Commitment {
             type Type = super::super::DateTime;
             const NAME: &'static str = "createdAt";
         }
-        impl cynic::schema::HasField<createdAt> for super::super::Commitment {
-            type Type = super::super::DateTime;
-        }
         pub struct updatedAt;
-        impl cynic::schema::Field for updatedAt {
+        impl cynic::schema::HasField<updatedAt> for super::super::Commitment {
             type Type = super::super::DateTime;
             const NAME: &'static str = "updatedAt";
         }
-        impl cynic::schema::HasField<updatedAt> for super::super::Commitment {
-            type Type = super::super::DateTime;
-        }
         pub struct __typename;
-        impl cynic::schema::Field for __typename {
-            type Type = super::super::String;
-            const NAME: &'static str = "__typename";
-        }
         impl cynic::schema::HasField<__typename> for super::super::Commitment {
             type Type = super::super::String;
+            const NAME: &'static str = "__typename";
         }
     }
     pub mod CommitmentWhereInput {
         pub struct id;
-        impl cynic::schema::Field for id {
+        impl cynic::schema::HasInputField<id> for super::super::CommitmentWhereInput {
             type Type = Option<super::super::ID>;
             const NAME: &'static str = "id";
         }
-        impl cynic::schema::HasInputField<id, Option<super::super::ID>>
-            for super::super::CommitmentWhereInput
-        {
-        }
         pub struct id_not;
-        impl cynic::schema::Field for id_not {
+        impl cynic::schema::HasInputField<id_not> for super::super::CommitmentWhereInput {
             type Type = Option<super::super::ID>;
             const NAME: &'static str = "id_not";
         }
-        impl cynic::schema::HasInputField<id_not, Option<super::super::ID>>
-            for super::super::CommitmentWhereInput
-        {
-        }
         pub struct id_in;
-        impl cynic::schema::Field for id_in {
+        impl cynic::schema::HasInputField<id_in> for super::super::CommitmentWhereInput {
             type Type = Option<Vec<super::super::ID>>;
             const NAME: &'static str = "id_in";
         }
-        impl cynic::schema::HasInputField<id_in, Option<Vec<super::super::ID>>>
-            for super::super::CommitmentWhereInput
-        {
-        }
         pub struct id_not_in;
-        impl cynic::schema::Field for id_not_in {
+        impl cynic::schema::HasInputField<id_not_in> for super::super::CommitmentWhereInput {
             type Type = Option<Vec<super::super::ID>>;
             const NAME: &'static str = "id_not_in";
         }
-        impl cynic::schema::HasInputField<id_not_in, Option<Vec<super::super::ID>>>
-            for super::super::CommitmentWhereInput
-        {
-        }
         pub struct id_lt;
-        impl cynic::schema::Field for id_lt {
+        impl cynic::schema::HasInputField<id_lt> for super::super::CommitmentWhereInput {
             type Type = Option<super::super::ID>;
             const NAME: &'static str = "id_lt";
         }
-        impl cynic::schema::HasInputField<id_lt, Option<super::super::ID>>
-            for super::super::CommitmentWhereInput
-        {
-        }
         pub struct id_lte;
-        impl cynic::schema::Field for id_lte {
+        impl cynic::schema::HasInputField<id_lte> for super::super::CommitmentWhereInput {
             type Type = Option<super::super::ID>;
             const NAME: &'static str = "id_lte";
         }
-        impl cynic::schema::HasInputField<id_lte, Option<super::super::ID>>
-            for super::super::CommitmentWhereInput
-        {
-        }
         pub struct id_gt;
-        impl cynic::schema::Field for id_gt {
+        impl cynic::schema::HasInputField<id_gt> for super::super::CommitmentWhereInput {
             type Type = Option<super::super::ID>;
             const NAME: &'static str = "id_gt";
         }
-        impl cynic::schema::HasInputField<id_gt, Option<super::super::ID>>
-            for super::super::CommitmentWhereInput
-        {
-        }
         pub struct id_gte;
-        impl cynic::schema::Field for id_gte {
+        impl cynic::schema::HasInputField<id_gte> for super::super::CommitmentWhereInput {
             type Type = Option<super::super::ID>;
             const NAME: &'static str = "id_gte";
         }
-        impl cynic::schema::HasInputField<id_gte, Option<super::super::ID>>
-            for super::super::CommitmentWhereInput
-        {
-        }
         pub struct id_contains;
-        impl cynic::schema::Field for id_contains {
+        impl cynic::schema::HasInputField<id_contains> for super::super::CommitmentWhereInput {
             type Type = Option<super::super::ID>;
             const NAME: &'static str = "id_contains";
         }
-        impl cynic::schema::HasInputField<id_contains, Option<super::super::ID>>
-            for super::super::CommitmentWhereInput
-        {
-        }
         pub struct id_not_contains;
-        impl cynic::schema::Field for id_not_contains {
+        impl cynic::schema::HasInputField<id_not_contains> for super::super::CommitmentWhereInput {
             type Type = Option<super::super::ID>;
             const NAME: &'static str = "id_not_contains";
         }
-        impl cynic::schema::HasInputField<id_not_contains, Option<super::super::ID>>
-            for super::super::CommitmentWhereInput
-        {
-        }
         pub struct id_starts_with;
-        impl cynic::schema::Field for id_starts_with {
+        impl cynic::schema::HasInputField<id_starts_with> for super::super::CommitmentWhereInput {
             type Type = Option<super::super::ID>;
             const NAME: &'static str = "id_starts_with";
         }
-        impl cynic::schema::HasInputField<id_starts_with, Option<super::super::ID>>
-            for super::super::CommitmentWhereInput
-        {
-        }
         pub struct id_not_starts_with;
-        impl cynic::schema::Field for id_not_starts_with {
+        impl cynic::schema::HasInputField<id_not_starts_with> for super::super::CommitmentWhereInput {
             type Type = Option<super::super::ID>;
             const NAME: &'static str = "id_not_starts_with";
         }
-        impl cynic::schema::HasInputField<id_not_starts_with, Option<super::super::ID>>
-            for super::super::CommitmentWhereInput
-        {
-        }
         pub struct id_ends_with;
-        impl cynic::schema::Field for id_ends_with {
+        impl cynic::schema::HasInputField<id_ends_with> for super::super::CommitmentWhereInput {
             type Type = Option<super::super::ID>;
             const NAME: &'static str = "id_ends_with";
         }
-        impl cynic::schema::HasInputField<id_ends_with, Option<super::super::ID>>
-            for super::super::CommitmentWhereInput
-        {
-        }
         pub struct id_not_ends_with;
-        impl cynic::schema::Field for id_not_ends_with {
+        impl cynic::schema::HasInputField<id_not_ends_with> for super::super::CommitmentWhereInput {
             type Type = Option<super::super::ID>;
             const NAME: &'static str = "id_not_ends_with";
         }
-        impl cynic::schema::HasInputField<id_not_ends_with, Option<super::super::ID>>
-            for super::super::CommitmentWhereInput
-        {
-        }
         pub struct title;
-        impl cynic::schema::Field for title {
+        impl cynic::schema::HasInputField<title> for super::super::CommitmentWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "title";
         }
-        impl cynic::schema::HasInputField<title, Option<super::super::String>>
-            for super::super::CommitmentWhereInput
-        {
-        }
         pub struct title_not;
-        impl cynic::schema::Field for title_not {
+        impl cynic::schema::HasInputField<title_not> for super::super::CommitmentWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "title_not";
         }
-        impl cynic::schema::HasInputField<title_not, Option<super::super::String>>
-            for super::super::CommitmentWhereInput
-        {
-        }
         pub struct title_in;
-        impl cynic::schema::Field for title_in {
+        impl cynic::schema::HasInputField<title_in> for super::super::CommitmentWhereInput {
             type Type = Option<Vec<super::super::String>>;
             const NAME: &'static str = "title_in";
         }
-        impl cynic::schema::HasInputField<title_in, Option<Vec<super::super::String>>>
-            for super::super::CommitmentWhereInput
-        {
-        }
         pub struct title_not_in;
-        impl cynic::schema::Field for title_not_in {
+        impl cynic::schema::HasInputField<title_not_in> for super::super::CommitmentWhereInput {
             type Type = Option<Vec<super::super::String>>;
             const NAME: &'static str = "title_not_in";
         }
-        impl cynic::schema::HasInputField<title_not_in, Option<Vec<super::super::String>>>
-            for super::super::CommitmentWhereInput
-        {
-        }
         pub struct title_lt;
-        impl cynic::schema::Field for title_lt {
+        impl cynic::schema::HasInputField<title_lt> for super::super::CommitmentWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "title_lt";
         }
-        impl cynic::schema::HasInputField<title_lt, Option<super::super::String>>
-            for super::super::CommitmentWhereInput
-        {
-        }
         pub struct title_lte;
-        impl cynic::schema::Field for title_lte {
+        impl cynic::schema::HasInputField<title_lte> for super::super::CommitmentWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "title_lte";
         }
-        impl cynic::schema::HasInputField<title_lte, Option<super::super::String>>
-            for super::super::CommitmentWhereInput
-        {
-        }
         pub struct title_gt;
-        impl cynic::schema::Field for title_gt {
+        impl cynic::schema::HasInputField<title_gt> for super::super::CommitmentWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "title_gt";
         }
-        impl cynic::schema::HasInputField<title_gt, Option<super::super::String>>
-            for super::super::CommitmentWhereInput
-        {
-        }
         pub struct title_gte;
-        impl cynic::schema::Field for title_gte {
+        impl cynic::schema::HasInputField<title_gte> for super::super::CommitmentWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "title_gte";
         }
-        impl cynic::schema::HasInputField<title_gte, Option<super::super::String>>
-            for super::super::CommitmentWhereInput
-        {
-        }
         pub struct title_contains;
-        impl cynic::schema::Field for title_contains {
+        impl cynic::schema::HasInputField<title_contains> for super::super::CommitmentWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "title_contains";
         }
-        impl cynic::schema::HasInputField<title_contains, Option<super::super::String>>
-            for super::super::CommitmentWhereInput
-        {
-        }
         pub struct title_not_contains;
-        impl cynic::schema::Field for title_not_contains {
+        impl cynic::schema::HasInputField<title_not_contains> for super::super::CommitmentWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "title_not_contains";
         }
-        impl cynic::schema::HasInputField<title_not_contains, Option<super::super::String>>
-            for super::super::CommitmentWhereInput
-        {
-        }
         pub struct title_starts_with;
-        impl cynic::schema::Field for title_starts_with {
+        impl cynic::schema::HasInputField<title_starts_with> for super::super::CommitmentWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "title_starts_with";
         }
-        impl cynic::schema::HasInputField<title_starts_with, Option<super::super::String>>
-            for super::super::CommitmentWhereInput
-        {
-        }
         pub struct title_not_starts_with;
-        impl cynic::schema::Field for title_not_starts_with {
+        impl cynic::schema::HasInputField<title_not_starts_with> for super::super::CommitmentWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "title_not_starts_with";
         }
-        impl cynic::schema::HasInputField<title_not_starts_with, Option<super::super::String>>
-            for super::super::CommitmentWhereInput
-        {
-        }
         pub struct title_ends_with;
-        impl cynic::schema::Field for title_ends_with {
+        impl cynic::schema::HasInputField<title_ends_with> for super::super::CommitmentWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "title_ends_with";
         }
-        impl cynic::schema::HasInputField<title_ends_with, Option<super::super::String>>
-            for super::super::CommitmentWhereInput
-        {
-        }
         pub struct title_not_ends_with;
-        impl cynic::schema::Field for title_not_ends_with {
+        impl cynic::schema::HasInputField<title_not_ends_with> for super::super::CommitmentWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "title_not_ends_with";
         }
-        impl cynic::schema::HasInputField<title_not_ends_with, Option<super::super::String>>
-            for super::super::CommitmentWhereInput
-        {
-        }
         pub struct slug;
-        impl cynic::schema::Field for slug {
+        impl cynic::schema::HasInputField<slug> for super::super::CommitmentWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "slug";
         }
-        impl cynic::schema::HasInputField<slug, Option<super::super::String>>
-            for super::super::CommitmentWhereInput
-        {
-        }
         pub struct slug_not;
-        impl cynic::schema::Field for slug_not {
+        impl cynic::schema::HasInputField<slug_not> for super::super::CommitmentWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "slug_not";
         }
-        impl cynic::schema::HasInputField<slug_not, Option<super::super::String>>
-            for super::super::CommitmentWhereInput
-        {
-        }
         pub struct slug_in;
-        impl cynic::schema::Field for slug_in {
+        impl cynic::schema::HasInputField<slug_in> for super::super::CommitmentWhereInput {
             type Type = Option<Vec<super::super::String>>;
             const NAME: &'static str = "slug_in";
         }
-        impl cynic::schema::HasInputField<slug_in, Option<Vec<super::super::String>>>
-            for super::super::CommitmentWhereInput
-        {
-        }
         pub struct slug_not_in;
-        impl cynic::schema::Field for slug_not_in {
+        impl cynic::schema::HasInputField<slug_not_in> for super::super::CommitmentWhereInput {
             type Type = Option<Vec<super::super::String>>;
             const NAME: &'static str = "slug_not_in";
         }
-        impl cynic::schema::HasInputField<slug_not_in, Option<Vec<super::super::String>>>
-            for super::super::CommitmentWhereInput
-        {
-        }
         pub struct slug_lt;
-        impl cynic::schema::Field for slug_lt {
+        impl cynic::schema::HasInputField<slug_lt> for super::super::CommitmentWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "slug_lt";
         }
-        impl cynic::schema::HasInputField<slug_lt, Option<super::super::String>>
-            for super::super::CommitmentWhereInput
-        {
-        }
         pub struct slug_lte;
-        impl cynic::schema::Field for slug_lte {
+        impl cynic::schema::HasInputField<slug_lte> for super::super::CommitmentWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "slug_lte";
         }
-        impl cynic::schema::HasInputField<slug_lte, Option<super::super::String>>
-            for super::super::CommitmentWhereInput
-        {
-        }
         pub struct slug_gt;
-        impl cynic::schema::Field for slug_gt {
+        impl cynic::schema::HasInputField<slug_gt> for super::super::CommitmentWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "slug_gt";
         }
-        impl cynic::schema::HasInputField<slug_gt, Option<super::super::String>>
-            for super::super::CommitmentWhereInput
-        {
-        }
         pub struct slug_gte;
-        impl cynic::schema::Field for slug_gte {
+        impl cynic::schema::HasInputField<slug_gte> for super::super::CommitmentWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "slug_gte";
         }
-        impl cynic::schema::HasInputField<slug_gte, Option<super::super::String>>
-            for super::super::CommitmentWhereInput
-        {
-        }
         pub struct slug_contains;
-        impl cynic::schema::Field for slug_contains {
+        impl cynic::schema::HasInputField<slug_contains> for super::super::CommitmentWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "slug_contains";
         }
-        impl cynic::schema::HasInputField<slug_contains, Option<super::super::String>>
-            for super::super::CommitmentWhereInput
-        {
-        }
         pub struct slug_not_contains;
-        impl cynic::schema::Field for slug_not_contains {
+        impl cynic::schema::HasInputField<slug_not_contains> for super::super::CommitmentWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "slug_not_contains";
         }
-        impl cynic::schema::HasInputField<slug_not_contains, Option<super::super::String>>
-            for super::super::CommitmentWhereInput
-        {
-        }
         pub struct slug_starts_with;
-        impl cynic::schema::Field for slug_starts_with {
+        impl cynic::schema::HasInputField<slug_starts_with> for super::super::CommitmentWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "slug_starts_with";
         }
-        impl cynic::schema::HasInputField<slug_starts_with, Option<super::super::String>>
-            for super::super::CommitmentWhereInput
-        {
-        }
         pub struct slug_not_starts_with;
-        impl cynic::schema::Field for slug_not_starts_with {
+        impl cynic::schema::HasInputField<slug_not_starts_with> for super::super::CommitmentWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "slug_not_starts_with";
         }
-        impl cynic::schema::HasInputField<slug_not_starts_with, Option<super::super::String>>
-            for super::super::CommitmentWhereInput
-        {
-        }
         pub struct slug_ends_with;
-        impl cynic::schema::Field for slug_ends_with {
+        impl cynic::schema::HasInputField<slug_ends_with> for super::super::CommitmentWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "slug_ends_with";
         }
-        impl cynic::schema::HasInputField<slug_ends_with, Option<super::super::String>>
-            for super::super::CommitmentWhereInput
-        {
-        }
         pub struct slug_not_ends_with;
-        impl cynic::schema::Field for slug_not_ends_with {
+        impl cynic::schema::HasInputField<slug_not_ends_with> for super::super::CommitmentWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "slug_not_ends_with";
         }
-        impl cynic::schema::HasInputField<slug_not_ends_with, Option<super::super::String>>
-            for super::super::CommitmentWhereInput
-        {
-        }
         pub struct jobs_every;
-        impl cynic::schema::Field for jobs_every {
+        impl cynic::schema::HasInputField<jobs_every> for super::super::CommitmentWhereInput {
             type Type = Option<super::super::JobWhereInput>;
             const NAME: &'static str = "jobs_every";
         }
-        impl cynic::schema::HasInputField<jobs_every, Option<super::super::JobWhereInput>>
-            for super::super::CommitmentWhereInput
-        {
-        }
         pub struct jobs_some;
-        impl cynic::schema::Field for jobs_some {
+        impl cynic::schema::HasInputField<jobs_some> for super::super::CommitmentWhereInput {
             type Type = Option<super::super::JobWhereInput>;
             const NAME: &'static str = "jobs_some";
         }
-        impl cynic::schema::HasInputField<jobs_some, Option<super::super::JobWhereInput>>
-            for super::super::CommitmentWhereInput
-        {
-        }
         pub struct jobs_none;
-        impl cynic::schema::Field for jobs_none {
+        impl cynic::schema::HasInputField<jobs_none> for super::super::CommitmentWhereInput {
             type Type = Option<super::super::JobWhereInput>;
             const NAME: &'static str = "jobs_none";
         }
-        impl cynic::schema::HasInputField<jobs_none, Option<super::super::JobWhereInput>>
-            for super::super::CommitmentWhereInput
-        {
-        }
         pub struct createdAt;
-        impl cynic::schema::Field for createdAt {
+        impl cynic::schema::HasInputField<createdAt> for super::super::CommitmentWhereInput {
             type Type = Option<super::super::DateTime>;
             const NAME: &'static str = "createdAt";
         }
-        impl cynic::schema::HasInputField<createdAt, Option<super::super::DateTime>>
-            for super::super::CommitmentWhereInput
-        {
-        }
         pub struct createdAt_not;
-        impl cynic::schema::Field for createdAt_not {
+        impl cynic::schema::HasInputField<createdAt_not> for super::super::CommitmentWhereInput {
             type Type = Option<super::super::DateTime>;
             const NAME: &'static str = "createdAt_not";
         }
-        impl cynic::schema::HasInputField<createdAt_not, Option<super::super::DateTime>>
-            for super::super::CommitmentWhereInput
-        {
-        }
         pub struct createdAt_in;
-        impl cynic::schema::Field for createdAt_in {
+        impl cynic::schema::HasInputField<createdAt_in> for super::super::CommitmentWhereInput {
             type Type = Option<Vec<super::super::DateTime>>;
             const NAME: &'static str = "createdAt_in";
         }
-        impl cynic::schema::HasInputField<createdAt_in, Option<Vec<super::super::DateTime>>>
-            for super::super::CommitmentWhereInput
-        {
-        }
         pub struct createdAt_not_in;
-        impl cynic::schema::Field for createdAt_not_in {
+        impl cynic::schema::HasInputField<createdAt_not_in> for super::super::CommitmentWhereInput {
             type Type = Option<Vec<super::super::DateTime>>;
             const NAME: &'static str = "createdAt_not_in";
         }
-        impl cynic::schema::HasInputField<createdAt_not_in, Option<Vec<super::super::DateTime>>>
-            for super::super::CommitmentWhereInput
-        {
-        }
         pub struct createdAt_lt;
-        impl cynic::schema::Field for createdAt_lt {
+        impl cynic::schema::HasInputField<createdAt_lt> for super::super::CommitmentWhereInput {
             type Type = Option<super::super::DateTime>;
             const NAME: &'static str = "createdAt_lt";
         }
-        impl cynic::schema::HasInputField<createdAt_lt, Option<super::super::DateTime>>
-            for super::super::CommitmentWhereInput
-        {
-        }
         pub struct createdAt_lte;
-        impl cynic::schema::Field for createdAt_lte {
+        impl cynic::schema::HasInputField<createdAt_lte> for super::super::CommitmentWhereInput {
             type Type = Option<super::super::DateTime>;
             const NAME: &'static str = "createdAt_lte";
         }
-        impl cynic::schema::HasInputField<createdAt_lte, Option<super::super::DateTime>>
-            for super::super::CommitmentWhereInput
-        {
-        }
         pub struct createdAt_gt;
-        impl cynic::schema::Field for createdAt_gt {
+        impl cynic::schema::HasInputField<createdAt_gt> for super::super::CommitmentWhereInput {
             type Type = Option<super::super::DateTime>;
             const NAME: &'static str = "createdAt_gt";
         }
-        impl cynic::schema::HasInputField<createdAt_gt, Option<super::super::DateTime>>
-            for super::super::CommitmentWhereInput
-        {
-        }
         pub struct createdAt_gte;
-        impl cynic::schema::Field for createdAt_gte {
+        impl cynic::schema::HasInputField<createdAt_gte> for super::super::CommitmentWhereInput {
             type Type = Option<super::super::DateTime>;
             const NAME: &'static str = "createdAt_gte";
         }
-        impl cynic::schema::HasInputField<createdAt_gte, Option<super::super::DateTime>>
-            for super::super::CommitmentWhereInput
-        {
-        }
         pub struct updatedAt;
-        impl cynic::schema::Field for updatedAt {
+        impl cynic::schema::HasInputField<updatedAt> for super::super::CommitmentWhereInput {
             type Type = Option<super::super::DateTime>;
             const NAME: &'static str = "updatedAt";
         }
-        impl cynic::schema::HasInputField<updatedAt, Option<super::super::DateTime>>
-            for super::super::CommitmentWhereInput
-        {
-        }
         pub struct updatedAt_not;
-        impl cynic::schema::Field for updatedAt_not {
+        impl cynic::schema::HasInputField<updatedAt_not> for super::super::CommitmentWhereInput {
             type Type = Option<super::super::DateTime>;
             const NAME: &'static str = "updatedAt_not";
         }
-        impl cynic::schema::HasInputField<updatedAt_not, Option<super::super::DateTime>>
-            for super::super::CommitmentWhereInput
-        {
-        }
         pub struct updatedAt_in;
-        impl cynic::schema::Field for updatedAt_in {
+        impl cynic::schema::HasInputField<updatedAt_in> for super::super::CommitmentWhereInput {
             type Type = Option<Vec<super::super::DateTime>>;
             const NAME: &'static str = "updatedAt_in";
         }
-        impl cynic::schema::HasInputField<updatedAt_in, Option<Vec<super::super::DateTime>>>
-            for super::super::CommitmentWhereInput
-        {
-        }
         pub struct updatedAt_not_in;
-        impl cynic::schema::Field for updatedAt_not_in {
+        impl cynic::schema::HasInputField<updatedAt_not_in> for super::super::CommitmentWhereInput {
             type Type = Option<Vec<super::super::DateTime>>;
             const NAME: &'static str = "updatedAt_not_in";
         }
-        impl cynic::schema::HasInputField<updatedAt_not_in, Option<Vec<super::super::DateTime>>>
-            for super::super::CommitmentWhereInput
-        {
-        }
         pub struct updatedAt_lt;
-        impl cynic::schema::Field for updatedAt_lt {
+        impl cynic::schema::HasInputField<updatedAt_lt> for super::super::CommitmentWhereInput {
             type Type = Option<super::super::DateTime>;
             const NAME: &'static str = "updatedAt_lt";
         }
-        impl cynic::schema::HasInputField<updatedAt_lt, Option<super::super::DateTime>>
-            for super::super::CommitmentWhereInput
-        {
-        }
         pub struct updatedAt_lte;
-        impl cynic::schema::Field for updatedAt_lte {
+        impl cynic::schema::HasInputField<updatedAt_lte> for super::super::CommitmentWhereInput {
             type Type = Option<super::super::DateTime>;
             const NAME: &'static str = "updatedAt_lte";
         }
-        impl cynic::schema::HasInputField<updatedAt_lte, Option<super::super::DateTime>>
-            for super::super::CommitmentWhereInput
-        {
-        }
         pub struct updatedAt_gt;
-        impl cynic::schema::Field for updatedAt_gt {
+        impl cynic::schema::HasInputField<updatedAt_gt> for super::super::CommitmentWhereInput {
             type Type = Option<super::super::DateTime>;
             const NAME: &'static str = "updatedAt_gt";
         }
-        impl cynic::schema::HasInputField<updatedAt_gt, Option<super::super::DateTime>>
-            for super::super::CommitmentWhereInput
-        {
-        }
         pub struct updatedAt_gte;
-        impl cynic::schema::Field for updatedAt_gte {
+        impl cynic::schema::HasInputField<updatedAt_gte> for super::super::CommitmentWhereInput {
             type Type = Option<super::super::DateTime>;
             const NAME: &'static str = "updatedAt_gte";
         }
-        impl cynic::schema::HasInputField<updatedAt_gte, Option<super::super::DateTime>>
-            for super::super::CommitmentWhereInput
-        {
-        }
         pub struct AND;
-        impl cynic::schema::Field for AND {
+        impl cynic::schema::HasInputField<AND> for super::super::CommitmentWhereInput {
             type Type = Option<Vec<super::super::CommitmentWhereInput>>;
             const NAME: &'static str = "AND";
         }
-        impl cynic::schema::HasInputField<AND, Option<Vec<super::super::CommitmentWhereInput>>>
-            for super::super::CommitmentWhereInput
-        {
-        }
         pub struct OR;
-        impl cynic::schema::Field for OR {
+        impl cynic::schema::HasInputField<OR> for super::super::CommitmentWhereInput {
             type Type = Option<Vec<super::super::CommitmentWhereInput>>;
             const NAME: &'static str = "OR";
         }
-        impl cynic::schema::HasInputField<OR, Option<Vec<super::super::CommitmentWhereInput>>>
-            for super::super::CommitmentWhereInput
-        {
-        }
         pub struct NOT;
-        impl cynic::schema::Field for NOT {
+        impl cynic::schema::HasInputField<NOT> for super::super::CommitmentWhereInput {
             type Type = Option<Vec<super::super::CommitmentWhereInput>>;
             const NAME: &'static str = "NOT";
-        }
-        impl cynic::schema::HasInputField<NOT, Option<Vec<super::super::CommitmentWhereInput>>>
-            for super::super::CommitmentWhereInput
-        {
         }
     }
     pub mod Company {
         pub struct id;
-        impl cynic::schema::Field for id {
+        impl cynic::schema::HasField<id> for super::super::Company {
             type Type = super::super::ID;
             const NAME: &'static str = "id";
         }
-        impl cynic::schema::HasField<id> for super::super::Company {
-            type Type = super::super::ID;
-        }
         pub struct name;
-        impl cynic::schema::Field for name {
+        impl cynic::schema::HasField<name> for super::super::Company {
             type Type = super::super::String;
             const NAME: &'static str = "name";
         }
-        impl cynic::schema::HasField<name> for super::super::Company {
-            type Type = super::super::String;
-        }
         pub struct slug;
-        impl cynic::schema::Field for slug {
+        impl cynic::schema::HasField<slug> for super::super::Company {
             type Type = super::super::String;
             const NAME: &'static str = "slug";
         }
-        impl cynic::schema::HasField<slug> for super::super::Company {
-            type Type = super::super::String;
-        }
         pub struct websiteUrl;
-        impl cynic::schema::Field for websiteUrl {
+        impl cynic::schema::HasField<websiteUrl> for super::super::Company {
             type Type = super::super::String;
             const NAME: &'static str = "websiteUrl";
         }
-        impl cynic::schema::HasField<websiteUrl> for super::super::Company {
-            type Type = super::super::String;
-        }
         pub struct logoUrl;
-        impl cynic::schema::Field for logoUrl {
+        impl cynic::schema::HasField<logoUrl> for super::super::Company {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "logoUrl";
         }
-        impl cynic::schema::HasField<logoUrl> for super::super::Company {
-            type Type = Option<super::super::String>;
-        }
         pub struct jobs;
-        impl cynic::schema::Field for jobs {
-            type Type = Option<Vec<super::super::Job>>;
-            const NAME: &'static str = "jobs";
-        }
         impl cynic::schema::HasField<jobs> for super::super::Company {
             type Type = Option<Vec<super::super::Job>>;
+            const NAME: &'static str = "jobs";
         }
         pub mod _jobs_arguments {
             pub struct r#where;
@@ -1670,1068 +1035,603 @@ pub mod __fields {
             }
         }
         pub struct twitter;
-        impl cynic::schema::Field for twitter {
+        impl cynic::schema::HasField<twitter> for super::super::Company {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "twitter";
         }
-        impl cynic::schema::HasField<twitter> for super::super::Company {
-            type Type = Option<super::super::String>;
-        }
         pub struct emailed;
-        impl cynic::schema::Field for emailed {
+        impl cynic::schema::HasField<emailed> for super::super::Company {
             type Type = Option<super::super::Boolean>;
             const NAME: &'static str = "emailed";
         }
-        impl cynic::schema::HasField<emailed> for super::super::Company {
-            type Type = Option<super::super::Boolean>;
-        }
         pub struct createdAt;
-        impl cynic::schema::Field for createdAt {
+        impl cynic::schema::HasField<createdAt> for super::super::Company {
             type Type = super::super::DateTime;
             const NAME: &'static str = "createdAt";
         }
-        impl cynic::schema::HasField<createdAt> for super::super::Company {
-            type Type = super::super::DateTime;
-        }
         pub struct updatedAt;
-        impl cynic::schema::Field for updatedAt {
+        impl cynic::schema::HasField<updatedAt> for super::super::Company {
             type Type = super::super::DateTime;
             const NAME: &'static str = "updatedAt";
         }
-        impl cynic::schema::HasField<updatedAt> for super::super::Company {
-            type Type = super::super::DateTime;
-        }
         pub struct __typename;
-        impl cynic::schema::Field for __typename {
-            type Type = super::super::String;
-            const NAME: &'static str = "__typename";
-        }
         impl cynic::schema::HasField<__typename> for super::super::Company {
             type Type = super::super::String;
+            const NAME: &'static str = "__typename";
         }
     }
     pub mod CompanyWhereInput {
         pub struct id;
-        impl cynic::schema::Field for id {
+        impl cynic::schema::HasInputField<id> for super::super::CompanyWhereInput {
             type Type = Option<super::super::ID>;
             const NAME: &'static str = "id";
         }
-        impl cynic::schema::HasInputField<id, Option<super::super::ID>>
-            for super::super::CompanyWhereInput
-        {
-        }
         pub struct id_not;
-        impl cynic::schema::Field for id_not {
+        impl cynic::schema::HasInputField<id_not> for super::super::CompanyWhereInput {
             type Type = Option<super::super::ID>;
             const NAME: &'static str = "id_not";
         }
-        impl cynic::schema::HasInputField<id_not, Option<super::super::ID>>
-            for super::super::CompanyWhereInput
-        {
-        }
         pub struct id_in;
-        impl cynic::schema::Field for id_in {
+        impl cynic::schema::HasInputField<id_in> for super::super::CompanyWhereInput {
             type Type = Option<Vec<super::super::ID>>;
             const NAME: &'static str = "id_in";
         }
-        impl cynic::schema::HasInputField<id_in, Option<Vec<super::super::ID>>>
-            for super::super::CompanyWhereInput
-        {
-        }
         pub struct id_not_in;
-        impl cynic::schema::Field for id_not_in {
+        impl cynic::schema::HasInputField<id_not_in> for super::super::CompanyWhereInput {
             type Type = Option<Vec<super::super::ID>>;
             const NAME: &'static str = "id_not_in";
         }
-        impl cynic::schema::HasInputField<id_not_in, Option<Vec<super::super::ID>>>
-            for super::super::CompanyWhereInput
-        {
-        }
         pub struct id_lt;
-        impl cynic::schema::Field for id_lt {
+        impl cynic::schema::HasInputField<id_lt> for super::super::CompanyWhereInput {
             type Type = Option<super::super::ID>;
             const NAME: &'static str = "id_lt";
         }
-        impl cynic::schema::HasInputField<id_lt, Option<super::super::ID>>
-            for super::super::CompanyWhereInput
-        {
-        }
         pub struct id_lte;
-        impl cynic::schema::Field for id_lte {
+        impl cynic::schema::HasInputField<id_lte> for super::super::CompanyWhereInput {
             type Type = Option<super::super::ID>;
             const NAME: &'static str = "id_lte";
         }
-        impl cynic::schema::HasInputField<id_lte, Option<super::super::ID>>
-            for super::super::CompanyWhereInput
-        {
-        }
         pub struct id_gt;
-        impl cynic::schema::Field for id_gt {
+        impl cynic::schema::HasInputField<id_gt> for super::super::CompanyWhereInput {
             type Type = Option<super::super::ID>;
             const NAME: &'static str = "id_gt";
         }
-        impl cynic::schema::HasInputField<id_gt, Option<super::super::ID>>
-            for super::super::CompanyWhereInput
-        {
-        }
         pub struct id_gte;
-        impl cynic::schema::Field for id_gte {
+        impl cynic::schema::HasInputField<id_gte> for super::super::CompanyWhereInput {
             type Type = Option<super::super::ID>;
             const NAME: &'static str = "id_gte";
         }
-        impl cynic::schema::HasInputField<id_gte, Option<super::super::ID>>
-            for super::super::CompanyWhereInput
-        {
-        }
         pub struct id_contains;
-        impl cynic::schema::Field for id_contains {
+        impl cynic::schema::HasInputField<id_contains> for super::super::CompanyWhereInput {
             type Type = Option<super::super::ID>;
             const NAME: &'static str = "id_contains";
         }
-        impl cynic::schema::HasInputField<id_contains, Option<super::super::ID>>
-            for super::super::CompanyWhereInput
-        {
-        }
         pub struct id_not_contains;
-        impl cynic::schema::Field for id_not_contains {
+        impl cynic::schema::HasInputField<id_not_contains> for super::super::CompanyWhereInput {
             type Type = Option<super::super::ID>;
             const NAME: &'static str = "id_not_contains";
         }
-        impl cynic::schema::HasInputField<id_not_contains, Option<super::super::ID>>
-            for super::super::CompanyWhereInput
-        {
-        }
         pub struct id_starts_with;
-        impl cynic::schema::Field for id_starts_with {
+        impl cynic::schema::HasInputField<id_starts_with> for super::super::CompanyWhereInput {
             type Type = Option<super::super::ID>;
             const NAME: &'static str = "id_starts_with";
         }
-        impl cynic::schema::HasInputField<id_starts_with, Option<super::super::ID>>
-            for super::super::CompanyWhereInput
-        {
-        }
         pub struct id_not_starts_with;
-        impl cynic::schema::Field for id_not_starts_with {
+        impl cynic::schema::HasInputField<id_not_starts_with> for super::super::CompanyWhereInput {
             type Type = Option<super::super::ID>;
             const NAME: &'static str = "id_not_starts_with";
         }
-        impl cynic::schema::HasInputField<id_not_starts_with, Option<super::super::ID>>
-            for super::super::CompanyWhereInput
-        {
-        }
         pub struct id_ends_with;
-        impl cynic::schema::Field for id_ends_with {
+        impl cynic::schema::HasInputField<id_ends_with> for super::super::CompanyWhereInput {
             type Type = Option<super::super::ID>;
             const NAME: &'static str = "id_ends_with";
         }
-        impl cynic::schema::HasInputField<id_ends_with, Option<super::super::ID>>
-            for super::super::CompanyWhereInput
-        {
-        }
         pub struct id_not_ends_with;
-        impl cynic::schema::Field for id_not_ends_with {
+        impl cynic::schema::HasInputField<id_not_ends_with> for super::super::CompanyWhereInput {
             type Type = Option<super::super::ID>;
             const NAME: &'static str = "id_not_ends_with";
         }
-        impl cynic::schema::HasInputField<id_not_ends_with, Option<super::super::ID>>
-            for super::super::CompanyWhereInput
-        {
-        }
         pub struct name;
-        impl cynic::schema::Field for name {
+        impl cynic::schema::HasInputField<name> for super::super::CompanyWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "name";
         }
-        impl cynic::schema::HasInputField<name, Option<super::super::String>>
-            for super::super::CompanyWhereInput
-        {
-        }
         pub struct name_not;
-        impl cynic::schema::Field for name_not {
+        impl cynic::schema::HasInputField<name_not> for super::super::CompanyWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "name_not";
         }
-        impl cynic::schema::HasInputField<name_not, Option<super::super::String>>
-            for super::super::CompanyWhereInput
-        {
-        }
         pub struct name_in;
-        impl cynic::schema::Field for name_in {
+        impl cynic::schema::HasInputField<name_in> for super::super::CompanyWhereInput {
             type Type = Option<Vec<super::super::String>>;
             const NAME: &'static str = "name_in";
         }
-        impl cynic::schema::HasInputField<name_in, Option<Vec<super::super::String>>>
-            for super::super::CompanyWhereInput
-        {
-        }
         pub struct name_not_in;
-        impl cynic::schema::Field for name_not_in {
+        impl cynic::schema::HasInputField<name_not_in> for super::super::CompanyWhereInput {
             type Type = Option<Vec<super::super::String>>;
             const NAME: &'static str = "name_not_in";
         }
-        impl cynic::schema::HasInputField<name_not_in, Option<Vec<super::super::String>>>
-            for super::super::CompanyWhereInput
-        {
-        }
         pub struct name_lt;
-        impl cynic::schema::Field for name_lt {
+        impl cynic::schema::HasInputField<name_lt> for super::super::CompanyWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "name_lt";
         }
-        impl cynic::schema::HasInputField<name_lt, Option<super::super::String>>
-            for super::super::CompanyWhereInput
-        {
-        }
         pub struct name_lte;
-        impl cynic::schema::Field for name_lte {
+        impl cynic::schema::HasInputField<name_lte> for super::super::CompanyWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "name_lte";
         }
-        impl cynic::schema::HasInputField<name_lte, Option<super::super::String>>
-            for super::super::CompanyWhereInput
-        {
-        }
         pub struct name_gt;
-        impl cynic::schema::Field for name_gt {
+        impl cynic::schema::HasInputField<name_gt> for super::super::CompanyWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "name_gt";
         }
-        impl cynic::schema::HasInputField<name_gt, Option<super::super::String>>
-            for super::super::CompanyWhereInput
-        {
-        }
         pub struct name_gte;
-        impl cynic::schema::Field for name_gte {
+        impl cynic::schema::HasInputField<name_gte> for super::super::CompanyWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "name_gte";
         }
-        impl cynic::schema::HasInputField<name_gte, Option<super::super::String>>
-            for super::super::CompanyWhereInput
-        {
-        }
         pub struct name_contains;
-        impl cynic::schema::Field for name_contains {
+        impl cynic::schema::HasInputField<name_contains> for super::super::CompanyWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "name_contains";
         }
-        impl cynic::schema::HasInputField<name_contains, Option<super::super::String>>
-            for super::super::CompanyWhereInput
-        {
-        }
         pub struct name_not_contains;
-        impl cynic::schema::Field for name_not_contains {
+        impl cynic::schema::HasInputField<name_not_contains> for super::super::CompanyWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "name_not_contains";
         }
-        impl cynic::schema::HasInputField<name_not_contains, Option<super::super::String>>
-            for super::super::CompanyWhereInput
-        {
-        }
         pub struct name_starts_with;
-        impl cynic::schema::Field for name_starts_with {
+        impl cynic::schema::HasInputField<name_starts_with> for super::super::CompanyWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "name_starts_with";
         }
-        impl cynic::schema::HasInputField<name_starts_with, Option<super::super::String>>
-            for super::super::CompanyWhereInput
-        {
-        }
         pub struct name_not_starts_with;
-        impl cynic::schema::Field for name_not_starts_with {
+        impl cynic::schema::HasInputField<name_not_starts_with> for super::super::CompanyWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "name_not_starts_with";
         }
-        impl cynic::schema::HasInputField<name_not_starts_with, Option<super::super::String>>
-            for super::super::CompanyWhereInput
-        {
-        }
         pub struct name_ends_with;
-        impl cynic::schema::Field for name_ends_with {
+        impl cynic::schema::HasInputField<name_ends_with> for super::super::CompanyWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "name_ends_with";
         }
-        impl cynic::schema::HasInputField<name_ends_with, Option<super::super::String>>
-            for super::super::CompanyWhereInput
-        {
-        }
         pub struct name_not_ends_with;
-        impl cynic::schema::Field for name_not_ends_with {
+        impl cynic::schema::HasInputField<name_not_ends_with> for super::super::CompanyWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "name_not_ends_with";
         }
-        impl cynic::schema::HasInputField<name_not_ends_with, Option<super::super::String>>
-            for super::super::CompanyWhereInput
-        {
-        }
         pub struct slug;
-        impl cynic::schema::Field for slug {
+        impl cynic::schema::HasInputField<slug> for super::super::CompanyWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "slug";
         }
-        impl cynic::schema::HasInputField<slug, Option<super::super::String>>
-            for super::super::CompanyWhereInput
-        {
-        }
         pub struct slug_not;
-        impl cynic::schema::Field for slug_not {
+        impl cynic::schema::HasInputField<slug_not> for super::super::CompanyWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "slug_not";
         }
-        impl cynic::schema::HasInputField<slug_not, Option<super::super::String>>
-            for super::super::CompanyWhereInput
-        {
-        }
         pub struct slug_in;
-        impl cynic::schema::Field for slug_in {
+        impl cynic::schema::HasInputField<slug_in> for super::super::CompanyWhereInput {
             type Type = Option<Vec<super::super::String>>;
             const NAME: &'static str = "slug_in";
         }
-        impl cynic::schema::HasInputField<slug_in, Option<Vec<super::super::String>>>
-            for super::super::CompanyWhereInput
-        {
-        }
         pub struct slug_not_in;
-        impl cynic::schema::Field for slug_not_in {
+        impl cynic::schema::HasInputField<slug_not_in> for super::super::CompanyWhereInput {
             type Type = Option<Vec<super::super::String>>;
             const NAME: &'static str = "slug_not_in";
         }
-        impl cynic::schema::HasInputField<slug_not_in, Option<Vec<super::super::String>>>
-            for super::super::CompanyWhereInput
-        {
-        }
         pub struct slug_lt;
-        impl cynic::schema::Field for slug_lt {
+        impl cynic::schema::HasInputField<slug_lt> for super::super::CompanyWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "slug_lt";
         }
-        impl cynic::schema::HasInputField<slug_lt, Option<super::super::String>>
-            for super::super::CompanyWhereInput
-        {
-        }
         pub struct slug_lte;
-        impl cynic::schema::Field for slug_lte {
+        impl cynic::schema::HasInputField<slug_lte> for super::super::CompanyWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "slug_lte";
         }
-        impl cynic::schema::HasInputField<slug_lte, Option<super::super::String>>
-            for super::super::CompanyWhereInput
-        {
-        }
         pub struct slug_gt;
-        impl cynic::schema::Field for slug_gt {
+        impl cynic::schema::HasInputField<slug_gt> for super::super::CompanyWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "slug_gt";
         }
-        impl cynic::schema::HasInputField<slug_gt, Option<super::super::String>>
-            for super::super::CompanyWhereInput
-        {
-        }
         pub struct slug_gte;
-        impl cynic::schema::Field for slug_gte {
+        impl cynic::schema::HasInputField<slug_gte> for super::super::CompanyWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "slug_gte";
         }
-        impl cynic::schema::HasInputField<slug_gte, Option<super::super::String>>
-            for super::super::CompanyWhereInput
-        {
-        }
         pub struct slug_contains;
-        impl cynic::schema::Field for slug_contains {
+        impl cynic::schema::HasInputField<slug_contains> for super::super::CompanyWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "slug_contains";
         }
-        impl cynic::schema::HasInputField<slug_contains, Option<super::super::String>>
-            for super::super::CompanyWhereInput
-        {
-        }
         pub struct slug_not_contains;
-        impl cynic::schema::Field for slug_not_contains {
+        impl cynic::schema::HasInputField<slug_not_contains> for super::super::CompanyWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "slug_not_contains";
         }
-        impl cynic::schema::HasInputField<slug_not_contains, Option<super::super::String>>
-            for super::super::CompanyWhereInput
-        {
-        }
         pub struct slug_starts_with;
-        impl cynic::schema::Field for slug_starts_with {
+        impl cynic::schema::HasInputField<slug_starts_with> for super::super::CompanyWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "slug_starts_with";
         }
-        impl cynic::schema::HasInputField<slug_starts_with, Option<super::super::String>>
-            for super::super::CompanyWhereInput
-        {
-        }
         pub struct slug_not_starts_with;
-        impl cynic::schema::Field for slug_not_starts_with {
+        impl cynic::schema::HasInputField<slug_not_starts_with> for super::super::CompanyWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "slug_not_starts_with";
         }
-        impl cynic::schema::HasInputField<slug_not_starts_with, Option<super::super::String>>
-            for super::super::CompanyWhereInput
-        {
-        }
         pub struct slug_ends_with;
-        impl cynic::schema::Field for slug_ends_with {
+        impl cynic::schema::HasInputField<slug_ends_with> for super::super::CompanyWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "slug_ends_with";
         }
-        impl cynic::schema::HasInputField<slug_ends_with, Option<super::super::String>>
-            for super::super::CompanyWhereInput
-        {
-        }
         pub struct slug_not_ends_with;
-        impl cynic::schema::Field for slug_not_ends_with {
+        impl cynic::schema::HasInputField<slug_not_ends_with> for super::super::CompanyWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "slug_not_ends_with";
         }
-        impl cynic::schema::HasInputField<slug_not_ends_with, Option<super::super::String>>
-            for super::super::CompanyWhereInput
-        {
-        }
         pub struct websiteUrl;
-        impl cynic::schema::Field for websiteUrl {
+        impl cynic::schema::HasInputField<websiteUrl> for super::super::CompanyWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "websiteUrl";
         }
-        impl cynic::schema::HasInputField<websiteUrl, Option<super::super::String>>
-            for super::super::CompanyWhereInput
-        {
-        }
         pub struct websiteUrl_not;
-        impl cynic::schema::Field for websiteUrl_not {
+        impl cynic::schema::HasInputField<websiteUrl_not> for super::super::CompanyWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "websiteUrl_not";
         }
-        impl cynic::schema::HasInputField<websiteUrl_not, Option<super::super::String>>
-            for super::super::CompanyWhereInput
-        {
-        }
         pub struct websiteUrl_in;
-        impl cynic::schema::Field for websiteUrl_in {
+        impl cynic::schema::HasInputField<websiteUrl_in> for super::super::CompanyWhereInput {
             type Type = Option<Vec<super::super::String>>;
             const NAME: &'static str = "websiteUrl_in";
         }
-        impl cynic::schema::HasInputField<websiteUrl_in, Option<Vec<super::super::String>>>
-            for super::super::CompanyWhereInput
-        {
-        }
         pub struct websiteUrl_not_in;
-        impl cynic::schema::Field for websiteUrl_not_in {
+        impl cynic::schema::HasInputField<websiteUrl_not_in> for super::super::CompanyWhereInput {
             type Type = Option<Vec<super::super::String>>;
             const NAME: &'static str = "websiteUrl_not_in";
         }
-        impl cynic::schema::HasInputField<websiteUrl_not_in, Option<Vec<super::super::String>>>
-            for super::super::CompanyWhereInput
-        {
-        }
         pub struct websiteUrl_lt;
-        impl cynic::schema::Field for websiteUrl_lt {
+        impl cynic::schema::HasInputField<websiteUrl_lt> for super::super::CompanyWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "websiteUrl_lt";
         }
-        impl cynic::schema::HasInputField<websiteUrl_lt, Option<super::super::String>>
-            for super::super::CompanyWhereInput
-        {
-        }
         pub struct websiteUrl_lte;
-        impl cynic::schema::Field for websiteUrl_lte {
+        impl cynic::schema::HasInputField<websiteUrl_lte> for super::super::CompanyWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "websiteUrl_lte";
         }
-        impl cynic::schema::HasInputField<websiteUrl_lte, Option<super::super::String>>
-            for super::super::CompanyWhereInput
-        {
-        }
         pub struct websiteUrl_gt;
-        impl cynic::schema::Field for websiteUrl_gt {
+        impl cynic::schema::HasInputField<websiteUrl_gt> for super::super::CompanyWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "websiteUrl_gt";
         }
-        impl cynic::schema::HasInputField<websiteUrl_gt, Option<super::super::String>>
-            for super::super::CompanyWhereInput
-        {
-        }
         pub struct websiteUrl_gte;
-        impl cynic::schema::Field for websiteUrl_gte {
+        impl cynic::schema::HasInputField<websiteUrl_gte> for super::super::CompanyWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "websiteUrl_gte";
         }
-        impl cynic::schema::HasInputField<websiteUrl_gte, Option<super::super::String>>
-            for super::super::CompanyWhereInput
-        {
-        }
         pub struct websiteUrl_contains;
-        impl cynic::schema::Field for websiteUrl_contains {
+        impl cynic::schema::HasInputField<websiteUrl_contains> for super::super::CompanyWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "websiteUrl_contains";
         }
-        impl cynic::schema::HasInputField<websiteUrl_contains, Option<super::super::String>>
-            for super::super::CompanyWhereInput
-        {
-        }
         pub struct websiteUrl_not_contains;
-        impl cynic::schema::Field for websiteUrl_not_contains {
+        impl cynic::schema::HasInputField<websiteUrl_not_contains> for super::super::CompanyWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "websiteUrl_not_contains";
         }
-        impl cynic::schema::HasInputField<websiteUrl_not_contains, Option<super::super::String>>
-            for super::super::CompanyWhereInput
-        {
-        }
         pub struct websiteUrl_starts_with;
-        impl cynic::schema::Field for websiteUrl_starts_with {
+        impl cynic::schema::HasInputField<websiteUrl_starts_with> for super::super::CompanyWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "websiteUrl_starts_with";
         }
-        impl cynic::schema::HasInputField<websiteUrl_starts_with, Option<super::super::String>>
-            for super::super::CompanyWhereInput
-        {
-        }
         pub struct websiteUrl_not_starts_with;
-        impl cynic::schema::Field for websiteUrl_not_starts_with {
+        impl cynic::schema::HasInputField<websiteUrl_not_starts_with> for super::super::CompanyWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "websiteUrl_not_starts_with";
         }
-        impl cynic::schema::HasInputField<websiteUrl_not_starts_with, Option<super::super::String>>
-            for super::super::CompanyWhereInput
-        {
-        }
         pub struct websiteUrl_ends_with;
-        impl cynic::schema::Field for websiteUrl_ends_with {
+        impl cynic::schema::HasInputField<websiteUrl_ends_with> for super::super::CompanyWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "websiteUrl_ends_with";
         }
-        impl cynic::schema::HasInputField<websiteUrl_ends_with, Option<super::super::String>>
-            for super::super::CompanyWhereInput
-        {
-        }
         pub struct websiteUrl_not_ends_with;
-        impl cynic::schema::Field for websiteUrl_not_ends_with {
+        impl cynic::schema::HasInputField<websiteUrl_not_ends_with> for super::super::CompanyWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "websiteUrl_not_ends_with";
         }
-        impl cynic::schema::HasInputField<websiteUrl_not_ends_with, Option<super::super::String>>
-            for super::super::CompanyWhereInput
-        {
-        }
         pub struct logoUrl;
-        impl cynic::schema::Field for logoUrl {
+        impl cynic::schema::HasInputField<logoUrl> for super::super::CompanyWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "logoUrl";
         }
-        impl cynic::schema::HasInputField<logoUrl, Option<super::super::String>>
-            for super::super::CompanyWhereInput
-        {
-        }
         pub struct logoUrl_not;
-        impl cynic::schema::Field for logoUrl_not {
+        impl cynic::schema::HasInputField<logoUrl_not> for super::super::CompanyWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "logoUrl_not";
         }
-        impl cynic::schema::HasInputField<logoUrl_not, Option<super::super::String>>
-            for super::super::CompanyWhereInput
-        {
-        }
         pub struct logoUrl_in;
-        impl cynic::schema::Field for logoUrl_in {
+        impl cynic::schema::HasInputField<logoUrl_in> for super::super::CompanyWhereInput {
             type Type = Option<Vec<super::super::String>>;
             const NAME: &'static str = "logoUrl_in";
         }
-        impl cynic::schema::HasInputField<logoUrl_in, Option<Vec<super::super::String>>>
-            for super::super::CompanyWhereInput
-        {
-        }
         pub struct logoUrl_not_in;
-        impl cynic::schema::Field for logoUrl_not_in {
+        impl cynic::schema::HasInputField<logoUrl_not_in> for super::super::CompanyWhereInput {
             type Type = Option<Vec<super::super::String>>;
             const NAME: &'static str = "logoUrl_not_in";
         }
-        impl cynic::schema::HasInputField<logoUrl_not_in, Option<Vec<super::super::String>>>
-            for super::super::CompanyWhereInput
-        {
-        }
         pub struct logoUrl_lt;
-        impl cynic::schema::Field for logoUrl_lt {
+        impl cynic::schema::HasInputField<logoUrl_lt> for super::super::CompanyWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "logoUrl_lt";
         }
-        impl cynic::schema::HasInputField<logoUrl_lt, Option<super::super::String>>
-            for super::super::CompanyWhereInput
-        {
-        }
         pub struct logoUrl_lte;
-        impl cynic::schema::Field for logoUrl_lte {
+        impl cynic::schema::HasInputField<logoUrl_lte> for super::super::CompanyWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "logoUrl_lte";
         }
-        impl cynic::schema::HasInputField<logoUrl_lte, Option<super::super::String>>
-            for super::super::CompanyWhereInput
-        {
-        }
         pub struct logoUrl_gt;
-        impl cynic::schema::Field for logoUrl_gt {
+        impl cynic::schema::HasInputField<logoUrl_gt> for super::super::CompanyWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "logoUrl_gt";
         }
-        impl cynic::schema::HasInputField<logoUrl_gt, Option<super::super::String>>
-            for super::super::CompanyWhereInput
-        {
-        }
         pub struct logoUrl_gte;
-        impl cynic::schema::Field for logoUrl_gte {
+        impl cynic::schema::HasInputField<logoUrl_gte> for super::super::CompanyWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "logoUrl_gte";
         }
-        impl cynic::schema::HasInputField<logoUrl_gte, Option<super::super::String>>
-            for super::super::CompanyWhereInput
-        {
-        }
         pub struct logoUrl_contains;
-        impl cynic::schema::Field for logoUrl_contains {
+        impl cynic::schema::HasInputField<logoUrl_contains> for super::super::CompanyWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "logoUrl_contains";
         }
-        impl cynic::schema::HasInputField<logoUrl_contains, Option<super::super::String>>
-            for super::super::CompanyWhereInput
-        {
-        }
         pub struct logoUrl_not_contains;
-        impl cynic::schema::Field for logoUrl_not_contains {
+        impl cynic::schema::HasInputField<logoUrl_not_contains> for super::super::CompanyWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "logoUrl_not_contains";
         }
-        impl cynic::schema::HasInputField<logoUrl_not_contains, Option<super::super::String>>
-            for super::super::CompanyWhereInput
-        {
-        }
         pub struct logoUrl_starts_with;
-        impl cynic::schema::Field for logoUrl_starts_with {
+        impl cynic::schema::HasInputField<logoUrl_starts_with> for super::super::CompanyWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "logoUrl_starts_with";
         }
-        impl cynic::schema::HasInputField<logoUrl_starts_with, Option<super::super::String>>
-            for super::super::CompanyWhereInput
-        {
-        }
         pub struct logoUrl_not_starts_with;
-        impl cynic::schema::Field for logoUrl_not_starts_with {
+        impl cynic::schema::HasInputField<logoUrl_not_starts_with> for super::super::CompanyWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "logoUrl_not_starts_with";
         }
-        impl cynic::schema::HasInputField<logoUrl_not_starts_with, Option<super::super::String>>
-            for super::super::CompanyWhereInput
-        {
-        }
         pub struct logoUrl_ends_with;
-        impl cynic::schema::Field for logoUrl_ends_with {
+        impl cynic::schema::HasInputField<logoUrl_ends_with> for super::super::CompanyWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "logoUrl_ends_with";
         }
-        impl cynic::schema::HasInputField<logoUrl_ends_with, Option<super::super::String>>
-            for super::super::CompanyWhereInput
-        {
-        }
         pub struct logoUrl_not_ends_with;
-        impl cynic::schema::Field for logoUrl_not_ends_with {
+        impl cynic::schema::HasInputField<logoUrl_not_ends_with> for super::super::CompanyWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "logoUrl_not_ends_with";
         }
-        impl cynic::schema::HasInputField<logoUrl_not_ends_with, Option<super::super::String>>
-            for super::super::CompanyWhereInput
-        {
-        }
         pub struct jobs_every;
-        impl cynic::schema::Field for jobs_every {
+        impl cynic::schema::HasInputField<jobs_every> for super::super::CompanyWhereInput {
             type Type = Option<super::super::JobWhereInput>;
             const NAME: &'static str = "jobs_every";
         }
-        impl cynic::schema::HasInputField<jobs_every, Option<super::super::JobWhereInput>>
-            for super::super::CompanyWhereInput
-        {
-        }
         pub struct jobs_some;
-        impl cynic::schema::Field for jobs_some {
+        impl cynic::schema::HasInputField<jobs_some> for super::super::CompanyWhereInput {
             type Type = Option<super::super::JobWhereInput>;
             const NAME: &'static str = "jobs_some";
         }
-        impl cynic::schema::HasInputField<jobs_some, Option<super::super::JobWhereInput>>
-            for super::super::CompanyWhereInput
-        {
-        }
         pub struct jobs_none;
-        impl cynic::schema::Field for jobs_none {
+        impl cynic::schema::HasInputField<jobs_none> for super::super::CompanyWhereInput {
             type Type = Option<super::super::JobWhereInput>;
             const NAME: &'static str = "jobs_none";
         }
-        impl cynic::schema::HasInputField<jobs_none, Option<super::super::JobWhereInput>>
-            for super::super::CompanyWhereInput
-        {
-        }
         pub struct twitter;
-        impl cynic::schema::Field for twitter {
+        impl cynic::schema::HasInputField<twitter> for super::super::CompanyWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "twitter";
         }
-        impl cynic::schema::HasInputField<twitter, Option<super::super::String>>
-            for super::super::CompanyWhereInput
-        {
-        }
         pub struct twitter_not;
-        impl cynic::schema::Field for twitter_not {
+        impl cynic::schema::HasInputField<twitter_not> for super::super::CompanyWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "twitter_not";
         }
-        impl cynic::schema::HasInputField<twitter_not, Option<super::super::String>>
-            for super::super::CompanyWhereInput
-        {
-        }
         pub struct twitter_in;
-        impl cynic::schema::Field for twitter_in {
+        impl cynic::schema::HasInputField<twitter_in> for super::super::CompanyWhereInput {
             type Type = Option<Vec<super::super::String>>;
             const NAME: &'static str = "twitter_in";
         }
-        impl cynic::schema::HasInputField<twitter_in, Option<Vec<super::super::String>>>
-            for super::super::CompanyWhereInput
-        {
-        }
         pub struct twitter_not_in;
-        impl cynic::schema::Field for twitter_not_in {
+        impl cynic::schema::HasInputField<twitter_not_in> for super::super::CompanyWhereInput {
             type Type = Option<Vec<super::super::String>>;
             const NAME: &'static str = "twitter_not_in";
         }
-        impl cynic::schema::HasInputField<twitter_not_in, Option<Vec<super::super::String>>>
-            for super::super::CompanyWhereInput
-        {
-        }
         pub struct twitter_lt;
-        impl cynic::schema::Field for twitter_lt {
+        impl cynic::schema::HasInputField<twitter_lt> for super::super::CompanyWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "twitter_lt";
         }
-        impl cynic::schema::HasInputField<twitter_lt, Option<super::super::String>>
-            for super::super::CompanyWhereInput
-        {
-        }
         pub struct twitter_lte;
-        impl cynic::schema::Field for twitter_lte {
+        impl cynic::schema::HasInputField<twitter_lte> for super::super::CompanyWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "twitter_lte";
         }
-        impl cynic::schema::HasInputField<twitter_lte, Option<super::super::String>>
-            for super::super::CompanyWhereInput
-        {
-        }
         pub struct twitter_gt;
-        impl cynic::schema::Field for twitter_gt {
+        impl cynic::schema::HasInputField<twitter_gt> for super::super::CompanyWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "twitter_gt";
         }
-        impl cynic::schema::HasInputField<twitter_gt, Option<super::super::String>>
-            for super::super::CompanyWhereInput
-        {
-        }
         pub struct twitter_gte;
-        impl cynic::schema::Field for twitter_gte {
+        impl cynic::schema::HasInputField<twitter_gte> for super::super::CompanyWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "twitter_gte";
         }
-        impl cynic::schema::HasInputField<twitter_gte, Option<super::super::String>>
-            for super::super::CompanyWhereInput
-        {
-        }
         pub struct twitter_contains;
-        impl cynic::schema::Field for twitter_contains {
+        impl cynic::schema::HasInputField<twitter_contains> for super::super::CompanyWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "twitter_contains";
         }
-        impl cynic::schema::HasInputField<twitter_contains, Option<super::super::String>>
-            for super::super::CompanyWhereInput
-        {
-        }
         pub struct twitter_not_contains;
-        impl cynic::schema::Field for twitter_not_contains {
+        impl cynic::schema::HasInputField<twitter_not_contains> for super::super::CompanyWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "twitter_not_contains";
         }
-        impl cynic::schema::HasInputField<twitter_not_contains, Option<super::super::String>>
-            for super::super::CompanyWhereInput
-        {
-        }
         pub struct twitter_starts_with;
-        impl cynic::schema::Field for twitter_starts_with {
+        impl cynic::schema::HasInputField<twitter_starts_with> for super::super::CompanyWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "twitter_starts_with";
         }
-        impl cynic::schema::HasInputField<twitter_starts_with, Option<super::super::String>>
-            for super::super::CompanyWhereInput
-        {
-        }
         pub struct twitter_not_starts_with;
-        impl cynic::schema::Field for twitter_not_starts_with {
+        impl cynic::schema::HasInputField<twitter_not_starts_with> for super::super::CompanyWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "twitter_not_starts_with";
         }
-        impl cynic::schema::HasInputField<twitter_not_starts_with, Option<super::super::String>>
-            for super::super::CompanyWhereInput
-        {
-        }
         pub struct twitter_ends_with;
-        impl cynic::schema::Field for twitter_ends_with {
+        impl cynic::schema::HasInputField<twitter_ends_with> for super::super::CompanyWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "twitter_ends_with";
         }
-        impl cynic::schema::HasInputField<twitter_ends_with, Option<super::super::String>>
-            for super::super::CompanyWhereInput
-        {
-        }
         pub struct twitter_not_ends_with;
-        impl cynic::schema::Field for twitter_not_ends_with {
+        impl cynic::schema::HasInputField<twitter_not_ends_with> for super::super::CompanyWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "twitter_not_ends_with";
         }
-        impl cynic::schema::HasInputField<twitter_not_ends_with, Option<super::super::String>>
-            for super::super::CompanyWhereInput
-        {
-        }
         pub struct emailed;
-        impl cynic::schema::Field for emailed {
+        impl cynic::schema::HasInputField<emailed> for super::super::CompanyWhereInput {
             type Type = Option<super::super::Boolean>;
             const NAME: &'static str = "emailed";
         }
-        impl cynic::schema::HasInputField<emailed, Option<super::super::Boolean>>
-            for super::super::CompanyWhereInput
-        {
-        }
         pub struct emailed_not;
-        impl cynic::schema::Field for emailed_not {
+        impl cynic::schema::HasInputField<emailed_not> for super::super::CompanyWhereInput {
             type Type = Option<super::super::Boolean>;
             const NAME: &'static str = "emailed_not";
         }
-        impl cynic::schema::HasInputField<emailed_not, Option<super::super::Boolean>>
-            for super::super::CompanyWhereInput
-        {
-        }
         pub struct createdAt;
-        impl cynic::schema::Field for createdAt {
+        impl cynic::schema::HasInputField<createdAt> for super::super::CompanyWhereInput {
             type Type = Option<super::super::DateTime>;
             const NAME: &'static str = "createdAt";
         }
-        impl cynic::schema::HasInputField<createdAt, Option<super::super::DateTime>>
-            for super::super::CompanyWhereInput
-        {
-        }
         pub struct createdAt_not;
-        impl cynic::schema::Field for createdAt_not {
+        impl cynic::schema::HasInputField<createdAt_not> for super::super::CompanyWhereInput {
             type Type = Option<super::super::DateTime>;
             const NAME: &'static str = "createdAt_not";
         }
-        impl cynic::schema::HasInputField<createdAt_not, Option<super::super::DateTime>>
-            for super::super::CompanyWhereInput
-        {
-        }
         pub struct createdAt_in;
-        impl cynic::schema::Field for createdAt_in {
+        impl cynic::schema::HasInputField<createdAt_in> for super::super::CompanyWhereInput {
             type Type = Option<Vec<super::super::DateTime>>;
             const NAME: &'static str = "createdAt_in";
         }
-        impl cynic::schema::HasInputField<createdAt_in, Option<Vec<super::super::DateTime>>>
-            for super::super::CompanyWhereInput
-        {
-        }
         pub struct createdAt_not_in;
-        impl cynic::schema::Field for createdAt_not_in {
+        impl cynic::schema::HasInputField<createdAt_not_in> for super::super::CompanyWhereInput {
             type Type = Option<Vec<super::super::DateTime>>;
             const NAME: &'static str = "createdAt_not_in";
         }
-        impl cynic::schema::HasInputField<createdAt_not_in, Option<Vec<super::super::DateTime>>>
-            for super::super::CompanyWhereInput
-        {
-        }
         pub struct createdAt_lt;
-        impl cynic::schema::Field for createdAt_lt {
+        impl cynic::schema::HasInputField<createdAt_lt> for super::super::CompanyWhereInput {
             type Type = Option<super::super::DateTime>;
             const NAME: &'static str = "createdAt_lt";
         }
-        impl cynic::schema::HasInputField<createdAt_lt, Option<super::super::DateTime>>
-            for super::super::CompanyWhereInput
-        {
-        }
         pub struct createdAt_lte;
-        impl cynic::schema::Field for createdAt_lte {
+        impl cynic::schema::HasInputField<createdAt_lte> for super::super::CompanyWhereInput {
             type Type = Option<super::super::DateTime>;
             const NAME: &'static str = "createdAt_lte";
         }
-        impl cynic::schema::HasInputField<createdAt_lte, Option<super::super::DateTime>>
-            for super::super::CompanyWhereInput
-        {
-        }
         pub struct createdAt_gt;
-        impl cynic::schema::Field for createdAt_gt {
+        impl cynic::schema::HasInputField<createdAt_gt> for super::super::CompanyWhereInput {
             type Type = Option<super::super::DateTime>;
             const NAME: &'static str = "createdAt_gt";
         }
-        impl cynic::schema::HasInputField<createdAt_gt, Option<super::super::DateTime>>
-            for super::super::CompanyWhereInput
-        {
-        }
         pub struct createdAt_gte;
-        impl cynic::schema::Field for createdAt_gte {
+        impl cynic::schema::HasInputField<createdAt_gte> for super::super::CompanyWhereInput {
             type Type = Option<super::super::DateTime>;
             const NAME: &'static str = "createdAt_gte";
         }
-        impl cynic::schema::HasInputField<createdAt_gte, Option<super::super::DateTime>>
-            for super::super::CompanyWhereInput
-        {
-        }
         pub struct updatedAt;
-        impl cynic::schema::Field for updatedAt {
+        impl cynic::schema::HasInputField<updatedAt> for super::super::CompanyWhereInput {
             type Type = Option<super::super::DateTime>;
             const NAME: &'static str = "updatedAt";
         }
-        impl cynic::schema::HasInputField<updatedAt, Option<super::super::DateTime>>
-            for super::super::CompanyWhereInput
-        {
-        }
         pub struct updatedAt_not;
-        impl cynic::schema::Field for updatedAt_not {
+        impl cynic::schema::HasInputField<updatedAt_not> for super::super::CompanyWhereInput {
             type Type = Option<super::super::DateTime>;
             const NAME: &'static str = "updatedAt_not";
         }
-        impl cynic::schema::HasInputField<updatedAt_not, Option<super::super::DateTime>>
-            for super::super::CompanyWhereInput
-        {
-        }
         pub struct updatedAt_in;
-        impl cynic::schema::Field for updatedAt_in {
+        impl cynic::schema::HasInputField<updatedAt_in> for super::super::CompanyWhereInput {
             type Type = Option<Vec<super::super::DateTime>>;
             const NAME: &'static str = "updatedAt_in";
         }
-        impl cynic::schema::HasInputField<updatedAt_in, Option<Vec<super::super::DateTime>>>
-            for super::super::CompanyWhereInput
-        {
-        }
         pub struct updatedAt_not_in;
-        impl cynic::schema::Field for updatedAt_not_in {
+        impl cynic::schema::HasInputField<updatedAt_not_in> for super::super::CompanyWhereInput {
             type Type = Option<Vec<super::super::DateTime>>;
             const NAME: &'static str = "updatedAt_not_in";
         }
-        impl cynic::schema::HasInputField<updatedAt_not_in, Option<Vec<super::super::DateTime>>>
-            for super::super::CompanyWhereInput
-        {
-        }
         pub struct updatedAt_lt;
-        impl cynic::schema::Field for updatedAt_lt {
+        impl cynic::schema::HasInputField<updatedAt_lt> for super::super::CompanyWhereInput {
             type Type = Option<super::super::DateTime>;
             const NAME: &'static str = "updatedAt_lt";
         }
-        impl cynic::schema::HasInputField<updatedAt_lt, Option<super::super::DateTime>>
-            for super::super::CompanyWhereInput
-        {
-        }
         pub struct updatedAt_lte;
-        impl cynic::schema::Field for updatedAt_lte {
+        impl cynic::schema::HasInputField<updatedAt_lte> for super::super::CompanyWhereInput {
             type Type = Option<super::super::DateTime>;
             const NAME: &'static str = "updatedAt_lte";
         }
-        impl cynic::schema::HasInputField<updatedAt_lte, Option<super::super::DateTime>>
-            for super::super::CompanyWhereInput
-        {
-        }
         pub struct updatedAt_gt;
-        impl cynic::schema::Field for updatedAt_gt {
+        impl cynic::schema::HasInputField<updatedAt_gt> for super::super::CompanyWhereInput {
             type Type = Option<super::super::DateTime>;
             const NAME: &'static str = "updatedAt_gt";
         }
-        impl cynic::schema::HasInputField<updatedAt_gt, Option<super::super::DateTime>>
-            for super::super::CompanyWhereInput
-        {
-        }
         pub struct updatedAt_gte;
-        impl cynic::schema::Field for updatedAt_gte {
+        impl cynic::schema::HasInputField<updatedAt_gte> for super::super::CompanyWhereInput {
             type Type = Option<super::super::DateTime>;
             const NAME: &'static str = "updatedAt_gte";
         }
-        impl cynic::schema::HasInputField<updatedAt_gte, Option<super::super::DateTime>>
-            for super::super::CompanyWhereInput
-        {
-        }
         pub struct AND;
-        impl cynic::schema::Field for AND {
+        impl cynic::schema::HasInputField<AND> for super::super::CompanyWhereInput {
             type Type = Option<Vec<super::super::CompanyWhereInput>>;
             const NAME: &'static str = "AND";
         }
-        impl cynic::schema::HasInputField<AND, Option<Vec<super::super::CompanyWhereInput>>>
-            for super::super::CompanyWhereInput
-        {
-        }
         pub struct OR;
-        impl cynic::schema::Field for OR {
+        impl cynic::schema::HasInputField<OR> for super::super::CompanyWhereInput {
             type Type = Option<Vec<super::super::CompanyWhereInput>>;
             const NAME: &'static str = "OR";
         }
-        impl cynic::schema::HasInputField<OR, Option<Vec<super::super::CompanyWhereInput>>>
-            for super::super::CompanyWhereInput
-        {
-        }
         pub struct NOT;
-        impl cynic::schema::Field for NOT {
+        impl cynic::schema::HasInputField<NOT> for super::super::CompanyWhereInput {
             type Type = Option<Vec<super::super::CompanyWhereInput>>;
             const NAME: &'static str = "NOT";
-        }
-        impl cynic::schema::HasInputField<NOT, Option<Vec<super::super::CompanyWhereInput>>>
-            for super::super::CompanyWhereInput
-        {
         }
     }
     pub mod Country {
         pub struct id;
-        impl cynic::schema::Field for id {
+        impl cynic::schema::HasField<id> for super::super::Country {
             type Type = super::super::ID;
             const NAME: &'static str = "id";
         }
-        impl cynic::schema::HasField<id> for super::super::Country {
-            type Type = super::super::ID;
-        }
         pub struct name;
-        impl cynic::schema::Field for name {
+        impl cynic::schema::HasField<name> for super::super::Country {
             type Type = super::super::String;
             const NAME: &'static str = "name";
         }
-        impl cynic::schema::HasField<name> for super::super::Country {
-            type Type = super::super::String;
-        }
         pub struct slug;
-        impl cynic::schema::Field for slug {
+        impl cynic::schema::HasField<slug> for super::super::Country {
             type Type = super::super::String;
             const NAME: &'static str = "slug";
         }
-        impl cynic::schema::HasField<slug> for super::super::Country {
-            type Type = super::super::String;
-        }
         pub struct r#type;
-        impl cynic::schema::Field for r#type {
+        impl cynic::schema::HasField<r#type> for super::super::Country {
             type Type = super::super::String;
             const NAME: &'static str = "type";
         }
-        impl cynic::schema::HasField<r#type> for super::super::Country {
-            type Type = super::super::String;
-        }
         pub struct isoCode;
-        impl cynic::schema::Field for isoCode {
+        impl cynic::schema::HasField<isoCode> for super::super::Country {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "isoCode";
         }
-        impl cynic::schema::HasField<isoCode> for super::super::Country {
-            type Type = Option<super::super::String>;
-        }
         pub struct cities;
-        impl cynic::schema::Field for cities {
-            type Type = Option<Vec<super::super::City>>;
-            const NAME: &'static str = "cities";
-        }
         impl cynic::schema::HasField<cities> for super::super::Country {
             type Type = Option<Vec<super::super::City>>;
+            const NAME: &'static str = "cities";
         }
         pub mod _cities_arguments {
             pub struct r#where;
@@ -2771,12 +1671,9 @@ pub mod __fields {
             }
         }
         pub struct jobs;
-        impl cynic::schema::Field for jobs {
-            type Type = Option<Vec<super::super::Job>>;
-            const NAME: &'static str = "jobs";
-        }
         impl cynic::schema::HasField<jobs> for super::super::Country {
             type Type = Option<Vec<super::super::Job>>;
+            const NAME: &'static str = "jobs";
         }
         pub mod _jobs_arguments {
             pub struct r#where;
@@ -2816,927 +1713,523 @@ pub mod __fields {
             }
         }
         pub struct createdAt;
-        impl cynic::schema::Field for createdAt {
+        impl cynic::schema::HasField<createdAt> for super::super::Country {
             type Type = super::super::DateTime;
             const NAME: &'static str = "createdAt";
         }
-        impl cynic::schema::HasField<createdAt> for super::super::Country {
-            type Type = super::super::DateTime;
-        }
         pub struct updatedAt;
-        impl cynic::schema::Field for updatedAt {
+        impl cynic::schema::HasField<updatedAt> for super::super::Country {
             type Type = super::super::DateTime;
             const NAME: &'static str = "updatedAt";
         }
-        impl cynic::schema::HasField<updatedAt> for super::super::Country {
-            type Type = super::super::DateTime;
-        }
         pub struct __typename;
-        impl cynic::schema::Field for __typename {
-            type Type = super::super::String;
-            const NAME: &'static str = "__typename";
-        }
         impl cynic::schema::HasField<__typename> for super::super::Country {
             type Type = super::super::String;
+            const NAME: &'static str = "__typename";
         }
     }
     pub mod CountryWhereInput {
         pub struct id;
-        impl cynic::schema::Field for id {
+        impl cynic::schema::HasInputField<id> for super::super::CountryWhereInput {
             type Type = Option<super::super::ID>;
             const NAME: &'static str = "id";
         }
-        impl cynic::schema::HasInputField<id, Option<super::super::ID>>
-            for super::super::CountryWhereInput
-        {
-        }
         pub struct id_not;
-        impl cynic::schema::Field for id_not {
+        impl cynic::schema::HasInputField<id_not> for super::super::CountryWhereInput {
             type Type = Option<super::super::ID>;
             const NAME: &'static str = "id_not";
         }
-        impl cynic::schema::HasInputField<id_not, Option<super::super::ID>>
-            for super::super::CountryWhereInput
-        {
-        }
         pub struct id_in;
-        impl cynic::schema::Field for id_in {
+        impl cynic::schema::HasInputField<id_in> for super::super::CountryWhereInput {
             type Type = Option<Vec<super::super::ID>>;
             const NAME: &'static str = "id_in";
         }
-        impl cynic::schema::HasInputField<id_in, Option<Vec<super::super::ID>>>
-            for super::super::CountryWhereInput
-        {
-        }
         pub struct id_not_in;
-        impl cynic::schema::Field for id_not_in {
+        impl cynic::schema::HasInputField<id_not_in> for super::super::CountryWhereInput {
             type Type = Option<Vec<super::super::ID>>;
             const NAME: &'static str = "id_not_in";
         }
-        impl cynic::schema::HasInputField<id_not_in, Option<Vec<super::super::ID>>>
-            for super::super::CountryWhereInput
-        {
-        }
         pub struct id_lt;
-        impl cynic::schema::Field for id_lt {
+        impl cynic::schema::HasInputField<id_lt> for super::super::CountryWhereInput {
             type Type = Option<super::super::ID>;
             const NAME: &'static str = "id_lt";
         }
-        impl cynic::schema::HasInputField<id_lt, Option<super::super::ID>>
-            for super::super::CountryWhereInput
-        {
-        }
         pub struct id_lte;
-        impl cynic::schema::Field for id_lte {
+        impl cynic::schema::HasInputField<id_lte> for super::super::CountryWhereInput {
             type Type = Option<super::super::ID>;
             const NAME: &'static str = "id_lte";
         }
-        impl cynic::schema::HasInputField<id_lte, Option<super::super::ID>>
-            for super::super::CountryWhereInput
-        {
-        }
         pub struct id_gt;
-        impl cynic::schema::Field for id_gt {
+        impl cynic::schema::HasInputField<id_gt> for super::super::CountryWhereInput {
             type Type = Option<super::super::ID>;
             const NAME: &'static str = "id_gt";
         }
-        impl cynic::schema::HasInputField<id_gt, Option<super::super::ID>>
-            for super::super::CountryWhereInput
-        {
-        }
         pub struct id_gte;
-        impl cynic::schema::Field for id_gte {
+        impl cynic::schema::HasInputField<id_gte> for super::super::CountryWhereInput {
             type Type = Option<super::super::ID>;
             const NAME: &'static str = "id_gte";
         }
-        impl cynic::schema::HasInputField<id_gte, Option<super::super::ID>>
-            for super::super::CountryWhereInput
-        {
-        }
         pub struct id_contains;
-        impl cynic::schema::Field for id_contains {
+        impl cynic::schema::HasInputField<id_contains> for super::super::CountryWhereInput {
             type Type = Option<super::super::ID>;
             const NAME: &'static str = "id_contains";
         }
-        impl cynic::schema::HasInputField<id_contains, Option<super::super::ID>>
-            for super::super::CountryWhereInput
-        {
-        }
         pub struct id_not_contains;
-        impl cynic::schema::Field for id_not_contains {
+        impl cynic::schema::HasInputField<id_not_contains> for super::super::CountryWhereInput {
             type Type = Option<super::super::ID>;
             const NAME: &'static str = "id_not_contains";
         }
-        impl cynic::schema::HasInputField<id_not_contains, Option<super::super::ID>>
-            for super::super::CountryWhereInput
-        {
-        }
         pub struct id_starts_with;
-        impl cynic::schema::Field for id_starts_with {
+        impl cynic::schema::HasInputField<id_starts_with> for super::super::CountryWhereInput {
             type Type = Option<super::super::ID>;
             const NAME: &'static str = "id_starts_with";
         }
-        impl cynic::schema::HasInputField<id_starts_with, Option<super::super::ID>>
-            for super::super::CountryWhereInput
-        {
-        }
         pub struct id_not_starts_with;
-        impl cynic::schema::Field for id_not_starts_with {
+        impl cynic::schema::HasInputField<id_not_starts_with> for super::super::CountryWhereInput {
             type Type = Option<super::super::ID>;
             const NAME: &'static str = "id_not_starts_with";
         }
-        impl cynic::schema::HasInputField<id_not_starts_with, Option<super::super::ID>>
-            for super::super::CountryWhereInput
-        {
-        }
         pub struct id_ends_with;
-        impl cynic::schema::Field for id_ends_with {
+        impl cynic::schema::HasInputField<id_ends_with> for super::super::CountryWhereInput {
             type Type = Option<super::super::ID>;
             const NAME: &'static str = "id_ends_with";
         }
-        impl cynic::schema::HasInputField<id_ends_with, Option<super::super::ID>>
-            for super::super::CountryWhereInput
-        {
-        }
         pub struct id_not_ends_with;
-        impl cynic::schema::Field for id_not_ends_with {
+        impl cynic::schema::HasInputField<id_not_ends_with> for super::super::CountryWhereInput {
             type Type = Option<super::super::ID>;
             const NAME: &'static str = "id_not_ends_with";
         }
-        impl cynic::schema::HasInputField<id_not_ends_with, Option<super::super::ID>>
-            for super::super::CountryWhereInput
-        {
-        }
         pub struct name;
-        impl cynic::schema::Field for name {
+        impl cynic::schema::HasInputField<name> for super::super::CountryWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "name";
         }
-        impl cynic::schema::HasInputField<name, Option<super::super::String>>
-            for super::super::CountryWhereInput
-        {
-        }
         pub struct name_not;
-        impl cynic::schema::Field for name_not {
+        impl cynic::schema::HasInputField<name_not> for super::super::CountryWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "name_not";
         }
-        impl cynic::schema::HasInputField<name_not, Option<super::super::String>>
-            for super::super::CountryWhereInput
-        {
-        }
         pub struct name_in;
-        impl cynic::schema::Field for name_in {
+        impl cynic::schema::HasInputField<name_in> for super::super::CountryWhereInput {
             type Type = Option<Vec<super::super::String>>;
             const NAME: &'static str = "name_in";
         }
-        impl cynic::schema::HasInputField<name_in, Option<Vec<super::super::String>>>
-            for super::super::CountryWhereInput
-        {
-        }
         pub struct name_not_in;
-        impl cynic::schema::Field for name_not_in {
+        impl cynic::schema::HasInputField<name_not_in> for super::super::CountryWhereInput {
             type Type = Option<Vec<super::super::String>>;
             const NAME: &'static str = "name_not_in";
         }
-        impl cynic::schema::HasInputField<name_not_in, Option<Vec<super::super::String>>>
-            for super::super::CountryWhereInput
-        {
-        }
         pub struct name_lt;
-        impl cynic::schema::Field for name_lt {
+        impl cynic::schema::HasInputField<name_lt> for super::super::CountryWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "name_lt";
         }
-        impl cynic::schema::HasInputField<name_lt, Option<super::super::String>>
-            for super::super::CountryWhereInput
-        {
-        }
         pub struct name_lte;
-        impl cynic::schema::Field for name_lte {
+        impl cynic::schema::HasInputField<name_lte> for super::super::CountryWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "name_lte";
         }
-        impl cynic::schema::HasInputField<name_lte, Option<super::super::String>>
-            for super::super::CountryWhereInput
-        {
-        }
         pub struct name_gt;
-        impl cynic::schema::Field for name_gt {
+        impl cynic::schema::HasInputField<name_gt> for super::super::CountryWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "name_gt";
         }
-        impl cynic::schema::HasInputField<name_gt, Option<super::super::String>>
-            for super::super::CountryWhereInput
-        {
-        }
         pub struct name_gte;
-        impl cynic::schema::Field for name_gte {
+        impl cynic::schema::HasInputField<name_gte> for super::super::CountryWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "name_gte";
         }
-        impl cynic::schema::HasInputField<name_gte, Option<super::super::String>>
-            for super::super::CountryWhereInput
-        {
-        }
         pub struct name_contains;
-        impl cynic::schema::Field for name_contains {
+        impl cynic::schema::HasInputField<name_contains> for super::super::CountryWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "name_contains";
         }
-        impl cynic::schema::HasInputField<name_contains, Option<super::super::String>>
-            for super::super::CountryWhereInput
-        {
-        }
         pub struct name_not_contains;
-        impl cynic::schema::Field for name_not_contains {
+        impl cynic::schema::HasInputField<name_not_contains> for super::super::CountryWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "name_not_contains";
         }
-        impl cynic::schema::HasInputField<name_not_contains, Option<super::super::String>>
-            for super::super::CountryWhereInput
-        {
-        }
         pub struct name_starts_with;
-        impl cynic::schema::Field for name_starts_with {
+        impl cynic::schema::HasInputField<name_starts_with> for super::super::CountryWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "name_starts_with";
         }
-        impl cynic::schema::HasInputField<name_starts_with, Option<super::super::String>>
-            for super::super::CountryWhereInput
-        {
-        }
         pub struct name_not_starts_with;
-        impl cynic::schema::Field for name_not_starts_with {
+        impl cynic::schema::HasInputField<name_not_starts_with> for super::super::CountryWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "name_not_starts_with";
         }
-        impl cynic::schema::HasInputField<name_not_starts_with, Option<super::super::String>>
-            for super::super::CountryWhereInput
-        {
-        }
         pub struct name_ends_with;
-        impl cynic::schema::Field for name_ends_with {
+        impl cynic::schema::HasInputField<name_ends_with> for super::super::CountryWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "name_ends_with";
         }
-        impl cynic::schema::HasInputField<name_ends_with, Option<super::super::String>>
-            for super::super::CountryWhereInput
-        {
-        }
         pub struct name_not_ends_with;
-        impl cynic::schema::Field for name_not_ends_with {
+        impl cynic::schema::HasInputField<name_not_ends_with> for super::super::CountryWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "name_not_ends_with";
         }
-        impl cynic::schema::HasInputField<name_not_ends_with, Option<super::super::String>>
-            for super::super::CountryWhereInput
-        {
-        }
         pub struct slug;
-        impl cynic::schema::Field for slug {
+        impl cynic::schema::HasInputField<slug> for super::super::CountryWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "slug";
         }
-        impl cynic::schema::HasInputField<slug, Option<super::super::String>>
-            for super::super::CountryWhereInput
-        {
-        }
         pub struct slug_not;
-        impl cynic::schema::Field for slug_not {
+        impl cynic::schema::HasInputField<slug_not> for super::super::CountryWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "slug_not";
         }
-        impl cynic::schema::HasInputField<slug_not, Option<super::super::String>>
-            for super::super::CountryWhereInput
-        {
-        }
         pub struct slug_in;
-        impl cynic::schema::Field for slug_in {
+        impl cynic::schema::HasInputField<slug_in> for super::super::CountryWhereInput {
             type Type = Option<Vec<super::super::String>>;
             const NAME: &'static str = "slug_in";
         }
-        impl cynic::schema::HasInputField<slug_in, Option<Vec<super::super::String>>>
-            for super::super::CountryWhereInput
-        {
-        }
         pub struct slug_not_in;
-        impl cynic::schema::Field for slug_not_in {
+        impl cynic::schema::HasInputField<slug_not_in> for super::super::CountryWhereInput {
             type Type = Option<Vec<super::super::String>>;
             const NAME: &'static str = "slug_not_in";
         }
-        impl cynic::schema::HasInputField<slug_not_in, Option<Vec<super::super::String>>>
-            for super::super::CountryWhereInput
-        {
-        }
         pub struct slug_lt;
-        impl cynic::schema::Field for slug_lt {
+        impl cynic::schema::HasInputField<slug_lt> for super::super::CountryWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "slug_lt";
         }
-        impl cynic::schema::HasInputField<slug_lt, Option<super::super::String>>
-            for super::super::CountryWhereInput
-        {
-        }
         pub struct slug_lte;
-        impl cynic::schema::Field for slug_lte {
+        impl cynic::schema::HasInputField<slug_lte> for super::super::CountryWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "slug_lte";
         }
-        impl cynic::schema::HasInputField<slug_lte, Option<super::super::String>>
-            for super::super::CountryWhereInput
-        {
-        }
         pub struct slug_gt;
-        impl cynic::schema::Field for slug_gt {
+        impl cynic::schema::HasInputField<slug_gt> for super::super::CountryWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "slug_gt";
         }
-        impl cynic::schema::HasInputField<slug_gt, Option<super::super::String>>
-            for super::super::CountryWhereInput
-        {
-        }
         pub struct slug_gte;
-        impl cynic::schema::Field for slug_gte {
+        impl cynic::schema::HasInputField<slug_gte> for super::super::CountryWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "slug_gte";
         }
-        impl cynic::schema::HasInputField<slug_gte, Option<super::super::String>>
-            for super::super::CountryWhereInput
-        {
-        }
         pub struct slug_contains;
-        impl cynic::schema::Field for slug_contains {
+        impl cynic::schema::HasInputField<slug_contains> for super::super::CountryWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "slug_contains";
         }
-        impl cynic::schema::HasInputField<slug_contains, Option<super::super::String>>
-            for super::super::CountryWhereInput
-        {
-        }
         pub struct slug_not_contains;
-        impl cynic::schema::Field for slug_not_contains {
+        impl cynic::schema::HasInputField<slug_not_contains> for super::super::CountryWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "slug_not_contains";
         }
-        impl cynic::schema::HasInputField<slug_not_contains, Option<super::super::String>>
-            for super::super::CountryWhereInput
-        {
-        }
         pub struct slug_starts_with;
-        impl cynic::schema::Field for slug_starts_with {
+        impl cynic::schema::HasInputField<slug_starts_with> for super::super::CountryWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "slug_starts_with";
         }
-        impl cynic::schema::HasInputField<slug_starts_with, Option<super::super::String>>
-            for super::super::CountryWhereInput
-        {
-        }
         pub struct slug_not_starts_with;
-        impl cynic::schema::Field for slug_not_starts_with {
+        impl cynic::schema::HasInputField<slug_not_starts_with> for super::super::CountryWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "slug_not_starts_with";
         }
-        impl cynic::schema::HasInputField<slug_not_starts_with, Option<super::super::String>>
-            for super::super::CountryWhereInput
-        {
-        }
         pub struct slug_ends_with;
-        impl cynic::schema::Field for slug_ends_with {
+        impl cynic::schema::HasInputField<slug_ends_with> for super::super::CountryWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "slug_ends_with";
         }
-        impl cynic::schema::HasInputField<slug_ends_with, Option<super::super::String>>
-            for super::super::CountryWhereInput
-        {
-        }
         pub struct slug_not_ends_with;
-        impl cynic::schema::Field for slug_not_ends_with {
+        impl cynic::schema::HasInputField<slug_not_ends_with> for super::super::CountryWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "slug_not_ends_with";
         }
-        impl cynic::schema::HasInputField<slug_not_ends_with, Option<super::super::String>>
-            for super::super::CountryWhereInput
-        {
-        }
         pub struct r#type;
-        impl cynic::schema::Field for r#type {
+        impl cynic::schema::HasInputField<r#type> for super::super::CountryWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "type";
         }
-        impl cynic::schema::HasInputField<r#type, Option<super::super::String>>
-            for super::super::CountryWhereInput
-        {
-        }
         pub struct type_not;
-        impl cynic::schema::Field for type_not {
+        impl cynic::schema::HasInputField<type_not> for super::super::CountryWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "type_not";
         }
-        impl cynic::schema::HasInputField<type_not, Option<super::super::String>>
-            for super::super::CountryWhereInput
-        {
-        }
         pub struct type_in;
-        impl cynic::schema::Field for type_in {
+        impl cynic::schema::HasInputField<type_in> for super::super::CountryWhereInput {
             type Type = Option<Vec<super::super::String>>;
             const NAME: &'static str = "type_in";
         }
-        impl cynic::schema::HasInputField<type_in, Option<Vec<super::super::String>>>
-            for super::super::CountryWhereInput
-        {
-        }
         pub struct type_not_in;
-        impl cynic::schema::Field for type_not_in {
+        impl cynic::schema::HasInputField<type_not_in> for super::super::CountryWhereInput {
             type Type = Option<Vec<super::super::String>>;
             const NAME: &'static str = "type_not_in";
         }
-        impl cynic::schema::HasInputField<type_not_in, Option<Vec<super::super::String>>>
-            for super::super::CountryWhereInput
-        {
-        }
         pub struct type_lt;
-        impl cynic::schema::Field for type_lt {
+        impl cynic::schema::HasInputField<type_lt> for super::super::CountryWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "type_lt";
         }
-        impl cynic::schema::HasInputField<type_lt, Option<super::super::String>>
-            for super::super::CountryWhereInput
-        {
-        }
         pub struct type_lte;
-        impl cynic::schema::Field for type_lte {
+        impl cynic::schema::HasInputField<type_lte> for super::super::CountryWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "type_lte";
         }
-        impl cynic::schema::HasInputField<type_lte, Option<super::super::String>>
-            for super::super::CountryWhereInput
-        {
-        }
         pub struct type_gt;
-        impl cynic::schema::Field for type_gt {
+        impl cynic::schema::HasInputField<type_gt> for super::super::CountryWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "type_gt";
         }
-        impl cynic::schema::HasInputField<type_gt, Option<super::super::String>>
-            for super::super::CountryWhereInput
-        {
-        }
         pub struct type_gte;
-        impl cynic::schema::Field for type_gte {
+        impl cynic::schema::HasInputField<type_gte> for super::super::CountryWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "type_gte";
         }
-        impl cynic::schema::HasInputField<type_gte, Option<super::super::String>>
-            for super::super::CountryWhereInput
-        {
-        }
         pub struct type_contains;
-        impl cynic::schema::Field for type_contains {
+        impl cynic::schema::HasInputField<type_contains> for super::super::CountryWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "type_contains";
         }
-        impl cynic::schema::HasInputField<type_contains, Option<super::super::String>>
-            for super::super::CountryWhereInput
-        {
-        }
         pub struct type_not_contains;
-        impl cynic::schema::Field for type_not_contains {
+        impl cynic::schema::HasInputField<type_not_contains> for super::super::CountryWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "type_not_contains";
         }
-        impl cynic::schema::HasInputField<type_not_contains, Option<super::super::String>>
-            for super::super::CountryWhereInput
-        {
-        }
         pub struct type_starts_with;
-        impl cynic::schema::Field for type_starts_with {
+        impl cynic::schema::HasInputField<type_starts_with> for super::super::CountryWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "type_starts_with";
         }
-        impl cynic::schema::HasInputField<type_starts_with, Option<super::super::String>>
-            for super::super::CountryWhereInput
-        {
-        }
         pub struct type_not_starts_with;
-        impl cynic::schema::Field for type_not_starts_with {
+        impl cynic::schema::HasInputField<type_not_starts_with> for super::super::CountryWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "type_not_starts_with";
         }
-        impl cynic::schema::HasInputField<type_not_starts_with, Option<super::super::String>>
-            for super::super::CountryWhereInput
-        {
-        }
         pub struct type_ends_with;
-        impl cynic::schema::Field for type_ends_with {
+        impl cynic::schema::HasInputField<type_ends_with> for super::super::CountryWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "type_ends_with";
         }
-        impl cynic::schema::HasInputField<type_ends_with, Option<super::super::String>>
-            for super::super::CountryWhereInput
-        {
-        }
         pub struct type_not_ends_with;
-        impl cynic::schema::Field for type_not_ends_with {
+        impl cynic::schema::HasInputField<type_not_ends_with> for super::super::CountryWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "type_not_ends_with";
         }
-        impl cynic::schema::HasInputField<type_not_ends_with, Option<super::super::String>>
-            for super::super::CountryWhereInput
-        {
-        }
         pub struct isoCode;
-        impl cynic::schema::Field for isoCode {
+        impl cynic::schema::HasInputField<isoCode> for super::super::CountryWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "isoCode";
         }
-        impl cynic::schema::HasInputField<isoCode, Option<super::super::String>>
-            for super::super::CountryWhereInput
-        {
-        }
         pub struct isoCode_not;
-        impl cynic::schema::Field for isoCode_not {
+        impl cynic::schema::HasInputField<isoCode_not> for super::super::CountryWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "isoCode_not";
         }
-        impl cynic::schema::HasInputField<isoCode_not, Option<super::super::String>>
-            for super::super::CountryWhereInput
-        {
-        }
         pub struct isoCode_in;
-        impl cynic::schema::Field for isoCode_in {
+        impl cynic::schema::HasInputField<isoCode_in> for super::super::CountryWhereInput {
             type Type = Option<Vec<super::super::String>>;
             const NAME: &'static str = "isoCode_in";
         }
-        impl cynic::schema::HasInputField<isoCode_in, Option<Vec<super::super::String>>>
-            for super::super::CountryWhereInput
-        {
-        }
         pub struct isoCode_not_in;
-        impl cynic::schema::Field for isoCode_not_in {
+        impl cynic::schema::HasInputField<isoCode_not_in> for super::super::CountryWhereInput {
             type Type = Option<Vec<super::super::String>>;
             const NAME: &'static str = "isoCode_not_in";
         }
-        impl cynic::schema::HasInputField<isoCode_not_in, Option<Vec<super::super::String>>>
-            for super::super::CountryWhereInput
-        {
-        }
         pub struct isoCode_lt;
-        impl cynic::schema::Field for isoCode_lt {
+        impl cynic::schema::HasInputField<isoCode_lt> for super::super::CountryWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "isoCode_lt";
         }
-        impl cynic::schema::HasInputField<isoCode_lt, Option<super::super::String>>
-            for super::super::CountryWhereInput
-        {
-        }
         pub struct isoCode_lte;
-        impl cynic::schema::Field for isoCode_lte {
+        impl cynic::schema::HasInputField<isoCode_lte> for super::super::CountryWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "isoCode_lte";
         }
-        impl cynic::schema::HasInputField<isoCode_lte, Option<super::super::String>>
-            for super::super::CountryWhereInput
-        {
-        }
         pub struct isoCode_gt;
-        impl cynic::schema::Field for isoCode_gt {
+        impl cynic::schema::HasInputField<isoCode_gt> for super::super::CountryWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "isoCode_gt";
         }
-        impl cynic::schema::HasInputField<isoCode_gt, Option<super::super::String>>
-            for super::super::CountryWhereInput
-        {
-        }
         pub struct isoCode_gte;
-        impl cynic::schema::Field for isoCode_gte {
+        impl cynic::schema::HasInputField<isoCode_gte> for super::super::CountryWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "isoCode_gte";
         }
-        impl cynic::schema::HasInputField<isoCode_gte, Option<super::super::String>>
-            for super::super::CountryWhereInput
-        {
-        }
         pub struct isoCode_contains;
-        impl cynic::schema::Field for isoCode_contains {
+        impl cynic::schema::HasInputField<isoCode_contains> for super::super::CountryWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "isoCode_contains";
         }
-        impl cynic::schema::HasInputField<isoCode_contains, Option<super::super::String>>
-            for super::super::CountryWhereInput
-        {
-        }
         pub struct isoCode_not_contains;
-        impl cynic::schema::Field for isoCode_not_contains {
+        impl cynic::schema::HasInputField<isoCode_not_contains> for super::super::CountryWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "isoCode_not_contains";
         }
-        impl cynic::schema::HasInputField<isoCode_not_contains, Option<super::super::String>>
-            for super::super::CountryWhereInput
-        {
-        }
         pub struct isoCode_starts_with;
-        impl cynic::schema::Field for isoCode_starts_with {
+        impl cynic::schema::HasInputField<isoCode_starts_with> for super::super::CountryWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "isoCode_starts_with";
         }
-        impl cynic::schema::HasInputField<isoCode_starts_with, Option<super::super::String>>
-            for super::super::CountryWhereInput
-        {
-        }
         pub struct isoCode_not_starts_with;
-        impl cynic::schema::Field for isoCode_not_starts_with {
+        impl cynic::schema::HasInputField<isoCode_not_starts_with> for super::super::CountryWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "isoCode_not_starts_with";
         }
-        impl cynic::schema::HasInputField<isoCode_not_starts_with, Option<super::super::String>>
-            for super::super::CountryWhereInput
-        {
-        }
         pub struct isoCode_ends_with;
-        impl cynic::schema::Field for isoCode_ends_with {
+        impl cynic::schema::HasInputField<isoCode_ends_with> for super::super::CountryWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "isoCode_ends_with";
         }
-        impl cynic::schema::HasInputField<isoCode_ends_with, Option<super::super::String>>
-            for super::super::CountryWhereInput
-        {
-        }
         pub struct isoCode_not_ends_with;
-        impl cynic::schema::Field for isoCode_not_ends_with {
+        impl cynic::schema::HasInputField<isoCode_not_ends_with> for super::super::CountryWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "isoCode_not_ends_with";
         }
-        impl cynic::schema::HasInputField<isoCode_not_ends_with, Option<super::super::String>>
-            for super::super::CountryWhereInput
-        {
-        }
         pub struct cities_every;
-        impl cynic::schema::Field for cities_every {
+        impl cynic::schema::HasInputField<cities_every> for super::super::CountryWhereInput {
             type Type = Option<super::super::CityWhereInput>;
             const NAME: &'static str = "cities_every";
         }
-        impl cynic::schema::HasInputField<cities_every, Option<super::super::CityWhereInput>>
-            for super::super::CountryWhereInput
-        {
-        }
         pub struct cities_some;
-        impl cynic::schema::Field for cities_some {
+        impl cynic::schema::HasInputField<cities_some> for super::super::CountryWhereInput {
             type Type = Option<super::super::CityWhereInput>;
             const NAME: &'static str = "cities_some";
         }
-        impl cynic::schema::HasInputField<cities_some, Option<super::super::CityWhereInput>>
-            for super::super::CountryWhereInput
-        {
-        }
         pub struct cities_none;
-        impl cynic::schema::Field for cities_none {
+        impl cynic::schema::HasInputField<cities_none> for super::super::CountryWhereInput {
             type Type = Option<super::super::CityWhereInput>;
             const NAME: &'static str = "cities_none";
         }
-        impl cynic::schema::HasInputField<cities_none, Option<super::super::CityWhereInput>>
-            for super::super::CountryWhereInput
-        {
-        }
         pub struct jobs_every;
-        impl cynic::schema::Field for jobs_every {
+        impl cynic::schema::HasInputField<jobs_every> for super::super::CountryWhereInput {
             type Type = Option<super::super::JobWhereInput>;
             const NAME: &'static str = "jobs_every";
         }
-        impl cynic::schema::HasInputField<jobs_every, Option<super::super::JobWhereInput>>
-            for super::super::CountryWhereInput
-        {
-        }
         pub struct jobs_some;
-        impl cynic::schema::Field for jobs_some {
+        impl cynic::schema::HasInputField<jobs_some> for super::super::CountryWhereInput {
             type Type = Option<super::super::JobWhereInput>;
             const NAME: &'static str = "jobs_some";
         }
-        impl cynic::schema::HasInputField<jobs_some, Option<super::super::JobWhereInput>>
-            for super::super::CountryWhereInput
-        {
-        }
         pub struct jobs_none;
-        impl cynic::schema::Field for jobs_none {
+        impl cynic::schema::HasInputField<jobs_none> for super::super::CountryWhereInput {
             type Type = Option<super::super::JobWhereInput>;
             const NAME: &'static str = "jobs_none";
         }
-        impl cynic::schema::HasInputField<jobs_none, Option<super::super::JobWhereInput>>
-            for super::super::CountryWhereInput
-        {
-        }
         pub struct createdAt;
-        impl cynic::schema::Field for createdAt {
+        impl cynic::schema::HasInputField<createdAt> for super::super::CountryWhereInput {
             type Type = Option<super::super::DateTime>;
             const NAME: &'static str = "createdAt";
         }
-        impl cynic::schema::HasInputField<createdAt, Option<super::super::DateTime>>
-            for super::super::CountryWhereInput
-        {
-        }
         pub struct createdAt_not;
-        impl cynic::schema::Field for createdAt_not {
+        impl cynic::schema::HasInputField<createdAt_not> for super::super::CountryWhereInput {
             type Type = Option<super::super::DateTime>;
             const NAME: &'static str = "createdAt_not";
         }
-        impl cynic::schema::HasInputField<createdAt_not, Option<super::super::DateTime>>
-            for super::super::CountryWhereInput
-        {
-        }
         pub struct createdAt_in;
-        impl cynic::schema::Field for createdAt_in {
+        impl cynic::schema::HasInputField<createdAt_in> for super::super::CountryWhereInput {
             type Type = Option<Vec<super::super::DateTime>>;
             const NAME: &'static str = "createdAt_in";
         }
-        impl cynic::schema::HasInputField<createdAt_in, Option<Vec<super::super::DateTime>>>
-            for super::super::CountryWhereInput
-        {
-        }
         pub struct createdAt_not_in;
-        impl cynic::schema::Field for createdAt_not_in {
+        impl cynic::schema::HasInputField<createdAt_not_in> for super::super::CountryWhereInput {
             type Type = Option<Vec<super::super::DateTime>>;
             const NAME: &'static str = "createdAt_not_in";
         }
-        impl cynic::schema::HasInputField<createdAt_not_in, Option<Vec<super::super::DateTime>>>
-            for super::super::CountryWhereInput
-        {
-        }
         pub struct createdAt_lt;
-        impl cynic::schema::Field for createdAt_lt {
+        impl cynic::schema::HasInputField<createdAt_lt> for super::super::CountryWhereInput {
             type Type = Option<super::super::DateTime>;
             const NAME: &'static str = "createdAt_lt";
         }
-        impl cynic::schema::HasInputField<createdAt_lt, Option<super::super::DateTime>>
-            for super::super::CountryWhereInput
-        {
-        }
         pub struct createdAt_lte;
-        impl cynic::schema::Field for createdAt_lte {
+        impl cynic::schema::HasInputField<createdAt_lte> for super::super::CountryWhereInput {
             type Type = Option<super::super::DateTime>;
             const NAME: &'static str = "createdAt_lte";
         }
-        impl cynic::schema::HasInputField<createdAt_lte, Option<super::super::DateTime>>
-            for super::super::CountryWhereInput
-        {
-        }
         pub struct createdAt_gt;
-        impl cynic::schema::Field for createdAt_gt {
+        impl cynic::schema::HasInputField<createdAt_gt> for super::super::CountryWhereInput {
             type Type = Option<super::super::DateTime>;
             const NAME: &'static str = "createdAt_gt";
         }
-        impl cynic::schema::HasInputField<createdAt_gt, Option<super::super::DateTime>>
-            for super::super::CountryWhereInput
-        {
-        }
         pub struct createdAt_gte;
-        impl cynic::schema::Field for createdAt_gte {
+        impl cynic::schema::HasInputField<createdAt_gte> for super::super::CountryWhereInput {
             type Type = Option<super::super::DateTime>;
             const NAME: &'static str = "createdAt_gte";
         }
-        impl cynic::schema::HasInputField<createdAt_gte, Option<super::super::DateTime>>
-            for super::super::CountryWhereInput
-        {
-        }
         pub struct updatedAt;
-        impl cynic::schema::Field for updatedAt {
+        impl cynic::schema::HasInputField<updatedAt> for super::super::CountryWhereInput {
             type Type = Option<super::super::DateTime>;
             const NAME: &'static str = "updatedAt";
         }
-        impl cynic::schema::HasInputField<updatedAt, Option<super::super::DateTime>>
-            for super::super::CountryWhereInput
-        {
-        }
         pub struct updatedAt_not;
-        impl cynic::schema::Field for updatedAt_not {
+        impl cynic::schema::HasInputField<updatedAt_not> for super::super::CountryWhereInput {
             type Type = Option<super::super::DateTime>;
             const NAME: &'static str = "updatedAt_not";
         }
-        impl cynic::schema::HasInputField<updatedAt_not, Option<super::super::DateTime>>
-            for super::super::CountryWhereInput
-        {
-        }
         pub struct updatedAt_in;
-        impl cynic::schema::Field for updatedAt_in {
+        impl cynic::schema::HasInputField<updatedAt_in> for super::super::CountryWhereInput {
             type Type = Option<Vec<super::super::DateTime>>;
             const NAME: &'static str = "updatedAt_in";
         }
-        impl cynic::schema::HasInputField<updatedAt_in, Option<Vec<super::super::DateTime>>>
-            for super::super::CountryWhereInput
-        {
-        }
         pub struct updatedAt_not_in;
-        impl cynic::schema::Field for updatedAt_not_in {
+        impl cynic::schema::HasInputField<updatedAt_not_in> for super::super::CountryWhereInput {
             type Type = Option<Vec<super::super::DateTime>>;
             const NAME: &'static str = "updatedAt_not_in";
         }
-        impl cynic::schema::HasInputField<updatedAt_not_in, Option<Vec<super::super::DateTime>>>
-            for super::super::CountryWhereInput
-        {
-        }
         pub struct updatedAt_lt;
-        impl cynic::schema::Field for updatedAt_lt {
+        impl cynic::schema::HasInputField<updatedAt_lt> for super::super::CountryWhereInput {
             type Type = Option<super::super::DateTime>;
             const NAME: &'static str = "updatedAt_lt";
         }
-        impl cynic::schema::HasInputField<updatedAt_lt, Option<super::super::DateTime>>
-            for super::super::CountryWhereInput
-        {
-        }
         pub struct updatedAt_lte;
-        impl cynic::schema::Field for updatedAt_lte {
+        impl cynic::schema::HasInputField<updatedAt_lte> for super::super::CountryWhereInput {
             type Type = Option<super::super::DateTime>;
             const NAME: &'static str = "updatedAt_lte";
         }
-        impl cynic::schema::HasInputField<updatedAt_lte, Option<super::super::DateTime>>
-            for super::super::CountryWhereInput
-        {
-        }
         pub struct updatedAt_gt;
-        impl cynic::schema::Field for updatedAt_gt {
+        impl cynic::schema::HasInputField<updatedAt_gt> for super::super::CountryWhereInput {
             type Type = Option<super::super::DateTime>;
             const NAME: &'static str = "updatedAt_gt";
         }
-        impl cynic::schema::HasInputField<updatedAt_gt, Option<super::super::DateTime>>
-            for super::super::CountryWhereInput
-        {
-        }
         pub struct updatedAt_gte;
-        impl cynic::schema::Field for updatedAt_gte {
+        impl cynic::schema::HasInputField<updatedAt_gte> for super::super::CountryWhereInput {
             type Type = Option<super::super::DateTime>;
             const NAME: &'static str = "updatedAt_gte";
         }
-        impl cynic::schema::HasInputField<updatedAt_gte, Option<super::super::DateTime>>
-            for super::super::CountryWhereInput
-        {
-        }
         pub struct AND;
-        impl cynic::schema::Field for AND {
+        impl cynic::schema::HasInputField<AND> for super::super::CountryWhereInput {
             type Type = Option<Vec<super::super::CountryWhereInput>>;
             const NAME: &'static str = "AND";
         }
-        impl cynic::schema::HasInputField<AND, Option<Vec<super::super::CountryWhereInput>>>
-            for super::super::CountryWhereInput
-        {
-        }
         pub struct OR;
-        impl cynic::schema::Field for OR {
+        impl cynic::schema::HasInputField<OR> for super::super::CountryWhereInput {
             type Type = Option<Vec<super::super::CountryWhereInput>>;
             const NAME: &'static str = "OR";
         }
-        impl cynic::schema::HasInputField<OR, Option<Vec<super::super::CountryWhereInput>>>
-            for super::super::CountryWhereInput
-        {
-        }
         pub struct NOT;
-        impl cynic::schema::Field for NOT {
+        impl cynic::schema::HasInputField<NOT> for super::super::CountryWhereInput {
             type Type = Option<Vec<super::super::CountryWhereInput>>;
             const NAME: &'static str = "NOT";
-        }
-        impl cynic::schema::HasInputField<NOT, Option<Vec<super::super::CountryWhereInput>>>
-            for super::super::CountryWhereInput
-        {
         }
     }
     pub mod Job {
         pub struct id;
-        impl cynic::schema::Field for id {
+        impl cynic::schema::HasField<id> for super::super::Job {
             type Type = super::super::ID;
             const NAME: &'static str = "id";
         }
-        impl cynic::schema::HasField<id> for super::super::Job {
-            type Type = super::super::ID;
-        }
         pub struct title;
-        impl cynic::schema::Field for title {
+        impl cynic::schema::HasField<title> for super::super::Job {
             type Type = super::super::String;
             const NAME: &'static str = "title";
         }
-        impl cynic::schema::HasField<title> for super::super::Job {
-            type Type = super::super::String;
-        }
         pub struct slug;
-        impl cynic::schema::Field for slug {
+        impl cynic::schema::HasField<slug> for super::super::Job {
             type Type = super::super::String;
             const NAME: &'static str = "slug";
         }
-        impl cynic::schema::HasField<slug> for super::super::Job {
-            type Type = super::super::String;
-        }
         pub struct commitment;
-        impl cynic::schema::Field for commitment {
+        impl cynic::schema::HasField<commitment> for super::super::Job {
             type Type = super::super::Commitment;
             const NAME: &'static str = "commitment";
         }
-        impl cynic::schema::HasField<commitment> for super::super::Job {
-            type Type = super::super::Commitment;
-        }
         pub struct cities;
-        impl cynic::schema::Field for cities {
-            type Type = Option<Vec<super::super::City>>;
-            const NAME: &'static str = "cities";
-        }
         impl cynic::schema::HasField<cities> for super::super::Job {
             type Type = Option<Vec<super::super::City>>;
+            const NAME: &'static str = "cities";
         }
         pub mod _cities_arguments {
             pub struct r#where;
@@ -3776,12 +2269,9 @@ pub mod __fields {
             }
         }
         pub struct countries;
-        impl cynic::schema::Field for countries {
-            type Type = Option<Vec<super::super::Country>>;
-            const NAME: &'static str = "countries";
-        }
         impl cynic::schema::HasField<countries> for super::super::Job {
             type Type = Option<Vec<super::super::Country>>;
+            const NAME: &'static str = "countries";
         }
         pub mod _countries_arguments {
             pub struct r#where;
@@ -3821,12 +2311,9 @@ pub mod __fields {
             }
         }
         pub struct remotes;
-        impl cynic::schema::Field for remotes {
-            type Type = Option<Vec<super::super::Remote>>;
-            const NAME: &'static str = "remotes";
-        }
         impl cynic::schema::HasField<remotes> for super::super::Job {
             type Type = Option<Vec<super::super::Remote>>;
+            const NAME: &'static str = "remotes";
         }
         pub mod _remotes_arguments {
             pub struct r#where;
@@ -3866,36 +2353,24 @@ pub mod __fields {
             }
         }
         pub struct description;
-        impl cynic::schema::Field for description {
+        impl cynic::schema::HasField<description> for super::super::Job {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "description";
         }
-        impl cynic::schema::HasField<description> for super::super::Job {
-            type Type = Option<super::super::String>;
-        }
         pub struct applyUrl;
-        impl cynic::schema::Field for applyUrl {
+        impl cynic::schema::HasField<applyUrl> for super::super::Job {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "applyUrl";
         }
-        impl cynic::schema::HasField<applyUrl> for super::super::Job {
-            type Type = Option<super::super::String>;
-        }
         pub struct company;
-        impl cynic::schema::Field for company {
+        impl cynic::schema::HasField<company> for super::super::Job {
             type Type = Option<super::super::Company>;
             const NAME: &'static str = "company";
         }
-        impl cynic::schema::HasField<company> for super::super::Job {
-            type Type = Option<super::super::Company>;
-        }
         pub struct tags;
-        impl cynic::schema::Field for tags {
-            type Type = Option<Vec<super::super::Tag>>;
-            const NAME: &'static str = "tags";
-        }
         impl cynic::schema::HasField<tags> for super::super::Job {
             type Type = Option<Vec<super::super::Tag>>;
+            const NAME: &'static str = "tags";
         }
         pub mod _tags_arguments {
             pub struct r#where;
@@ -3935,1450 +2410,833 @@ pub mod __fields {
             }
         }
         pub struct isPublished;
-        impl cynic::schema::Field for isPublished {
+        impl cynic::schema::HasField<isPublished> for super::super::Job {
             type Type = Option<super::super::Boolean>;
             const NAME: &'static str = "isPublished";
         }
-        impl cynic::schema::HasField<isPublished> for super::super::Job {
-            type Type = Option<super::super::Boolean>;
-        }
         pub struct isFeatured;
-        impl cynic::schema::Field for isFeatured {
+        impl cynic::schema::HasField<isFeatured> for super::super::Job {
             type Type = Option<super::super::Boolean>;
             const NAME: &'static str = "isFeatured";
         }
-        impl cynic::schema::HasField<isFeatured> for super::super::Job {
-            type Type = Option<super::super::Boolean>;
-        }
         pub struct locationNames;
-        impl cynic::schema::Field for locationNames {
+        impl cynic::schema::HasField<locationNames> for super::super::Job {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "locationNames";
         }
-        impl cynic::schema::HasField<locationNames> for super::super::Job {
-            type Type = Option<super::super::String>;
-        }
         pub struct userEmail;
-        impl cynic::schema::Field for userEmail {
+        impl cynic::schema::HasField<userEmail> for super::super::Job {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "userEmail";
         }
-        impl cynic::schema::HasField<userEmail> for super::super::Job {
-            type Type = Option<super::super::String>;
-        }
         pub struct postedAt;
-        impl cynic::schema::Field for postedAt {
+        impl cynic::schema::HasField<postedAt> for super::super::Job {
             type Type = super::super::DateTime;
             const NAME: &'static str = "postedAt";
         }
-        impl cynic::schema::HasField<postedAt> for super::super::Job {
-            type Type = super::super::DateTime;
-        }
         pub struct createdAt;
-        impl cynic::schema::Field for createdAt {
+        impl cynic::schema::HasField<createdAt> for super::super::Job {
             type Type = super::super::DateTime;
             const NAME: &'static str = "createdAt";
         }
-        impl cynic::schema::HasField<createdAt> for super::super::Job {
-            type Type = super::super::DateTime;
-        }
         pub struct updatedAt;
-        impl cynic::schema::Field for updatedAt {
+        impl cynic::schema::HasField<updatedAt> for super::super::Job {
             type Type = super::super::DateTime;
             const NAME: &'static str = "updatedAt";
         }
-        impl cynic::schema::HasField<updatedAt> for super::super::Job {
-            type Type = super::super::DateTime;
-        }
         pub struct __typename;
-        impl cynic::schema::Field for __typename {
-            type Type = super::super::String;
-            const NAME: &'static str = "__typename";
-        }
         impl cynic::schema::HasField<__typename> for super::super::Job {
             type Type = super::super::String;
+            const NAME: &'static str = "__typename";
         }
     }
     pub mod JobInput {
         pub struct companySlug;
-        impl cynic::schema::Field for companySlug {
+        impl cynic::schema::HasInputField<companySlug> for super::super::JobInput {
             type Type = super::super::String;
             const NAME: &'static str = "companySlug";
         }
-        impl cynic::schema::HasInputField<companySlug, super::super::String> for super::super::JobInput {}
         pub struct jobSlug;
-        impl cynic::schema::Field for jobSlug {
+        impl cynic::schema::HasInputField<jobSlug> for super::super::JobInput {
             type Type = super::super::String;
             const NAME: &'static str = "jobSlug";
         }
-        impl cynic::schema::HasInputField<jobSlug, super::super::String> for super::super::JobInput {}
     }
     pub mod JobWhereInput {
         pub struct id;
-        impl cynic::schema::Field for id {
+        impl cynic::schema::HasInputField<id> for super::super::JobWhereInput {
             type Type = Option<super::super::ID>;
             const NAME: &'static str = "id";
         }
-        impl cynic::schema::HasInputField<id, Option<super::super::ID>> for super::super::JobWhereInput {}
         pub struct id_not;
-        impl cynic::schema::Field for id_not {
+        impl cynic::schema::HasInputField<id_not> for super::super::JobWhereInput {
             type Type = Option<super::super::ID>;
             const NAME: &'static str = "id_not";
         }
-        impl cynic::schema::HasInputField<id_not, Option<super::super::ID>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct id_in;
-        impl cynic::schema::Field for id_in {
+        impl cynic::schema::HasInputField<id_in> for super::super::JobWhereInput {
             type Type = Option<Vec<super::super::ID>>;
             const NAME: &'static str = "id_in";
         }
-        impl cynic::schema::HasInputField<id_in, Option<Vec<super::super::ID>>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct id_not_in;
-        impl cynic::schema::Field for id_not_in {
+        impl cynic::schema::HasInputField<id_not_in> for super::super::JobWhereInput {
             type Type = Option<Vec<super::super::ID>>;
             const NAME: &'static str = "id_not_in";
         }
-        impl cynic::schema::HasInputField<id_not_in, Option<Vec<super::super::ID>>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct id_lt;
-        impl cynic::schema::Field for id_lt {
+        impl cynic::schema::HasInputField<id_lt> for super::super::JobWhereInput {
             type Type = Option<super::super::ID>;
             const NAME: &'static str = "id_lt";
         }
-        impl cynic::schema::HasInputField<id_lt, Option<super::super::ID>> for super::super::JobWhereInput {}
         pub struct id_lte;
-        impl cynic::schema::Field for id_lte {
+        impl cynic::schema::HasInputField<id_lte> for super::super::JobWhereInput {
             type Type = Option<super::super::ID>;
             const NAME: &'static str = "id_lte";
         }
-        impl cynic::schema::HasInputField<id_lte, Option<super::super::ID>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct id_gt;
-        impl cynic::schema::Field for id_gt {
+        impl cynic::schema::HasInputField<id_gt> for super::super::JobWhereInput {
             type Type = Option<super::super::ID>;
             const NAME: &'static str = "id_gt";
         }
-        impl cynic::schema::HasInputField<id_gt, Option<super::super::ID>> for super::super::JobWhereInput {}
         pub struct id_gte;
-        impl cynic::schema::Field for id_gte {
+        impl cynic::schema::HasInputField<id_gte> for super::super::JobWhereInput {
             type Type = Option<super::super::ID>;
             const NAME: &'static str = "id_gte";
         }
-        impl cynic::schema::HasInputField<id_gte, Option<super::super::ID>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct id_contains;
-        impl cynic::schema::Field for id_contains {
+        impl cynic::schema::HasInputField<id_contains> for super::super::JobWhereInput {
             type Type = Option<super::super::ID>;
             const NAME: &'static str = "id_contains";
         }
-        impl cynic::schema::HasInputField<id_contains, Option<super::super::ID>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct id_not_contains;
-        impl cynic::schema::Field for id_not_contains {
+        impl cynic::schema::HasInputField<id_not_contains> for super::super::JobWhereInput {
             type Type = Option<super::super::ID>;
             const NAME: &'static str = "id_not_contains";
         }
-        impl cynic::schema::HasInputField<id_not_contains, Option<super::super::ID>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct id_starts_with;
-        impl cynic::schema::Field for id_starts_with {
+        impl cynic::schema::HasInputField<id_starts_with> for super::super::JobWhereInput {
             type Type = Option<super::super::ID>;
             const NAME: &'static str = "id_starts_with";
         }
-        impl cynic::schema::HasInputField<id_starts_with, Option<super::super::ID>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct id_not_starts_with;
-        impl cynic::schema::Field for id_not_starts_with {
+        impl cynic::schema::HasInputField<id_not_starts_with> for super::super::JobWhereInput {
             type Type = Option<super::super::ID>;
             const NAME: &'static str = "id_not_starts_with";
         }
-        impl cynic::schema::HasInputField<id_not_starts_with, Option<super::super::ID>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct id_ends_with;
-        impl cynic::schema::Field for id_ends_with {
+        impl cynic::schema::HasInputField<id_ends_with> for super::super::JobWhereInput {
             type Type = Option<super::super::ID>;
             const NAME: &'static str = "id_ends_with";
         }
-        impl cynic::schema::HasInputField<id_ends_with, Option<super::super::ID>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct id_not_ends_with;
-        impl cynic::schema::Field for id_not_ends_with {
+        impl cynic::schema::HasInputField<id_not_ends_with> for super::super::JobWhereInput {
             type Type = Option<super::super::ID>;
             const NAME: &'static str = "id_not_ends_with";
         }
-        impl cynic::schema::HasInputField<id_not_ends_with, Option<super::super::ID>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct title;
-        impl cynic::schema::Field for title {
+        impl cynic::schema::HasInputField<title> for super::super::JobWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "title";
         }
-        impl cynic::schema::HasInputField<title, Option<super::super::String>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct title_not;
-        impl cynic::schema::Field for title_not {
+        impl cynic::schema::HasInputField<title_not> for super::super::JobWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "title_not";
         }
-        impl cynic::schema::HasInputField<title_not, Option<super::super::String>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct title_in;
-        impl cynic::schema::Field for title_in {
+        impl cynic::schema::HasInputField<title_in> for super::super::JobWhereInput {
             type Type = Option<Vec<super::super::String>>;
             const NAME: &'static str = "title_in";
         }
-        impl cynic::schema::HasInputField<title_in, Option<Vec<super::super::String>>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct title_not_in;
-        impl cynic::schema::Field for title_not_in {
+        impl cynic::schema::HasInputField<title_not_in> for super::super::JobWhereInput {
             type Type = Option<Vec<super::super::String>>;
             const NAME: &'static str = "title_not_in";
         }
-        impl cynic::schema::HasInputField<title_not_in, Option<Vec<super::super::String>>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct title_lt;
-        impl cynic::schema::Field for title_lt {
+        impl cynic::schema::HasInputField<title_lt> for super::super::JobWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "title_lt";
         }
-        impl cynic::schema::HasInputField<title_lt, Option<super::super::String>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct title_lte;
-        impl cynic::schema::Field for title_lte {
+        impl cynic::schema::HasInputField<title_lte> for super::super::JobWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "title_lte";
         }
-        impl cynic::schema::HasInputField<title_lte, Option<super::super::String>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct title_gt;
-        impl cynic::schema::Field for title_gt {
+        impl cynic::schema::HasInputField<title_gt> for super::super::JobWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "title_gt";
         }
-        impl cynic::schema::HasInputField<title_gt, Option<super::super::String>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct title_gte;
-        impl cynic::schema::Field for title_gte {
+        impl cynic::schema::HasInputField<title_gte> for super::super::JobWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "title_gte";
         }
-        impl cynic::schema::HasInputField<title_gte, Option<super::super::String>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct title_contains;
-        impl cynic::schema::Field for title_contains {
+        impl cynic::schema::HasInputField<title_contains> for super::super::JobWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "title_contains";
         }
-        impl cynic::schema::HasInputField<title_contains, Option<super::super::String>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct title_not_contains;
-        impl cynic::schema::Field for title_not_contains {
+        impl cynic::schema::HasInputField<title_not_contains> for super::super::JobWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "title_not_contains";
         }
-        impl cynic::schema::HasInputField<title_not_contains, Option<super::super::String>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct title_starts_with;
-        impl cynic::schema::Field for title_starts_with {
+        impl cynic::schema::HasInputField<title_starts_with> for super::super::JobWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "title_starts_with";
         }
-        impl cynic::schema::HasInputField<title_starts_with, Option<super::super::String>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct title_not_starts_with;
-        impl cynic::schema::Field for title_not_starts_with {
+        impl cynic::schema::HasInputField<title_not_starts_with> for super::super::JobWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "title_not_starts_with";
         }
-        impl cynic::schema::HasInputField<title_not_starts_with, Option<super::super::String>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct title_ends_with;
-        impl cynic::schema::Field for title_ends_with {
+        impl cynic::schema::HasInputField<title_ends_with> for super::super::JobWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "title_ends_with";
         }
-        impl cynic::schema::HasInputField<title_ends_with, Option<super::super::String>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct title_not_ends_with;
-        impl cynic::schema::Field for title_not_ends_with {
+        impl cynic::schema::HasInputField<title_not_ends_with> for super::super::JobWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "title_not_ends_with";
         }
-        impl cynic::schema::HasInputField<title_not_ends_with, Option<super::super::String>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct slug;
-        impl cynic::schema::Field for slug {
+        impl cynic::schema::HasInputField<slug> for super::super::JobWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "slug";
         }
-        impl cynic::schema::HasInputField<slug, Option<super::super::String>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct slug_not;
-        impl cynic::schema::Field for slug_not {
+        impl cynic::schema::HasInputField<slug_not> for super::super::JobWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "slug_not";
         }
-        impl cynic::schema::HasInputField<slug_not, Option<super::super::String>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct slug_in;
-        impl cynic::schema::Field for slug_in {
+        impl cynic::schema::HasInputField<slug_in> for super::super::JobWhereInput {
             type Type = Option<Vec<super::super::String>>;
             const NAME: &'static str = "slug_in";
         }
-        impl cynic::schema::HasInputField<slug_in, Option<Vec<super::super::String>>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct slug_not_in;
-        impl cynic::schema::Field for slug_not_in {
+        impl cynic::schema::HasInputField<slug_not_in> for super::super::JobWhereInput {
             type Type = Option<Vec<super::super::String>>;
             const NAME: &'static str = "slug_not_in";
         }
-        impl cynic::schema::HasInputField<slug_not_in, Option<Vec<super::super::String>>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct slug_lt;
-        impl cynic::schema::Field for slug_lt {
+        impl cynic::schema::HasInputField<slug_lt> for super::super::JobWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "slug_lt";
         }
-        impl cynic::schema::HasInputField<slug_lt, Option<super::super::String>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct slug_lte;
-        impl cynic::schema::Field for slug_lte {
+        impl cynic::schema::HasInputField<slug_lte> for super::super::JobWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "slug_lte";
         }
-        impl cynic::schema::HasInputField<slug_lte, Option<super::super::String>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct slug_gt;
-        impl cynic::schema::Field for slug_gt {
+        impl cynic::schema::HasInputField<slug_gt> for super::super::JobWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "slug_gt";
         }
-        impl cynic::schema::HasInputField<slug_gt, Option<super::super::String>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct slug_gte;
-        impl cynic::schema::Field for slug_gte {
+        impl cynic::schema::HasInputField<slug_gte> for super::super::JobWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "slug_gte";
         }
-        impl cynic::schema::HasInputField<slug_gte, Option<super::super::String>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct slug_contains;
-        impl cynic::schema::Field for slug_contains {
+        impl cynic::schema::HasInputField<slug_contains> for super::super::JobWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "slug_contains";
         }
-        impl cynic::schema::HasInputField<slug_contains, Option<super::super::String>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct slug_not_contains;
-        impl cynic::schema::Field for slug_not_contains {
+        impl cynic::schema::HasInputField<slug_not_contains> for super::super::JobWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "slug_not_contains";
         }
-        impl cynic::schema::HasInputField<slug_not_contains, Option<super::super::String>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct slug_starts_with;
-        impl cynic::schema::Field for slug_starts_with {
+        impl cynic::schema::HasInputField<slug_starts_with> for super::super::JobWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "slug_starts_with";
         }
-        impl cynic::schema::HasInputField<slug_starts_with, Option<super::super::String>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct slug_not_starts_with;
-        impl cynic::schema::Field for slug_not_starts_with {
+        impl cynic::schema::HasInputField<slug_not_starts_with> for super::super::JobWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "slug_not_starts_with";
         }
-        impl cynic::schema::HasInputField<slug_not_starts_with, Option<super::super::String>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct slug_ends_with;
-        impl cynic::schema::Field for slug_ends_with {
+        impl cynic::schema::HasInputField<slug_ends_with> for super::super::JobWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "slug_ends_with";
         }
-        impl cynic::schema::HasInputField<slug_ends_with, Option<super::super::String>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct slug_not_ends_with;
-        impl cynic::schema::Field for slug_not_ends_with {
+        impl cynic::schema::HasInputField<slug_not_ends_with> for super::super::JobWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "slug_not_ends_with";
         }
-        impl cynic::schema::HasInputField<slug_not_ends_with, Option<super::super::String>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct commitment;
-        impl cynic::schema::Field for commitment {
+        impl cynic::schema::HasInputField<commitment> for super::super::JobWhereInput {
             type Type = Option<super::super::CommitmentWhereInput>;
             const NAME: &'static str = "commitment";
         }
-        impl cynic::schema::HasInputField<commitment, Option<super::super::CommitmentWhereInput>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct cities_every;
-        impl cynic::schema::Field for cities_every {
+        impl cynic::schema::HasInputField<cities_every> for super::super::JobWhereInput {
             type Type = Option<super::super::CityWhereInput>;
             const NAME: &'static str = "cities_every";
         }
-        impl cynic::schema::HasInputField<cities_every, Option<super::super::CityWhereInput>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct cities_some;
-        impl cynic::schema::Field for cities_some {
+        impl cynic::schema::HasInputField<cities_some> for super::super::JobWhereInput {
             type Type = Option<super::super::CityWhereInput>;
             const NAME: &'static str = "cities_some";
         }
-        impl cynic::schema::HasInputField<cities_some, Option<super::super::CityWhereInput>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct cities_none;
-        impl cynic::schema::Field for cities_none {
+        impl cynic::schema::HasInputField<cities_none> for super::super::JobWhereInput {
             type Type = Option<super::super::CityWhereInput>;
             const NAME: &'static str = "cities_none";
         }
-        impl cynic::schema::HasInputField<cities_none, Option<super::super::CityWhereInput>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct countries_every;
-        impl cynic::schema::Field for countries_every {
+        impl cynic::schema::HasInputField<countries_every> for super::super::JobWhereInput {
             type Type = Option<super::super::CountryWhereInput>;
             const NAME: &'static str = "countries_every";
         }
-        impl cynic::schema::HasInputField<countries_every, Option<super::super::CountryWhereInput>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct countries_some;
-        impl cynic::schema::Field for countries_some {
+        impl cynic::schema::HasInputField<countries_some> for super::super::JobWhereInput {
             type Type = Option<super::super::CountryWhereInput>;
             const NAME: &'static str = "countries_some";
         }
-        impl cynic::schema::HasInputField<countries_some, Option<super::super::CountryWhereInput>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct countries_none;
-        impl cynic::schema::Field for countries_none {
+        impl cynic::schema::HasInputField<countries_none> for super::super::JobWhereInput {
             type Type = Option<super::super::CountryWhereInput>;
             const NAME: &'static str = "countries_none";
         }
-        impl cynic::schema::HasInputField<countries_none, Option<super::super::CountryWhereInput>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct remotes_every;
-        impl cynic::schema::Field for remotes_every {
+        impl cynic::schema::HasInputField<remotes_every> for super::super::JobWhereInput {
             type Type = Option<super::super::RemoteWhereInput>;
             const NAME: &'static str = "remotes_every";
         }
-        impl cynic::schema::HasInputField<remotes_every, Option<super::super::RemoteWhereInput>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct remotes_some;
-        impl cynic::schema::Field for remotes_some {
+        impl cynic::schema::HasInputField<remotes_some> for super::super::JobWhereInput {
             type Type = Option<super::super::RemoteWhereInput>;
             const NAME: &'static str = "remotes_some";
         }
-        impl cynic::schema::HasInputField<remotes_some, Option<super::super::RemoteWhereInput>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct remotes_none;
-        impl cynic::schema::Field for remotes_none {
+        impl cynic::schema::HasInputField<remotes_none> for super::super::JobWhereInput {
             type Type = Option<super::super::RemoteWhereInput>;
             const NAME: &'static str = "remotes_none";
         }
-        impl cynic::schema::HasInputField<remotes_none, Option<super::super::RemoteWhereInput>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct description;
-        impl cynic::schema::Field for description {
+        impl cynic::schema::HasInputField<description> for super::super::JobWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "description";
         }
-        impl cynic::schema::HasInputField<description, Option<super::super::String>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct description_not;
-        impl cynic::schema::Field for description_not {
+        impl cynic::schema::HasInputField<description_not> for super::super::JobWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "description_not";
         }
-        impl cynic::schema::HasInputField<description_not, Option<super::super::String>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct description_in;
-        impl cynic::schema::Field for description_in {
+        impl cynic::schema::HasInputField<description_in> for super::super::JobWhereInput {
             type Type = Option<Vec<super::super::String>>;
             const NAME: &'static str = "description_in";
         }
-        impl cynic::schema::HasInputField<description_in, Option<Vec<super::super::String>>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct description_not_in;
-        impl cynic::schema::Field for description_not_in {
+        impl cynic::schema::HasInputField<description_not_in> for super::super::JobWhereInput {
             type Type = Option<Vec<super::super::String>>;
             const NAME: &'static str = "description_not_in";
         }
-        impl cynic::schema::HasInputField<description_not_in, Option<Vec<super::super::String>>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct description_lt;
-        impl cynic::schema::Field for description_lt {
+        impl cynic::schema::HasInputField<description_lt> for super::super::JobWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "description_lt";
         }
-        impl cynic::schema::HasInputField<description_lt, Option<super::super::String>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct description_lte;
-        impl cynic::schema::Field for description_lte {
+        impl cynic::schema::HasInputField<description_lte> for super::super::JobWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "description_lte";
         }
-        impl cynic::schema::HasInputField<description_lte, Option<super::super::String>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct description_gt;
-        impl cynic::schema::Field for description_gt {
+        impl cynic::schema::HasInputField<description_gt> for super::super::JobWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "description_gt";
         }
-        impl cynic::schema::HasInputField<description_gt, Option<super::super::String>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct description_gte;
-        impl cynic::schema::Field for description_gte {
+        impl cynic::schema::HasInputField<description_gte> for super::super::JobWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "description_gte";
         }
-        impl cynic::schema::HasInputField<description_gte, Option<super::super::String>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct description_contains;
-        impl cynic::schema::Field for description_contains {
+        impl cynic::schema::HasInputField<description_contains> for super::super::JobWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "description_contains";
         }
-        impl cynic::schema::HasInputField<description_contains, Option<super::super::String>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct description_not_contains;
-        impl cynic::schema::Field for description_not_contains {
+        impl cynic::schema::HasInputField<description_not_contains> for super::super::JobWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "description_not_contains";
         }
-        impl cynic::schema::HasInputField<description_not_contains, Option<super::super::String>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct description_starts_with;
-        impl cynic::schema::Field for description_starts_with {
+        impl cynic::schema::HasInputField<description_starts_with> for super::super::JobWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "description_starts_with";
         }
-        impl cynic::schema::HasInputField<description_starts_with, Option<super::super::String>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct description_not_starts_with;
-        impl cynic::schema::Field for description_not_starts_with {
+        impl cynic::schema::HasInputField<description_not_starts_with> for super::super::JobWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "description_not_starts_with";
         }
-        impl cynic::schema::HasInputField<description_not_starts_with, Option<super::super::String>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct description_ends_with;
-        impl cynic::schema::Field for description_ends_with {
+        impl cynic::schema::HasInputField<description_ends_with> for super::super::JobWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "description_ends_with";
         }
-        impl cynic::schema::HasInputField<description_ends_with, Option<super::super::String>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct description_not_ends_with;
-        impl cynic::schema::Field for description_not_ends_with {
+        impl cynic::schema::HasInputField<description_not_ends_with> for super::super::JobWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "description_not_ends_with";
         }
-        impl cynic::schema::HasInputField<description_not_ends_with, Option<super::super::String>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct applyUrl;
-        impl cynic::schema::Field for applyUrl {
+        impl cynic::schema::HasInputField<applyUrl> for super::super::JobWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "applyUrl";
         }
-        impl cynic::schema::HasInputField<applyUrl, Option<super::super::String>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct applyUrl_not;
-        impl cynic::schema::Field for applyUrl_not {
+        impl cynic::schema::HasInputField<applyUrl_not> for super::super::JobWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "applyUrl_not";
         }
-        impl cynic::schema::HasInputField<applyUrl_not, Option<super::super::String>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct applyUrl_in;
-        impl cynic::schema::Field for applyUrl_in {
+        impl cynic::schema::HasInputField<applyUrl_in> for super::super::JobWhereInput {
             type Type = Option<Vec<super::super::String>>;
             const NAME: &'static str = "applyUrl_in";
         }
-        impl cynic::schema::HasInputField<applyUrl_in, Option<Vec<super::super::String>>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct applyUrl_not_in;
-        impl cynic::schema::Field for applyUrl_not_in {
+        impl cynic::schema::HasInputField<applyUrl_not_in> for super::super::JobWhereInput {
             type Type = Option<Vec<super::super::String>>;
             const NAME: &'static str = "applyUrl_not_in";
         }
-        impl cynic::schema::HasInputField<applyUrl_not_in, Option<Vec<super::super::String>>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct applyUrl_lt;
-        impl cynic::schema::Field for applyUrl_lt {
+        impl cynic::schema::HasInputField<applyUrl_lt> for super::super::JobWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "applyUrl_lt";
         }
-        impl cynic::schema::HasInputField<applyUrl_lt, Option<super::super::String>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct applyUrl_lte;
-        impl cynic::schema::Field for applyUrl_lte {
+        impl cynic::schema::HasInputField<applyUrl_lte> for super::super::JobWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "applyUrl_lte";
         }
-        impl cynic::schema::HasInputField<applyUrl_lte, Option<super::super::String>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct applyUrl_gt;
-        impl cynic::schema::Field for applyUrl_gt {
+        impl cynic::schema::HasInputField<applyUrl_gt> for super::super::JobWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "applyUrl_gt";
         }
-        impl cynic::schema::HasInputField<applyUrl_gt, Option<super::super::String>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct applyUrl_gte;
-        impl cynic::schema::Field for applyUrl_gte {
+        impl cynic::schema::HasInputField<applyUrl_gte> for super::super::JobWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "applyUrl_gte";
         }
-        impl cynic::schema::HasInputField<applyUrl_gte, Option<super::super::String>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct applyUrl_contains;
-        impl cynic::schema::Field for applyUrl_contains {
+        impl cynic::schema::HasInputField<applyUrl_contains> for super::super::JobWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "applyUrl_contains";
         }
-        impl cynic::schema::HasInputField<applyUrl_contains, Option<super::super::String>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct applyUrl_not_contains;
-        impl cynic::schema::Field for applyUrl_not_contains {
+        impl cynic::schema::HasInputField<applyUrl_not_contains> for super::super::JobWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "applyUrl_not_contains";
         }
-        impl cynic::schema::HasInputField<applyUrl_not_contains, Option<super::super::String>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct applyUrl_starts_with;
-        impl cynic::schema::Field for applyUrl_starts_with {
+        impl cynic::schema::HasInputField<applyUrl_starts_with> for super::super::JobWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "applyUrl_starts_with";
         }
-        impl cynic::schema::HasInputField<applyUrl_starts_with, Option<super::super::String>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct applyUrl_not_starts_with;
-        impl cynic::schema::Field for applyUrl_not_starts_with {
+        impl cynic::schema::HasInputField<applyUrl_not_starts_with> for super::super::JobWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "applyUrl_not_starts_with";
         }
-        impl cynic::schema::HasInputField<applyUrl_not_starts_with, Option<super::super::String>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct applyUrl_ends_with;
-        impl cynic::schema::Field for applyUrl_ends_with {
+        impl cynic::schema::HasInputField<applyUrl_ends_with> for super::super::JobWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "applyUrl_ends_with";
         }
-        impl cynic::schema::HasInputField<applyUrl_ends_with, Option<super::super::String>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct applyUrl_not_ends_with;
-        impl cynic::schema::Field for applyUrl_not_ends_with {
+        impl cynic::schema::HasInputField<applyUrl_not_ends_with> for super::super::JobWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "applyUrl_not_ends_with";
         }
-        impl cynic::schema::HasInputField<applyUrl_not_ends_with, Option<super::super::String>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct company;
-        impl cynic::schema::Field for company {
+        impl cynic::schema::HasInputField<company> for super::super::JobWhereInput {
             type Type = Option<super::super::CompanyWhereInput>;
             const NAME: &'static str = "company";
         }
-        impl cynic::schema::HasInputField<company, Option<super::super::CompanyWhereInput>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct tags_every;
-        impl cynic::schema::Field for tags_every {
+        impl cynic::schema::HasInputField<tags_every> for super::super::JobWhereInput {
             type Type = Option<super::super::TagWhereInput>;
             const NAME: &'static str = "tags_every";
         }
-        impl cynic::schema::HasInputField<tags_every, Option<super::super::TagWhereInput>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct tags_some;
-        impl cynic::schema::Field for tags_some {
+        impl cynic::schema::HasInputField<tags_some> for super::super::JobWhereInput {
             type Type = Option<super::super::TagWhereInput>;
             const NAME: &'static str = "tags_some";
         }
-        impl cynic::schema::HasInputField<tags_some, Option<super::super::TagWhereInput>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct tags_none;
-        impl cynic::schema::Field for tags_none {
+        impl cynic::schema::HasInputField<tags_none> for super::super::JobWhereInput {
             type Type = Option<super::super::TagWhereInput>;
             const NAME: &'static str = "tags_none";
         }
-        impl cynic::schema::HasInputField<tags_none, Option<super::super::TagWhereInput>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct isPublished;
-        impl cynic::schema::Field for isPublished {
+        impl cynic::schema::HasInputField<isPublished> for super::super::JobWhereInput {
             type Type = Option<super::super::Boolean>;
             const NAME: &'static str = "isPublished";
         }
-        impl cynic::schema::HasInputField<isPublished, Option<super::super::Boolean>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct isPublished_not;
-        impl cynic::schema::Field for isPublished_not {
+        impl cynic::schema::HasInputField<isPublished_not> for super::super::JobWhereInput {
             type Type = Option<super::super::Boolean>;
             const NAME: &'static str = "isPublished_not";
         }
-        impl cynic::schema::HasInputField<isPublished_not, Option<super::super::Boolean>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct isFeatured;
-        impl cynic::schema::Field for isFeatured {
+        impl cynic::schema::HasInputField<isFeatured> for super::super::JobWhereInput {
             type Type = Option<super::super::Boolean>;
             const NAME: &'static str = "isFeatured";
         }
-        impl cynic::schema::HasInputField<isFeatured, Option<super::super::Boolean>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct isFeatured_not;
-        impl cynic::schema::Field for isFeatured_not {
+        impl cynic::schema::HasInputField<isFeatured_not> for super::super::JobWhereInput {
             type Type = Option<super::super::Boolean>;
             const NAME: &'static str = "isFeatured_not";
         }
-        impl cynic::schema::HasInputField<isFeatured_not, Option<super::super::Boolean>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct locationNames;
-        impl cynic::schema::Field for locationNames {
+        impl cynic::schema::HasInputField<locationNames> for super::super::JobWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "locationNames";
         }
-        impl cynic::schema::HasInputField<locationNames, Option<super::super::String>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct locationNames_not;
-        impl cynic::schema::Field for locationNames_not {
+        impl cynic::schema::HasInputField<locationNames_not> for super::super::JobWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "locationNames_not";
         }
-        impl cynic::schema::HasInputField<locationNames_not, Option<super::super::String>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct locationNames_in;
-        impl cynic::schema::Field for locationNames_in {
+        impl cynic::schema::HasInputField<locationNames_in> for super::super::JobWhereInput {
             type Type = Option<Vec<super::super::String>>;
             const NAME: &'static str = "locationNames_in";
         }
-        impl cynic::schema::HasInputField<locationNames_in, Option<Vec<super::super::String>>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct locationNames_not_in;
-        impl cynic::schema::Field for locationNames_not_in {
+        impl cynic::schema::HasInputField<locationNames_not_in> for super::super::JobWhereInput {
             type Type = Option<Vec<super::super::String>>;
             const NAME: &'static str = "locationNames_not_in";
         }
-        impl cynic::schema::HasInputField<locationNames_not_in, Option<Vec<super::super::String>>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct locationNames_lt;
-        impl cynic::schema::Field for locationNames_lt {
+        impl cynic::schema::HasInputField<locationNames_lt> for super::super::JobWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "locationNames_lt";
         }
-        impl cynic::schema::HasInputField<locationNames_lt, Option<super::super::String>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct locationNames_lte;
-        impl cynic::schema::Field for locationNames_lte {
+        impl cynic::schema::HasInputField<locationNames_lte> for super::super::JobWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "locationNames_lte";
         }
-        impl cynic::schema::HasInputField<locationNames_lte, Option<super::super::String>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct locationNames_gt;
-        impl cynic::schema::Field for locationNames_gt {
+        impl cynic::schema::HasInputField<locationNames_gt> for super::super::JobWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "locationNames_gt";
         }
-        impl cynic::schema::HasInputField<locationNames_gt, Option<super::super::String>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct locationNames_gte;
-        impl cynic::schema::Field for locationNames_gte {
+        impl cynic::schema::HasInputField<locationNames_gte> for super::super::JobWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "locationNames_gte";
         }
-        impl cynic::schema::HasInputField<locationNames_gte, Option<super::super::String>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct locationNames_contains;
-        impl cynic::schema::Field for locationNames_contains {
+        impl cynic::schema::HasInputField<locationNames_contains> for super::super::JobWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "locationNames_contains";
         }
-        impl cynic::schema::HasInputField<locationNames_contains, Option<super::super::String>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct locationNames_not_contains;
-        impl cynic::schema::Field for locationNames_not_contains {
+        impl cynic::schema::HasInputField<locationNames_not_contains> for super::super::JobWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "locationNames_not_contains";
         }
-        impl cynic::schema::HasInputField<locationNames_not_contains, Option<super::super::String>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct locationNames_starts_with;
-        impl cynic::schema::Field for locationNames_starts_with {
+        impl cynic::schema::HasInputField<locationNames_starts_with> for super::super::JobWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "locationNames_starts_with";
         }
-        impl cynic::schema::HasInputField<locationNames_starts_with, Option<super::super::String>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct locationNames_not_starts_with;
-        impl cynic::schema::Field for locationNames_not_starts_with {
+        impl cynic::schema::HasInputField<locationNames_not_starts_with> for super::super::JobWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "locationNames_not_starts_with";
         }
-        impl
-            cynic::schema::HasInputField<
-                locationNames_not_starts_with,
-                Option<super::super::String>,
-            > for super::super::JobWhereInput
-        {
-        }
         pub struct locationNames_ends_with;
-        impl cynic::schema::Field for locationNames_ends_with {
+        impl cynic::schema::HasInputField<locationNames_ends_with> for super::super::JobWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "locationNames_ends_with";
         }
-        impl cynic::schema::HasInputField<locationNames_ends_with, Option<super::super::String>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct locationNames_not_ends_with;
-        impl cynic::schema::Field for locationNames_not_ends_with {
+        impl cynic::schema::HasInputField<locationNames_not_ends_with> for super::super::JobWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "locationNames_not_ends_with";
         }
-        impl cynic::schema::HasInputField<locationNames_not_ends_with, Option<super::super::String>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct userEmail;
-        impl cynic::schema::Field for userEmail {
+        impl cynic::schema::HasInputField<userEmail> for super::super::JobWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "userEmail";
         }
-        impl cynic::schema::HasInputField<userEmail, Option<super::super::String>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct userEmail_not;
-        impl cynic::schema::Field for userEmail_not {
+        impl cynic::schema::HasInputField<userEmail_not> for super::super::JobWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "userEmail_not";
         }
-        impl cynic::schema::HasInputField<userEmail_not, Option<super::super::String>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct userEmail_in;
-        impl cynic::schema::Field for userEmail_in {
+        impl cynic::schema::HasInputField<userEmail_in> for super::super::JobWhereInput {
             type Type = Option<Vec<super::super::String>>;
             const NAME: &'static str = "userEmail_in";
         }
-        impl cynic::schema::HasInputField<userEmail_in, Option<Vec<super::super::String>>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct userEmail_not_in;
-        impl cynic::schema::Field for userEmail_not_in {
+        impl cynic::schema::HasInputField<userEmail_not_in> for super::super::JobWhereInput {
             type Type = Option<Vec<super::super::String>>;
             const NAME: &'static str = "userEmail_not_in";
         }
-        impl cynic::schema::HasInputField<userEmail_not_in, Option<Vec<super::super::String>>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct userEmail_lt;
-        impl cynic::schema::Field for userEmail_lt {
+        impl cynic::schema::HasInputField<userEmail_lt> for super::super::JobWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "userEmail_lt";
         }
-        impl cynic::schema::HasInputField<userEmail_lt, Option<super::super::String>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct userEmail_lte;
-        impl cynic::schema::Field for userEmail_lte {
+        impl cynic::schema::HasInputField<userEmail_lte> for super::super::JobWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "userEmail_lte";
         }
-        impl cynic::schema::HasInputField<userEmail_lte, Option<super::super::String>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct userEmail_gt;
-        impl cynic::schema::Field for userEmail_gt {
+        impl cynic::schema::HasInputField<userEmail_gt> for super::super::JobWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "userEmail_gt";
         }
-        impl cynic::schema::HasInputField<userEmail_gt, Option<super::super::String>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct userEmail_gte;
-        impl cynic::schema::Field for userEmail_gte {
+        impl cynic::schema::HasInputField<userEmail_gte> for super::super::JobWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "userEmail_gte";
         }
-        impl cynic::schema::HasInputField<userEmail_gte, Option<super::super::String>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct userEmail_contains;
-        impl cynic::schema::Field for userEmail_contains {
+        impl cynic::schema::HasInputField<userEmail_contains> for super::super::JobWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "userEmail_contains";
         }
-        impl cynic::schema::HasInputField<userEmail_contains, Option<super::super::String>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct userEmail_not_contains;
-        impl cynic::schema::Field for userEmail_not_contains {
+        impl cynic::schema::HasInputField<userEmail_not_contains> for super::super::JobWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "userEmail_not_contains";
         }
-        impl cynic::schema::HasInputField<userEmail_not_contains, Option<super::super::String>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct userEmail_starts_with;
-        impl cynic::schema::Field for userEmail_starts_with {
+        impl cynic::schema::HasInputField<userEmail_starts_with> for super::super::JobWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "userEmail_starts_with";
         }
-        impl cynic::schema::HasInputField<userEmail_starts_with, Option<super::super::String>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct userEmail_not_starts_with;
-        impl cynic::schema::Field for userEmail_not_starts_with {
+        impl cynic::schema::HasInputField<userEmail_not_starts_with> for super::super::JobWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "userEmail_not_starts_with";
         }
-        impl cynic::schema::HasInputField<userEmail_not_starts_with, Option<super::super::String>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct userEmail_ends_with;
-        impl cynic::schema::Field for userEmail_ends_with {
+        impl cynic::schema::HasInputField<userEmail_ends_with> for super::super::JobWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "userEmail_ends_with";
         }
-        impl cynic::schema::HasInputField<userEmail_ends_with, Option<super::super::String>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct userEmail_not_ends_with;
-        impl cynic::schema::Field for userEmail_not_ends_with {
+        impl cynic::schema::HasInputField<userEmail_not_ends_with> for super::super::JobWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "userEmail_not_ends_with";
         }
-        impl cynic::schema::HasInputField<userEmail_not_ends_with, Option<super::super::String>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct postedAt;
-        impl cynic::schema::Field for postedAt {
+        impl cynic::schema::HasInputField<postedAt> for super::super::JobWhereInput {
             type Type = Option<super::super::DateTime>;
             const NAME: &'static str = "postedAt";
         }
-        impl cynic::schema::HasInputField<postedAt, Option<super::super::DateTime>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct postedAt_not;
-        impl cynic::schema::Field for postedAt_not {
+        impl cynic::schema::HasInputField<postedAt_not> for super::super::JobWhereInput {
             type Type = Option<super::super::DateTime>;
             const NAME: &'static str = "postedAt_not";
         }
-        impl cynic::schema::HasInputField<postedAt_not, Option<super::super::DateTime>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct postedAt_in;
-        impl cynic::schema::Field for postedAt_in {
+        impl cynic::schema::HasInputField<postedAt_in> for super::super::JobWhereInput {
             type Type = Option<Vec<super::super::DateTime>>;
             const NAME: &'static str = "postedAt_in";
         }
-        impl cynic::schema::HasInputField<postedAt_in, Option<Vec<super::super::DateTime>>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct postedAt_not_in;
-        impl cynic::schema::Field for postedAt_not_in {
+        impl cynic::schema::HasInputField<postedAt_not_in> for super::super::JobWhereInput {
             type Type = Option<Vec<super::super::DateTime>>;
             const NAME: &'static str = "postedAt_not_in";
         }
-        impl cynic::schema::HasInputField<postedAt_not_in, Option<Vec<super::super::DateTime>>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct postedAt_lt;
-        impl cynic::schema::Field for postedAt_lt {
+        impl cynic::schema::HasInputField<postedAt_lt> for super::super::JobWhereInput {
             type Type = Option<super::super::DateTime>;
             const NAME: &'static str = "postedAt_lt";
         }
-        impl cynic::schema::HasInputField<postedAt_lt, Option<super::super::DateTime>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct postedAt_lte;
-        impl cynic::schema::Field for postedAt_lte {
+        impl cynic::schema::HasInputField<postedAt_lte> for super::super::JobWhereInput {
             type Type = Option<super::super::DateTime>;
             const NAME: &'static str = "postedAt_lte";
         }
-        impl cynic::schema::HasInputField<postedAt_lte, Option<super::super::DateTime>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct postedAt_gt;
-        impl cynic::schema::Field for postedAt_gt {
+        impl cynic::schema::HasInputField<postedAt_gt> for super::super::JobWhereInput {
             type Type = Option<super::super::DateTime>;
             const NAME: &'static str = "postedAt_gt";
         }
-        impl cynic::schema::HasInputField<postedAt_gt, Option<super::super::DateTime>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct postedAt_gte;
-        impl cynic::schema::Field for postedAt_gte {
+        impl cynic::schema::HasInputField<postedAt_gte> for super::super::JobWhereInput {
             type Type = Option<super::super::DateTime>;
             const NAME: &'static str = "postedAt_gte";
         }
-        impl cynic::schema::HasInputField<postedAt_gte, Option<super::super::DateTime>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct createdAt;
-        impl cynic::schema::Field for createdAt {
+        impl cynic::schema::HasInputField<createdAt> for super::super::JobWhereInput {
             type Type = Option<super::super::DateTime>;
             const NAME: &'static str = "createdAt";
         }
-        impl cynic::schema::HasInputField<createdAt, Option<super::super::DateTime>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct createdAt_not;
-        impl cynic::schema::Field for createdAt_not {
+        impl cynic::schema::HasInputField<createdAt_not> for super::super::JobWhereInput {
             type Type = Option<super::super::DateTime>;
             const NAME: &'static str = "createdAt_not";
         }
-        impl cynic::schema::HasInputField<createdAt_not, Option<super::super::DateTime>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct createdAt_in;
-        impl cynic::schema::Field for createdAt_in {
+        impl cynic::schema::HasInputField<createdAt_in> for super::super::JobWhereInput {
             type Type = Option<Vec<super::super::DateTime>>;
             const NAME: &'static str = "createdAt_in";
         }
-        impl cynic::schema::HasInputField<createdAt_in, Option<Vec<super::super::DateTime>>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct createdAt_not_in;
-        impl cynic::schema::Field for createdAt_not_in {
+        impl cynic::schema::HasInputField<createdAt_not_in> for super::super::JobWhereInput {
             type Type = Option<Vec<super::super::DateTime>>;
             const NAME: &'static str = "createdAt_not_in";
         }
-        impl cynic::schema::HasInputField<createdAt_not_in, Option<Vec<super::super::DateTime>>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct createdAt_lt;
-        impl cynic::schema::Field for createdAt_lt {
+        impl cynic::schema::HasInputField<createdAt_lt> for super::super::JobWhereInput {
             type Type = Option<super::super::DateTime>;
             const NAME: &'static str = "createdAt_lt";
         }
-        impl cynic::schema::HasInputField<createdAt_lt, Option<super::super::DateTime>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct createdAt_lte;
-        impl cynic::schema::Field for createdAt_lte {
+        impl cynic::schema::HasInputField<createdAt_lte> for super::super::JobWhereInput {
             type Type = Option<super::super::DateTime>;
             const NAME: &'static str = "createdAt_lte";
         }
-        impl cynic::schema::HasInputField<createdAt_lte, Option<super::super::DateTime>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct createdAt_gt;
-        impl cynic::schema::Field for createdAt_gt {
+        impl cynic::schema::HasInputField<createdAt_gt> for super::super::JobWhereInput {
             type Type = Option<super::super::DateTime>;
             const NAME: &'static str = "createdAt_gt";
         }
-        impl cynic::schema::HasInputField<createdAt_gt, Option<super::super::DateTime>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct createdAt_gte;
-        impl cynic::schema::Field for createdAt_gte {
+        impl cynic::schema::HasInputField<createdAt_gte> for super::super::JobWhereInput {
             type Type = Option<super::super::DateTime>;
             const NAME: &'static str = "createdAt_gte";
         }
-        impl cynic::schema::HasInputField<createdAt_gte, Option<super::super::DateTime>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct updatedAt;
-        impl cynic::schema::Field for updatedAt {
+        impl cynic::schema::HasInputField<updatedAt> for super::super::JobWhereInput {
             type Type = Option<super::super::DateTime>;
             const NAME: &'static str = "updatedAt";
         }
-        impl cynic::schema::HasInputField<updatedAt, Option<super::super::DateTime>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct updatedAt_not;
-        impl cynic::schema::Field for updatedAt_not {
+        impl cynic::schema::HasInputField<updatedAt_not> for super::super::JobWhereInput {
             type Type = Option<super::super::DateTime>;
             const NAME: &'static str = "updatedAt_not";
         }
-        impl cynic::schema::HasInputField<updatedAt_not, Option<super::super::DateTime>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct updatedAt_in;
-        impl cynic::schema::Field for updatedAt_in {
+        impl cynic::schema::HasInputField<updatedAt_in> for super::super::JobWhereInput {
             type Type = Option<Vec<super::super::DateTime>>;
             const NAME: &'static str = "updatedAt_in";
         }
-        impl cynic::schema::HasInputField<updatedAt_in, Option<Vec<super::super::DateTime>>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct updatedAt_not_in;
-        impl cynic::schema::Field for updatedAt_not_in {
+        impl cynic::schema::HasInputField<updatedAt_not_in> for super::super::JobWhereInput {
             type Type = Option<Vec<super::super::DateTime>>;
             const NAME: &'static str = "updatedAt_not_in";
         }
-        impl cynic::schema::HasInputField<updatedAt_not_in, Option<Vec<super::super::DateTime>>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct updatedAt_lt;
-        impl cynic::schema::Field for updatedAt_lt {
+        impl cynic::schema::HasInputField<updatedAt_lt> for super::super::JobWhereInput {
             type Type = Option<super::super::DateTime>;
             const NAME: &'static str = "updatedAt_lt";
         }
-        impl cynic::schema::HasInputField<updatedAt_lt, Option<super::super::DateTime>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct updatedAt_lte;
-        impl cynic::schema::Field for updatedAt_lte {
+        impl cynic::schema::HasInputField<updatedAt_lte> for super::super::JobWhereInput {
             type Type = Option<super::super::DateTime>;
             const NAME: &'static str = "updatedAt_lte";
         }
-        impl cynic::schema::HasInputField<updatedAt_lte, Option<super::super::DateTime>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct updatedAt_gt;
-        impl cynic::schema::Field for updatedAt_gt {
+        impl cynic::schema::HasInputField<updatedAt_gt> for super::super::JobWhereInput {
             type Type = Option<super::super::DateTime>;
             const NAME: &'static str = "updatedAt_gt";
         }
-        impl cynic::schema::HasInputField<updatedAt_gt, Option<super::super::DateTime>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct updatedAt_gte;
-        impl cynic::schema::Field for updatedAt_gte {
+        impl cynic::schema::HasInputField<updatedAt_gte> for super::super::JobWhereInput {
             type Type = Option<super::super::DateTime>;
             const NAME: &'static str = "updatedAt_gte";
         }
-        impl cynic::schema::HasInputField<updatedAt_gte, Option<super::super::DateTime>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct AND;
-        impl cynic::schema::Field for AND {
+        impl cynic::schema::HasInputField<AND> for super::super::JobWhereInput {
             type Type = Option<Vec<super::super::JobWhereInput>>;
             const NAME: &'static str = "AND";
         }
-        impl cynic::schema::HasInputField<AND, Option<Vec<super::super::JobWhereInput>>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct OR;
-        impl cynic::schema::Field for OR {
+        impl cynic::schema::HasInputField<OR> for super::super::JobWhereInput {
             type Type = Option<Vec<super::super::JobWhereInput>>;
             const NAME: &'static str = "OR";
         }
-        impl cynic::schema::HasInputField<OR, Option<Vec<super::super::JobWhereInput>>>
-            for super::super::JobWhereInput
-        {
-        }
         pub struct NOT;
-        impl cynic::schema::Field for NOT {
+        impl cynic::schema::HasInputField<NOT> for super::super::JobWhereInput {
             type Type = Option<Vec<super::super::JobWhereInput>>;
             const NAME: &'static str = "NOT";
-        }
-        impl cynic::schema::HasInputField<NOT, Option<Vec<super::super::JobWhereInput>>>
-            for super::super::JobWhereInput
-        {
         }
     }
     pub mod JobsInput {
         pub struct r#type;
-        impl cynic::schema::Field for r#type {
+        impl cynic::schema::HasInputField<r#type> for super::super::JobsInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "type";
         }
-        impl cynic::schema::HasInputField<r#type, Option<super::super::String>>
-            for super::super::JobsInput
-        {
-        }
         pub struct slug;
-        impl cynic::schema::Field for slug {
+        impl cynic::schema::HasInputField<slug> for super::super::JobsInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "slug";
         }
-        impl cynic::schema::HasInputField<slug, Option<super::super::String>> for super::super::JobsInput {}
     }
     pub mod Location {
         pub struct id;
-        impl cynic::schema::Field for id {
+        impl cynic::schema::HasField<id> for super::super::Location {
             type Type = super::super::ID;
             const NAME: &'static str = "id";
         }
-        impl cynic::schema::HasField<id> for super::super::Location {
-            type Type = super::super::ID;
-        }
         pub struct slug;
-        impl cynic::schema::Field for slug {
+        impl cynic::schema::HasField<slug> for super::super::Location {
             type Type = super::super::String;
             const NAME: &'static str = "slug";
         }
-        impl cynic::schema::HasField<slug> for super::super::Location {
-            type Type = super::super::String;
-        }
         pub struct name;
-        impl cynic::schema::Field for name {
+        impl cynic::schema::HasField<name> for super::super::Location {
             type Type = super::super::String;
             const NAME: &'static str = "name";
         }
-        impl cynic::schema::HasField<name> for super::super::Location {
-            type Type = super::super::String;
-        }
         pub struct r#type;
-        impl cynic::schema::Field for r#type {
+        impl cynic::schema::HasField<r#type> for super::super::Location {
             type Type = super::super::String;
             const NAME: &'static str = "type";
         }
-        impl cynic::schema::HasField<r#type> for super::super::Location {
-            type Type = super::super::String;
-        }
         pub struct __typename;
-        impl cynic::schema::Field for __typename {
-            type Type = super::super::String;
-            const NAME: &'static str = "__typename";
-        }
         impl cynic::schema::HasField<__typename> for super::super::Location {
             type Type = super::super::String;
+            const NAME: &'static str = "__typename";
         }
     }
     pub mod LocationInput {
         pub struct slug;
-        impl cynic::schema::Field for slug {
+        impl cynic::schema::HasInputField<slug> for super::super::LocationInput {
             type Type = super::super::String;
             const NAME: &'static str = "slug";
         }
-        impl cynic::schema::HasInputField<slug, super::super::String> for super::super::LocationInput {}
     }
     pub mod LocationsInput {
         pub struct value;
-        impl cynic::schema::Field for value {
+        impl cynic::schema::HasInputField<value> for super::super::LocationsInput {
             type Type = super::super::String;
             const NAME: &'static str = "value";
         }
-        impl cynic::schema::HasInputField<value, super::super::String> for super::super::LocationsInput {}
     }
     pub mod Mutation {
         pub struct subscribe;
-        impl cynic::schema::Field for subscribe {
-            type Type = super::super::User;
-            const NAME: &'static str = "subscribe";
-        }
         impl cynic::schema::HasField<subscribe> for super::super::Mutation {
             type Type = super::super::User;
+            const NAME: &'static str = "subscribe";
         }
         pub mod _subscribe_arguments {
             pub struct input;
@@ -5388,12 +3246,9 @@ pub mod __fields {
             }
         }
         pub struct postJob;
-        impl cynic::schema::Field for postJob {
-            type Type = super::super::Job;
-            const NAME: &'static str = "postJob";
-        }
         impl cynic::schema::HasField<postJob> for super::super::Mutation {
             type Type = super::super::Job;
+            const NAME: &'static str = "postJob";
         }
         pub mod _post_job_arguments {
             pub struct input;
@@ -5403,12 +3258,9 @@ pub mod __fields {
             }
         }
         pub struct updateJob;
-        impl cynic::schema::Field for updateJob {
-            type Type = super::super::Job;
-            const NAME: &'static str = "updateJob";
-        }
         impl cynic::schema::HasField<updateJob> for super::super::Mutation {
             type Type = super::super::Job;
+            const NAME: &'static str = "updateJob";
         }
         pub mod _update_job_arguments {
             pub struct input;
@@ -5423,12 +3275,9 @@ pub mod __fields {
             }
         }
         pub struct updateCompany;
-        impl cynic::schema::Field for updateCompany {
-            type Type = super::super::Company;
-            const NAME: &'static str = "updateCompany";
-        }
         impl cynic::schema::HasField<updateCompany> for super::super::Mutation {
             type Type = super::super::Company;
+            const NAME: &'static str = "updateCompany";
         }
         pub mod _update_company_arguments {
             pub struct input;
@@ -5443,75 +3292,53 @@ pub mod __fields {
             }
         }
         pub struct __typename;
-        impl cynic::schema::Field for __typename {
-            type Type = super::super::String;
-            const NAME: &'static str = "__typename";
-        }
         impl cynic::schema::HasField<__typename> for super::super::Mutation {
             type Type = super::super::String;
+            const NAME: &'static str = "__typename";
         }
     }
     pub mod PostJobInput {
         pub struct title;
-        impl cynic::schema::Field for title {
+        impl cynic::schema::HasInputField<title> for super::super::PostJobInput {
             type Type = super::super::String;
             const NAME: &'static str = "title";
         }
-        impl cynic::schema::HasInputField<title, super::super::String> for super::super::PostJobInput {}
         pub struct commitmentId;
-        impl cynic::schema::Field for commitmentId {
+        impl cynic::schema::HasInputField<commitmentId> for super::super::PostJobInput {
             type Type = super::super::ID;
             const NAME: &'static str = "commitmentId";
         }
-        impl cynic::schema::HasInputField<commitmentId, super::super::ID> for super::super::PostJobInput {}
         pub struct companyName;
-        impl cynic::schema::Field for companyName {
+        impl cynic::schema::HasInputField<companyName> for super::super::PostJobInput {
             type Type = super::super::String;
             const NAME: &'static str = "companyName";
         }
-        impl cynic::schema::HasInputField<companyName, super::super::String>
-            for super::super::PostJobInput
-        {
-        }
         pub struct locationNames;
-        impl cynic::schema::Field for locationNames {
+        impl cynic::schema::HasInputField<locationNames> for super::super::PostJobInput {
             type Type = super::super::String;
             const NAME: &'static str = "locationNames";
         }
-        impl cynic::schema::HasInputField<locationNames, super::super::String>
-            for super::super::PostJobInput
-        {
-        }
         pub struct userEmail;
-        impl cynic::schema::Field for userEmail {
+        impl cynic::schema::HasInputField<userEmail> for super::super::PostJobInput {
             type Type = super::super::String;
             const NAME: &'static str = "userEmail";
         }
-        impl cynic::schema::HasInputField<userEmail, super::super::String> for super::super::PostJobInput {}
         pub struct description;
-        impl cynic::schema::Field for description {
+        impl cynic::schema::HasInputField<description> for super::super::PostJobInput {
             type Type = super::super::String;
             const NAME: &'static str = "description";
         }
-        impl cynic::schema::HasInputField<description, super::super::String>
-            for super::super::PostJobInput
-        {
-        }
         pub struct applyUrl;
-        impl cynic::schema::Field for applyUrl {
+        impl cynic::schema::HasInputField<applyUrl> for super::super::PostJobInput {
             type Type = super::super::String;
             const NAME: &'static str = "applyUrl";
         }
-        impl cynic::schema::HasInputField<applyUrl, super::super::String> for super::super::PostJobInput {}
     }
     pub mod Query {
         pub struct jobs;
-        impl cynic::schema::Field for jobs {
-            type Type = Vec<super::super::Job>;
-            const NAME: &'static str = "jobs";
-        }
         impl cynic::schema::HasField<jobs> for super::super::Query {
             type Type = Vec<super::super::Job>;
+            const NAME: &'static str = "jobs";
         }
         pub mod _jobs_arguments {
             pub struct input;
@@ -5521,12 +3348,9 @@ pub mod __fields {
             }
         }
         pub struct job;
-        impl cynic::schema::Field for job {
-            type Type = super::super::Job;
-            const NAME: &'static str = "job";
-        }
         impl cynic::schema::HasField<job> for super::super::Query {
             type Type = super::super::Job;
+            const NAME: &'static str = "job";
         }
         pub mod _job_arguments {
             pub struct input;
@@ -5536,12 +3360,9 @@ pub mod __fields {
             }
         }
         pub struct locations;
-        impl cynic::schema::Field for locations {
-            type Type = Vec<super::super::Location>;
-            const NAME: &'static str = "locations";
-        }
         impl cynic::schema::HasField<locations> for super::super::Query {
             type Type = Vec<super::super::Location>;
+            const NAME: &'static str = "locations";
         }
         pub mod _locations_arguments {
             pub struct input;
@@ -5551,12 +3372,9 @@ pub mod __fields {
             }
         }
         pub struct city;
-        impl cynic::schema::Field for city {
-            type Type = super::super::City;
-            const NAME: &'static str = "city";
-        }
         impl cynic::schema::HasField<city> for super::super::Query {
             type Type = super::super::City;
+            const NAME: &'static str = "city";
         }
         pub mod _city_arguments {
             pub struct input;
@@ -5566,12 +3384,9 @@ pub mod __fields {
             }
         }
         pub struct country;
-        impl cynic::schema::Field for country {
-            type Type = super::super::Country;
-            const NAME: &'static str = "country";
-        }
         impl cynic::schema::HasField<country> for super::super::Query {
             type Type = super::super::Country;
+            const NAME: &'static str = "country";
         }
         pub mod _country_arguments {
             pub struct input;
@@ -5581,12 +3396,9 @@ pub mod __fields {
             }
         }
         pub struct remote;
-        impl cynic::schema::Field for remote {
-            type Type = super::super::Remote;
-            const NAME: &'static str = "remote";
-        }
         impl cynic::schema::HasField<remote> for super::super::Query {
             type Type = super::super::Remote;
+            const NAME: &'static str = "remote";
         }
         pub mod _remote_arguments {
             pub struct input;
@@ -5596,94 +3408,61 @@ pub mod __fields {
             }
         }
         pub struct commitments;
-        impl cynic::schema::Field for commitments {
+        impl cynic::schema::HasField<commitments> for super::super::Query {
             type Type = Vec<super::super::Commitment>;
             const NAME: &'static str = "commitments";
         }
-        impl cynic::schema::HasField<commitments> for super::super::Query {
-            type Type = Vec<super::super::Commitment>;
-        }
         pub struct cities;
-        impl cynic::schema::Field for cities {
+        impl cynic::schema::HasField<cities> for super::super::Query {
             type Type = Vec<super::super::City>;
             const NAME: &'static str = "cities";
         }
-        impl cynic::schema::HasField<cities> for super::super::Query {
-            type Type = Vec<super::super::City>;
-        }
         pub struct countries;
-        impl cynic::schema::Field for countries {
+        impl cynic::schema::HasField<countries> for super::super::Query {
             type Type = Vec<super::super::Country>;
             const NAME: &'static str = "countries";
         }
-        impl cynic::schema::HasField<countries> for super::super::Query {
-            type Type = Vec<super::super::Country>;
-        }
         pub struct remotes;
-        impl cynic::schema::Field for remotes {
+        impl cynic::schema::HasField<remotes> for super::super::Query {
             type Type = Vec<super::super::Remote>;
             const NAME: &'static str = "remotes";
         }
-        impl cynic::schema::HasField<remotes> for super::super::Query {
-            type Type = Vec<super::super::Remote>;
-        }
         pub struct companies;
-        impl cynic::schema::Field for companies {
+        impl cynic::schema::HasField<companies> for super::super::Query {
             type Type = Vec<super::super::Company>;
             const NAME: &'static str = "companies";
         }
-        impl cynic::schema::HasField<companies> for super::super::Query {
-            type Type = Vec<super::super::Company>;
-        }
         pub struct __typename;
-        impl cynic::schema::Field for __typename {
-            type Type = super::super::String;
-            const NAME: &'static str = "__typename";
-        }
         impl cynic::schema::HasField<__typename> for super::super::Query {
             type Type = super::super::String;
+            const NAME: &'static str = "__typename";
         }
     }
     pub mod Remote {
         pub struct id;
-        impl cynic::schema::Field for id {
+        impl cynic::schema::HasField<id> for super::super::Remote {
             type Type = super::super::ID;
             const NAME: &'static str = "id";
         }
-        impl cynic::schema::HasField<id> for super::super::Remote {
-            type Type = super::super::ID;
-        }
         pub struct name;
-        impl cynic::schema::Field for name {
+        impl cynic::schema::HasField<name> for super::super::Remote {
             type Type = super::super::String;
             const NAME: &'static str = "name";
         }
-        impl cynic::schema::HasField<name> for super::super::Remote {
-            type Type = super::super::String;
-        }
         pub struct slug;
-        impl cynic::schema::Field for slug {
+        impl cynic::schema::HasField<slug> for super::super::Remote {
             type Type = super::super::String;
             const NAME: &'static str = "slug";
         }
-        impl cynic::schema::HasField<slug> for super::super::Remote {
-            type Type = super::super::String;
-        }
         pub struct r#type;
-        impl cynic::schema::Field for r#type {
+        impl cynic::schema::HasField<r#type> for super::super::Remote {
             type Type = super::super::String;
             const NAME: &'static str = "type";
         }
-        impl cynic::schema::HasField<r#type> for super::super::Remote {
-            type Type = super::super::String;
-        }
         pub struct jobs;
-        impl cynic::schema::Field for jobs {
-            type Type = Option<Vec<super::super::Job>>;
-            const NAME: &'static str = "jobs";
-        }
         impl cynic::schema::HasField<jobs> for super::super::Remote {
             type Type = Option<Vec<super::super::Job>>;
+            const NAME: &'static str = "jobs";
         }
         pub mod _jobs_arguments {
             pub struct r#where;
@@ -5723,777 +3502,445 @@ pub mod __fields {
             }
         }
         pub struct createdAt;
-        impl cynic::schema::Field for createdAt {
+        impl cynic::schema::HasField<createdAt> for super::super::Remote {
             type Type = super::super::DateTime;
             const NAME: &'static str = "createdAt";
         }
-        impl cynic::schema::HasField<createdAt> for super::super::Remote {
-            type Type = super::super::DateTime;
-        }
         pub struct updatedAt;
-        impl cynic::schema::Field for updatedAt {
+        impl cynic::schema::HasField<updatedAt> for super::super::Remote {
             type Type = super::super::DateTime;
             const NAME: &'static str = "updatedAt";
         }
-        impl cynic::schema::HasField<updatedAt> for super::super::Remote {
-            type Type = super::super::DateTime;
-        }
         pub struct __typename;
-        impl cynic::schema::Field for __typename {
-            type Type = super::super::String;
-            const NAME: &'static str = "__typename";
-        }
         impl cynic::schema::HasField<__typename> for super::super::Remote {
             type Type = super::super::String;
+            const NAME: &'static str = "__typename";
         }
     }
     pub mod RemoteWhereInput {
         pub struct id;
-        impl cynic::schema::Field for id {
+        impl cynic::schema::HasInputField<id> for super::super::RemoteWhereInput {
             type Type = Option<super::super::ID>;
             const NAME: &'static str = "id";
         }
-        impl cynic::schema::HasInputField<id, Option<super::super::ID>> for super::super::RemoteWhereInput {}
         pub struct id_not;
-        impl cynic::schema::Field for id_not {
+        impl cynic::schema::HasInputField<id_not> for super::super::RemoteWhereInput {
             type Type = Option<super::super::ID>;
             const NAME: &'static str = "id_not";
         }
-        impl cynic::schema::HasInputField<id_not, Option<super::super::ID>>
-            for super::super::RemoteWhereInput
-        {
-        }
         pub struct id_in;
-        impl cynic::schema::Field for id_in {
+        impl cynic::schema::HasInputField<id_in> for super::super::RemoteWhereInput {
             type Type = Option<Vec<super::super::ID>>;
             const NAME: &'static str = "id_in";
         }
-        impl cynic::schema::HasInputField<id_in, Option<Vec<super::super::ID>>>
-            for super::super::RemoteWhereInput
-        {
-        }
         pub struct id_not_in;
-        impl cynic::schema::Field for id_not_in {
+        impl cynic::schema::HasInputField<id_not_in> for super::super::RemoteWhereInput {
             type Type = Option<Vec<super::super::ID>>;
             const NAME: &'static str = "id_not_in";
         }
-        impl cynic::schema::HasInputField<id_not_in, Option<Vec<super::super::ID>>>
-            for super::super::RemoteWhereInput
-        {
-        }
         pub struct id_lt;
-        impl cynic::schema::Field for id_lt {
+        impl cynic::schema::HasInputField<id_lt> for super::super::RemoteWhereInput {
             type Type = Option<super::super::ID>;
             const NAME: &'static str = "id_lt";
         }
-        impl cynic::schema::HasInputField<id_lt, Option<super::super::ID>>
-            for super::super::RemoteWhereInput
-        {
-        }
         pub struct id_lte;
-        impl cynic::schema::Field for id_lte {
+        impl cynic::schema::HasInputField<id_lte> for super::super::RemoteWhereInput {
             type Type = Option<super::super::ID>;
             const NAME: &'static str = "id_lte";
         }
-        impl cynic::schema::HasInputField<id_lte, Option<super::super::ID>>
-            for super::super::RemoteWhereInput
-        {
-        }
         pub struct id_gt;
-        impl cynic::schema::Field for id_gt {
+        impl cynic::schema::HasInputField<id_gt> for super::super::RemoteWhereInput {
             type Type = Option<super::super::ID>;
             const NAME: &'static str = "id_gt";
         }
-        impl cynic::schema::HasInputField<id_gt, Option<super::super::ID>>
-            for super::super::RemoteWhereInput
-        {
-        }
         pub struct id_gte;
-        impl cynic::schema::Field for id_gte {
+        impl cynic::schema::HasInputField<id_gte> for super::super::RemoteWhereInput {
             type Type = Option<super::super::ID>;
             const NAME: &'static str = "id_gte";
         }
-        impl cynic::schema::HasInputField<id_gte, Option<super::super::ID>>
-            for super::super::RemoteWhereInput
-        {
-        }
         pub struct id_contains;
-        impl cynic::schema::Field for id_contains {
+        impl cynic::schema::HasInputField<id_contains> for super::super::RemoteWhereInput {
             type Type = Option<super::super::ID>;
             const NAME: &'static str = "id_contains";
         }
-        impl cynic::schema::HasInputField<id_contains, Option<super::super::ID>>
-            for super::super::RemoteWhereInput
-        {
-        }
         pub struct id_not_contains;
-        impl cynic::schema::Field for id_not_contains {
+        impl cynic::schema::HasInputField<id_not_contains> for super::super::RemoteWhereInput {
             type Type = Option<super::super::ID>;
             const NAME: &'static str = "id_not_contains";
         }
-        impl cynic::schema::HasInputField<id_not_contains, Option<super::super::ID>>
-            for super::super::RemoteWhereInput
-        {
-        }
         pub struct id_starts_with;
-        impl cynic::schema::Field for id_starts_with {
+        impl cynic::schema::HasInputField<id_starts_with> for super::super::RemoteWhereInput {
             type Type = Option<super::super::ID>;
             const NAME: &'static str = "id_starts_with";
         }
-        impl cynic::schema::HasInputField<id_starts_with, Option<super::super::ID>>
-            for super::super::RemoteWhereInput
-        {
-        }
         pub struct id_not_starts_with;
-        impl cynic::schema::Field for id_not_starts_with {
+        impl cynic::schema::HasInputField<id_not_starts_with> for super::super::RemoteWhereInput {
             type Type = Option<super::super::ID>;
             const NAME: &'static str = "id_not_starts_with";
         }
-        impl cynic::schema::HasInputField<id_not_starts_with, Option<super::super::ID>>
-            for super::super::RemoteWhereInput
-        {
-        }
         pub struct id_ends_with;
-        impl cynic::schema::Field for id_ends_with {
+        impl cynic::schema::HasInputField<id_ends_with> for super::super::RemoteWhereInput {
             type Type = Option<super::super::ID>;
             const NAME: &'static str = "id_ends_with";
         }
-        impl cynic::schema::HasInputField<id_ends_with, Option<super::super::ID>>
-            for super::super::RemoteWhereInput
-        {
-        }
         pub struct id_not_ends_with;
-        impl cynic::schema::Field for id_not_ends_with {
+        impl cynic::schema::HasInputField<id_not_ends_with> for super::super::RemoteWhereInput {
             type Type = Option<super::super::ID>;
             const NAME: &'static str = "id_not_ends_with";
         }
-        impl cynic::schema::HasInputField<id_not_ends_with, Option<super::super::ID>>
-            for super::super::RemoteWhereInput
-        {
-        }
         pub struct name;
-        impl cynic::schema::Field for name {
+        impl cynic::schema::HasInputField<name> for super::super::RemoteWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "name";
         }
-        impl cynic::schema::HasInputField<name, Option<super::super::String>>
-            for super::super::RemoteWhereInput
-        {
-        }
         pub struct name_not;
-        impl cynic::schema::Field for name_not {
+        impl cynic::schema::HasInputField<name_not> for super::super::RemoteWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "name_not";
         }
-        impl cynic::schema::HasInputField<name_not, Option<super::super::String>>
-            for super::super::RemoteWhereInput
-        {
-        }
         pub struct name_in;
-        impl cynic::schema::Field for name_in {
+        impl cynic::schema::HasInputField<name_in> for super::super::RemoteWhereInput {
             type Type = Option<Vec<super::super::String>>;
             const NAME: &'static str = "name_in";
         }
-        impl cynic::schema::HasInputField<name_in, Option<Vec<super::super::String>>>
-            for super::super::RemoteWhereInput
-        {
-        }
         pub struct name_not_in;
-        impl cynic::schema::Field for name_not_in {
+        impl cynic::schema::HasInputField<name_not_in> for super::super::RemoteWhereInput {
             type Type = Option<Vec<super::super::String>>;
             const NAME: &'static str = "name_not_in";
         }
-        impl cynic::schema::HasInputField<name_not_in, Option<Vec<super::super::String>>>
-            for super::super::RemoteWhereInput
-        {
-        }
         pub struct name_lt;
-        impl cynic::schema::Field for name_lt {
+        impl cynic::schema::HasInputField<name_lt> for super::super::RemoteWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "name_lt";
         }
-        impl cynic::schema::HasInputField<name_lt, Option<super::super::String>>
-            for super::super::RemoteWhereInput
-        {
-        }
         pub struct name_lte;
-        impl cynic::schema::Field for name_lte {
+        impl cynic::schema::HasInputField<name_lte> for super::super::RemoteWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "name_lte";
         }
-        impl cynic::schema::HasInputField<name_lte, Option<super::super::String>>
-            for super::super::RemoteWhereInput
-        {
-        }
         pub struct name_gt;
-        impl cynic::schema::Field for name_gt {
+        impl cynic::schema::HasInputField<name_gt> for super::super::RemoteWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "name_gt";
         }
-        impl cynic::schema::HasInputField<name_gt, Option<super::super::String>>
-            for super::super::RemoteWhereInput
-        {
-        }
         pub struct name_gte;
-        impl cynic::schema::Field for name_gte {
+        impl cynic::schema::HasInputField<name_gte> for super::super::RemoteWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "name_gte";
         }
-        impl cynic::schema::HasInputField<name_gte, Option<super::super::String>>
-            for super::super::RemoteWhereInput
-        {
-        }
         pub struct name_contains;
-        impl cynic::schema::Field for name_contains {
+        impl cynic::schema::HasInputField<name_contains> for super::super::RemoteWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "name_contains";
         }
-        impl cynic::schema::HasInputField<name_contains, Option<super::super::String>>
-            for super::super::RemoteWhereInput
-        {
-        }
         pub struct name_not_contains;
-        impl cynic::schema::Field for name_not_contains {
+        impl cynic::schema::HasInputField<name_not_contains> for super::super::RemoteWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "name_not_contains";
         }
-        impl cynic::schema::HasInputField<name_not_contains, Option<super::super::String>>
-            for super::super::RemoteWhereInput
-        {
-        }
         pub struct name_starts_with;
-        impl cynic::schema::Field for name_starts_with {
+        impl cynic::schema::HasInputField<name_starts_with> for super::super::RemoteWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "name_starts_with";
         }
-        impl cynic::schema::HasInputField<name_starts_with, Option<super::super::String>>
-            for super::super::RemoteWhereInput
-        {
-        }
         pub struct name_not_starts_with;
-        impl cynic::schema::Field for name_not_starts_with {
+        impl cynic::schema::HasInputField<name_not_starts_with> for super::super::RemoteWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "name_not_starts_with";
         }
-        impl cynic::schema::HasInputField<name_not_starts_with, Option<super::super::String>>
-            for super::super::RemoteWhereInput
-        {
-        }
         pub struct name_ends_with;
-        impl cynic::schema::Field for name_ends_with {
+        impl cynic::schema::HasInputField<name_ends_with> for super::super::RemoteWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "name_ends_with";
         }
-        impl cynic::schema::HasInputField<name_ends_with, Option<super::super::String>>
-            for super::super::RemoteWhereInput
-        {
-        }
         pub struct name_not_ends_with;
-        impl cynic::schema::Field for name_not_ends_with {
+        impl cynic::schema::HasInputField<name_not_ends_with> for super::super::RemoteWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "name_not_ends_with";
         }
-        impl cynic::schema::HasInputField<name_not_ends_with, Option<super::super::String>>
-            for super::super::RemoteWhereInput
-        {
-        }
         pub struct slug;
-        impl cynic::schema::Field for slug {
+        impl cynic::schema::HasInputField<slug> for super::super::RemoteWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "slug";
         }
-        impl cynic::schema::HasInputField<slug, Option<super::super::String>>
-            for super::super::RemoteWhereInput
-        {
-        }
         pub struct slug_not;
-        impl cynic::schema::Field for slug_not {
+        impl cynic::schema::HasInputField<slug_not> for super::super::RemoteWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "slug_not";
         }
-        impl cynic::schema::HasInputField<slug_not, Option<super::super::String>>
-            for super::super::RemoteWhereInput
-        {
-        }
         pub struct slug_in;
-        impl cynic::schema::Field for slug_in {
+        impl cynic::schema::HasInputField<slug_in> for super::super::RemoteWhereInput {
             type Type = Option<Vec<super::super::String>>;
             const NAME: &'static str = "slug_in";
         }
-        impl cynic::schema::HasInputField<slug_in, Option<Vec<super::super::String>>>
-            for super::super::RemoteWhereInput
-        {
-        }
         pub struct slug_not_in;
-        impl cynic::schema::Field for slug_not_in {
+        impl cynic::schema::HasInputField<slug_not_in> for super::super::RemoteWhereInput {
             type Type = Option<Vec<super::super::String>>;
             const NAME: &'static str = "slug_not_in";
         }
-        impl cynic::schema::HasInputField<slug_not_in, Option<Vec<super::super::String>>>
-            for super::super::RemoteWhereInput
-        {
-        }
         pub struct slug_lt;
-        impl cynic::schema::Field for slug_lt {
+        impl cynic::schema::HasInputField<slug_lt> for super::super::RemoteWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "slug_lt";
         }
-        impl cynic::schema::HasInputField<slug_lt, Option<super::super::String>>
-            for super::super::RemoteWhereInput
-        {
-        }
         pub struct slug_lte;
-        impl cynic::schema::Field for slug_lte {
+        impl cynic::schema::HasInputField<slug_lte> for super::super::RemoteWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "slug_lte";
         }
-        impl cynic::schema::HasInputField<slug_lte, Option<super::super::String>>
-            for super::super::RemoteWhereInput
-        {
-        }
         pub struct slug_gt;
-        impl cynic::schema::Field for slug_gt {
+        impl cynic::schema::HasInputField<slug_gt> for super::super::RemoteWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "slug_gt";
         }
-        impl cynic::schema::HasInputField<slug_gt, Option<super::super::String>>
-            for super::super::RemoteWhereInput
-        {
-        }
         pub struct slug_gte;
-        impl cynic::schema::Field for slug_gte {
+        impl cynic::schema::HasInputField<slug_gte> for super::super::RemoteWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "slug_gte";
         }
-        impl cynic::schema::HasInputField<slug_gte, Option<super::super::String>>
-            for super::super::RemoteWhereInput
-        {
-        }
         pub struct slug_contains;
-        impl cynic::schema::Field for slug_contains {
+        impl cynic::schema::HasInputField<slug_contains> for super::super::RemoteWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "slug_contains";
         }
-        impl cynic::schema::HasInputField<slug_contains, Option<super::super::String>>
-            for super::super::RemoteWhereInput
-        {
-        }
         pub struct slug_not_contains;
-        impl cynic::schema::Field for slug_not_contains {
+        impl cynic::schema::HasInputField<slug_not_contains> for super::super::RemoteWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "slug_not_contains";
         }
-        impl cynic::schema::HasInputField<slug_not_contains, Option<super::super::String>>
-            for super::super::RemoteWhereInput
-        {
-        }
         pub struct slug_starts_with;
-        impl cynic::schema::Field for slug_starts_with {
+        impl cynic::schema::HasInputField<slug_starts_with> for super::super::RemoteWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "slug_starts_with";
         }
-        impl cynic::schema::HasInputField<slug_starts_with, Option<super::super::String>>
-            for super::super::RemoteWhereInput
-        {
-        }
         pub struct slug_not_starts_with;
-        impl cynic::schema::Field for slug_not_starts_with {
+        impl cynic::schema::HasInputField<slug_not_starts_with> for super::super::RemoteWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "slug_not_starts_with";
         }
-        impl cynic::schema::HasInputField<slug_not_starts_with, Option<super::super::String>>
-            for super::super::RemoteWhereInput
-        {
-        }
         pub struct slug_ends_with;
-        impl cynic::schema::Field for slug_ends_with {
+        impl cynic::schema::HasInputField<slug_ends_with> for super::super::RemoteWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "slug_ends_with";
         }
-        impl cynic::schema::HasInputField<slug_ends_with, Option<super::super::String>>
-            for super::super::RemoteWhereInput
-        {
-        }
         pub struct slug_not_ends_with;
-        impl cynic::schema::Field for slug_not_ends_with {
+        impl cynic::schema::HasInputField<slug_not_ends_with> for super::super::RemoteWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "slug_not_ends_with";
         }
-        impl cynic::schema::HasInputField<slug_not_ends_with, Option<super::super::String>>
-            for super::super::RemoteWhereInput
-        {
-        }
         pub struct r#type;
-        impl cynic::schema::Field for r#type {
+        impl cynic::schema::HasInputField<r#type> for super::super::RemoteWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "type";
         }
-        impl cynic::schema::HasInputField<r#type, Option<super::super::String>>
-            for super::super::RemoteWhereInput
-        {
-        }
         pub struct type_not;
-        impl cynic::schema::Field for type_not {
+        impl cynic::schema::HasInputField<type_not> for super::super::RemoteWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "type_not";
         }
-        impl cynic::schema::HasInputField<type_not, Option<super::super::String>>
-            for super::super::RemoteWhereInput
-        {
-        }
         pub struct type_in;
-        impl cynic::schema::Field for type_in {
+        impl cynic::schema::HasInputField<type_in> for super::super::RemoteWhereInput {
             type Type = Option<Vec<super::super::String>>;
             const NAME: &'static str = "type_in";
         }
-        impl cynic::schema::HasInputField<type_in, Option<Vec<super::super::String>>>
-            for super::super::RemoteWhereInput
-        {
-        }
         pub struct type_not_in;
-        impl cynic::schema::Field for type_not_in {
+        impl cynic::schema::HasInputField<type_not_in> for super::super::RemoteWhereInput {
             type Type = Option<Vec<super::super::String>>;
             const NAME: &'static str = "type_not_in";
         }
-        impl cynic::schema::HasInputField<type_not_in, Option<Vec<super::super::String>>>
-            for super::super::RemoteWhereInput
-        {
-        }
         pub struct type_lt;
-        impl cynic::schema::Field for type_lt {
+        impl cynic::schema::HasInputField<type_lt> for super::super::RemoteWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "type_lt";
         }
-        impl cynic::schema::HasInputField<type_lt, Option<super::super::String>>
-            for super::super::RemoteWhereInput
-        {
-        }
         pub struct type_lte;
-        impl cynic::schema::Field for type_lte {
+        impl cynic::schema::HasInputField<type_lte> for super::super::RemoteWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "type_lte";
         }
-        impl cynic::schema::HasInputField<type_lte, Option<super::super::String>>
-            for super::super::RemoteWhereInput
-        {
-        }
         pub struct type_gt;
-        impl cynic::schema::Field for type_gt {
+        impl cynic::schema::HasInputField<type_gt> for super::super::RemoteWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "type_gt";
         }
-        impl cynic::schema::HasInputField<type_gt, Option<super::super::String>>
-            for super::super::RemoteWhereInput
-        {
-        }
         pub struct type_gte;
-        impl cynic::schema::Field for type_gte {
+        impl cynic::schema::HasInputField<type_gte> for super::super::RemoteWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "type_gte";
         }
-        impl cynic::schema::HasInputField<type_gte, Option<super::super::String>>
-            for super::super::RemoteWhereInput
-        {
-        }
         pub struct type_contains;
-        impl cynic::schema::Field for type_contains {
+        impl cynic::schema::HasInputField<type_contains> for super::super::RemoteWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "type_contains";
         }
-        impl cynic::schema::HasInputField<type_contains, Option<super::super::String>>
-            for super::super::RemoteWhereInput
-        {
-        }
         pub struct type_not_contains;
-        impl cynic::schema::Field for type_not_contains {
+        impl cynic::schema::HasInputField<type_not_contains> for super::super::RemoteWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "type_not_contains";
         }
-        impl cynic::schema::HasInputField<type_not_contains, Option<super::super::String>>
-            for super::super::RemoteWhereInput
-        {
-        }
         pub struct type_starts_with;
-        impl cynic::schema::Field for type_starts_with {
+        impl cynic::schema::HasInputField<type_starts_with> for super::super::RemoteWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "type_starts_with";
         }
-        impl cynic::schema::HasInputField<type_starts_with, Option<super::super::String>>
-            for super::super::RemoteWhereInput
-        {
-        }
         pub struct type_not_starts_with;
-        impl cynic::schema::Field for type_not_starts_with {
+        impl cynic::schema::HasInputField<type_not_starts_with> for super::super::RemoteWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "type_not_starts_with";
         }
-        impl cynic::schema::HasInputField<type_not_starts_with, Option<super::super::String>>
-            for super::super::RemoteWhereInput
-        {
-        }
         pub struct type_ends_with;
-        impl cynic::schema::Field for type_ends_with {
+        impl cynic::schema::HasInputField<type_ends_with> for super::super::RemoteWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "type_ends_with";
         }
-        impl cynic::schema::HasInputField<type_ends_with, Option<super::super::String>>
-            for super::super::RemoteWhereInput
-        {
-        }
         pub struct type_not_ends_with;
-        impl cynic::schema::Field for type_not_ends_with {
+        impl cynic::schema::HasInputField<type_not_ends_with> for super::super::RemoteWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "type_not_ends_with";
         }
-        impl cynic::schema::HasInputField<type_not_ends_with, Option<super::super::String>>
-            for super::super::RemoteWhereInput
-        {
-        }
         pub struct jobs_every;
-        impl cynic::schema::Field for jobs_every {
+        impl cynic::schema::HasInputField<jobs_every> for super::super::RemoteWhereInput {
             type Type = Option<super::super::JobWhereInput>;
             const NAME: &'static str = "jobs_every";
         }
-        impl cynic::schema::HasInputField<jobs_every, Option<super::super::JobWhereInput>>
-            for super::super::RemoteWhereInput
-        {
-        }
         pub struct jobs_some;
-        impl cynic::schema::Field for jobs_some {
+        impl cynic::schema::HasInputField<jobs_some> for super::super::RemoteWhereInput {
             type Type = Option<super::super::JobWhereInput>;
             const NAME: &'static str = "jobs_some";
         }
-        impl cynic::schema::HasInputField<jobs_some, Option<super::super::JobWhereInput>>
-            for super::super::RemoteWhereInput
-        {
-        }
         pub struct jobs_none;
-        impl cynic::schema::Field for jobs_none {
+        impl cynic::schema::HasInputField<jobs_none> for super::super::RemoteWhereInput {
             type Type = Option<super::super::JobWhereInput>;
             const NAME: &'static str = "jobs_none";
         }
-        impl cynic::schema::HasInputField<jobs_none, Option<super::super::JobWhereInput>>
-            for super::super::RemoteWhereInput
-        {
-        }
         pub struct createdAt;
-        impl cynic::schema::Field for createdAt {
+        impl cynic::schema::HasInputField<createdAt> for super::super::RemoteWhereInput {
             type Type = Option<super::super::DateTime>;
             const NAME: &'static str = "createdAt";
         }
-        impl cynic::schema::HasInputField<createdAt, Option<super::super::DateTime>>
-            for super::super::RemoteWhereInput
-        {
-        }
         pub struct createdAt_not;
-        impl cynic::schema::Field for createdAt_not {
+        impl cynic::schema::HasInputField<createdAt_not> for super::super::RemoteWhereInput {
             type Type = Option<super::super::DateTime>;
             const NAME: &'static str = "createdAt_not";
         }
-        impl cynic::schema::HasInputField<createdAt_not, Option<super::super::DateTime>>
-            for super::super::RemoteWhereInput
-        {
-        }
         pub struct createdAt_in;
-        impl cynic::schema::Field for createdAt_in {
+        impl cynic::schema::HasInputField<createdAt_in> for super::super::RemoteWhereInput {
             type Type = Option<Vec<super::super::DateTime>>;
             const NAME: &'static str = "createdAt_in";
         }
-        impl cynic::schema::HasInputField<createdAt_in, Option<Vec<super::super::DateTime>>>
-            for super::super::RemoteWhereInput
-        {
-        }
         pub struct createdAt_not_in;
-        impl cynic::schema::Field for createdAt_not_in {
+        impl cynic::schema::HasInputField<createdAt_not_in> for super::super::RemoteWhereInput {
             type Type = Option<Vec<super::super::DateTime>>;
             const NAME: &'static str = "createdAt_not_in";
         }
-        impl cynic::schema::HasInputField<createdAt_not_in, Option<Vec<super::super::DateTime>>>
-            for super::super::RemoteWhereInput
-        {
-        }
         pub struct createdAt_lt;
-        impl cynic::schema::Field for createdAt_lt {
+        impl cynic::schema::HasInputField<createdAt_lt> for super::super::RemoteWhereInput {
             type Type = Option<super::super::DateTime>;
             const NAME: &'static str = "createdAt_lt";
         }
-        impl cynic::schema::HasInputField<createdAt_lt, Option<super::super::DateTime>>
-            for super::super::RemoteWhereInput
-        {
-        }
         pub struct createdAt_lte;
-        impl cynic::schema::Field for createdAt_lte {
+        impl cynic::schema::HasInputField<createdAt_lte> for super::super::RemoteWhereInput {
             type Type = Option<super::super::DateTime>;
             const NAME: &'static str = "createdAt_lte";
         }
-        impl cynic::schema::HasInputField<createdAt_lte, Option<super::super::DateTime>>
-            for super::super::RemoteWhereInput
-        {
-        }
         pub struct createdAt_gt;
-        impl cynic::schema::Field for createdAt_gt {
+        impl cynic::schema::HasInputField<createdAt_gt> for super::super::RemoteWhereInput {
             type Type = Option<super::super::DateTime>;
             const NAME: &'static str = "createdAt_gt";
         }
-        impl cynic::schema::HasInputField<createdAt_gt, Option<super::super::DateTime>>
-            for super::super::RemoteWhereInput
-        {
-        }
         pub struct createdAt_gte;
-        impl cynic::schema::Field for createdAt_gte {
+        impl cynic::schema::HasInputField<createdAt_gte> for super::super::RemoteWhereInput {
             type Type = Option<super::super::DateTime>;
             const NAME: &'static str = "createdAt_gte";
         }
-        impl cynic::schema::HasInputField<createdAt_gte, Option<super::super::DateTime>>
-            for super::super::RemoteWhereInput
-        {
-        }
         pub struct updatedAt;
-        impl cynic::schema::Field for updatedAt {
+        impl cynic::schema::HasInputField<updatedAt> for super::super::RemoteWhereInput {
             type Type = Option<super::super::DateTime>;
             const NAME: &'static str = "updatedAt";
         }
-        impl cynic::schema::HasInputField<updatedAt, Option<super::super::DateTime>>
-            for super::super::RemoteWhereInput
-        {
-        }
         pub struct updatedAt_not;
-        impl cynic::schema::Field for updatedAt_not {
+        impl cynic::schema::HasInputField<updatedAt_not> for super::super::RemoteWhereInput {
             type Type = Option<super::super::DateTime>;
             const NAME: &'static str = "updatedAt_not";
         }
-        impl cynic::schema::HasInputField<updatedAt_not, Option<super::super::DateTime>>
-            for super::super::RemoteWhereInput
-        {
-        }
         pub struct updatedAt_in;
-        impl cynic::schema::Field for updatedAt_in {
+        impl cynic::schema::HasInputField<updatedAt_in> for super::super::RemoteWhereInput {
             type Type = Option<Vec<super::super::DateTime>>;
             const NAME: &'static str = "updatedAt_in";
         }
-        impl cynic::schema::HasInputField<updatedAt_in, Option<Vec<super::super::DateTime>>>
-            for super::super::RemoteWhereInput
-        {
-        }
         pub struct updatedAt_not_in;
-        impl cynic::schema::Field for updatedAt_not_in {
+        impl cynic::schema::HasInputField<updatedAt_not_in> for super::super::RemoteWhereInput {
             type Type = Option<Vec<super::super::DateTime>>;
             const NAME: &'static str = "updatedAt_not_in";
         }
-        impl cynic::schema::HasInputField<updatedAt_not_in, Option<Vec<super::super::DateTime>>>
-            for super::super::RemoteWhereInput
-        {
-        }
         pub struct updatedAt_lt;
-        impl cynic::schema::Field for updatedAt_lt {
+        impl cynic::schema::HasInputField<updatedAt_lt> for super::super::RemoteWhereInput {
             type Type = Option<super::super::DateTime>;
             const NAME: &'static str = "updatedAt_lt";
         }
-        impl cynic::schema::HasInputField<updatedAt_lt, Option<super::super::DateTime>>
-            for super::super::RemoteWhereInput
-        {
-        }
         pub struct updatedAt_lte;
-        impl cynic::schema::Field for updatedAt_lte {
+        impl cynic::schema::HasInputField<updatedAt_lte> for super::super::RemoteWhereInput {
             type Type = Option<super::super::DateTime>;
             const NAME: &'static str = "updatedAt_lte";
         }
-        impl cynic::schema::HasInputField<updatedAt_lte, Option<super::super::DateTime>>
-            for super::super::RemoteWhereInput
-        {
-        }
         pub struct updatedAt_gt;
-        impl cynic::schema::Field for updatedAt_gt {
+        impl cynic::schema::HasInputField<updatedAt_gt> for super::super::RemoteWhereInput {
             type Type = Option<super::super::DateTime>;
             const NAME: &'static str = "updatedAt_gt";
         }
-        impl cynic::schema::HasInputField<updatedAt_gt, Option<super::super::DateTime>>
-            for super::super::RemoteWhereInput
-        {
-        }
         pub struct updatedAt_gte;
-        impl cynic::schema::Field for updatedAt_gte {
+        impl cynic::schema::HasInputField<updatedAt_gte> for super::super::RemoteWhereInput {
             type Type = Option<super::super::DateTime>;
             const NAME: &'static str = "updatedAt_gte";
         }
-        impl cynic::schema::HasInputField<updatedAt_gte, Option<super::super::DateTime>>
-            for super::super::RemoteWhereInput
-        {
-        }
         pub struct AND;
-        impl cynic::schema::Field for AND {
+        impl cynic::schema::HasInputField<AND> for super::super::RemoteWhereInput {
             type Type = Option<Vec<super::super::RemoteWhereInput>>;
             const NAME: &'static str = "AND";
         }
-        impl cynic::schema::HasInputField<AND, Option<Vec<super::super::RemoteWhereInput>>>
-            for super::super::RemoteWhereInput
-        {
-        }
         pub struct OR;
-        impl cynic::schema::Field for OR {
+        impl cynic::schema::HasInputField<OR> for super::super::RemoteWhereInput {
             type Type = Option<Vec<super::super::RemoteWhereInput>>;
             const NAME: &'static str = "OR";
         }
-        impl cynic::schema::HasInputField<OR, Option<Vec<super::super::RemoteWhereInput>>>
-            for super::super::RemoteWhereInput
-        {
-        }
         pub struct NOT;
-        impl cynic::schema::Field for NOT {
+        impl cynic::schema::HasInputField<NOT> for super::super::RemoteWhereInput {
             type Type = Option<Vec<super::super::RemoteWhereInput>>;
             const NAME: &'static str = "NOT";
-        }
-        impl cynic::schema::HasInputField<NOT, Option<Vec<super::super::RemoteWhereInput>>>
-            for super::super::RemoteWhereInput
-        {
         }
     }
     pub mod SubscribeInput {
         pub struct name;
-        impl cynic::schema::Field for name {
+        impl cynic::schema::HasInputField<name> for super::super::SubscribeInput {
             type Type = super::super::String;
             const NAME: &'static str = "name";
         }
-        impl cynic::schema::HasInputField<name, super::super::String> for super::super::SubscribeInput {}
         pub struct email;
-        impl cynic::schema::Field for email {
+        impl cynic::schema::HasInputField<email> for super::super::SubscribeInput {
             type Type = super::super::String;
             const NAME: &'static str = "email";
         }
-        impl cynic::schema::HasInputField<email, super::super::String> for super::super::SubscribeInput {}
     }
     pub mod Tag {
         pub struct id;
-        impl cynic::schema::Field for id {
+        impl cynic::schema::HasField<id> for super::super::Tag {
             type Type = super::super::ID;
             const NAME: &'static str = "id";
         }
-        impl cynic::schema::HasField<id> for super::super::Tag {
-            type Type = super::super::ID;
-        }
         pub struct name;
-        impl cynic::schema::Field for name {
+        impl cynic::schema::HasField<name> for super::super::Tag {
             type Type = super::super::String;
             const NAME: &'static str = "name";
         }
-        impl cynic::schema::HasField<name> for super::super::Tag {
-            type Type = super::super::String;
-        }
         pub struct slug;
-        impl cynic::schema::Field for slug {
+        impl cynic::schema::HasField<slug> for super::super::Tag {
             type Type = super::super::String;
             const NAME: &'static str = "slug";
         }
-        impl cynic::schema::HasField<slug> for super::super::Tag {
-            type Type = super::super::String;
-        }
         pub struct jobs;
-        impl cynic::schema::Field for jobs {
-            type Type = Option<Vec<super::super::Job>>;
-            const NAME: &'static str = "jobs";
-        }
         impl cynic::schema::HasField<jobs> for super::super::Tag {
             type Type = Option<Vec<super::super::Job>>;
+            const NAME: &'static str = "jobs";
         }
         pub mod _jobs_arguments {
             pub struct r#where;
@@ -6533,689 +3980,402 @@ pub mod __fields {
             }
         }
         pub struct createdAt;
-        impl cynic::schema::Field for createdAt {
+        impl cynic::schema::HasField<createdAt> for super::super::Tag {
             type Type = super::super::DateTime;
             const NAME: &'static str = "createdAt";
         }
-        impl cynic::schema::HasField<createdAt> for super::super::Tag {
-            type Type = super::super::DateTime;
-        }
         pub struct updatedAt;
-        impl cynic::schema::Field for updatedAt {
+        impl cynic::schema::HasField<updatedAt> for super::super::Tag {
             type Type = super::super::DateTime;
             const NAME: &'static str = "updatedAt";
         }
-        impl cynic::schema::HasField<updatedAt> for super::super::Tag {
-            type Type = super::super::DateTime;
-        }
         pub struct __typename;
-        impl cynic::schema::Field for __typename {
-            type Type = super::super::String;
-            const NAME: &'static str = "__typename";
-        }
         impl cynic::schema::HasField<__typename> for super::super::Tag {
             type Type = super::super::String;
+            const NAME: &'static str = "__typename";
         }
     }
     pub mod TagWhereInput {
         pub struct id;
-        impl cynic::schema::Field for id {
+        impl cynic::schema::HasInputField<id> for super::super::TagWhereInput {
             type Type = Option<super::super::ID>;
             const NAME: &'static str = "id";
         }
-        impl cynic::schema::HasInputField<id, Option<super::super::ID>> for super::super::TagWhereInput {}
         pub struct id_not;
-        impl cynic::schema::Field for id_not {
+        impl cynic::schema::HasInputField<id_not> for super::super::TagWhereInput {
             type Type = Option<super::super::ID>;
             const NAME: &'static str = "id_not";
         }
-        impl cynic::schema::HasInputField<id_not, Option<super::super::ID>>
-            for super::super::TagWhereInput
-        {
-        }
         pub struct id_in;
-        impl cynic::schema::Field for id_in {
+        impl cynic::schema::HasInputField<id_in> for super::super::TagWhereInput {
             type Type = Option<Vec<super::super::ID>>;
             const NAME: &'static str = "id_in";
         }
-        impl cynic::schema::HasInputField<id_in, Option<Vec<super::super::ID>>>
-            for super::super::TagWhereInput
-        {
-        }
         pub struct id_not_in;
-        impl cynic::schema::Field for id_not_in {
+        impl cynic::schema::HasInputField<id_not_in> for super::super::TagWhereInput {
             type Type = Option<Vec<super::super::ID>>;
             const NAME: &'static str = "id_not_in";
         }
-        impl cynic::schema::HasInputField<id_not_in, Option<Vec<super::super::ID>>>
-            for super::super::TagWhereInput
-        {
-        }
         pub struct id_lt;
-        impl cynic::schema::Field for id_lt {
+        impl cynic::schema::HasInputField<id_lt> for super::super::TagWhereInput {
             type Type = Option<super::super::ID>;
             const NAME: &'static str = "id_lt";
         }
-        impl cynic::schema::HasInputField<id_lt, Option<super::super::ID>> for super::super::TagWhereInput {}
         pub struct id_lte;
-        impl cynic::schema::Field for id_lte {
+        impl cynic::schema::HasInputField<id_lte> for super::super::TagWhereInput {
             type Type = Option<super::super::ID>;
             const NAME: &'static str = "id_lte";
         }
-        impl cynic::schema::HasInputField<id_lte, Option<super::super::ID>>
-            for super::super::TagWhereInput
-        {
-        }
         pub struct id_gt;
-        impl cynic::schema::Field for id_gt {
+        impl cynic::schema::HasInputField<id_gt> for super::super::TagWhereInput {
             type Type = Option<super::super::ID>;
             const NAME: &'static str = "id_gt";
         }
-        impl cynic::schema::HasInputField<id_gt, Option<super::super::ID>> for super::super::TagWhereInput {}
         pub struct id_gte;
-        impl cynic::schema::Field for id_gte {
+        impl cynic::schema::HasInputField<id_gte> for super::super::TagWhereInput {
             type Type = Option<super::super::ID>;
             const NAME: &'static str = "id_gte";
         }
-        impl cynic::schema::HasInputField<id_gte, Option<super::super::ID>>
-            for super::super::TagWhereInput
-        {
-        }
         pub struct id_contains;
-        impl cynic::schema::Field for id_contains {
+        impl cynic::schema::HasInputField<id_contains> for super::super::TagWhereInput {
             type Type = Option<super::super::ID>;
             const NAME: &'static str = "id_contains";
         }
-        impl cynic::schema::HasInputField<id_contains, Option<super::super::ID>>
-            for super::super::TagWhereInput
-        {
-        }
         pub struct id_not_contains;
-        impl cynic::schema::Field for id_not_contains {
+        impl cynic::schema::HasInputField<id_not_contains> for super::super::TagWhereInput {
             type Type = Option<super::super::ID>;
             const NAME: &'static str = "id_not_contains";
         }
-        impl cynic::schema::HasInputField<id_not_contains, Option<super::super::ID>>
-            for super::super::TagWhereInput
-        {
-        }
         pub struct id_starts_with;
-        impl cynic::schema::Field for id_starts_with {
+        impl cynic::schema::HasInputField<id_starts_with> for super::super::TagWhereInput {
             type Type = Option<super::super::ID>;
             const NAME: &'static str = "id_starts_with";
         }
-        impl cynic::schema::HasInputField<id_starts_with, Option<super::super::ID>>
-            for super::super::TagWhereInput
-        {
-        }
         pub struct id_not_starts_with;
-        impl cynic::schema::Field for id_not_starts_with {
+        impl cynic::schema::HasInputField<id_not_starts_with> for super::super::TagWhereInput {
             type Type = Option<super::super::ID>;
             const NAME: &'static str = "id_not_starts_with";
         }
-        impl cynic::schema::HasInputField<id_not_starts_with, Option<super::super::ID>>
-            for super::super::TagWhereInput
-        {
-        }
         pub struct id_ends_with;
-        impl cynic::schema::Field for id_ends_with {
+        impl cynic::schema::HasInputField<id_ends_with> for super::super::TagWhereInput {
             type Type = Option<super::super::ID>;
             const NAME: &'static str = "id_ends_with";
         }
-        impl cynic::schema::HasInputField<id_ends_with, Option<super::super::ID>>
-            for super::super::TagWhereInput
-        {
-        }
         pub struct id_not_ends_with;
-        impl cynic::schema::Field for id_not_ends_with {
+        impl cynic::schema::HasInputField<id_not_ends_with> for super::super::TagWhereInput {
             type Type = Option<super::super::ID>;
             const NAME: &'static str = "id_not_ends_with";
         }
-        impl cynic::schema::HasInputField<id_not_ends_with, Option<super::super::ID>>
-            for super::super::TagWhereInput
-        {
-        }
         pub struct name;
-        impl cynic::schema::Field for name {
+        impl cynic::schema::HasInputField<name> for super::super::TagWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "name";
         }
-        impl cynic::schema::HasInputField<name, Option<super::super::String>>
-            for super::super::TagWhereInput
-        {
-        }
         pub struct name_not;
-        impl cynic::schema::Field for name_not {
+        impl cynic::schema::HasInputField<name_not> for super::super::TagWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "name_not";
         }
-        impl cynic::schema::HasInputField<name_not, Option<super::super::String>>
-            for super::super::TagWhereInput
-        {
-        }
         pub struct name_in;
-        impl cynic::schema::Field for name_in {
+        impl cynic::schema::HasInputField<name_in> for super::super::TagWhereInput {
             type Type = Option<Vec<super::super::String>>;
             const NAME: &'static str = "name_in";
         }
-        impl cynic::schema::HasInputField<name_in, Option<Vec<super::super::String>>>
-            for super::super::TagWhereInput
-        {
-        }
         pub struct name_not_in;
-        impl cynic::schema::Field for name_not_in {
+        impl cynic::schema::HasInputField<name_not_in> for super::super::TagWhereInput {
             type Type = Option<Vec<super::super::String>>;
             const NAME: &'static str = "name_not_in";
         }
-        impl cynic::schema::HasInputField<name_not_in, Option<Vec<super::super::String>>>
-            for super::super::TagWhereInput
-        {
-        }
         pub struct name_lt;
-        impl cynic::schema::Field for name_lt {
+        impl cynic::schema::HasInputField<name_lt> for super::super::TagWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "name_lt";
         }
-        impl cynic::schema::HasInputField<name_lt, Option<super::super::String>>
-            for super::super::TagWhereInput
-        {
-        }
         pub struct name_lte;
-        impl cynic::schema::Field for name_lte {
+        impl cynic::schema::HasInputField<name_lte> for super::super::TagWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "name_lte";
         }
-        impl cynic::schema::HasInputField<name_lte, Option<super::super::String>>
-            for super::super::TagWhereInput
-        {
-        }
         pub struct name_gt;
-        impl cynic::schema::Field for name_gt {
+        impl cynic::schema::HasInputField<name_gt> for super::super::TagWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "name_gt";
         }
-        impl cynic::schema::HasInputField<name_gt, Option<super::super::String>>
-            for super::super::TagWhereInput
-        {
-        }
         pub struct name_gte;
-        impl cynic::schema::Field for name_gte {
+        impl cynic::schema::HasInputField<name_gte> for super::super::TagWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "name_gte";
         }
-        impl cynic::schema::HasInputField<name_gte, Option<super::super::String>>
-            for super::super::TagWhereInput
-        {
-        }
         pub struct name_contains;
-        impl cynic::schema::Field for name_contains {
+        impl cynic::schema::HasInputField<name_contains> for super::super::TagWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "name_contains";
         }
-        impl cynic::schema::HasInputField<name_contains, Option<super::super::String>>
-            for super::super::TagWhereInput
-        {
-        }
         pub struct name_not_contains;
-        impl cynic::schema::Field for name_not_contains {
+        impl cynic::schema::HasInputField<name_not_contains> for super::super::TagWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "name_not_contains";
         }
-        impl cynic::schema::HasInputField<name_not_contains, Option<super::super::String>>
-            for super::super::TagWhereInput
-        {
-        }
         pub struct name_starts_with;
-        impl cynic::schema::Field for name_starts_with {
+        impl cynic::schema::HasInputField<name_starts_with> for super::super::TagWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "name_starts_with";
         }
-        impl cynic::schema::HasInputField<name_starts_with, Option<super::super::String>>
-            for super::super::TagWhereInput
-        {
-        }
         pub struct name_not_starts_with;
-        impl cynic::schema::Field for name_not_starts_with {
+        impl cynic::schema::HasInputField<name_not_starts_with> for super::super::TagWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "name_not_starts_with";
         }
-        impl cynic::schema::HasInputField<name_not_starts_with, Option<super::super::String>>
-            for super::super::TagWhereInput
-        {
-        }
         pub struct name_ends_with;
-        impl cynic::schema::Field for name_ends_with {
+        impl cynic::schema::HasInputField<name_ends_with> for super::super::TagWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "name_ends_with";
         }
-        impl cynic::schema::HasInputField<name_ends_with, Option<super::super::String>>
-            for super::super::TagWhereInput
-        {
-        }
         pub struct name_not_ends_with;
-        impl cynic::schema::Field for name_not_ends_with {
+        impl cynic::schema::HasInputField<name_not_ends_with> for super::super::TagWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "name_not_ends_with";
         }
-        impl cynic::schema::HasInputField<name_not_ends_with, Option<super::super::String>>
-            for super::super::TagWhereInput
-        {
-        }
         pub struct slug;
-        impl cynic::schema::Field for slug {
+        impl cynic::schema::HasInputField<slug> for super::super::TagWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "slug";
         }
-        impl cynic::schema::HasInputField<slug, Option<super::super::String>>
-            for super::super::TagWhereInput
-        {
-        }
         pub struct slug_not;
-        impl cynic::schema::Field for slug_not {
+        impl cynic::schema::HasInputField<slug_not> for super::super::TagWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "slug_not";
         }
-        impl cynic::schema::HasInputField<slug_not, Option<super::super::String>>
-            for super::super::TagWhereInput
-        {
-        }
         pub struct slug_in;
-        impl cynic::schema::Field for slug_in {
+        impl cynic::schema::HasInputField<slug_in> for super::super::TagWhereInput {
             type Type = Option<Vec<super::super::String>>;
             const NAME: &'static str = "slug_in";
         }
-        impl cynic::schema::HasInputField<slug_in, Option<Vec<super::super::String>>>
-            for super::super::TagWhereInput
-        {
-        }
         pub struct slug_not_in;
-        impl cynic::schema::Field for slug_not_in {
+        impl cynic::schema::HasInputField<slug_not_in> for super::super::TagWhereInput {
             type Type = Option<Vec<super::super::String>>;
             const NAME: &'static str = "slug_not_in";
         }
-        impl cynic::schema::HasInputField<slug_not_in, Option<Vec<super::super::String>>>
-            for super::super::TagWhereInput
-        {
-        }
         pub struct slug_lt;
-        impl cynic::schema::Field for slug_lt {
+        impl cynic::schema::HasInputField<slug_lt> for super::super::TagWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "slug_lt";
         }
-        impl cynic::schema::HasInputField<slug_lt, Option<super::super::String>>
-            for super::super::TagWhereInput
-        {
-        }
         pub struct slug_lte;
-        impl cynic::schema::Field for slug_lte {
+        impl cynic::schema::HasInputField<slug_lte> for super::super::TagWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "slug_lte";
         }
-        impl cynic::schema::HasInputField<slug_lte, Option<super::super::String>>
-            for super::super::TagWhereInput
-        {
-        }
         pub struct slug_gt;
-        impl cynic::schema::Field for slug_gt {
+        impl cynic::schema::HasInputField<slug_gt> for super::super::TagWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "slug_gt";
         }
-        impl cynic::schema::HasInputField<slug_gt, Option<super::super::String>>
-            for super::super::TagWhereInput
-        {
-        }
         pub struct slug_gte;
-        impl cynic::schema::Field for slug_gte {
+        impl cynic::schema::HasInputField<slug_gte> for super::super::TagWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "slug_gte";
         }
-        impl cynic::schema::HasInputField<slug_gte, Option<super::super::String>>
-            for super::super::TagWhereInput
-        {
-        }
         pub struct slug_contains;
-        impl cynic::schema::Field for slug_contains {
+        impl cynic::schema::HasInputField<slug_contains> for super::super::TagWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "slug_contains";
         }
-        impl cynic::schema::HasInputField<slug_contains, Option<super::super::String>>
-            for super::super::TagWhereInput
-        {
-        }
         pub struct slug_not_contains;
-        impl cynic::schema::Field for slug_not_contains {
+        impl cynic::schema::HasInputField<slug_not_contains> for super::super::TagWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "slug_not_contains";
         }
-        impl cynic::schema::HasInputField<slug_not_contains, Option<super::super::String>>
-            for super::super::TagWhereInput
-        {
-        }
         pub struct slug_starts_with;
-        impl cynic::schema::Field for slug_starts_with {
+        impl cynic::schema::HasInputField<slug_starts_with> for super::super::TagWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "slug_starts_with";
         }
-        impl cynic::schema::HasInputField<slug_starts_with, Option<super::super::String>>
-            for super::super::TagWhereInput
-        {
-        }
         pub struct slug_not_starts_with;
-        impl cynic::schema::Field for slug_not_starts_with {
+        impl cynic::schema::HasInputField<slug_not_starts_with> for super::super::TagWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "slug_not_starts_with";
         }
-        impl cynic::schema::HasInputField<slug_not_starts_with, Option<super::super::String>>
-            for super::super::TagWhereInput
-        {
-        }
         pub struct slug_ends_with;
-        impl cynic::schema::Field for slug_ends_with {
+        impl cynic::schema::HasInputField<slug_ends_with> for super::super::TagWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "slug_ends_with";
         }
-        impl cynic::schema::HasInputField<slug_ends_with, Option<super::super::String>>
-            for super::super::TagWhereInput
-        {
-        }
         pub struct slug_not_ends_with;
-        impl cynic::schema::Field for slug_not_ends_with {
+        impl cynic::schema::HasInputField<slug_not_ends_with> for super::super::TagWhereInput {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "slug_not_ends_with";
         }
-        impl cynic::schema::HasInputField<slug_not_ends_with, Option<super::super::String>>
-            for super::super::TagWhereInput
-        {
-        }
         pub struct jobs_every;
-        impl cynic::schema::Field for jobs_every {
+        impl cynic::schema::HasInputField<jobs_every> for super::super::TagWhereInput {
             type Type = Option<super::super::JobWhereInput>;
             const NAME: &'static str = "jobs_every";
         }
-        impl cynic::schema::HasInputField<jobs_every, Option<super::super::JobWhereInput>>
-            for super::super::TagWhereInput
-        {
-        }
         pub struct jobs_some;
-        impl cynic::schema::Field for jobs_some {
+        impl cynic::schema::HasInputField<jobs_some> for super::super::TagWhereInput {
             type Type = Option<super::super::JobWhereInput>;
             const NAME: &'static str = "jobs_some";
         }
-        impl cynic::schema::HasInputField<jobs_some, Option<super::super::JobWhereInput>>
-            for super::super::TagWhereInput
-        {
-        }
         pub struct jobs_none;
-        impl cynic::schema::Field for jobs_none {
+        impl cynic::schema::HasInputField<jobs_none> for super::super::TagWhereInput {
             type Type = Option<super::super::JobWhereInput>;
             const NAME: &'static str = "jobs_none";
         }
-        impl cynic::schema::HasInputField<jobs_none, Option<super::super::JobWhereInput>>
-            for super::super::TagWhereInput
-        {
-        }
         pub struct createdAt;
-        impl cynic::schema::Field for createdAt {
+        impl cynic::schema::HasInputField<createdAt> for super::super::TagWhereInput {
             type Type = Option<super::super::DateTime>;
             const NAME: &'static str = "createdAt";
         }
-        impl cynic::schema::HasInputField<createdAt, Option<super::super::DateTime>>
-            for super::super::TagWhereInput
-        {
-        }
         pub struct createdAt_not;
-        impl cynic::schema::Field for createdAt_not {
+        impl cynic::schema::HasInputField<createdAt_not> for super::super::TagWhereInput {
             type Type = Option<super::super::DateTime>;
             const NAME: &'static str = "createdAt_not";
         }
-        impl cynic::schema::HasInputField<createdAt_not, Option<super::super::DateTime>>
-            for super::super::TagWhereInput
-        {
-        }
         pub struct createdAt_in;
-        impl cynic::schema::Field for createdAt_in {
+        impl cynic::schema::HasInputField<createdAt_in> for super::super::TagWhereInput {
             type Type = Option<Vec<super::super::DateTime>>;
             const NAME: &'static str = "createdAt_in";
         }
-        impl cynic::schema::HasInputField<createdAt_in, Option<Vec<super::super::DateTime>>>
-            for super::super::TagWhereInput
-        {
-        }
         pub struct createdAt_not_in;
-        impl cynic::schema::Field for createdAt_not_in {
+        impl cynic::schema::HasInputField<createdAt_not_in> for super::super::TagWhereInput {
             type Type = Option<Vec<super::super::DateTime>>;
             const NAME: &'static str = "createdAt_not_in";
         }
-        impl cynic::schema::HasInputField<createdAt_not_in, Option<Vec<super::super::DateTime>>>
-            for super::super::TagWhereInput
-        {
-        }
         pub struct createdAt_lt;
-        impl cynic::schema::Field for createdAt_lt {
+        impl cynic::schema::HasInputField<createdAt_lt> for super::super::TagWhereInput {
             type Type = Option<super::super::DateTime>;
             const NAME: &'static str = "createdAt_lt";
         }
-        impl cynic::schema::HasInputField<createdAt_lt, Option<super::super::DateTime>>
-            for super::super::TagWhereInput
-        {
-        }
         pub struct createdAt_lte;
-        impl cynic::schema::Field for createdAt_lte {
+        impl cynic::schema::HasInputField<createdAt_lte> for super::super::TagWhereInput {
             type Type = Option<super::super::DateTime>;
             const NAME: &'static str = "createdAt_lte";
         }
-        impl cynic::schema::HasInputField<createdAt_lte, Option<super::super::DateTime>>
-            for super::super::TagWhereInput
-        {
-        }
         pub struct createdAt_gt;
-        impl cynic::schema::Field for createdAt_gt {
+        impl cynic::schema::HasInputField<createdAt_gt> for super::super::TagWhereInput {
             type Type = Option<super::super::DateTime>;
             const NAME: &'static str = "createdAt_gt";
         }
-        impl cynic::schema::HasInputField<createdAt_gt, Option<super::super::DateTime>>
-            for super::super::TagWhereInput
-        {
-        }
         pub struct createdAt_gte;
-        impl cynic::schema::Field for createdAt_gte {
+        impl cynic::schema::HasInputField<createdAt_gte> for super::super::TagWhereInput {
             type Type = Option<super::super::DateTime>;
             const NAME: &'static str = "createdAt_gte";
         }
-        impl cynic::schema::HasInputField<createdAt_gte, Option<super::super::DateTime>>
-            for super::super::TagWhereInput
-        {
-        }
         pub struct updatedAt;
-        impl cynic::schema::Field for updatedAt {
+        impl cynic::schema::HasInputField<updatedAt> for super::super::TagWhereInput {
             type Type = Option<super::super::DateTime>;
             const NAME: &'static str = "updatedAt";
         }
-        impl cynic::schema::HasInputField<updatedAt, Option<super::super::DateTime>>
-            for super::super::TagWhereInput
-        {
-        }
         pub struct updatedAt_not;
-        impl cynic::schema::Field for updatedAt_not {
+        impl cynic::schema::HasInputField<updatedAt_not> for super::super::TagWhereInput {
             type Type = Option<super::super::DateTime>;
             const NAME: &'static str = "updatedAt_not";
         }
-        impl cynic::schema::HasInputField<updatedAt_not, Option<super::super::DateTime>>
-            for super::super::TagWhereInput
-        {
-        }
         pub struct updatedAt_in;
-        impl cynic::schema::Field for updatedAt_in {
+        impl cynic::schema::HasInputField<updatedAt_in> for super::super::TagWhereInput {
             type Type = Option<Vec<super::super::DateTime>>;
             const NAME: &'static str = "updatedAt_in";
         }
-        impl cynic::schema::HasInputField<updatedAt_in, Option<Vec<super::super::DateTime>>>
-            for super::super::TagWhereInput
-        {
-        }
         pub struct updatedAt_not_in;
-        impl cynic::schema::Field for updatedAt_not_in {
+        impl cynic::schema::HasInputField<updatedAt_not_in> for super::super::TagWhereInput {
             type Type = Option<Vec<super::super::DateTime>>;
             const NAME: &'static str = "updatedAt_not_in";
         }
-        impl cynic::schema::HasInputField<updatedAt_not_in, Option<Vec<super::super::DateTime>>>
-            for super::super::TagWhereInput
-        {
-        }
         pub struct updatedAt_lt;
-        impl cynic::schema::Field for updatedAt_lt {
+        impl cynic::schema::HasInputField<updatedAt_lt> for super::super::TagWhereInput {
             type Type = Option<super::super::DateTime>;
             const NAME: &'static str = "updatedAt_lt";
         }
-        impl cynic::schema::HasInputField<updatedAt_lt, Option<super::super::DateTime>>
-            for super::super::TagWhereInput
-        {
-        }
         pub struct updatedAt_lte;
-        impl cynic::schema::Field for updatedAt_lte {
+        impl cynic::schema::HasInputField<updatedAt_lte> for super::super::TagWhereInput {
             type Type = Option<super::super::DateTime>;
             const NAME: &'static str = "updatedAt_lte";
         }
-        impl cynic::schema::HasInputField<updatedAt_lte, Option<super::super::DateTime>>
-            for super::super::TagWhereInput
-        {
-        }
         pub struct updatedAt_gt;
-        impl cynic::schema::Field for updatedAt_gt {
+        impl cynic::schema::HasInputField<updatedAt_gt> for super::super::TagWhereInput {
             type Type = Option<super::super::DateTime>;
             const NAME: &'static str = "updatedAt_gt";
         }
-        impl cynic::schema::HasInputField<updatedAt_gt, Option<super::super::DateTime>>
-            for super::super::TagWhereInput
-        {
-        }
         pub struct updatedAt_gte;
-        impl cynic::schema::Field for updatedAt_gte {
+        impl cynic::schema::HasInputField<updatedAt_gte> for super::super::TagWhereInput {
             type Type = Option<super::super::DateTime>;
             const NAME: &'static str = "updatedAt_gte";
         }
-        impl cynic::schema::HasInputField<updatedAt_gte, Option<super::super::DateTime>>
-            for super::super::TagWhereInput
-        {
-        }
         pub struct AND;
-        impl cynic::schema::Field for AND {
+        impl cynic::schema::HasInputField<AND> for super::super::TagWhereInput {
             type Type = Option<Vec<super::super::TagWhereInput>>;
             const NAME: &'static str = "AND";
         }
-        impl cynic::schema::HasInputField<AND, Option<Vec<super::super::TagWhereInput>>>
-            for super::super::TagWhereInput
-        {
-        }
         pub struct OR;
-        impl cynic::schema::Field for OR {
+        impl cynic::schema::HasInputField<OR> for super::super::TagWhereInput {
             type Type = Option<Vec<super::super::TagWhereInput>>;
             const NAME: &'static str = "OR";
         }
-        impl cynic::schema::HasInputField<OR, Option<Vec<super::super::TagWhereInput>>>
-            for super::super::TagWhereInput
-        {
-        }
         pub struct NOT;
-        impl cynic::schema::Field for NOT {
+        impl cynic::schema::HasInputField<NOT> for super::super::TagWhereInput {
             type Type = Option<Vec<super::super::TagWhereInput>>;
             const NAME: &'static str = "NOT";
-        }
-        impl cynic::schema::HasInputField<NOT, Option<Vec<super::super::TagWhereInput>>>
-            for super::super::TagWhereInput
-        {
         }
     }
     pub mod UpdateCompanyInput {
         pub struct id;
-        impl cynic::schema::Field for id {
+        impl cynic::schema::HasInputField<id> for super::super::UpdateCompanyInput {
             type Type = super::super::ID;
             const NAME: &'static str = "id";
         }
-        impl cynic::schema::HasInputField<id, super::super::ID> for super::super::UpdateCompanyInput {}
         pub struct logoUrl;
-        impl cynic::schema::Field for logoUrl {
+        impl cynic::schema::HasInputField<logoUrl> for super::super::UpdateCompanyInput {
             type Type = super::super::String;
             const NAME: &'static str = "logoUrl";
-        }
-        impl cynic::schema::HasInputField<logoUrl, super::super::String>
-            for super::super::UpdateCompanyInput
-        {
         }
     }
     pub mod UpdateJobInput {
         pub struct id;
-        impl cynic::schema::Field for id {
+        impl cynic::schema::HasInputField<id> for super::super::UpdateJobInput {
             type Type = super::super::ID;
             const NAME: &'static str = "id";
         }
-        impl cynic::schema::HasInputField<id, super::super::ID> for super::super::UpdateJobInput {}
         pub struct description;
-        impl cynic::schema::Field for description {
+        impl cynic::schema::HasInputField<description> for super::super::UpdateJobInput {
             type Type = super::super::String;
             const NAME: &'static str = "description";
-        }
-        impl cynic::schema::HasInputField<description, super::super::String>
-            for super::super::UpdateJobInput
-        {
         }
     }
     pub mod User {
         pub struct id;
-        impl cynic::schema::Field for id {
+        impl cynic::schema::HasField<id> for super::super::User {
             type Type = super::super::ID;
             const NAME: &'static str = "id";
         }
-        impl cynic::schema::HasField<id> for super::super::User {
-            type Type = super::super::ID;
-        }
         pub struct name;
-        impl cynic::schema::Field for name {
+        impl cynic::schema::HasField<name> for super::super::User {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "name";
         }
-        impl cynic::schema::HasField<name> for super::super::User {
-            type Type = Option<super::super::String>;
-        }
         pub struct email;
-        impl cynic::schema::Field for email {
+        impl cynic::schema::HasField<email> for super::super::User {
             type Type = super::super::String;
             const NAME: &'static str = "email";
         }
-        impl cynic::schema::HasField<email> for super::super::User {
-            type Type = super::super::String;
-        }
         pub struct subscribe;
-        impl cynic::schema::Field for subscribe {
+        impl cynic::schema::HasField<subscribe> for super::super::User {
             type Type = super::super::Boolean;
             const NAME: &'static str = "subscribe";
         }
-        impl cynic::schema::HasField<subscribe> for super::super::User {
-            type Type = super::super::Boolean;
-        }
         pub struct createdAt;
-        impl cynic::schema::Field for createdAt {
+        impl cynic::schema::HasField<createdAt> for super::super::User {
             type Type = super::super::DateTime;
             const NAME: &'static str = "createdAt";
         }
-        impl cynic::schema::HasField<createdAt> for super::super::User {
-            type Type = super::super::DateTime;
-        }
         pub struct updatedAt;
-        impl cynic::schema::Field for updatedAt {
+        impl cynic::schema::HasField<updatedAt> for super::super::User {
             type Type = super::super::DateTime;
             const NAME: &'static str = "updatedAt";
         }
-        impl cynic::schema::HasField<updatedAt> for super::super::User {
-            type Type = super::super::DateTime;
-        }
         pub struct __typename;
-        impl cynic::schema::Field for __typename {
-            type Type = super::super::String;
-            const NAME: &'static str = "__typename";
-        }
         impl cynic::schema::HasField<__typename> for super::super::User {
             type Type = super::super::String;
+            const NAME: &'static str = "__typename";
         }
     }
 }

--- a/cynic-codegen/tests/snapshots/use_schema__simple.graphql.snap
+++ b/cynic-codegen/tests/snapshots/use_schema__simple.graphql.snap
@@ -32,75 +32,50 @@ impl cynic::schema::NamedType for TestStruct {
 pub mod __fields {
     pub mod AnInputType {
         pub struct favouriteDessert;
-        impl cynic::schema::Field for favouriteDessert {
+        impl cynic::schema::HasInputField<favouriteDessert> for super::super::AnInputType {
             type Type = Option<super::super::Dessert>;
             const NAME: &'static str = "favouriteDessert";
-        }
-        impl cynic::schema::HasInputField<favouriteDessert, Option<super::super::Dessert>>
-            for super::super::AnInputType
-        {
         }
     }
     pub mod Nested {
         pub struct aString;
-        impl cynic::schema::Field for aString {
+        impl cynic::schema::HasField<aString> for super::super::Nested {
             type Type = super::super::String;
             const NAME: &'static str = "aString";
         }
-        impl cynic::schema::HasField<aString> for super::super::Nested {
-            type Type = super::super::String;
-        }
         pub struct optString;
-        impl cynic::schema::Field for optString {
+        impl cynic::schema::HasField<optString> for super::super::Nested {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "optString";
         }
-        impl cynic::schema::HasField<optString> for super::super::Nested {
-            type Type = Option<super::super::String>;
-        }
         pub struct __typename;
-        impl cynic::schema::Field for __typename {
-            type Type = super::super::String;
-            const NAME: &'static str = "__typename";
-        }
         impl cynic::schema::HasField<__typename> for super::super::Nested {
             type Type = super::super::String;
+            const NAME: &'static str = "__typename";
         }
     }
     pub mod Query {
         pub struct testStruct;
-        impl cynic::schema::Field for testStruct {
+        impl cynic::schema::HasField<testStruct> for super::super::Query {
             type Type = Option<super::super::TestStruct>;
             const NAME: &'static str = "testStruct";
         }
-        impl cynic::schema::HasField<testStruct> for super::super::Query {
-            type Type = Option<super::super::TestStruct>;
-        }
         pub struct myUnion;
-        impl cynic::schema::Field for myUnion {
+        impl cynic::schema::HasField<myUnion> for super::super::Query {
             type Type = Option<super::super::MyUnionType>;
             const NAME: &'static str = "myUnion";
         }
-        impl cynic::schema::HasField<myUnion> for super::super::Query {
-            type Type = Option<super::super::MyUnionType>;
-        }
         pub struct __typename;
-        impl cynic::schema::Field for __typename {
-            type Type = super::super::String;
-            const NAME: &'static str = "__typename";
-        }
         impl cynic::schema::HasField<__typename> for super::super::Query {
             type Type = super::super::String;
+            const NAME: &'static str = "__typename";
         }
     }
     pub mod TestStruct {
         pub struct fieldOne;
-        impl cynic::schema::Field for fieldOne {
-            type Type = super::super::String;
-            const NAME: &'static str = "fieldOne";
-        }
         impl cynic::schema::HasField<fieldOne> for super::super::TestStruct {
             type Type = super::super::String;
+            const NAME: &'static str = "fieldOne";
         }
         pub mod _field_one_arguments {
             pub struct x;
@@ -115,12 +90,9 @@ pub mod __fields {
             }
         }
         pub struct tastyCakes;
-        impl cynic::schema::Field for tastyCakes {
-            type Type = super::super::Dessert;
-            const NAME: &'static str = "tastyCakes";
-        }
         impl cynic::schema::HasField<tastyCakes> for super::super::TestStruct {
             type Type = super::super::Dessert;
+            const NAME: &'static str = "tastyCakes";
         }
         pub mod _tasty_cakes_arguments {
             pub struct first;
@@ -135,12 +107,9 @@ pub mod __fields {
             }
         }
         pub struct fieldWithInput;
-        impl cynic::schema::Field for fieldWithInput {
-            type Type = super::super::Dessert;
-            const NAME: &'static str = "fieldWithInput";
-        }
         impl cynic::schema::HasField<fieldWithInput> for super::super::TestStruct {
             type Type = super::super::Dessert;
+            const NAME: &'static str = "fieldWithInput";
         }
         pub mod _field_with_input_arguments {
             pub struct input;
@@ -150,44 +119,29 @@ pub mod __fields {
             }
         }
         pub struct nested;
-        impl cynic::schema::Field for nested {
+        impl cynic::schema::HasField<nested> for super::super::TestStruct {
             type Type = super::super::Nested;
             const NAME: &'static str = "nested";
         }
-        impl cynic::schema::HasField<nested> for super::super::TestStruct {
-            type Type = super::super::Nested;
-        }
         pub struct optNested;
-        impl cynic::schema::Field for optNested {
+        impl cynic::schema::HasField<optNested> for super::super::TestStruct {
             type Type = Option<super::super::Nested>;
             const NAME: &'static str = "optNested";
         }
-        impl cynic::schema::HasField<optNested> for super::super::TestStruct {
-            type Type = Option<super::super::Nested>;
-        }
         pub struct dessert;
-        impl cynic::schema::Field for dessert {
+        impl cynic::schema::HasField<dessert> for super::super::TestStruct {
             type Type = Option<super::super::Dessert>;
             const NAME: &'static str = "dessert";
         }
-        impl cynic::schema::HasField<dessert> for super::super::TestStruct {
-            type Type = Option<super::super::Dessert>;
-        }
         pub struct json;
-        impl cynic::schema::Field for json {
+        impl cynic::schema::HasField<json> for super::super::TestStruct {
             type Type = Option<super::super::JSON>;
             const NAME: &'static str = "json";
         }
-        impl cynic::schema::HasField<json> for super::super::TestStruct {
-            type Type = Option<super::super::JSON>;
-        }
         pub struct __typename;
-        impl cynic::schema::Field for __typename {
-            type Type = super::super::String;
-            const NAME: &'static str = "__typename";
-        }
         impl cynic::schema::HasField<__typename> for super::super::TestStruct {
             type Type = super::super::String;
+            const NAME: &'static str = "__typename";
         }
     }
 }

--- a/cynic-codegen/tests/snapshots/use_schema__starwars.schema.graphql.snap
+++ b/cynic-codegen/tests/snapshots/use_schema__starwars.schema.graphql.snap
@@ -226,60 +226,39 @@ impl cynic::schema::NamedType for VehiclesEdge {
 pub mod __fields {
     pub mod Film {
         pub struct title;
-        impl cynic::schema::Field for title {
+        impl cynic::schema::HasField<title> for super::super::Film {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "title";
         }
-        impl cynic::schema::HasField<title> for super::super::Film {
-            type Type = Option<super::super::String>;
-        }
         pub struct episodeID;
-        impl cynic::schema::Field for episodeID {
+        impl cynic::schema::HasField<episodeID> for super::super::Film {
             type Type = Option<super::super::Int>;
             const NAME: &'static str = "episodeID";
         }
-        impl cynic::schema::HasField<episodeID> for super::super::Film {
-            type Type = Option<super::super::Int>;
-        }
         pub struct openingCrawl;
-        impl cynic::schema::Field for openingCrawl {
+        impl cynic::schema::HasField<openingCrawl> for super::super::Film {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "openingCrawl";
         }
-        impl cynic::schema::HasField<openingCrawl> for super::super::Film {
-            type Type = Option<super::super::String>;
-        }
         pub struct director;
-        impl cynic::schema::Field for director {
+        impl cynic::schema::HasField<director> for super::super::Film {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "director";
         }
-        impl cynic::schema::HasField<director> for super::super::Film {
-            type Type = Option<super::super::String>;
-        }
         pub struct producers;
-        impl cynic::schema::Field for producers {
+        impl cynic::schema::HasField<producers> for super::super::Film {
             type Type = Option<Vec<Option<super::super::String>>>;
             const NAME: &'static str = "producers";
         }
-        impl cynic::schema::HasField<producers> for super::super::Film {
-            type Type = Option<Vec<Option<super::super::String>>>;
-        }
         pub struct releaseDate;
-        impl cynic::schema::Field for releaseDate {
+        impl cynic::schema::HasField<releaseDate> for super::super::Film {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "releaseDate";
         }
-        impl cynic::schema::HasField<releaseDate> for super::super::Film {
-            type Type = Option<super::super::String>;
-        }
         pub struct speciesConnection;
-        impl cynic::schema::Field for speciesConnection {
-            type Type = Option<super::super::FilmSpeciesConnection>;
-            const NAME: &'static str = "speciesConnection";
-        }
         impl cynic::schema::HasField<speciesConnection> for super::super::Film {
             type Type = Option<super::super::FilmSpeciesConnection>;
+            const NAME: &'static str = "speciesConnection";
         }
         pub mod _species_connection_arguments {
             pub struct after;
@@ -304,12 +283,9 @@ pub mod __fields {
             }
         }
         pub struct starshipConnection;
-        impl cynic::schema::Field for starshipConnection {
-            type Type = Option<super::super::FilmStarshipsConnection>;
-            const NAME: &'static str = "starshipConnection";
-        }
         impl cynic::schema::HasField<starshipConnection> for super::super::Film {
             type Type = Option<super::super::FilmStarshipsConnection>;
+            const NAME: &'static str = "starshipConnection";
         }
         pub mod _starship_connection_arguments {
             pub struct after;
@@ -334,12 +310,9 @@ pub mod __fields {
             }
         }
         pub struct vehicleConnection;
-        impl cynic::schema::Field for vehicleConnection {
-            type Type = Option<super::super::FilmVehiclesConnection>;
-            const NAME: &'static str = "vehicleConnection";
-        }
         impl cynic::schema::HasField<vehicleConnection> for super::super::Film {
             type Type = Option<super::super::FilmVehiclesConnection>;
+            const NAME: &'static str = "vehicleConnection";
         }
         pub mod _vehicle_connection_arguments {
             pub struct after;
@@ -364,12 +337,9 @@ pub mod __fields {
             }
         }
         pub struct characterConnection;
-        impl cynic::schema::Field for characterConnection {
-            type Type = Option<super::super::FilmCharactersConnection>;
-            const NAME: &'static str = "characterConnection";
-        }
         impl cynic::schema::HasField<characterConnection> for super::super::Film {
             type Type = Option<super::super::FilmCharactersConnection>;
+            const NAME: &'static str = "characterConnection";
         }
         pub mod _character_connection_arguments {
             pub struct after;
@@ -394,12 +364,9 @@ pub mod __fields {
             }
         }
         pub struct planetConnection;
-        impl cynic::schema::Field for planetConnection {
-            type Type = Option<super::super::FilmPlanetsConnection>;
-            const NAME: &'static str = "planetConnection";
-        }
         impl cynic::schema::HasField<planetConnection> for super::super::Film {
             type Type = Option<super::super::FilmPlanetsConnection>;
+            const NAME: &'static str = "planetConnection";
         }
         pub mod _planet_connection_arguments {
             pub struct after;
@@ -424,654 +391,423 @@ pub mod __fields {
             }
         }
         pub struct created;
-        impl cynic::schema::Field for created {
+        impl cynic::schema::HasField<created> for super::super::Film {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "created";
         }
-        impl cynic::schema::HasField<created> for super::super::Film {
-            type Type = Option<super::super::String>;
-        }
         pub struct edited;
-        impl cynic::schema::Field for edited {
+        impl cynic::schema::HasField<edited> for super::super::Film {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "edited";
         }
-        impl cynic::schema::HasField<edited> for super::super::Film {
-            type Type = Option<super::super::String>;
-        }
         pub struct id;
-        impl cynic::schema::Field for id {
+        impl cynic::schema::HasField<id> for super::super::Film {
             type Type = super::super::ID;
             const NAME: &'static str = "id";
         }
-        impl cynic::schema::HasField<id> for super::super::Film {
-            type Type = super::super::ID;
-        }
         pub struct __typename;
-        impl cynic::schema::Field for __typename {
-            type Type = super::super::String;
-            const NAME: &'static str = "__typename";
-        }
         impl cynic::schema::HasField<__typename> for super::super::Film {
             type Type = super::super::String;
+            const NAME: &'static str = "__typename";
         }
     }
     pub mod FilmCharactersConnection {
         pub struct pageInfo;
-        impl cynic::schema::Field for pageInfo {
+        impl cynic::schema::HasField<pageInfo> for super::super::FilmCharactersConnection {
             type Type = super::super::PageInfo;
             const NAME: &'static str = "pageInfo";
         }
-        impl cynic::schema::HasField<pageInfo> for super::super::FilmCharactersConnection {
-            type Type = super::super::PageInfo;
-        }
         pub struct edges;
-        impl cynic::schema::Field for edges {
+        impl cynic::schema::HasField<edges> for super::super::FilmCharactersConnection {
             type Type = Option<Vec<Option<super::super::FilmCharactersEdge>>>;
             const NAME: &'static str = "edges";
         }
-        impl cynic::schema::HasField<edges> for super::super::FilmCharactersConnection {
-            type Type = Option<Vec<Option<super::super::FilmCharactersEdge>>>;
-        }
         pub struct totalCount;
-        impl cynic::schema::Field for totalCount {
+        impl cynic::schema::HasField<totalCount> for super::super::FilmCharactersConnection {
             type Type = Option<super::super::Int>;
             const NAME: &'static str = "totalCount";
         }
-        impl cynic::schema::HasField<totalCount> for super::super::FilmCharactersConnection {
-            type Type = Option<super::super::Int>;
-        }
         pub struct characters;
-        impl cynic::schema::Field for characters {
+        impl cynic::schema::HasField<characters> for super::super::FilmCharactersConnection {
             type Type = Option<Vec<Option<super::super::Person>>>;
             const NAME: &'static str = "characters";
         }
-        impl cynic::schema::HasField<characters> for super::super::FilmCharactersConnection {
-            type Type = Option<Vec<Option<super::super::Person>>>;
-        }
         pub struct __typename;
-        impl cynic::schema::Field for __typename {
-            type Type = super::super::String;
-            const NAME: &'static str = "__typename";
-        }
         impl cynic::schema::HasField<__typename> for super::super::FilmCharactersConnection {
             type Type = super::super::String;
+            const NAME: &'static str = "__typename";
         }
     }
     pub mod FilmCharactersEdge {
         pub struct node;
-        impl cynic::schema::Field for node {
+        impl cynic::schema::HasField<node> for super::super::FilmCharactersEdge {
             type Type = Option<super::super::Person>;
             const NAME: &'static str = "node";
         }
-        impl cynic::schema::HasField<node> for super::super::FilmCharactersEdge {
-            type Type = Option<super::super::Person>;
-        }
         pub struct cursor;
-        impl cynic::schema::Field for cursor {
+        impl cynic::schema::HasField<cursor> for super::super::FilmCharactersEdge {
             type Type = super::super::String;
             const NAME: &'static str = "cursor";
         }
-        impl cynic::schema::HasField<cursor> for super::super::FilmCharactersEdge {
-            type Type = super::super::String;
-        }
         pub struct __typename;
-        impl cynic::schema::Field for __typename {
-            type Type = super::super::String;
-            const NAME: &'static str = "__typename";
-        }
         impl cynic::schema::HasField<__typename> for super::super::FilmCharactersEdge {
             type Type = super::super::String;
+            const NAME: &'static str = "__typename";
         }
     }
     pub mod FilmPlanetsConnection {
         pub struct pageInfo;
-        impl cynic::schema::Field for pageInfo {
+        impl cynic::schema::HasField<pageInfo> for super::super::FilmPlanetsConnection {
             type Type = super::super::PageInfo;
             const NAME: &'static str = "pageInfo";
         }
-        impl cynic::schema::HasField<pageInfo> for super::super::FilmPlanetsConnection {
-            type Type = super::super::PageInfo;
-        }
         pub struct edges;
-        impl cynic::schema::Field for edges {
+        impl cynic::schema::HasField<edges> for super::super::FilmPlanetsConnection {
             type Type = Option<Vec<Option<super::super::FilmPlanetsEdge>>>;
             const NAME: &'static str = "edges";
         }
-        impl cynic::schema::HasField<edges> for super::super::FilmPlanetsConnection {
-            type Type = Option<Vec<Option<super::super::FilmPlanetsEdge>>>;
-        }
         pub struct totalCount;
-        impl cynic::schema::Field for totalCount {
+        impl cynic::schema::HasField<totalCount> for super::super::FilmPlanetsConnection {
             type Type = Option<super::super::Int>;
             const NAME: &'static str = "totalCount";
         }
-        impl cynic::schema::HasField<totalCount> for super::super::FilmPlanetsConnection {
-            type Type = Option<super::super::Int>;
-        }
         pub struct planets;
-        impl cynic::schema::Field for planets {
+        impl cynic::schema::HasField<planets> for super::super::FilmPlanetsConnection {
             type Type = Option<Vec<Option<super::super::Planet>>>;
             const NAME: &'static str = "planets";
         }
-        impl cynic::schema::HasField<planets> for super::super::FilmPlanetsConnection {
-            type Type = Option<Vec<Option<super::super::Planet>>>;
-        }
         pub struct __typename;
-        impl cynic::schema::Field for __typename {
-            type Type = super::super::String;
-            const NAME: &'static str = "__typename";
-        }
         impl cynic::schema::HasField<__typename> for super::super::FilmPlanetsConnection {
             type Type = super::super::String;
+            const NAME: &'static str = "__typename";
         }
     }
     pub mod FilmPlanetsEdge {
         pub struct node;
-        impl cynic::schema::Field for node {
+        impl cynic::schema::HasField<node> for super::super::FilmPlanetsEdge {
             type Type = Option<super::super::Planet>;
             const NAME: &'static str = "node";
         }
-        impl cynic::schema::HasField<node> for super::super::FilmPlanetsEdge {
-            type Type = Option<super::super::Planet>;
-        }
         pub struct cursor;
-        impl cynic::schema::Field for cursor {
+        impl cynic::schema::HasField<cursor> for super::super::FilmPlanetsEdge {
             type Type = super::super::String;
             const NAME: &'static str = "cursor";
         }
-        impl cynic::schema::HasField<cursor> for super::super::FilmPlanetsEdge {
-            type Type = super::super::String;
-        }
         pub struct __typename;
-        impl cynic::schema::Field for __typename {
-            type Type = super::super::String;
-            const NAME: &'static str = "__typename";
-        }
         impl cynic::schema::HasField<__typename> for super::super::FilmPlanetsEdge {
             type Type = super::super::String;
+            const NAME: &'static str = "__typename";
         }
     }
     pub mod FilmSpeciesConnection {
         pub struct pageInfo;
-        impl cynic::schema::Field for pageInfo {
+        impl cynic::schema::HasField<pageInfo> for super::super::FilmSpeciesConnection {
             type Type = super::super::PageInfo;
             const NAME: &'static str = "pageInfo";
         }
-        impl cynic::schema::HasField<pageInfo> for super::super::FilmSpeciesConnection {
-            type Type = super::super::PageInfo;
-        }
         pub struct edges;
-        impl cynic::schema::Field for edges {
+        impl cynic::schema::HasField<edges> for super::super::FilmSpeciesConnection {
             type Type = Option<Vec<Option<super::super::FilmSpeciesEdge>>>;
             const NAME: &'static str = "edges";
         }
-        impl cynic::schema::HasField<edges> for super::super::FilmSpeciesConnection {
-            type Type = Option<Vec<Option<super::super::FilmSpeciesEdge>>>;
-        }
         pub struct totalCount;
-        impl cynic::schema::Field for totalCount {
+        impl cynic::schema::HasField<totalCount> for super::super::FilmSpeciesConnection {
             type Type = Option<super::super::Int>;
             const NAME: &'static str = "totalCount";
         }
-        impl cynic::schema::HasField<totalCount> for super::super::FilmSpeciesConnection {
-            type Type = Option<super::super::Int>;
-        }
         pub struct species;
-        impl cynic::schema::Field for species {
+        impl cynic::schema::HasField<species> for super::super::FilmSpeciesConnection {
             type Type = Option<Vec<Option<super::super::Species>>>;
             const NAME: &'static str = "species";
         }
-        impl cynic::schema::HasField<species> for super::super::FilmSpeciesConnection {
-            type Type = Option<Vec<Option<super::super::Species>>>;
-        }
         pub struct __typename;
-        impl cynic::schema::Field for __typename {
-            type Type = super::super::String;
-            const NAME: &'static str = "__typename";
-        }
         impl cynic::schema::HasField<__typename> for super::super::FilmSpeciesConnection {
             type Type = super::super::String;
+            const NAME: &'static str = "__typename";
         }
     }
     pub mod FilmSpeciesEdge {
         pub struct node;
-        impl cynic::schema::Field for node {
+        impl cynic::schema::HasField<node> for super::super::FilmSpeciesEdge {
             type Type = Option<super::super::Species>;
             const NAME: &'static str = "node";
         }
-        impl cynic::schema::HasField<node> for super::super::FilmSpeciesEdge {
-            type Type = Option<super::super::Species>;
-        }
         pub struct cursor;
-        impl cynic::schema::Field for cursor {
+        impl cynic::schema::HasField<cursor> for super::super::FilmSpeciesEdge {
             type Type = super::super::String;
             const NAME: &'static str = "cursor";
         }
-        impl cynic::schema::HasField<cursor> for super::super::FilmSpeciesEdge {
-            type Type = super::super::String;
-        }
         pub struct __typename;
-        impl cynic::schema::Field for __typename {
-            type Type = super::super::String;
-            const NAME: &'static str = "__typename";
-        }
         impl cynic::schema::HasField<__typename> for super::super::FilmSpeciesEdge {
             type Type = super::super::String;
+            const NAME: &'static str = "__typename";
         }
     }
     pub mod FilmStarshipsConnection {
         pub struct pageInfo;
-        impl cynic::schema::Field for pageInfo {
+        impl cynic::schema::HasField<pageInfo> for super::super::FilmStarshipsConnection {
             type Type = super::super::PageInfo;
             const NAME: &'static str = "pageInfo";
         }
-        impl cynic::schema::HasField<pageInfo> for super::super::FilmStarshipsConnection {
-            type Type = super::super::PageInfo;
-        }
         pub struct edges;
-        impl cynic::schema::Field for edges {
+        impl cynic::schema::HasField<edges> for super::super::FilmStarshipsConnection {
             type Type = Option<Vec<Option<super::super::FilmStarshipsEdge>>>;
             const NAME: &'static str = "edges";
         }
-        impl cynic::schema::HasField<edges> for super::super::FilmStarshipsConnection {
-            type Type = Option<Vec<Option<super::super::FilmStarshipsEdge>>>;
-        }
         pub struct totalCount;
-        impl cynic::schema::Field for totalCount {
+        impl cynic::schema::HasField<totalCount> for super::super::FilmStarshipsConnection {
             type Type = Option<super::super::Int>;
             const NAME: &'static str = "totalCount";
         }
-        impl cynic::schema::HasField<totalCount> for super::super::FilmStarshipsConnection {
-            type Type = Option<super::super::Int>;
-        }
         pub struct starships;
-        impl cynic::schema::Field for starships {
+        impl cynic::schema::HasField<starships> for super::super::FilmStarshipsConnection {
             type Type = Option<Vec<Option<super::super::Starship>>>;
             const NAME: &'static str = "starships";
         }
-        impl cynic::schema::HasField<starships> for super::super::FilmStarshipsConnection {
-            type Type = Option<Vec<Option<super::super::Starship>>>;
-        }
         pub struct __typename;
-        impl cynic::schema::Field for __typename {
-            type Type = super::super::String;
-            const NAME: &'static str = "__typename";
-        }
         impl cynic::schema::HasField<__typename> for super::super::FilmStarshipsConnection {
             type Type = super::super::String;
+            const NAME: &'static str = "__typename";
         }
     }
     pub mod FilmStarshipsEdge {
         pub struct node;
-        impl cynic::schema::Field for node {
+        impl cynic::schema::HasField<node> for super::super::FilmStarshipsEdge {
             type Type = Option<super::super::Starship>;
             const NAME: &'static str = "node";
         }
-        impl cynic::schema::HasField<node> for super::super::FilmStarshipsEdge {
-            type Type = Option<super::super::Starship>;
-        }
         pub struct cursor;
-        impl cynic::schema::Field for cursor {
+        impl cynic::schema::HasField<cursor> for super::super::FilmStarshipsEdge {
             type Type = super::super::String;
             const NAME: &'static str = "cursor";
         }
-        impl cynic::schema::HasField<cursor> for super::super::FilmStarshipsEdge {
-            type Type = super::super::String;
-        }
         pub struct __typename;
-        impl cynic::schema::Field for __typename {
-            type Type = super::super::String;
-            const NAME: &'static str = "__typename";
-        }
         impl cynic::schema::HasField<__typename> for super::super::FilmStarshipsEdge {
             type Type = super::super::String;
+            const NAME: &'static str = "__typename";
         }
     }
     pub mod FilmVehiclesConnection {
         pub struct pageInfo;
-        impl cynic::schema::Field for pageInfo {
+        impl cynic::schema::HasField<pageInfo> for super::super::FilmVehiclesConnection {
             type Type = super::super::PageInfo;
             const NAME: &'static str = "pageInfo";
         }
-        impl cynic::schema::HasField<pageInfo> for super::super::FilmVehiclesConnection {
-            type Type = super::super::PageInfo;
-        }
         pub struct edges;
-        impl cynic::schema::Field for edges {
+        impl cynic::schema::HasField<edges> for super::super::FilmVehiclesConnection {
             type Type = Option<Vec<Option<super::super::FilmVehiclesEdge>>>;
             const NAME: &'static str = "edges";
         }
-        impl cynic::schema::HasField<edges> for super::super::FilmVehiclesConnection {
-            type Type = Option<Vec<Option<super::super::FilmVehiclesEdge>>>;
-        }
         pub struct totalCount;
-        impl cynic::schema::Field for totalCount {
+        impl cynic::schema::HasField<totalCount> for super::super::FilmVehiclesConnection {
             type Type = Option<super::super::Int>;
             const NAME: &'static str = "totalCount";
         }
-        impl cynic::schema::HasField<totalCount> for super::super::FilmVehiclesConnection {
-            type Type = Option<super::super::Int>;
-        }
         pub struct vehicles;
-        impl cynic::schema::Field for vehicles {
+        impl cynic::schema::HasField<vehicles> for super::super::FilmVehiclesConnection {
             type Type = Option<Vec<Option<super::super::Vehicle>>>;
             const NAME: &'static str = "vehicles";
         }
-        impl cynic::schema::HasField<vehicles> for super::super::FilmVehiclesConnection {
-            type Type = Option<Vec<Option<super::super::Vehicle>>>;
-        }
         pub struct __typename;
-        impl cynic::schema::Field for __typename {
-            type Type = super::super::String;
-            const NAME: &'static str = "__typename";
-        }
         impl cynic::schema::HasField<__typename> for super::super::FilmVehiclesConnection {
             type Type = super::super::String;
+            const NAME: &'static str = "__typename";
         }
     }
     pub mod FilmVehiclesEdge {
         pub struct node;
-        impl cynic::schema::Field for node {
+        impl cynic::schema::HasField<node> for super::super::FilmVehiclesEdge {
             type Type = Option<super::super::Vehicle>;
             const NAME: &'static str = "node";
         }
-        impl cynic::schema::HasField<node> for super::super::FilmVehiclesEdge {
-            type Type = Option<super::super::Vehicle>;
-        }
         pub struct cursor;
-        impl cynic::schema::Field for cursor {
+        impl cynic::schema::HasField<cursor> for super::super::FilmVehiclesEdge {
             type Type = super::super::String;
             const NAME: &'static str = "cursor";
         }
-        impl cynic::schema::HasField<cursor> for super::super::FilmVehiclesEdge {
-            type Type = super::super::String;
-        }
         pub struct __typename;
-        impl cynic::schema::Field for __typename {
-            type Type = super::super::String;
-            const NAME: &'static str = "__typename";
-        }
         impl cynic::schema::HasField<__typename> for super::super::FilmVehiclesEdge {
             type Type = super::super::String;
+            const NAME: &'static str = "__typename";
         }
     }
     pub mod FilmsConnection {
         pub struct pageInfo;
-        impl cynic::schema::Field for pageInfo {
+        impl cynic::schema::HasField<pageInfo> for super::super::FilmsConnection {
             type Type = super::super::PageInfo;
             const NAME: &'static str = "pageInfo";
         }
-        impl cynic::schema::HasField<pageInfo> for super::super::FilmsConnection {
-            type Type = super::super::PageInfo;
-        }
         pub struct edges;
-        impl cynic::schema::Field for edges {
+        impl cynic::schema::HasField<edges> for super::super::FilmsConnection {
             type Type = Option<Vec<Option<super::super::FilmsEdge>>>;
             const NAME: &'static str = "edges";
         }
-        impl cynic::schema::HasField<edges> for super::super::FilmsConnection {
-            type Type = Option<Vec<Option<super::super::FilmsEdge>>>;
-        }
         pub struct totalCount;
-        impl cynic::schema::Field for totalCount {
+        impl cynic::schema::HasField<totalCount> for super::super::FilmsConnection {
             type Type = Option<super::super::Int>;
             const NAME: &'static str = "totalCount";
         }
-        impl cynic::schema::HasField<totalCount> for super::super::FilmsConnection {
-            type Type = Option<super::super::Int>;
-        }
         pub struct films;
-        impl cynic::schema::Field for films {
+        impl cynic::schema::HasField<films> for super::super::FilmsConnection {
             type Type = Option<Vec<Option<super::super::Film>>>;
             const NAME: &'static str = "films";
         }
-        impl cynic::schema::HasField<films> for super::super::FilmsConnection {
-            type Type = Option<Vec<Option<super::super::Film>>>;
-        }
         pub struct __typename;
-        impl cynic::schema::Field for __typename {
-            type Type = super::super::String;
-            const NAME: &'static str = "__typename";
-        }
         impl cynic::schema::HasField<__typename> for super::super::FilmsConnection {
             type Type = super::super::String;
+            const NAME: &'static str = "__typename";
         }
     }
     pub mod FilmsEdge {
         pub struct node;
-        impl cynic::schema::Field for node {
+        impl cynic::schema::HasField<node> for super::super::FilmsEdge {
             type Type = Option<super::super::Film>;
             const NAME: &'static str = "node";
         }
-        impl cynic::schema::HasField<node> for super::super::FilmsEdge {
-            type Type = Option<super::super::Film>;
-        }
         pub struct cursor;
-        impl cynic::schema::Field for cursor {
+        impl cynic::schema::HasField<cursor> for super::super::FilmsEdge {
             type Type = super::super::String;
             const NAME: &'static str = "cursor";
         }
-        impl cynic::schema::HasField<cursor> for super::super::FilmsEdge {
-            type Type = super::super::String;
-        }
         pub struct __typename;
-        impl cynic::schema::Field for __typename {
-            type Type = super::super::String;
-            const NAME: &'static str = "__typename";
-        }
         impl cynic::schema::HasField<__typename> for super::super::FilmsEdge {
             type Type = super::super::String;
+            const NAME: &'static str = "__typename";
         }
     }
     pub mod Node {
         pub struct id;
-        impl cynic::schema::Field for id {
+        impl cynic::schema::HasField<id> for super::super::Node {
             type Type = super::super::ID;
             const NAME: &'static str = "id";
         }
-        impl cynic::schema::HasField<id> for super::super::Node {
-            type Type = super::super::ID;
-        }
         pub struct __typename;
-        impl cynic::schema::Field for __typename {
-            type Type = super::super::String;
-            const NAME: &'static str = "__typename";
-        }
         impl cynic::schema::HasField<__typename> for super::super::Node {
             type Type = super::super::String;
+            const NAME: &'static str = "__typename";
         }
     }
     pub mod PageInfo {
         pub struct hasNextPage;
-        impl cynic::schema::Field for hasNextPage {
+        impl cynic::schema::HasField<hasNextPage> for super::super::PageInfo {
             type Type = super::super::Boolean;
             const NAME: &'static str = "hasNextPage";
         }
-        impl cynic::schema::HasField<hasNextPage> for super::super::PageInfo {
-            type Type = super::super::Boolean;
-        }
         pub struct hasPreviousPage;
-        impl cynic::schema::Field for hasPreviousPage {
+        impl cynic::schema::HasField<hasPreviousPage> for super::super::PageInfo {
             type Type = super::super::Boolean;
             const NAME: &'static str = "hasPreviousPage";
         }
-        impl cynic::schema::HasField<hasPreviousPage> for super::super::PageInfo {
-            type Type = super::super::Boolean;
-        }
         pub struct startCursor;
-        impl cynic::schema::Field for startCursor {
+        impl cynic::schema::HasField<startCursor> for super::super::PageInfo {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "startCursor";
         }
-        impl cynic::schema::HasField<startCursor> for super::super::PageInfo {
-            type Type = Option<super::super::String>;
-        }
         pub struct endCursor;
-        impl cynic::schema::Field for endCursor {
+        impl cynic::schema::HasField<endCursor> for super::super::PageInfo {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "endCursor";
         }
-        impl cynic::schema::HasField<endCursor> for super::super::PageInfo {
-            type Type = Option<super::super::String>;
-        }
         pub struct __typename;
-        impl cynic::schema::Field for __typename {
-            type Type = super::super::String;
-            const NAME: &'static str = "__typename";
-        }
         impl cynic::schema::HasField<__typename> for super::super::PageInfo {
             type Type = super::super::String;
+            const NAME: &'static str = "__typename";
         }
     }
     pub mod PeopleConnection {
         pub struct pageInfo;
-        impl cynic::schema::Field for pageInfo {
+        impl cynic::schema::HasField<pageInfo> for super::super::PeopleConnection {
             type Type = super::super::PageInfo;
             const NAME: &'static str = "pageInfo";
         }
-        impl cynic::schema::HasField<pageInfo> for super::super::PeopleConnection {
-            type Type = super::super::PageInfo;
-        }
         pub struct edges;
-        impl cynic::schema::Field for edges {
+        impl cynic::schema::HasField<edges> for super::super::PeopleConnection {
             type Type = Option<Vec<Option<super::super::PeopleEdge>>>;
             const NAME: &'static str = "edges";
         }
-        impl cynic::schema::HasField<edges> for super::super::PeopleConnection {
-            type Type = Option<Vec<Option<super::super::PeopleEdge>>>;
-        }
         pub struct totalCount;
-        impl cynic::schema::Field for totalCount {
+        impl cynic::schema::HasField<totalCount> for super::super::PeopleConnection {
             type Type = Option<super::super::Int>;
             const NAME: &'static str = "totalCount";
         }
-        impl cynic::schema::HasField<totalCount> for super::super::PeopleConnection {
-            type Type = Option<super::super::Int>;
-        }
         pub struct people;
-        impl cynic::schema::Field for people {
+        impl cynic::schema::HasField<people> for super::super::PeopleConnection {
             type Type = Option<Vec<Option<super::super::Person>>>;
             const NAME: &'static str = "people";
         }
-        impl cynic::schema::HasField<people> for super::super::PeopleConnection {
-            type Type = Option<Vec<Option<super::super::Person>>>;
-        }
         pub struct __typename;
-        impl cynic::schema::Field for __typename {
-            type Type = super::super::String;
-            const NAME: &'static str = "__typename";
-        }
         impl cynic::schema::HasField<__typename> for super::super::PeopleConnection {
             type Type = super::super::String;
+            const NAME: &'static str = "__typename";
         }
     }
     pub mod PeopleEdge {
         pub struct node;
-        impl cynic::schema::Field for node {
+        impl cynic::schema::HasField<node> for super::super::PeopleEdge {
             type Type = Option<super::super::Person>;
             const NAME: &'static str = "node";
         }
-        impl cynic::schema::HasField<node> for super::super::PeopleEdge {
-            type Type = Option<super::super::Person>;
-        }
         pub struct cursor;
-        impl cynic::schema::Field for cursor {
+        impl cynic::schema::HasField<cursor> for super::super::PeopleEdge {
             type Type = super::super::String;
             const NAME: &'static str = "cursor";
         }
-        impl cynic::schema::HasField<cursor> for super::super::PeopleEdge {
-            type Type = super::super::String;
-        }
         pub struct __typename;
-        impl cynic::schema::Field for __typename {
-            type Type = super::super::String;
-            const NAME: &'static str = "__typename";
-        }
         impl cynic::schema::HasField<__typename> for super::super::PeopleEdge {
             type Type = super::super::String;
+            const NAME: &'static str = "__typename";
         }
     }
     pub mod Person {
         pub struct name;
-        impl cynic::schema::Field for name {
+        impl cynic::schema::HasField<name> for super::super::Person {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "name";
         }
-        impl cynic::schema::HasField<name> for super::super::Person {
-            type Type = Option<super::super::String>;
-        }
         pub struct birthYear;
-        impl cynic::schema::Field for birthYear {
+        impl cynic::schema::HasField<birthYear> for super::super::Person {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "birthYear";
         }
-        impl cynic::schema::HasField<birthYear> for super::super::Person {
-            type Type = Option<super::super::String>;
-        }
         pub struct eyeColor;
-        impl cynic::schema::Field for eyeColor {
+        impl cynic::schema::HasField<eyeColor> for super::super::Person {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "eyeColor";
         }
-        impl cynic::schema::HasField<eyeColor> for super::super::Person {
-            type Type = Option<super::super::String>;
-        }
         pub struct gender;
-        impl cynic::schema::Field for gender {
+        impl cynic::schema::HasField<gender> for super::super::Person {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "gender";
         }
-        impl cynic::schema::HasField<gender> for super::super::Person {
-            type Type = Option<super::super::String>;
-        }
         pub struct hairColor;
-        impl cynic::schema::Field for hairColor {
+        impl cynic::schema::HasField<hairColor> for super::super::Person {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "hairColor";
         }
-        impl cynic::schema::HasField<hairColor> for super::super::Person {
-            type Type = Option<super::super::String>;
-        }
         pub struct height;
-        impl cynic::schema::Field for height {
+        impl cynic::schema::HasField<height> for super::super::Person {
             type Type = Option<super::super::Int>;
             const NAME: &'static str = "height";
         }
-        impl cynic::schema::HasField<height> for super::super::Person {
-            type Type = Option<super::super::Int>;
-        }
         pub struct mass;
-        impl cynic::schema::Field for mass {
+        impl cynic::schema::HasField<mass> for super::super::Person {
             type Type = Option<super::super::Float>;
             const NAME: &'static str = "mass";
         }
-        impl cynic::schema::HasField<mass> for super::super::Person {
-            type Type = Option<super::super::Float>;
-        }
         pub struct skinColor;
-        impl cynic::schema::Field for skinColor {
+        impl cynic::schema::HasField<skinColor> for super::super::Person {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "skinColor";
         }
-        impl cynic::schema::HasField<skinColor> for super::super::Person {
-            type Type = Option<super::super::String>;
-        }
         pub struct homeworld;
-        impl cynic::schema::Field for homeworld {
+        impl cynic::schema::HasField<homeworld> for super::super::Person {
             type Type = Option<super::super::Planet>;
             const NAME: &'static str = "homeworld";
         }
-        impl cynic::schema::HasField<homeworld> for super::super::Person {
-            type Type = Option<super::super::Planet>;
-        }
         pub struct filmConnection;
-        impl cynic::schema::Field for filmConnection {
-            type Type = Option<super::super::PersonFilmsConnection>;
-            const NAME: &'static str = "filmConnection";
-        }
         impl cynic::schema::HasField<filmConnection> for super::super::Person {
             type Type = Option<super::super::PersonFilmsConnection>;
+            const NAME: &'static str = "filmConnection";
         }
         pub mod _film_connection_arguments {
             pub struct after;
@@ -1096,20 +832,14 @@ pub mod __fields {
             }
         }
         pub struct species;
-        impl cynic::schema::Field for species {
+        impl cynic::schema::HasField<species> for super::super::Person {
             type Type = Option<super::super::Species>;
             const NAME: &'static str = "species";
         }
-        impl cynic::schema::HasField<species> for super::super::Person {
-            type Type = Option<super::super::Species>;
-        }
         pub struct starshipConnection;
-        impl cynic::schema::Field for starshipConnection {
-            type Type = Option<super::super::PersonStarshipsConnection>;
-            const NAME: &'static str = "starshipConnection";
-        }
         impl cynic::schema::HasField<starshipConnection> for super::super::Person {
             type Type = Option<super::super::PersonStarshipsConnection>;
+            const NAME: &'static str = "starshipConnection";
         }
         pub mod _starship_connection_arguments {
             pub struct after;
@@ -1134,12 +864,9 @@ pub mod __fields {
             }
         }
         pub struct vehicleConnection;
-        impl cynic::schema::Field for vehicleConnection {
-            type Type = Option<super::super::PersonVehiclesConnection>;
-            const NAME: &'static str = "vehicleConnection";
-        }
         impl cynic::schema::HasField<vehicleConnection> for super::super::Person {
             type Type = Option<super::super::PersonVehiclesConnection>;
+            const NAME: &'static str = "vehicleConnection";
         }
         pub mod _vehicle_connection_arguments {
             pub struct after;
@@ -1164,322 +891,208 @@ pub mod __fields {
             }
         }
         pub struct created;
-        impl cynic::schema::Field for created {
+        impl cynic::schema::HasField<created> for super::super::Person {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "created";
         }
-        impl cynic::schema::HasField<created> for super::super::Person {
-            type Type = Option<super::super::String>;
-        }
         pub struct edited;
-        impl cynic::schema::Field for edited {
+        impl cynic::schema::HasField<edited> for super::super::Person {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "edited";
         }
-        impl cynic::schema::HasField<edited> for super::super::Person {
-            type Type = Option<super::super::String>;
-        }
         pub struct id;
-        impl cynic::schema::Field for id {
+        impl cynic::schema::HasField<id> for super::super::Person {
             type Type = super::super::ID;
             const NAME: &'static str = "id";
         }
-        impl cynic::schema::HasField<id> for super::super::Person {
-            type Type = super::super::ID;
-        }
         pub struct __typename;
-        impl cynic::schema::Field for __typename {
-            type Type = super::super::String;
-            const NAME: &'static str = "__typename";
-        }
         impl cynic::schema::HasField<__typename> for super::super::Person {
             type Type = super::super::String;
+            const NAME: &'static str = "__typename";
         }
     }
     pub mod PersonFilmsConnection {
         pub struct pageInfo;
-        impl cynic::schema::Field for pageInfo {
+        impl cynic::schema::HasField<pageInfo> for super::super::PersonFilmsConnection {
             type Type = super::super::PageInfo;
             const NAME: &'static str = "pageInfo";
         }
-        impl cynic::schema::HasField<pageInfo> for super::super::PersonFilmsConnection {
-            type Type = super::super::PageInfo;
-        }
         pub struct edges;
-        impl cynic::schema::Field for edges {
+        impl cynic::schema::HasField<edges> for super::super::PersonFilmsConnection {
             type Type = Option<Vec<Option<super::super::PersonFilmsEdge>>>;
             const NAME: &'static str = "edges";
         }
-        impl cynic::schema::HasField<edges> for super::super::PersonFilmsConnection {
-            type Type = Option<Vec<Option<super::super::PersonFilmsEdge>>>;
-        }
         pub struct totalCount;
-        impl cynic::schema::Field for totalCount {
+        impl cynic::schema::HasField<totalCount> for super::super::PersonFilmsConnection {
             type Type = Option<super::super::Int>;
             const NAME: &'static str = "totalCount";
         }
-        impl cynic::schema::HasField<totalCount> for super::super::PersonFilmsConnection {
-            type Type = Option<super::super::Int>;
-        }
         pub struct films;
-        impl cynic::schema::Field for films {
+        impl cynic::schema::HasField<films> for super::super::PersonFilmsConnection {
             type Type = Option<Vec<Option<super::super::Film>>>;
             const NAME: &'static str = "films";
         }
-        impl cynic::schema::HasField<films> for super::super::PersonFilmsConnection {
-            type Type = Option<Vec<Option<super::super::Film>>>;
-        }
         pub struct __typename;
-        impl cynic::schema::Field for __typename {
-            type Type = super::super::String;
-            const NAME: &'static str = "__typename";
-        }
         impl cynic::schema::HasField<__typename> for super::super::PersonFilmsConnection {
             type Type = super::super::String;
+            const NAME: &'static str = "__typename";
         }
     }
     pub mod PersonFilmsEdge {
         pub struct node;
-        impl cynic::schema::Field for node {
+        impl cynic::schema::HasField<node> for super::super::PersonFilmsEdge {
             type Type = Option<super::super::Film>;
             const NAME: &'static str = "node";
         }
-        impl cynic::schema::HasField<node> for super::super::PersonFilmsEdge {
-            type Type = Option<super::super::Film>;
-        }
         pub struct cursor;
-        impl cynic::schema::Field for cursor {
+        impl cynic::schema::HasField<cursor> for super::super::PersonFilmsEdge {
             type Type = super::super::String;
             const NAME: &'static str = "cursor";
         }
-        impl cynic::schema::HasField<cursor> for super::super::PersonFilmsEdge {
-            type Type = super::super::String;
-        }
         pub struct __typename;
-        impl cynic::schema::Field for __typename {
-            type Type = super::super::String;
-            const NAME: &'static str = "__typename";
-        }
         impl cynic::schema::HasField<__typename> for super::super::PersonFilmsEdge {
             type Type = super::super::String;
+            const NAME: &'static str = "__typename";
         }
     }
     pub mod PersonStarshipsConnection {
         pub struct pageInfo;
-        impl cynic::schema::Field for pageInfo {
+        impl cynic::schema::HasField<pageInfo> for super::super::PersonStarshipsConnection {
             type Type = super::super::PageInfo;
             const NAME: &'static str = "pageInfo";
         }
-        impl cynic::schema::HasField<pageInfo> for super::super::PersonStarshipsConnection {
-            type Type = super::super::PageInfo;
-        }
         pub struct edges;
-        impl cynic::schema::Field for edges {
+        impl cynic::schema::HasField<edges> for super::super::PersonStarshipsConnection {
             type Type = Option<Vec<Option<super::super::PersonStarshipsEdge>>>;
             const NAME: &'static str = "edges";
         }
-        impl cynic::schema::HasField<edges> for super::super::PersonStarshipsConnection {
-            type Type = Option<Vec<Option<super::super::PersonStarshipsEdge>>>;
-        }
         pub struct totalCount;
-        impl cynic::schema::Field for totalCount {
+        impl cynic::schema::HasField<totalCount> for super::super::PersonStarshipsConnection {
             type Type = Option<super::super::Int>;
             const NAME: &'static str = "totalCount";
         }
-        impl cynic::schema::HasField<totalCount> for super::super::PersonStarshipsConnection {
-            type Type = Option<super::super::Int>;
-        }
         pub struct starships;
-        impl cynic::schema::Field for starships {
+        impl cynic::schema::HasField<starships> for super::super::PersonStarshipsConnection {
             type Type = Option<Vec<Option<super::super::Starship>>>;
             const NAME: &'static str = "starships";
         }
-        impl cynic::schema::HasField<starships> for super::super::PersonStarshipsConnection {
-            type Type = Option<Vec<Option<super::super::Starship>>>;
-        }
         pub struct __typename;
-        impl cynic::schema::Field for __typename {
-            type Type = super::super::String;
-            const NAME: &'static str = "__typename";
-        }
         impl cynic::schema::HasField<__typename> for super::super::PersonStarshipsConnection {
             type Type = super::super::String;
+            const NAME: &'static str = "__typename";
         }
     }
     pub mod PersonStarshipsEdge {
         pub struct node;
-        impl cynic::schema::Field for node {
+        impl cynic::schema::HasField<node> for super::super::PersonStarshipsEdge {
             type Type = Option<super::super::Starship>;
             const NAME: &'static str = "node";
         }
-        impl cynic::schema::HasField<node> for super::super::PersonStarshipsEdge {
-            type Type = Option<super::super::Starship>;
-        }
         pub struct cursor;
-        impl cynic::schema::Field for cursor {
+        impl cynic::schema::HasField<cursor> for super::super::PersonStarshipsEdge {
             type Type = super::super::String;
             const NAME: &'static str = "cursor";
         }
-        impl cynic::schema::HasField<cursor> for super::super::PersonStarshipsEdge {
-            type Type = super::super::String;
-        }
         pub struct __typename;
-        impl cynic::schema::Field for __typename {
-            type Type = super::super::String;
-            const NAME: &'static str = "__typename";
-        }
         impl cynic::schema::HasField<__typename> for super::super::PersonStarshipsEdge {
             type Type = super::super::String;
+            const NAME: &'static str = "__typename";
         }
     }
     pub mod PersonVehiclesConnection {
         pub struct pageInfo;
-        impl cynic::schema::Field for pageInfo {
+        impl cynic::schema::HasField<pageInfo> for super::super::PersonVehiclesConnection {
             type Type = super::super::PageInfo;
             const NAME: &'static str = "pageInfo";
         }
-        impl cynic::schema::HasField<pageInfo> for super::super::PersonVehiclesConnection {
-            type Type = super::super::PageInfo;
-        }
         pub struct edges;
-        impl cynic::schema::Field for edges {
+        impl cynic::schema::HasField<edges> for super::super::PersonVehiclesConnection {
             type Type = Option<Vec<Option<super::super::PersonVehiclesEdge>>>;
             const NAME: &'static str = "edges";
         }
-        impl cynic::schema::HasField<edges> for super::super::PersonVehiclesConnection {
-            type Type = Option<Vec<Option<super::super::PersonVehiclesEdge>>>;
-        }
         pub struct totalCount;
-        impl cynic::schema::Field for totalCount {
+        impl cynic::schema::HasField<totalCount> for super::super::PersonVehiclesConnection {
             type Type = Option<super::super::Int>;
             const NAME: &'static str = "totalCount";
         }
-        impl cynic::schema::HasField<totalCount> for super::super::PersonVehiclesConnection {
-            type Type = Option<super::super::Int>;
-        }
         pub struct vehicles;
-        impl cynic::schema::Field for vehicles {
+        impl cynic::schema::HasField<vehicles> for super::super::PersonVehiclesConnection {
             type Type = Option<Vec<Option<super::super::Vehicle>>>;
             const NAME: &'static str = "vehicles";
         }
-        impl cynic::schema::HasField<vehicles> for super::super::PersonVehiclesConnection {
-            type Type = Option<Vec<Option<super::super::Vehicle>>>;
-        }
         pub struct __typename;
-        impl cynic::schema::Field for __typename {
-            type Type = super::super::String;
-            const NAME: &'static str = "__typename";
-        }
         impl cynic::schema::HasField<__typename> for super::super::PersonVehiclesConnection {
             type Type = super::super::String;
+            const NAME: &'static str = "__typename";
         }
     }
     pub mod PersonVehiclesEdge {
         pub struct node;
-        impl cynic::schema::Field for node {
+        impl cynic::schema::HasField<node> for super::super::PersonVehiclesEdge {
             type Type = Option<super::super::Vehicle>;
             const NAME: &'static str = "node";
         }
-        impl cynic::schema::HasField<node> for super::super::PersonVehiclesEdge {
-            type Type = Option<super::super::Vehicle>;
-        }
         pub struct cursor;
-        impl cynic::schema::Field for cursor {
+        impl cynic::schema::HasField<cursor> for super::super::PersonVehiclesEdge {
             type Type = super::super::String;
             const NAME: &'static str = "cursor";
         }
-        impl cynic::schema::HasField<cursor> for super::super::PersonVehiclesEdge {
-            type Type = super::super::String;
-        }
         pub struct __typename;
-        impl cynic::schema::Field for __typename {
-            type Type = super::super::String;
-            const NAME: &'static str = "__typename";
-        }
         impl cynic::schema::HasField<__typename> for super::super::PersonVehiclesEdge {
             type Type = super::super::String;
+            const NAME: &'static str = "__typename";
         }
     }
     pub mod Planet {
         pub struct name;
-        impl cynic::schema::Field for name {
+        impl cynic::schema::HasField<name> for super::super::Planet {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "name";
         }
-        impl cynic::schema::HasField<name> for super::super::Planet {
-            type Type = Option<super::super::String>;
-        }
         pub struct diameter;
-        impl cynic::schema::Field for diameter {
+        impl cynic::schema::HasField<diameter> for super::super::Planet {
             type Type = Option<super::super::Int>;
             const NAME: &'static str = "diameter";
         }
-        impl cynic::schema::HasField<diameter> for super::super::Planet {
-            type Type = Option<super::super::Int>;
-        }
         pub struct rotationPeriod;
-        impl cynic::schema::Field for rotationPeriod {
+        impl cynic::schema::HasField<rotationPeriod> for super::super::Planet {
             type Type = Option<super::super::Int>;
             const NAME: &'static str = "rotationPeriod";
         }
-        impl cynic::schema::HasField<rotationPeriod> for super::super::Planet {
-            type Type = Option<super::super::Int>;
-        }
         pub struct orbitalPeriod;
-        impl cynic::schema::Field for orbitalPeriod {
+        impl cynic::schema::HasField<orbitalPeriod> for super::super::Planet {
             type Type = Option<super::super::Int>;
             const NAME: &'static str = "orbitalPeriod";
         }
-        impl cynic::schema::HasField<orbitalPeriod> for super::super::Planet {
-            type Type = Option<super::super::Int>;
-        }
         pub struct gravity;
-        impl cynic::schema::Field for gravity {
+        impl cynic::schema::HasField<gravity> for super::super::Planet {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "gravity";
         }
-        impl cynic::schema::HasField<gravity> for super::super::Planet {
-            type Type = Option<super::super::String>;
-        }
         pub struct population;
-        impl cynic::schema::Field for population {
+        impl cynic::schema::HasField<population> for super::super::Planet {
             type Type = Option<super::super::Float>;
             const NAME: &'static str = "population";
         }
-        impl cynic::schema::HasField<population> for super::super::Planet {
-            type Type = Option<super::super::Float>;
-        }
         pub struct climates;
-        impl cynic::schema::Field for climates {
+        impl cynic::schema::HasField<climates> for super::super::Planet {
             type Type = Option<Vec<Option<super::super::String>>>;
             const NAME: &'static str = "climates";
         }
-        impl cynic::schema::HasField<climates> for super::super::Planet {
-            type Type = Option<Vec<Option<super::super::String>>>;
-        }
         pub struct terrains;
-        impl cynic::schema::Field for terrains {
+        impl cynic::schema::HasField<terrains> for super::super::Planet {
             type Type = Option<Vec<Option<super::super::String>>>;
             const NAME: &'static str = "terrains";
         }
-        impl cynic::schema::HasField<terrains> for super::super::Planet {
-            type Type = Option<Vec<Option<super::super::String>>>;
-        }
         pub struct surfaceWater;
-        impl cynic::schema::Field for surfaceWater {
+        impl cynic::schema::HasField<surfaceWater> for super::super::Planet {
             type Type = Option<super::super::Float>;
             const NAME: &'static str = "surfaceWater";
         }
-        impl cynic::schema::HasField<surfaceWater> for super::super::Planet {
-            type Type = Option<super::super::Float>;
-        }
         pub struct residentConnection;
-        impl cynic::schema::Field for residentConnection {
-            type Type = Option<super::super::PlanetResidentsConnection>;
-            const NAME: &'static str = "residentConnection";
-        }
         impl cynic::schema::HasField<residentConnection> for super::super::Planet {
             type Type = Option<super::super::PlanetResidentsConnection>;
+            const NAME: &'static str = "residentConnection";
         }
         pub mod _resident_connection_arguments {
             pub struct after;
@@ -1504,12 +1117,9 @@ pub mod __fields {
             }
         }
         pub struct filmConnection;
-        impl cynic::schema::Field for filmConnection {
-            type Type = Option<super::super::PlanetFilmsConnection>;
-            const NAME: &'static str = "filmConnection";
-        }
         impl cynic::schema::HasField<filmConnection> for super::super::Planet {
             type Type = Option<super::super::PlanetFilmsConnection>;
+            const NAME: &'static str = "filmConnection";
         }
         pub mod _film_connection_arguments {
             pub struct after;
@@ -1534,250 +1144,163 @@ pub mod __fields {
             }
         }
         pub struct created;
-        impl cynic::schema::Field for created {
+        impl cynic::schema::HasField<created> for super::super::Planet {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "created";
         }
-        impl cynic::schema::HasField<created> for super::super::Planet {
-            type Type = Option<super::super::String>;
-        }
         pub struct edited;
-        impl cynic::schema::Field for edited {
+        impl cynic::schema::HasField<edited> for super::super::Planet {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "edited";
         }
-        impl cynic::schema::HasField<edited> for super::super::Planet {
-            type Type = Option<super::super::String>;
-        }
         pub struct id;
-        impl cynic::schema::Field for id {
+        impl cynic::schema::HasField<id> for super::super::Planet {
             type Type = super::super::ID;
             const NAME: &'static str = "id";
         }
-        impl cynic::schema::HasField<id> for super::super::Planet {
-            type Type = super::super::ID;
-        }
         pub struct __typename;
-        impl cynic::schema::Field for __typename {
-            type Type = super::super::String;
-            const NAME: &'static str = "__typename";
-        }
         impl cynic::schema::HasField<__typename> for super::super::Planet {
             type Type = super::super::String;
+            const NAME: &'static str = "__typename";
         }
     }
     pub mod PlanetFilmsConnection {
         pub struct pageInfo;
-        impl cynic::schema::Field for pageInfo {
+        impl cynic::schema::HasField<pageInfo> for super::super::PlanetFilmsConnection {
             type Type = super::super::PageInfo;
             const NAME: &'static str = "pageInfo";
         }
-        impl cynic::schema::HasField<pageInfo> for super::super::PlanetFilmsConnection {
-            type Type = super::super::PageInfo;
-        }
         pub struct edges;
-        impl cynic::schema::Field for edges {
+        impl cynic::schema::HasField<edges> for super::super::PlanetFilmsConnection {
             type Type = Option<Vec<Option<super::super::PlanetFilmsEdge>>>;
             const NAME: &'static str = "edges";
         }
-        impl cynic::schema::HasField<edges> for super::super::PlanetFilmsConnection {
-            type Type = Option<Vec<Option<super::super::PlanetFilmsEdge>>>;
-        }
         pub struct totalCount;
-        impl cynic::schema::Field for totalCount {
+        impl cynic::schema::HasField<totalCount> for super::super::PlanetFilmsConnection {
             type Type = Option<super::super::Int>;
             const NAME: &'static str = "totalCount";
         }
-        impl cynic::schema::HasField<totalCount> for super::super::PlanetFilmsConnection {
-            type Type = Option<super::super::Int>;
-        }
         pub struct films;
-        impl cynic::schema::Field for films {
+        impl cynic::schema::HasField<films> for super::super::PlanetFilmsConnection {
             type Type = Option<Vec<Option<super::super::Film>>>;
             const NAME: &'static str = "films";
         }
-        impl cynic::schema::HasField<films> for super::super::PlanetFilmsConnection {
-            type Type = Option<Vec<Option<super::super::Film>>>;
-        }
         pub struct __typename;
-        impl cynic::schema::Field for __typename {
-            type Type = super::super::String;
-            const NAME: &'static str = "__typename";
-        }
         impl cynic::schema::HasField<__typename> for super::super::PlanetFilmsConnection {
             type Type = super::super::String;
+            const NAME: &'static str = "__typename";
         }
     }
     pub mod PlanetFilmsEdge {
         pub struct node;
-        impl cynic::schema::Field for node {
+        impl cynic::schema::HasField<node> for super::super::PlanetFilmsEdge {
             type Type = Option<super::super::Film>;
             const NAME: &'static str = "node";
         }
-        impl cynic::schema::HasField<node> for super::super::PlanetFilmsEdge {
-            type Type = Option<super::super::Film>;
-        }
         pub struct cursor;
-        impl cynic::schema::Field for cursor {
+        impl cynic::schema::HasField<cursor> for super::super::PlanetFilmsEdge {
             type Type = super::super::String;
             const NAME: &'static str = "cursor";
         }
-        impl cynic::schema::HasField<cursor> for super::super::PlanetFilmsEdge {
-            type Type = super::super::String;
-        }
         pub struct __typename;
-        impl cynic::schema::Field for __typename {
-            type Type = super::super::String;
-            const NAME: &'static str = "__typename";
-        }
         impl cynic::schema::HasField<__typename> for super::super::PlanetFilmsEdge {
             type Type = super::super::String;
+            const NAME: &'static str = "__typename";
         }
     }
     pub mod PlanetResidentsConnection {
         pub struct pageInfo;
-        impl cynic::schema::Field for pageInfo {
+        impl cynic::schema::HasField<pageInfo> for super::super::PlanetResidentsConnection {
             type Type = super::super::PageInfo;
             const NAME: &'static str = "pageInfo";
         }
-        impl cynic::schema::HasField<pageInfo> for super::super::PlanetResidentsConnection {
-            type Type = super::super::PageInfo;
-        }
         pub struct edges;
-        impl cynic::schema::Field for edges {
+        impl cynic::schema::HasField<edges> for super::super::PlanetResidentsConnection {
             type Type = Option<Vec<Option<super::super::PlanetResidentsEdge>>>;
             const NAME: &'static str = "edges";
         }
-        impl cynic::schema::HasField<edges> for super::super::PlanetResidentsConnection {
-            type Type = Option<Vec<Option<super::super::PlanetResidentsEdge>>>;
-        }
         pub struct totalCount;
-        impl cynic::schema::Field for totalCount {
+        impl cynic::schema::HasField<totalCount> for super::super::PlanetResidentsConnection {
             type Type = Option<super::super::Int>;
             const NAME: &'static str = "totalCount";
         }
-        impl cynic::schema::HasField<totalCount> for super::super::PlanetResidentsConnection {
-            type Type = Option<super::super::Int>;
-        }
         pub struct residents;
-        impl cynic::schema::Field for residents {
+        impl cynic::schema::HasField<residents> for super::super::PlanetResidentsConnection {
             type Type = Option<Vec<Option<super::super::Person>>>;
             const NAME: &'static str = "residents";
         }
-        impl cynic::schema::HasField<residents> for super::super::PlanetResidentsConnection {
-            type Type = Option<Vec<Option<super::super::Person>>>;
-        }
         pub struct __typename;
-        impl cynic::schema::Field for __typename {
-            type Type = super::super::String;
-            const NAME: &'static str = "__typename";
-        }
         impl cynic::schema::HasField<__typename> for super::super::PlanetResidentsConnection {
             type Type = super::super::String;
+            const NAME: &'static str = "__typename";
         }
     }
     pub mod PlanetResidentsEdge {
         pub struct node;
-        impl cynic::schema::Field for node {
+        impl cynic::schema::HasField<node> for super::super::PlanetResidentsEdge {
             type Type = Option<super::super::Person>;
             const NAME: &'static str = "node";
         }
-        impl cynic::schema::HasField<node> for super::super::PlanetResidentsEdge {
-            type Type = Option<super::super::Person>;
-        }
         pub struct cursor;
-        impl cynic::schema::Field for cursor {
+        impl cynic::schema::HasField<cursor> for super::super::PlanetResidentsEdge {
             type Type = super::super::String;
             const NAME: &'static str = "cursor";
         }
-        impl cynic::schema::HasField<cursor> for super::super::PlanetResidentsEdge {
-            type Type = super::super::String;
-        }
         pub struct __typename;
-        impl cynic::schema::Field for __typename {
-            type Type = super::super::String;
-            const NAME: &'static str = "__typename";
-        }
         impl cynic::schema::HasField<__typename> for super::super::PlanetResidentsEdge {
             type Type = super::super::String;
+            const NAME: &'static str = "__typename";
         }
     }
     pub mod PlanetsConnection {
         pub struct pageInfo;
-        impl cynic::schema::Field for pageInfo {
+        impl cynic::schema::HasField<pageInfo> for super::super::PlanetsConnection {
             type Type = super::super::PageInfo;
             const NAME: &'static str = "pageInfo";
         }
-        impl cynic::schema::HasField<pageInfo> for super::super::PlanetsConnection {
-            type Type = super::super::PageInfo;
-        }
         pub struct edges;
-        impl cynic::schema::Field for edges {
+        impl cynic::schema::HasField<edges> for super::super::PlanetsConnection {
             type Type = Option<Vec<Option<super::super::PlanetsEdge>>>;
             const NAME: &'static str = "edges";
         }
-        impl cynic::schema::HasField<edges> for super::super::PlanetsConnection {
-            type Type = Option<Vec<Option<super::super::PlanetsEdge>>>;
-        }
         pub struct totalCount;
-        impl cynic::schema::Field for totalCount {
+        impl cynic::schema::HasField<totalCount> for super::super::PlanetsConnection {
             type Type = Option<super::super::Int>;
             const NAME: &'static str = "totalCount";
         }
-        impl cynic::schema::HasField<totalCount> for super::super::PlanetsConnection {
-            type Type = Option<super::super::Int>;
-        }
         pub struct planets;
-        impl cynic::schema::Field for planets {
+        impl cynic::schema::HasField<planets> for super::super::PlanetsConnection {
             type Type = Option<Vec<Option<super::super::Planet>>>;
             const NAME: &'static str = "planets";
         }
-        impl cynic::schema::HasField<planets> for super::super::PlanetsConnection {
-            type Type = Option<Vec<Option<super::super::Planet>>>;
-        }
         pub struct __typename;
-        impl cynic::schema::Field for __typename {
-            type Type = super::super::String;
-            const NAME: &'static str = "__typename";
-        }
         impl cynic::schema::HasField<__typename> for super::super::PlanetsConnection {
             type Type = super::super::String;
+            const NAME: &'static str = "__typename";
         }
     }
     pub mod PlanetsEdge {
         pub struct node;
-        impl cynic::schema::Field for node {
+        impl cynic::schema::HasField<node> for super::super::PlanetsEdge {
             type Type = Option<super::super::Planet>;
             const NAME: &'static str = "node";
         }
-        impl cynic::schema::HasField<node> for super::super::PlanetsEdge {
-            type Type = Option<super::super::Planet>;
-        }
         pub struct cursor;
-        impl cynic::schema::Field for cursor {
+        impl cynic::schema::HasField<cursor> for super::super::PlanetsEdge {
             type Type = super::super::String;
             const NAME: &'static str = "cursor";
         }
-        impl cynic::schema::HasField<cursor> for super::super::PlanetsEdge {
-            type Type = super::super::String;
-        }
         pub struct __typename;
-        impl cynic::schema::Field for __typename {
-            type Type = super::super::String;
-            const NAME: &'static str = "__typename";
-        }
         impl cynic::schema::HasField<__typename> for super::super::PlanetsEdge {
             type Type = super::super::String;
+            const NAME: &'static str = "__typename";
         }
     }
     pub mod Root {
         pub struct allFilms;
-        impl cynic::schema::Field for allFilms {
-            type Type = Option<super::super::FilmsConnection>;
-            const NAME: &'static str = "allFilms";
-        }
         impl cynic::schema::HasField<allFilms> for super::super::Root {
             type Type = Option<super::super::FilmsConnection>;
+            const NAME: &'static str = "allFilms";
         }
         pub mod _all_films_arguments {
             pub struct after;
@@ -1802,12 +1325,9 @@ pub mod __fields {
             }
         }
         pub struct film;
-        impl cynic::schema::Field for film {
-            type Type = Option<super::super::Film>;
-            const NAME: &'static str = "film";
-        }
         impl cynic::schema::HasField<film> for super::super::Root {
             type Type = Option<super::super::Film>;
+            const NAME: &'static str = "film";
         }
         pub mod _film_arguments {
             pub struct id;
@@ -1822,12 +1342,9 @@ pub mod __fields {
             }
         }
         pub struct allPeople;
-        impl cynic::schema::Field for allPeople {
-            type Type = Option<super::super::PeopleConnection>;
-            const NAME: &'static str = "allPeople";
-        }
         impl cynic::schema::HasField<allPeople> for super::super::Root {
             type Type = Option<super::super::PeopleConnection>;
+            const NAME: &'static str = "allPeople";
         }
         pub mod _all_people_arguments {
             pub struct after;
@@ -1852,12 +1369,9 @@ pub mod __fields {
             }
         }
         pub struct person;
-        impl cynic::schema::Field for person {
-            type Type = Option<super::super::Person>;
-            const NAME: &'static str = "person";
-        }
         impl cynic::schema::HasField<person> for super::super::Root {
             type Type = Option<super::super::Person>;
+            const NAME: &'static str = "person";
         }
         pub mod _person_arguments {
             pub struct id;
@@ -1872,12 +1386,9 @@ pub mod __fields {
             }
         }
         pub struct allPlanets;
-        impl cynic::schema::Field for allPlanets {
-            type Type = Option<super::super::PlanetsConnection>;
-            const NAME: &'static str = "allPlanets";
-        }
         impl cynic::schema::HasField<allPlanets> for super::super::Root {
             type Type = Option<super::super::PlanetsConnection>;
+            const NAME: &'static str = "allPlanets";
         }
         pub mod _all_planets_arguments {
             pub struct after;
@@ -1902,12 +1413,9 @@ pub mod __fields {
             }
         }
         pub struct planet;
-        impl cynic::schema::Field for planet {
-            type Type = Option<super::super::Planet>;
-            const NAME: &'static str = "planet";
-        }
         impl cynic::schema::HasField<planet> for super::super::Root {
             type Type = Option<super::super::Planet>;
+            const NAME: &'static str = "planet";
         }
         pub mod _planet_arguments {
             pub struct id;
@@ -1922,12 +1430,9 @@ pub mod __fields {
             }
         }
         pub struct allSpecies;
-        impl cynic::schema::Field for allSpecies {
-            type Type = Option<super::super::SpeciesConnection>;
-            const NAME: &'static str = "allSpecies";
-        }
         impl cynic::schema::HasField<allSpecies> for super::super::Root {
             type Type = Option<super::super::SpeciesConnection>;
+            const NAME: &'static str = "allSpecies";
         }
         pub mod _all_species_arguments {
             pub struct after;
@@ -1952,12 +1457,9 @@ pub mod __fields {
             }
         }
         pub struct species;
-        impl cynic::schema::Field for species {
-            type Type = Option<super::super::Species>;
-            const NAME: &'static str = "species";
-        }
         impl cynic::schema::HasField<species> for super::super::Root {
             type Type = Option<super::super::Species>;
+            const NAME: &'static str = "species";
         }
         pub mod _species_arguments {
             pub struct id;
@@ -1972,12 +1474,9 @@ pub mod __fields {
             }
         }
         pub struct allStarships;
-        impl cynic::schema::Field for allStarships {
-            type Type = Option<super::super::StarshipsConnection>;
-            const NAME: &'static str = "allStarships";
-        }
         impl cynic::schema::HasField<allStarships> for super::super::Root {
             type Type = Option<super::super::StarshipsConnection>;
+            const NAME: &'static str = "allStarships";
         }
         pub mod _all_starships_arguments {
             pub struct after;
@@ -2002,12 +1501,9 @@ pub mod __fields {
             }
         }
         pub struct starship;
-        impl cynic::schema::Field for starship {
-            type Type = Option<super::super::Starship>;
-            const NAME: &'static str = "starship";
-        }
         impl cynic::schema::HasField<starship> for super::super::Root {
             type Type = Option<super::super::Starship>;
+            const NAME: &'static str = "starship";
         }
         pub mod _starship_arguments {
             pub struct id;
@@ -2022,12 +1518,9 @@ pub mod __fields {
             }
         }
         pub struct allVehicles;
-        impl cynic::schema::Field for allVehicles {
-            type Type = Option<super::super::VehiclesConnection>;
-            const NAME: &'static str = "allVehicles";
-        }
         impl cynic::schema::HasField<allVehicles> for super::super::Root {
             type Type = Option<super::super::VehiclesConnection>;
+            const NAME: &'static str = "allVehicles";
         }
         pub mod _all_vehicles_arguments {
             pub struct after;
@@ -2052,12 +1545,9 @@ pub mod __fields {
             }
         }
         pub struct vehicle;
-        impl cynic::schema::Field for vehicle {
-            type Type = Option<super::super::Vehicle>;
-            const NAME: &'static str = "vehicle";
-        }
         impl cynic::schema::HasField<vehicle> for super::super::Root {
             type Type = Option<super::super::Vehicle>;
+            const NAME: &'static str = "vehicle";
         }
         pub mod _vehicle_arguments {
             pub struct id;
@@ -2072,12 +1562,9 @@ pub mod __fields {
             }
         }
         pub struct node;
-        impl cynic::schema::Field for node {
-            type Type = Option<super::super::Node>;
-            const NAME: &'static str = "node";
-        }
         impl cynic::schema::HasField<node> for super::super::Root {
             type Type = Option<super::super::Node>;
+            const NAME: &'static str = "node";
         }
         pub mod _node_arguments {
             pub struct id;
@@ -2087,102 +1574,66 @@ pub mod __fields {
             }
         }
         pub struct __typename;
-        impl cynic::schema::Field for __typename {
-            type Type = super::super::String;
-            const NAME: &'static str = "__typename";
-        }
         impl cynic::schema::HasField<__typename> for super::super::Root {
             type Type = super::super::String;
+            const NAME: &'static str = "__typename";
         }
     }
     pub mod Species {
         pub struct name;
-        impl cynic::schema::Field for name {
+        impl cynic::schema::HasField<name> for super::super::Species {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "name";
         }
-        impl cynic::schema::HasField<name> for super::super::Species {
-            type Type = Option<super::super::String>;
-        }
         pub struct classification;
-        impl cynic::schema::Field for classification {
+        impl cynic::schema::HasField<classification> for super::super::Species {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "classification";
         }
-        impl cynic::schema::HasField<classification> for super::super::Species {
-            type Type = Option<super::super::String>;
-        }
         pub struct designation;
-        impl cynic::schema::Field for designation {
+        impl cynic::schema::HasField<designation> for super::super::Species {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "designation";
         }
-        impl cynic::schema::HasField<designation> for super::super::Species {
-            type Type = Option<super::super::String>;
-        }
         pub struct averageHeight;
-        impl cynic::schema::Field for averageHeight {
+        impl cynic::schema::HasField<averageHeight> for super::super::Species {
             type Type = Option<super::super::Float>;
             const NAME: &'static str = "averageHeight";
         }
-        impl cynic::schema::HasField<averageHeight> for super::super::Species {
-            type Type = Option<super::super::Float>;
-        }
         pub struct averageLifespan;
-        impl cynic::schema::Field for averageLifespan {
+        impl cynic::schema::HasField<averageLifespan> for super::super::Species {
             type Type = Option<super::super::Int>;
             const NAME: &'static str = "averageLifespan";
         }
-        impl cynic::schema::HasField<averageLifespan> for super::super::Species {
-            type Type = Option<super::super::Int>;
-        }
         pub struct eyeColors;
-        impl cynic::schema::Field for eyeColors {
+        impl cynic::schema::HasField<eyeColors> for super::super::Species {
             type Type = Option<Vec<Option<super::super::String>>>;
             const NAME: &'static str = "eyeColors";
         }
-        impl cynic::schema::HasField<eyeColors> for super::super::Species {
-            type Type = Option<Vec<Option<super::super::String>>>;
-        }
         pub struct hairColors;
-        impl cynic::schema::Field for hairColors {
+        impl cynic::schema::HasField<hairColors> for super::super::Species {
             type Type = Option<Vec<Option<super::super::String>>>;
             const NAME: &'static str = "hairColors";
         }
-        impl cynic::schema::HasField<hairColors> for super::super::Species {
-            type Type = Option<Vec<Option<super::super::String>>>;
-        }
         pub struct skinColors;
-        impl cynic::schema::Field for skinColors {
+        impl cynic::schema::HasField<skinColors> for super::super::Species {
             type Type = Option<Vec<Option<super::super::String>>>;
             const NAME: &'static str = "skinColors";
         }
-        impl cynic::schema::HasField<skinColors> for super::super::Species {
-            type Type = Option<Vec<Option<super::super::String>>>;
-        }
         pub struct language;
-        impl cynic::schema::Field for language {
+        impl cynic::schema::HasField<language> for super::super::Species {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "language";
         }
-        impl cynic::schema::HasField<language> for super::super::Species {
-            type Type = Option<super::super::String>;
-        }
         pub struct homeworld;
-        impl cynic::schema::Field for homeworld {
+        impl cynic::schema::HasField<homeworld> for super::super::Species {
             type Type = Option<super::super::Planet>;
             const NAME: &'static str = "homeworld";
         }
-        impl cynic::schema::HasField<homeworld> for super::super::Species {
-            type Type = Option<super::super::Planet>;
-        }
         pub struct personConnection;
-        impl cynic::schema::Field for personConnection {
-            type Type = Option<super::super::SpeciesPeopleConnection>;
-            const NAME: &'static str = "personConnection";
-        }
         impl cynic::schema::HasField<personConnection> for super::super::Species {
             type Type = Option<super::super::SpeciesPeopleConnection>;
+            const NAME: &'static str = "personConnection";
         }
         pub mod _person_connection_arguments {
             pub struct after;
@@ -2207,12 +1658,9 @@ pub mod __fields {
             }
         }
         pub struct filmConnection;
-        impl cynic::schema::Field for filmConnection {
-            type Type = Option<super::super::SpeciesFilmsConnection>;
-            const NAME: &'static str = "filmConnection";
-        }
         impl cynic::schema::HasField<filmConnection> for super::super::Species {
             type Type = Option<super::super::SpeciesFilmsConnection>;
+            const NAME: &'static str = "filmConnection";
         }
         pub mod _film_connection_arguments {
             pub struct after;
@@ -2237,354 +1685,228 @@ pub mod __fields {
             }
         }
         pub struct created;
-        impl cynic::schema::Field for created {
+        impl cynic::schema::HasField<created> for super::super::Species {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "created";
         }
-        impl cynic::schema::HasField<created> for super::super::Species {
-            type Type = Option<super::super::String>;
-        }
         pub struct edited;
-        impl cynic::schema::Field for edited {
+        impl cynic::schema::HasField<edited> for super::super::Species {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "edited";
         }
-        impl cynic::schema::HasField<edited> for super::super::Species {
-            type Type = Option<super::super::String>;
-        }
         pub struct id;
-        impl cynic::schema::Field for id {
+        impl cynic::schema::HasField<id> for super::super::Species {
             type Type = super::super::ID;
             const NAME: &'static str = "id";
         }
-        impl cynic::schema::HasField<id> for super::super::Species {
-            type Type = super::super::ID;
-        }
         pub struct __typename;
-        impl cynic::schema::Field for __typename {
-            type Type = super::super::String;
-            const NAME: &'static str = "__typename";
-        }
         impl cynic::schema::HasField<__typename> for super::super::Species {
             type Type = super::super::String;
+            const NAME: &'static str = "__typename";
         }
     }
     pub mod SpeciesConnection {
         pub struct pageInfo;
-        impl cynic::schema::Field for pageInfo {
+        impl cynic::schema::HasField<pageInfo> for super::super::SpeciesConnection {
             type Type = super::super::PageInfo;
             const NAME: &'static str = "pageInfo";
         }
-        impl cynic::schema::HasField<pageInfo> for super::super::SpeciesConnection {
-            type Type = super::super::PageInfo;
-        }
         pub struct edges;
-        impl cynic::schema::Field for edges {
+        impl cynic::schema::HasField<edges> for super::super::SpeciesConnection {
             type Type = Option<Vec<Option<super::super::SpeciesEdge>>>;
             const NAME: &'static str = "edges";
         }
-        impl cynic::schema::HasField<edges> for super::super::SpeciesConnection {
-            type Type = Option<Vec<Option<super::super::SpeciesEdge>>>;
-        }
         pub struct totalCount;
-        impl cynic::schema::Field for totalCount {
+        impl cynic::schema::HasField<totalCount> for super::super::SpeciesConnection {
             type Type = Option<super::super::Int>;
             const NAME: &'static str = "totalCount";
         }
-        impl cynic::schema::HasField<totalCount> for super::super::SpeciesConnection {
-            type Type = Option<super::super::Int>;
-        }
         pub struct species;
-        impl cynic::schema::Field for species {
+        impl cynic::schema::HasField<species> for super::super::SpeciesConnection {
             type Type = Option<Vec<Option<super::super::Species>>>;
             const NAME: &'static str = "species";
         }
-        impl cynic::schema::HasField<species> for super::super::SpeciesConnection {
-            type Type = Option<Vec<Option<super::super::Species>>>;
-        }
         pub struct __typename;
-        impl cynic::schema::Field for __typename {
-            type Type = super::super::String;
-            const NAME: &'static str = "__typename";
-        }
         impl cynic::schema::HasField<__typename> for super::super::SpeciesConnection {
             type Type = super::super::String;
+            const NAME: &'static str = "__typename";
         }
     }
     pub mod SpeciesEdge {
         pub struct node;
-        impl cynic::schema::Field for node {
+        impl cynic::schema::HasField<node> for super::super::SpeciesEdge {
             type Type = Option<super::super::Species>;
             const NAME: &'static str = "node";
         }
-        impl cynic::schema::HasField<node> for super::super::SpeciesEdge {
-            type Type = Option<super::super::Species>;
-        }
         pub struct cursor;
-        impl cynic::schema::Field for cursor {
+        impl cynic::schema::HasField<cursor> for super::super::SpeciesEdge {
             type Type = super::super::String;
             const NAME: &'static str = "cursor";
         }
-        impl cynic::schema::HasField<cursor> for super::super::SpeciesEdge {
-            type Type = super::super::String;
-        }
         pub struct __typename;
-        impl cynic::schema::Field for __typename {
-            type Type = super::super::String;
-            const NAME: &'static str = "__typename";
-        }
         impl cynic::schema::HasField<__typename> for super::super::SpeciesEdge {
             type Type = super::super::String;
+            const NAME: &'static str = "__typename";
         }
     }
     pub mod SpeciesFilmsConnection {
         pub struct pageInfo;
-        impl cynic::schema::Field for pageInfo {
+        impl cynic::schema::HasField<pageInfo> for super::super::SpeciesFilmsConnection {
             type Type = super::super::PageInfo;
             const NAME: &'static str = "pageInfo";
         }
-        impl cynic::schema::HasField<pageInfo> for super::super::SpeciesFilmsConnection {
-            type Type = super::super::PageInfo;
-        }
         pub struct edges;
-        impl cynic::schema::Field for edges {
+        impl cynic::schema::HasField<edges> for super::super::SpeciesFilmsConnection {
             type Type = Option<Vec<Option<super::super::SpeciesFilmsEdge>>>;
             const NAME: &'static str = "edges";
         }
-        impl cynic::schema::HasField<edges> for super::super::SpeciesFilmsConnection {
-            type Type = Option<Vec<Option<super::super::SpeciesFilmsEdge>>>;
-        }
         pub struct totalCount;
-        impl cynic::schema::Field for totalCount {
+        impl cynic::schema::HasField<totalCount> for super::super::SpeciesFilmsConnection {
             type Type = Option<super::super::Int>;
             const NAME: &'static str = "totalCount";
         }
-        impl cynic::schema::HasField<totalCount> for super::super::SpeciesFilmsConnection {
-            type Type = Option<super::super::Int>;
-        }
         pub struct films;
-        impl cynic::schema::Field for films {
+        impl cynic::schema::HasField<films> for super::super::SpeciesFilmsConnection {
             type Type = Option<Vec<Option<super::super::Film>>>;
             const NAME: &'static str = "films";
         }
-        impl cynic::schema::HasField<films> for super::super::SpeciesFilmsConnection {
-            type Type = Option<Vec<Option<super::super::Film>>>;
-        }
         pub struct __typename;
-        impl cynic::schema::Field for __typename {
-            type Type = super::super::String;
-            const NAME: &'static str = "__typename";
-        }
         impl cynic::schema::HasField<__typename> for super::super::SpeciesFilmsConnection {
             type Type = super::super::String;
+            const NAME: &'static str = "__typename";
         }
     }
     pub mod SpeciesFilmsEdge {
         pub struct node;
-        impl cynic::schema::Field for node {
+        impl cynic::schema::HasField<node> for super::super::SpeciesFilmsEdge {
             type Type = Option<super::super::Film>;
             const NAME: &'static str = "node";
         }
-        impl cynic::schema::HasField<node> for super::super::SpeciesFilmsEdge {
-            type Type = Option<super::super::Film>;
-        }
         pub struct cursor;
-        impl cynic::schema::Field for cursor {
+        impl cynic::schema::HasField<cursor> for super::super::SpeciesFilmsEdge {
             type Type = super::super::String;
             const NAME: &'static str = "cursor";
         }
-        impl cynic::schema::HasField<cursor> for super::super::SpeciesFilmsEdge {
-            type Type = super::super::String;
-        }
         pub struct __typename;
-        impl cynic::schema::Field for __typename {
-            type Type = super::super::String;
-            const NAME: &'static str = "__typename";
-        }
         impl cynic::schema::HasField<__typename> for super::super::SpeciesFilmsEdge {
             type Type = super::super::String;
+            const NAME: &'static str = "__typename";
         }
     }
     pub mod SpeciesPeopleConnection {
         pub struct pageInfo;
-        impl cynic::schema::Field for pageInfo {
+        impl cynic::schema::HasField<pageInfo> for super::super::SpeciesPeopleConnection {
             type Type = super::super::PageInfo;
             const NAME: &'static str = "pageInfo";
         }
-        impl cynic::schema::HasField<pageInfo> for super::super::SpeciesPeopleConnection {
-            type Type = super::super::PageInfo;
-        }
         pub struct edges;
-        impl cynic::schema::Field for edges {
+        impl cynic::schema::HasField<edges> for super::super::SpeciesPeopleConnection {
             type Type = Option<Vec<Option<super::super::SpeciesPeopleEdge>>>;
             const NAME: &'static str = "edges";
         }
-        impl cynic::schema::HasField<edges> for super::super::SpeciesPeopleConnection {
-            type Type = Option<Vec<Option<super::super::SpeciesPeopleEdge>>>;
-        }
         pub struct totalCount;
-        impl cynic::schema::Field for totalCount {
+        impl cynic::schema::HasField<totalCount> for super::super::SpeciesPeopleConnection {
             type Type = Option<super::super::Int>;
             const NAME: &'static str = "totalCount";
         }
-        impl cynic::schema::HasField<totalCount> for super::super::SpeciesPeopleConnection {
-            type Type = Option<super::super::Int>;
-        }
         pub struct people;
-        impl cynic::schema::Field for people {
+        impl cynic::schema::HasField<people> for super::super::SpeciesPeopleConnection {
             type Type = Option<Vec<Option<super::super::Person>>>;
             const NAME: &'static str = "people";
         }
-        impl cynic::schema::HasField<people> for super::super::SpeciesPeopleConnection {
-            type Type = Option<Vec<Option<super::super::Person>>>;
-        }
         pub struct __typename;
-        impl cynic::schema::Field for __typename {
-            type Type = super::super::String;
-            const NAME: &'static str = "__typename";
-        }
         impl cynic::schema::HasField<__typename> for super::super::SpeciesPeopleConnection {
             type Type = super::super::String;
+            const NAME: &'static str = "__typename";
         }
     }
     pub mod SpeciesPeopleEdge {
         pub struct node;
-        impl cynic::schema::Field for node {
+        impl cynic::schema::HasField<node> for super::super::SpeciesPeopleEdge {
             type Type = Option<super::super::Person>;
             const NAME: &'static str = "node";
         }
-        impl cynic::schema::HasField<node> for super::super::SpeciesPeopleEdge {
-            type Type = Option<super::super::Person>;
-        }
         pub struct cursor;
-        impl cynic::schema::Field for cursor {
+        impl cynic::schema::HasField<cursor> for super::super::SpeciesPeopleEdge {
             type Type = super::super::String;
             const NAME: &'static str = "cursor";
         }
-        impl cynic::schema::HasField<cursor> for super::super::SpeciesPeopleEdge {
-            type Type = super::super::String;
-        }
         pub struct __typename;
-        impl cynic::schema::Field for __typename {
-            type Type = super::super::String;
-            const NAME: &'static str = "__typename";
-        }
         impl cynic::schema::HasField<__typename> for super::super::SpeciesPeopleEdge {
             type Type = super::super::String;
+            const NAME: &'static str = "__typename";
         }
     }
     pub mod Starship {
         pub struct name;
-        impl cynic::schema::Field for name {
+        impl cynic::schema::HasField<name> for super::super::Starship {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "name";
         }
-        impl cynic::schema::HasField<name> for super::super::Starship {
-            type Type = Option<super::super::String>;
-        }
         pub struct model;
-        impl cynic::schema::Field for model {
+        impl cynic::schema::HasField<model> for super::super::Starship {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "model";
         }
-        impl cynic::schema::HasField<model> for super::super::Starship {
-            type Type = Option<super::super::String>;
-        }
         pub struct starshipClass;
-        impl cynic::schema::Field for starshipClass {
+        impl cynic::schema::HasField<starshipClass> for super::super::Starship {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "starshipClass";
         }
-        impl cynic::schema::HasField<starshipClass> for super::super::Starship {
-            type Type = Option<super::super::String>;
-        }
         pub struct manufacturers;
-        impl cynic::schema::Field for manufacturers {
+        impl cynic::schema::HasField<manufacturers> for super::super::Starship {
             type Type = Option<Vec<Option<super::super::String>>>;
             const NAME: &'static str = "manufacturers";
         }
-        impl cynic::schema::HasField<manufacturers> for super::super::Starship {
-            type Type = Option<Vec<Option<super::super::String>>>;
-        }
         pub struct costInCredits;
-        impl cynic::schema::Field for costInCredits {
+        impl cynic::schema::HasField<costInCredits> for super::super::Starship {
             type Type = Option<super::super::Float>;
             const NAME: &'static str = "costInCredits";
         }
-        impl cynic::schema::HasField<costInCredits> for super::super::Starship {
-            type Type = Option<super::super::Float>;
-        }
         pub struct length;
-        impl cynic::schema::Field for length {
+        impl cynic::schema::HasField<length> for super::super::Starship {
             type Type = Option<super::super::Float>;
             const NAME: &'static str = "length";
         }
-        impl cynic::schema::HasField<length> for super::super::Starship {
-            type Type = Option<super::super::Float>;
-        }
         pub struct crew;
-        impl cynic::schema::Field for crew {
+        impl cynic::schema::HasField<crew> for super::super::Starship {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "crew";
         }
-        impl cynic::schema::HasField<crew> for super::super::Starship {
-            type Type = Option<super::super::String>;
-        }
         pub struct passengers;
-        impl cynic::schema::Field for passengers {
+        impl cynic::schema::HasField<passengers> for super::super::Starship {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "passengers";
         }
-        impl cynic::schema::HasField<passengers> for super::super::Starship {
-            type Type = Option<super::super::String>;
-        }
         pub struct maxAtmospheringSpeed;
-        impl cynic::schema::Field for maxAtmospheringSpeed {
+        impl cynic::schema::HasField<maxAtmospheringSpeed> for super::super::Starship {
             type Type = Option<super::super::Int>;
             const NAME: &'static str = "maxAtmospheringSpeed";
         }
-        impl cynic::schema::HasField<maxAtmospheringSpeed> for super::super::Starship {
-            type Type = Option<super::super::Int>;
-        }
         pub struct hyperdriveRating;
-        impl cynic::schema::Field for hyperdriveRating {
+        impl cynic::schema::HasField<hyperdriveRating> for super::super::Starship {
             type Type = Option<super::super::Float>;
             const NAME: &'static str = "hyperdriveRating";
         }
-        impl cynic::schema::HasField<hyperdriveRating> for super::super::Starship {
-            type Type = Option<super::super::Float>;
-        }
         pub struct MGLT;
-        impl cynic::schema::Field for MGLT {
+        impl cynic::schema::HasField<MGLT> for super::super::Starship {
             type Type = Option<super::super::Int>;
             const NAME: &'static str = "MGLT";
         }
-        impl cynic::schema::HasField<MGLT> for super::super::Starship {
-            type Type = Option<super::super::Int>;
-        }
         pub struct cargoCapacity;
-        impl cynic::schema::Field for cargoCapacity {
+        impl cynic::schema::HasField<cargoCapacity> for super::super::Starship {
             type Type = Option<super::super::Float>;
             const NAME: &'static str = "cargoCapacity";
         }
-        impl cynic::schema::HasField<cargoCapacity> for super::super::Starship {
-            type Type = Option<super::super::Float>;
-        }
         pub struct consumables;
-        impl cynic::schema::Field for consumables {
+        impl cynic::schema::HasField<consumables> for super::super::Starship {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "consumables";
         }
-        impl cynic::schema::HasField<consumables> for super::super::Starship {
-            type Type = Option<super::super::String>;
-        }
         pub struct pilotConnection;
-        impl cynic::schema::Field for pilotConnection {
-            type Type = Option<super::super::StarshipPilotsConnection>;
-            const NAME: &'static str = "pilotConnection";
-        }
         impl cynic::schema::HasField<pilotConnection> for super::super::Starship {
             type Type = Option<super::super::StarshipPilotsConnection>;
+            const NAME: &'static str = "pilotConnection";
         }
         pub mod _pilot_connection_arguments {
             pub struct after;
@@ -2609,12 +1931,9 @@ pub mod __fields {
             }
         }
         pub struct filmConnection;
-        impl cynic::schema::Field for filmConnection {
-            type Type = Option<super::super::StarshipFilmsConnection>;
-            const NAME: &'static str = "filmConnection";
-        }
         impl cynic::schema::HasField<filmConnection> for super::super::Starship {
             type Type = Option<super::super::StarshipFilmsConnection>;
+            const NAME: &'static str = "filmConnection";
         }
         pub mod _film_connection_arguments {
             pub struct after;
@@ -2639,338 +1958,218 @@ pub mod __fields {
             }
         }
         pub struct created;
-        impl cynic::schema::Field for created {
+        impl cynic::schema::HasField<created> for super::super::Starship {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "created";
         }
-        impl cynic::schema::HasField<created> for super::super::Starship {
-            type Type = Option<super::super::String>;
-        }
         pub struct edited;
-        impl cynic::schema::Field for edited {
+        impl cynic::schema::HasField<edited> for super::super::Starship {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "edited";
         }
-        impl cynic::schema::HasField<edited> for super::super::Starship {
-            type Type = Option<super::super::String>;
-        }
         pub struct id;
-        impl cynic::schema::Field for id {
+        impl cynic::schema::HasField<id> for super::super::Starship {
             type Type = super::super::ID;
             const NAME: &'static str = "id";
         }
-        impl cynic::schema::HasField<id> for super::super::Starship {
-            type Type = super::super::ID;
-        }
         pub struct __typename;
-        impl cynic::schema::Field for __typename {
-            type Type = super::super::String;
-            const NAME: &'static str = "__typename";
-        }
         impl cynic::schema::HasField<__typename> for super::super::Starship {
             type Type = super::super::String;
+            const NAME: &'static str = "__typename";
         }
     }
     pub mod StarshipFilmsConnection {
         pub struct pageInfo;
-        impl cynic::schema::Field for pageInfo {
+        impl cynic::schema::HasField<pageInfo> for super::super::StarshipFilmsConnection {
             type Type = super::super::PageInfo;
             const NAME: &'static str = "pageInfo";
         }
-        impl cynic::schema::HasField<pageInfo> for super::super::StarshipFilmsConnection {
-            type Type = super::super::PageInfo;
-        }
         pub struct edges;
-        impl cynic::schema::Field for edges {
+        impl cynic::schema::HasField<edges> for super::super::StarshipFilmsConnection {
             type Type = Option<Vec<Option<super::super::StarshipFilmsEdge>>>;
             const NAME: &'static str = "edges";
         }
-        impl cynic::schema::HasField<edges> for super::super::StarshipFilmsConnection {
-            type Type = Option<Vec<Option<super::super::StarshipFilmsEdge>>>;
-        }
         pub struct totalCount;
-        impl cynic::schema::Field for totalCount {
+        impl cynic::schema::HasField<totalCount> for super::super::StarshipFilmsConnection {
             type Type = Option<super::super::Int>;
             const NAME: &'static str = "totalCount";
         }
-        impl cynic::schema::HasField<totalCount> for super::super::StarshipFilmsConnection {
-            type Type = Option<super::super::Int>;
-        }
         pub struct films;
-        impl cynic::schema::Field for films {
+        impl cynic::schema::HasField<films> for super::super::StarshipFilmsConnection {
             type Type = Option<Vec<Option<super::super::Film>>>;
             const NAME: &'static str = "films";
         }
-        impl cynic::schema::HasField<films> for super::super::StarshipFilmsConnection {
-            type Type = Option<Vec<Option<super::super::Film>>>;
-        }
         pub struct __typename;
-        impl cynic::schema::Field for __typename {
-            type Type = super::super::String;
-            const NAME: &'static str = "__typename";
-        }
         impl cynic::schema::HasField<__typename> for super::super::StarshipFilmsConnection {
             type Type = super::super::String;
+            const NAME: &'static str = "__typename";
         }
     }
     pub mod StarshipFilmsEdge {
         pub struct node;
-        impl cynic::schema::Field for node {
+        impl cynic::schema::HasField<node> for super::super::StarshipFilmsEdge {
             type Type = Option<super::super::Film>;
             const NAME: &'static str = "node";
         }
-        impl cynic::schema::HasField<node> for super::super::StarshipFilmsEdge {
-            type Type = Option<super::super::Film>;
-        }
         pub struct cursor;
-        impl cynic::schema::Field for cursor {
+        impl cynic::schema::HasField<cursor> for super::super::StarshipFilmsEdge {
             type Type = super::super::String;
             const NAME: &'static str = "cursor";
         }
-        impl cynic::schema::HasField<cursor> for super::super::StarshipFilmsEdge {
-            type Type = super::super::String;
-        }
         pub struct __typename;
-        impl cynic::schema::Field for __typename {
-            type Type = super::super::String;
-            const NAME: &'static str = "__typename";
-        }
         impl cynic::schema::HasField<__typename> for super::super::StarshipFilmsEdge {
             type Type = super::super::String;
+            const NAME: &'static str = "__typename";
         }
     }
     pub mod StarshipPilotsConnection {
         pub struct pageInfo;
-        impl cynic::schema::Field for pageInfo {
+        impl cynic::schema::HasField<pageInfo> for super::super::StarshipPilotsConnection {
             type Type = super::super::PageInfo;
             const NAME: &'static str = "pageInfo";
         }
-        impl cynic::schema::HasField<pageInfo> for super::super::StarshipPilotsConnection {
-            type Type = super::super::PageInfo;
-        }
         pub struct edges;
-        impl cynic::schema::Field for edges {
+        impl cynic::schema::HasField<edges> for super::super::StarshipPilotsConnection {
             type Type = Option<Vec<Option<super::super::StarshipPilotsEdge>>>;
             const NAME: &'static str = "edges";
         }
-        impl cynic::schema::HasField<edges> for super::super::StarshipPilotsConnection {
-            type Type = Option<Vec<Option<super::super::StarshipPilotsEdge>>>;
-        }
         pub struct totalCount;
-        impl cynic::schema::Field for totalCount {
+        impl cynic::schema::HasField<totalCount> for super::super::StarshipPilotsConnection {
             type Type = Option<super::super::Int>;
             const NAME: &'static str = "totalCount";
         }
-        impl cynic::schema::HasField<totalCount> for super::super::StarshipPilotsConnection {
-            type Type = Option<super::super::Int>;
-        }
         pub struct pilots;
-        impl cynic::schema::Field for pilots {
+        impl cynic::schema::HasField<pilots> for super::super::StarshipPilotsConnection {
             type Type = Option<Vec<Option<super::super::Person>>>;
             const NAME: &'static str = "pilots";
         }
-        impl cynic::schema::HasField<pilots> for super::super::StarshipPilotsConnection {
-            type Type = Option<Vec<Option<super::super::Person>>>;
-        }
         pub struct __typename;
-        impl cynic::schema::Field for __typename {
-            type Type = super::super::String;
-            const NAME: &'static str = "__typename";
-        }
         impl cynic::schema::HasField<__typename> for super::super::StarshipPilotsConnection {
             type Type = super::super::String;
+            const NAME: &'static str = "__typename";
         }
     }
     pub mod StarshipPilotsEdge {
         pub struct node;
-        impl cynic::schema::Field for node {
+        impl cynic::schema::HasField<node> for super::super::StarshipPilotsEdge {
             type Type = Option<super::super::Person>;
             const NAME: &'static str = "node";
         }
-        impl cynic::schema::HasField<node> for super::super::StarshipPilotsEdge {
-            type Type = Option<super::super::Person>;
-        }
         pub struct cursor;
-        impl cynic::schema::Field for cursor {
+        impl cynic::schema::HasField<cursor> for super::super::StarshipPilotsEdge {
             type Type = super::super::String;
             const NAME: &'static str = "cursor";
         }
-        impl cynic::schema::HasField<cursor> for super::super::StarshipPilotsEdge {
-            type Type = super::super::String;
-        }
         pub struct __typename;
-        impl cynic::schema::Field for __typename {
-            type Type = super::super::String;
-            const NAME: &'static str = "__typename";
-        }
         impl cynic::schema::HasField<__typename> for super::super::StarshipPilotsEdge {
             type Type = super::super::String;
+            const NAME: &'static str = "__typename";
         }
     }
     pub mod StarshipsConnection {
         pub struct pageInfo;
-        impl cynic::schema::Field for pageInfo {
+        impl cynic::schema::HasField<pageInfo> for super::super::StarshipsConnection {
             type Type = super::super::PageInfo;
             const NAME: &'static str = "pageInfo";
         }
-        impl cynic::schema::HasField<pageInfo> for super::super::StarshipsConnection {
-            type Type = super::super::PageInfo;
-        }
         pub struct edges;
-        impl cynic::schema::Field for edges {
+        impl cynic::schema::HasField<edges> for super::super::StarshipsConnection {
             type Type = Option<Vec<Option<super::super::StarshipsEdge>>>;
             const NAME: &'static str = "edges";
         }
-        impl cynic::schema::HasField<edges> for super::super::StarshipsConnection {
-            type Type = Option<Vec<Option<super::super::StarshipsEdge>>>;
-        }
         pub struct totalCount;
-        impl cynic::schema::Field for totalCount {
+        impl cynic::schema::HasField<totalCount> for super::super::StarshipsConnection {
             type Type = Option<super::super::Int>;
             const NAME: &'static str = "totalCount";
         }
-        impl cynic::schema::HasField<totalCount> for super::super::StarshipsConnection {
-            type Type = Option<super::super::Int>;
-        }
         pub struct starships;
-        impl cynic::schema::Field for starships {
+        impl cynic::schema::HasField<starships> for super::super::StarshipsConnection {
             type Type = Option<Vec<Option<super::super::Starship>>>;
             const NAME: &'static str = "starships";
         }
-        impl cynic::schema::HasField<starships> for super::super::StarshipsConnection {
-            type Type = Option<Vec<Option<super::super::Starship>>>;
-        }
         pub struct __typename;
-        impl cynic::schema::Field for __typename {
-            type Type = super::super::String;
-            const NAME: &'static str = "__typename";
-        }
         impl cynic::schema::HasField<__typename> for super::super::StarshipsConnection {
             type Type = super::super::String;
+            const NAME: &'static str = "__typename";
         }
     }
     pub mod StarshipsEdge {
         pub struct node;
-        impl cynic::schema::Field for node {
+        impl cynic::schema::HasField<node> for super::super::StarshipsEdge {
             type Type = Option<super::super::Starship>;
             const NAME: &'static str = "node";
         }
-        impl cynic::schema::HasField<node> for super::super::StarshipsEdge {
-            type Type = Option<super::super::Starship>;
-        }
         pub struct cursor;
-        impl cynic::schema::Field for cursor {
+        impl cynic::schema::HasField<cursor> for super::super::StarshipsEdge {
             type Type = super::super::String;
             const NAME: &'static str = "cursor";
         }
-        impl cynic::schema::HasField<cursor> for super::super::StarshipsEdge {
-            type Type = super::super::String;
-        }
         pub struct __typename;
-        impl cynic::schema::Field for __typename {
-            type Type = super::super::String;
-            const NAME: &'static str = "__typename";
-        }
         impl cynic::schema::HasField<__typename> for super::super::StarshipsEdge {
             type Type = super::super::String;
+            const NAME: &'static str = "__typename";
         }
     }
     pub mod Vehicle {
         pub struct name;
-        impl cynic::schema::Field for name {
+        impl cynic::schema::HasField<name> for super::super::Vehicle {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "name";
         }
-        impl cynic::schema::HasField<name> for super::super::Vehicle {
-            type Type = Option<super::super::String>;
-        }
         pub struct model;
-        impl cynic::schema::Field for model {
+        impl cynic::schema::HasField<model> for super::super::Vehicle {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "model";
         }
-        impl cynic::schema::HasField<model> for super::super::Vehicle {
-            type Type = Option<super::super::String>;
-        }
         pub struct vehicleClass;
-        impl cynic::schema::Field for vehicleClass {
+        impl cynic::schema::HasField<vehicleClass> for super::super::Vehicle {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "vehicleClass";
         }
-        impl cynic::schema::HasField<vehicleClass> for super::super::Vehicle {
-            type Type = Option<super::super::String>;
-        }
         pub struct manufacturers;
-        impl cynic::schema::Field for manufacturers {
+        impl cynic::schema::HasField<manufacturers> for super::super::Vehicle {
             type Type = Option<Vec<Option<super::super::String>>>;
             const NAME: &'static str = "manufacturers";
         }
-        impl cynic::schema::HasField<manufacturers> for super::super::Vehicle {
-            type Type = Option<Vec<Option<super::super::String>>>;
-        }
         pub struct costInCredits;
-        impl cynic::schema::Field for costInCredits {
+        impl cynic::schema::HasField<costInCredits> for super::super::Vehicle {
             type Type = Option<super::super::Float>;
             const NAME: &'static str = "costInCredits";
         }
-        impl cynic::schema::HasField<costInCredits> for super::super::Vehicle {
-            type Type = Option<super::super::Float>;
-        }
         pub struct length;
-        impl cynic::schema::Field for length {
+        impl cynic::schema::HasField<length> for super::super::Vehicle {
             type Type = Option<super::super::Float>;
             const NAME: &'static str = "length";
         }
-        impl cynic::schema::HasField<length> for super::super::Vehicle {
-            type Type = Option<super::super::Float>;
-        }
         pub struct crew;
-        impl cynic::schema::Field for crew {
+        impl cynic::schema::HasField<crew> for super::super::Vehicle {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "crew";
         }
-        impl cynic::schema::HasField<crew> for super::super::Vehicle {
-            type Type = Option<super::super::String>;
-        }
         pub struct passengers;
-        impl cynic::schema::Field for passengers {
+        impl cynic::schema::HasField<passengers> for super::super::Vehicle {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "passengers";
         }
-        impl cynic::schema::HasField<passengers> for super::super::Vehicle {
-            type Type = Option<super::super::String>;
-        }
         pub struct maxAtmospheringSpeed;
-        impl cynic::schema::Field for maxAtmospheringSpeed {
+        impl cynic::schema::HasField<maxAtmospheringSpeed> for super::super::Vehicle {
             type Type = Option<super::super::Int>;
             const NAME: &'static str = "maxAtmospheringSpeed";
         }
-        impl cynic::schema::HasField<maxAtmospheringSpeed> for super::super::Vehicle {
-            type Type = Option<super::super::Int>;
-        }
         pub struct cargoCapacity;
-        impl cynic::schema::Field for cargoCapacity {
+        impl cynic::schema::HasField<cargoCapacity> for super::super::Vehicle {
             type Type = Option<super::super::Float>;
             const NAME: &'static str = "cargoCapacity";
         }
-        impl cynic::schema::HasField<cargoCapacity> for super::super::Vehicle {
-            type Type = Option<super::super::Float>;
-        }
         pub struct consumables;
-        impl cynic::schema::Field for consumables {
+        impl cynic::schema::HasField<consumables> for super::super::Vehicle {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "consumables";
         }
-        impl cynic::schema::HasField<consumables> for super::super::Vehicle {
-            type Type = Option<super::super::String>;
-        }
         pub struct pilotConnection;
-        impl cynic::schema::Field for pilotConnection {
-            type Type = Option<super::super::VehiclePilotsConnection>;
-            const NAME: &'static str = "pilotConnection";
-        }
         impl cynic::schema::HasField<pilotConnection> for super::super::Vehicle {
             type Type = Option<super::super::VehiclePilotsConnection>;
+            const NAME: &'static str = "pilotConnection";
         }
         pub mod _pilot_connection_arguments {
             pub struct after;
@@ -2995,12 +2194,9 @@ pub mod __fields {
             }
         }
         pub struct filmConnection;
-        impl cynic::schema::Field for filmConnection {
-            type Type = Option<super::super::VehicleFilmsConnection>;
-            const NAME: &'static str = "filmConnection";
-        }
         impl cynic::schema::HasField<filmConnection> for super::super::Vehicle {
             type Type = Option<super::super::VehicleFilmsConnection>;
+            const NAME: &'static str = "filmConnection";
         }
         pub mod _film_connection_arguments {
             pub struct after;
@@ -3025,240 +2221,156 @@ pub mod __fields {
             }
         }
         pub struct created;
-        impl cynic::schema::Field for created {
+        impl cynic::schema::HasField<created> for super::super::Vehicle {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "created";
         }
-        impl cynic::schema::HasField<created> for super::super::Vehicle {
-            type Type = Option<super::super::String>;
-        }
         pub struct edited;
-        impl cynic::schema::Field for edited {
+        impl cynic::schema::HasField<edited> for super::super::Vehicle {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "edited";
         }
-        impl cynic::schema::HasField<edited> for super::super::Vehicle {
-            type Type = Option<super::super::String>;
-        }
         pub struct id;
-        impl cynic::schema::Field for id {
+        impl cynic::schema::HasField<id> for super::super::Vehicle {
             type Type = super::super::ID;
             const NAME: &'static str = "id";
         }
-        impl cynic::schema::HasField<id> for super::super::Vehicle {
-            type Type = super::super::ID;
-        }
         pub struct __typename;
-        impl cynic::schema::Field for __typename {
-            type Type = super::super::String;
-            const NAME: &'static str = "__typename";
-        }
         impl cynic::schema::HasField<__typename> for super::super::Vehicle {
             type Type = super::super::String;
+            const NAME: &'static str = "__typename";
         }
     }
     pub mod VehicleFilmsConnection {
         pub struct pageInfo;
-        impl cynic::schema::Field for pageInfo {
+        impl cynic::schema::HasField<pageInfo> for super::super::VehicleFilmsConnection {
             type Type = super::super::PageInfo;
             const NAME: &'static str = "pageInfo";
         }
-        impl cynic::schema::HasField<pageInfo> for super::super::VehicleFilmsConnection {
-            type Type = super::super::PageInfo;
-        }
         pub struct edges;
-        impl cynic::schema::Field for edges {
+        impl cynic::schema::HasField<edges> for super::super::VehicleFilmsConnection {
             type Type = Option<Vec<Option<super::super::VehicleFilmsEdge>>>;
             const NAME: &'static str = "edges";
         }
-        impl cynic::schema::HasField<edges> for super::super::VehicleFilmsConnection {
-            type Type = Option<Vec<Option<super::super::VehicleFilmsEdge>>>;
-        }
         pub struct totalCount;
-        impl cynic::schema::Field for totalCount {
+        impl cynic::schema::HasField<totalCount> for super::super::VehicleFilmsConnection {
             type Type = Option<super::super::Int>;
             const NAME: &'static str = "totalCount";
         }
-        impl cynic::schema::HasField<totalCount> for super::super::VehicleFilmsConnection {
-            type Type = Option<super::super::Int>;
-        }
         pub struct films;
-        impl cynic::schema::Field for films {
+        impl cynic::schema::HasField<films> for super::super::VehicleFilmsConnection {
             type Type = Option<Vec<Option<super::super::Film>>>;
             const NAME: &'static str = "films";
         }
-        impl cynic::schema::HasField<films> for super::super::VehicleFilmsConnection {
-            type Type = Option<Vec<Option<super::super::Film>>>;
-        }
         pub struct __typename;
-        impl cynic::schema::Field for __typename {
-            type Type = super::super::String;
-            const NAME: &'static str = "__typename";
-        }
         impl cynic::schema::HasField<__typename> for super::super::VehicleFilmsConnection {
             type Type = super::super::String;
+            const NAME: &'static str = "__typename";
         }
     }
     pub mod VehicleFilmsEdge {
         pub struct node;
-        impl cynic::schema::Field for node {
+        impl cynic::schema::HasField<node> for super::super::VehicleFilmsEdge {
             type Type = Option<super::super::Film>;
             const NAME: &'static str = "node";
         }
-        impl cynic::schema::HasField<node> for super::super::VehicleFilmsEdge {
-            type Type = Option<super::super::Film>;
-        }
         pub struct cursor;
-        impl cynic::schema::Field for cursor {
+        impl cynic::schema::HasField<cursor> for super::super::VehicleFilmsEdge {
             type Type = super::super::String;
             const NAME: &'static str = "cursor";
         }
-        impl cynic::schema::HasField<cursor> for super::super::VehicleFilmsEdge {
-            type Type = super::super::String;
-        }
         pub struct __typename;
-        impl cynic::schema::Field for __typename {
-            type Type = super::super::String;
-            const NAME: &'static str = "__typename";
-        }
         impl cynic::schema::HasField<__typename> for super::super::VehicleFilmsEdge {
             type Type = super::super::String;
+            const NAME: &'static str = "__typename";
         }
     }
     pub mod VehiclePilotsConnection {
         pub struct pageInfo;
-        impl cynic::schema::Field for pageInfo {
+        impl cynic::schema::HasField<pageInfo> for super::super::VehiclePilotsConnection {
             type Type = super::super::PageInfo;
             const NAME: &'static str = "pageInfo";
         }
-        impl cynic::schema::HasField<pageInfo> for super::super::VehiclePilotsConnection {
-            type Type = super::super::PageInfo;
-        }
         pub struct edges;
-        impl cynic::schema::Field for edges {
+        impl cynic::schema::HasField<edges> for super::super::VehiclePilotsConnection {
             type Type = Option<Vec<Option<super::super::VehiclePilotsEdge>>>;
             const NAME: &'static str = "edges";
         }
-        impl cynic::schema::HasField<edges> for super::super::VehiclePilotsConnection {
-            type Type = Option<Vec<Option<super::super::VehiclePilotsEdge>>>;
-        }
         pub struct totalCount;
-        impl cynic::schema::Field for totalCount {
+        impl cynic::schema::HasField<totalCount> for super::super::VehiclePilotsConnection {
             type Type = Option<super::super::Int>;
             const NAME: &'static str = "totalCount";
         }
-        impl cynic::schema::HasField<totalCount> for super::super::VehiclePilotsConnection {
-            type Type = Option<super::super::Int>;
-        }
         pub struct pilots;
-        impl cynic::schema::Field for pilots {
+        impl cynic::schema::HasField<pilots> for super::super::VehiclePilotsConnection {
             type Type = Option<Vec<Option<super::super::Person>>>;
             const NAME: &'static str = "pilots";
         }
-        impl cynic::schema::HasField<pilots> for super::super::VehiclePilotsConnection {
-            type Type = Option<Vec<Option<super::super::Person>>>;
-        }
         pub struct __typename;
-        impl cynic::schema::Field for __typename {
-            type Type = super::super::String;
-            const NAME: &'static str = "__typename";
-        }
         impl cynic::schema::HasField<__typename> for super::super::VehiclePilotsConnection {
             type Type = super::super::String;
+            const NAME: &'static str = "__typename";
         }
     }
     pub mod VehiclePilotsEdge {
         pub struct node;
-        impl cynic::schema::Field for node {
+        impl cynic::schema::HasField<node> for super::super::VehiclePilotsEdge {
             type Type = Option<super::super::Person>;
             const NAME: &'static str = "node";
         }
-        impl cynic::schema::HasField<node> for super::super::VehiclePilotsEdge {
-            type Type = Option<super::super::Person>;
-        }
         pub struct cursor;
-        impl cynic::schema::Field for cursor {
+        impl cynic::schema::HasField<cursor> for super::super::VehiclePilotsEdge {
             type Type = super::super::String;
             const NAME: &'static str = "cursor";
         }
-        impl cynic::schema::HasField<cursor> for super::super::VehiclePilotsEdge {
-            type Type = super::super::String;
-        }
         pub struct __typename;
-        impl cynic::schema::Field for __typename {
-            type Type = super::super::String;
-            const NAME: &'static str = "__typename";
-        }
         impl cynic::schema::HasField<__typename> for super::super::VehiclePilotsEdge {
             type Type = super::super::String;
+            const NAME: &'static str = "__typename";
         }
     }
     pub mod VehiclesConnection {
         pub struct pageInfo;
-        impl cynic::schema::Field for pageInfo {
+        impl cynic::schema::HasField<pageInfo> for super::super::VehiclesConnection {
             type Type = super::super::PageInfo;
             const NAME: &'static str = "pageInfo";
         }
-        impl cynic::schema::HasField<pageInfo> for super::super::VehiclesConnection {
-            type Type = super::super::PageInfo;
-        }
         pub struct edges;
-        impl cynic::schema::Field for edges {
+        impl cynic::schema::HasField<edges> for super::super::VehiclesConnection {
             type Type = Option<Vec<Option<super::super::VehiclesEdge>>>;
             const NAME: &'static str = "edges";
         }
-        impl cynic::schema::HasField<edges> for super::super::VehiclesConnection {
-            type Type = Option<Vec<Option<super::super::VehiclesEdge>>>;
-        }
         pub struct totalCount;
-        impl cynic::schema::Field for totalCount {
+        impl cynic::schema::HasField<totalCount> for super::super::VehiclesConnection {
             type Type = Option<super::super::Int>;
             const NAME: &'static str = "totalCount";
         }
-        impl cynic::schema::HasField<totalCount> for super::super::VehiclesConnection {
-            type Type = Option<super::super::Int>;
-        }
         pub struct vehicles;
-        impl cynic::schema::Field for vehicles {
+        impl cynic::schema::HasField<vehicles> for super::super::VehiclesConnection {
             type Type = Option<Vec<Option<super::super::Vehicle>>>;
             const NAME: &'static str = "vehicles";
         }
-        impl cynic::schema::HasField<vehicles> for super::super::VehiclesConnection {
-            type Type = Option<Vec<Option<super::super::Vehicle>>>;
-        }
         pub struct __typename;
-        impl cynic::schema::Field for __typename {
-            type Type = super::super::String;
-            const NAME: &'static str = "__typename";
-        }
         impl cynic::schema::HasField<__typename> for super::super::VehiclesConnection {
             type Type = super::super::String;
+            const NAME: &'static str = "__typename";
         }
     }
     pub mod VehiclesEdge {
         pub struct node;
-        impl cynic::schema::Field for node {
+        impl cynic::schema::HasField<node> for super::super::VehiclesEdge {
             type Type = Option<super::super::Vehicle>;
             const NAME: &'static str = "node";
         }
-        impl cynic::schema::HasField<node> for super::super::VehiclesEdge {
-            type Type = Option<super::super::Vehicle>;
-        }
         pub struct cursor;
-        impl cynic::schema::Field for cursor {
+        impl cynic::schema::HasField<cursor> for super::super::VehiclesEdge {
             type Type = super::super::String;
             const NAME: &'static str = "cursor";
         }
-        impl cynic::schema::HasField<cursor> for super::super::VehiclesEdge {
-            type Type = super::super::String;
-        }
         pub struct __typename;
-        impl cynic::schema::Field for __typename {
-            type Type = super::super::String;
-            const NAME: &'static str = "__typename";
-        }
         impl cynic::schema::HasField<__typename> for super::super::VehiclesEdge {
             type Type = super::super::String;
+            const NAME: &'static str = "__typename";
         }
     }
 }

--- a/cynic-codegen/tests/snapshots/use_schema__test_cases.graphql.snap
+++ b/cynic-codegen/tests/snapshots/use_schema__test_cases.graphql.snap
@@ -26,78 +26,51 @@ impl cynic::schema::NamedType for Foo {
 pub mod __fields {
     pub mod Bar {
         pub struct id;
-        impl cynic::schema::Field for id {
+        impl cynic::schema::HasField<id> for super::super::Bar {
             type Type = super::super::UUID;
             const NAME: &'static str = "id";
         }
-        impl cynic::schema::HasField<id> for super::super::Bar {
-            type Type = super::super::UUID;
-        }
         pub struct name;
-        impl cynic::schema::Field for name {
+        impl cynic::schema::HasField<name> for super::super::Bar {
             type Type = Option<super::super::String>;
             const NAME: &'static str = "name";
         }
-        impl cynic::schema::HasField<name> for super::super::Bar {
-            type Type = Option<super::super::String>;
-        }
         pub struct __typename;
-        impl cynic::schema::Field for __typename {
-            type Type = super::super::String;
-            const NAME: &'static str = "__typename";
-        }
         impl cynic::schema::HasField<__typename> for super::super::Bar {
             type Type = super::super::String;
+            const NAME: &'static str = "__typename";
         }
     }
     pub mod Foo {
         pub struct _Underscore;
-        impl cynic::schema::Field for _Underscore {
+        impl cynic::schema::HasField<_Underscore> for super::super::Foo {
             type Type = Option<super::super::Boolean>;
             const NAME: &'static str = "_";
         }
-        impl cynic::schema::HasField<_Underscore> for super::super::Foo {
-            type Type = Option<super::super::Boolean>;
-        }
         pub struct self_;
-        impl cynic::schema::Field for self_ {
+        impl cynic::schema::HasField<self_> for super::super::Foo {
             type Type = Option<super::super::Boolean>;
             const NAME: &'static str = "self";
         }
-        impl cynic::schema::HasField<self_> for super::super::Foo {
-            type Type = Option<super::super::Boolean>;
-        }
         pub struct super_;
-        impl cynic::schema::Field for super_ {
+        impl cynic::schema::HasField<super_> for super::super::Foo {
             type Type = Option<super::super::Boolean>;
             const NAME: &'static str = "super";
         }
-        impl cynic::schema::HasField<super_> for super::super::Foo {
-            type Type = Option<super::super::Boolean>;
-        }
         pub struct crate_;
-        impl cynic::schema::Field for crate_ {
+        impl cynic::schema::HasField<crate_> for super::super::Foo {
             type Type = Option<super::super::Boolean>;
             const NAME: &'static str = "crate";
         }
-        impl cynic::schema::HasField<crate_> for super::super::Foo {
-            type Type = Option<super::super::Boolean>;
-        }
         pub struct r#async;
-        impl cynic::schema::Field for r#async {
+        impl cynic::schema::HasField<r#async> for super::super::Foo {
             type Type = Option<super::super::Boolean>;
             const NAME: &'static str = "async";
         }
-        impl cynic::schema::HasField<r#async> for super::super::Foo {
-            type Type = Option<super::super::Boolean>;
-        }
         pub struct bar;
-        impl cynic::schema::Field for bar {
-            type Type = Option<super::super::Bar>;
-            const NAME: &'static str = "bar";
-        }
         impl cynic::schema::HasField<bar> for super::super::Foo {
             type Type = Option<super::super::Bar>;
+            const NAME: &'static str = "bar";
         }
         pub mod _bar_arguments {
             pub struct id;
@@ -107,12 +80,9 @@ pub mod __fields {
             }
         }
         pub struct fieldWithKeywordArg;
-        impl cynic::schema::Field for fieldWithKeywordArg {
-            type Type = Vec<super::super::Int>;
-            const NAME: &'static str = "fieldWithKeywordArg";
-        }
         impl cynic::schema::HasField<fieldWithKeywordArg> for super::super::Foo {
             type Type = Vec<super::super::Int>;
+            const NAME: &'static str = "fieldWithKeywordArg";
         }
         pub mod _field_with_keyword_arg_arguments {
             pub struct r#where;
@@ -122,12 +92,9 @@ pub mod __fields {
             }
         }
         pub struct recursiveInputField;
-        impl cynic::schema::Field for recursiveInputField {
-            type Type = Option<super::super::Boolean>;
-            const NAME: &'static str = "recursiveInputField";
-        }
         impl cynic::schema::HasField<recursiveInputField> for super::super::Foo {
             type Type = Option<super::super::Boolean>;
+            const NAME: &'static str = "recursiveInputField";
         }
         pub mod _recursive_input_field_arguments {
             pub struct recursive;
@@ -142,12 +109,9 @@ pub mod __fields {
             }
         }
         pub struct fieldWithStringArg;
-        impl cynic::schema::Field for fieldWithStringArg {
-            type Type = Option<super::super::Int>;
-            const NAME: &'static str = "fieldWithStringArg";
-        }
         impl cynic::schema::HasField<fieldWithStringArg> for super::super::Foo {
             type Type = Option<super::super::Int>;
+            const NAME: &'static str = "fieldWithStringArg";
         }
         pub mod _field_with_string_arg_arguments {
             pub struct input;
@@ -157,45 +121,30 @@ pub mod __fields {
             }
         }
         pub struct __typename;
-        impl cynic::schema::Field for __typename {
-            type Type = super::super::String;
-            const NAME: &'static str = "__typename";
-        }
         impl cynic::schema::HasField<__typename> for super::super::Foo {
             type Type = super::super::String;
+            const NAME: &'static str = "__typename";
         }
     }
     pub mod RecursiveInputChild {
         pub struct recurse;
-        impl cynic::schema::Field for recurse {
+        impl cynic::schema::HasInputField<recurse> for super::super::RecursiveInputChild {
             type Type = Option<super::super::RecursiveInputParent>;
             const NAME: &'static str = "recurse";
-        }
-        impl cynic::schema::HasInputField<recurse, Option<super::super::RecursiveInputParent>>
-            for super::super::RecursiveInputChild
-        {
         }
     }
     pub mod RecursiveInputParent {
         pub struct recurse;
-        impl cynic::schema::Field for recurse {
+        impl cynic::schema::HasInputField<recurse> for super::super::RecursiveInputParent {
             type Type = Option<super::super::RecursiveInputChild>;
             const NAME: &'static str = "recurse";
-        }
-        impl cynic::schema::HasInputField<recurse, Option<super::super::RecursiveInputChild>>
-            for super::super::RecursiveInputParent
-        {
         }
     }
     pub mod SelfRecursiveInput {
         pub struct recurse;
-        impl cynic::schema::Field for recurse {
+        impl cynic::schema::HasInputField<recurse> for super::super::SelfRecursiveInput {
             type Type = Option<super::super::SelfRecursiveInput>;
             const NAME: &'static str = "recurse";
-        }
-        impl cynic::schema::HasInputField<recurse, Option<super::super::SelfRecursiveInput>>
-            for super::super::SelfRecursiveInput
-        {
         }
     }
 }

--- a/cynic/src/queries/builders.rs
+++ b/cynic/src/queries/builders.rs
@@ -70,7 +70,6 @@ impl<'a, SchemaType, VariablesFields> SelectionBuilder<'a, SchemaType, Variables
         &'_ mut self,
     ) -> FieldSelectionBuilder<'_, FieldMarker, Flattened, VariablesFields>
     where
-        FieldMarker: schema::Field,
         FieldType: FlattensInto<Flattened>,
         SchemaType: schema::HasField<FieldMarker>,
         FieldType: IsFieldType<SchemaType::Type>,
@@ -78,7 +77,7 @@ impl<'a, SchemaType, VariablesFields> SelectionBuilder<'a, SchemaType, Variables
         FieldSelectionBuilder {
             recurse_depth: self.recurse_depth,
             context: self.context,
-            field: self.push_selection(FieldMarker::NAME),
+            field: self.push_selection(SchemaType::NAME),
             phantom: PhantomData,
         }
     }
@@ -93,14 +92,13 @@ impl<'a, SchemaType, VariablesFields> SelectionBuilder<'a, SchemaType, Variables
         &'_ mut self,
     ) -> FieldSelectionBuilder<'_, FieldMarker, FieldType, VariablesFields>
     where
-        FieldMarker: schema::Field,
         SchemaType: schema::HasField<FieldMarker>,
         FieldType: IsFieldType<SchemaType::Type>,
     {
         FieldSelectionBuilder {
             recurse_depth: self.recurse_depth,
             context: self.context,
-            field: self.push_selection(FieldMarker::NAME),
+            field: self.push_selection(SchemaType::NAME),
             phantom: PhantomData,
         }
     }
@@ -114,9 +112,8 @@ impl<'a, SchemaType, VariablesFields> SelectionBuilder<'a, SchemaType, Variables
         max_depth: u8,
     ) -> Option<FieldSelectionBuilder<'_, FieldMarker, FieldType, VariablesFields>>
     where
-        FieldMarker: schema::Field,
         SchemaType: schema::HasField<FieldMarker>,
-        FieldType: Recursable<FieldMarker::Type>,
+        FieldType: Recursable<SchemaType::Type>,
     {
         let new_depth = self.recurse_depth.map(|d| d + 1).unwrap_or(0);
         if new_depth >= max_depth {
@@ -126,7 +123,7 @@ impl<'a, SchemaType, VariablesFields> SelectionBuilder<'a, SchemaType, Variables
         Some(FieldSelectionBuilder {
             recurse_depth: Some(new_depth),
             context: self.context,
-            field: self.push_selection(FieldMarker::NAME),
+            field: self.push_selection(SchemaType::NAME),
             phantom: PhantomData,
         })
     }
@@ -341,12 +338,11 @@ impl<'a, SchemaType, ArgStruct> ObjectArgumentBuilder<'a, SchemaType, ArgStruct>
     /// contents of that field.
     pub fn field<FieldMarker, F>(self, field_fn: F) -> Self
     where
-        FieldMarker: schema::Field,
-        SchemaType: schema::HasInputField<FieldMarker, FieldMarker::Type>,
-        F: FnOnce(InputBuilder<'_, FieldMarker::Type, ArgStruct>),
+        SchemaType: schema::HasInputField<FieldMarker>,
+        F: FnOnce(InputBuilder<'_, SchemaType::Type, ArgStruct>),
     {
         field_fn(InputBuilder {
-            destination: InputLiteralContainer::object(FieldMarker::NAME, self.fields),
+            destination: InputLiteralContainer::object(SchemaType::NAME, self.fields),
             context: self.context,
             phantom: PhantomData,
         });

--- a/cynic/src/schema.rs
+++ b/cynic/src/schema.rs
@@ -11,15 +11,6 @@
 //! usually be marker types and the associated types will also usually be
 //! markers.
 
-/// Indicates that a struct represents a Field in a graphql schema.
-pub trait Field {
-    /// The schema marker type of this field.
-    type Type;
-
-    /// the name of this field
-    const NAME: &'static str;
-}
-
 // TODO: Get the terminology straight in this file, it's a mess.
 
 /// Indicates that a type has a given field
@@ -30,6 +21,9 @@ pub trait Field {
 pub trait HasField<FieldMarker> {
     /// The schema marker type of this field.
     type Type;
+
+    /// the name of this field
+    const NAME: &'static str;
 }
 
 /// Indicates that an input object has a given field
@@ -37,7 +31,13 @@ pub trait HasField<FieldMarker> {
 /// This should be implemented several times for any given input object,
 /// once per field. `FieldMarker` should be the marker type for the field,
 /// and `FieldType` should be the schema marker type of the field.
-pub trait HasInputField<FieldMarker, FieldType> {}
+pub trait HasInputField<FieldMarker> {
+    /// The schema marker type of this input field.
+    type Type;
+
+    /// the name of this field
+    const NAME: &'static str;
+}
 
 /// Indicates that a field has an argument
 ///


### PR DESCRIPTION
#### Why are we making this change?

The cynic schema module is overly verbose - the same data could be expressed with less code.

#### What effects does this change have?

- Removes the `Field` trait, moving its data into the `HasField` & `HasInputField` traits.
- Moves the second generic parameter of `HasInputField` to an associated type.

This reduces the size of the schema module quite considerably, which should have a reasonable impact on compile times (~a 10% reduction in compile times of my test crate that uses the GitHub schema).  It also has the bonus impact of simplifying some of the query building where clauses.

This is probably a breaking change though so should maybe be a major release.

Fixes #712 
