### PR TITLE
More cynic-parser work

### DIFF
--- a/cynic-parser/benches/parsing-benchmark.rs
+++ b/cynic-parser/benches/parsing-benchmark.rs
@@ -1,5 +1,5 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use cynic_parser::Ast;
+use cynic_parser::AstBuilder;
 
 pub fn criterion_benchmark(c: &mut Criterion) {
     let input = "type MyType { field: Whatever, field: Whatever }";
@@ -7,7 +7,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         b.iter(|| {
             let lexer = cynic_parser::Lexer::new(input);
             let object = cynic_parser::ObjectDefinitionParser::new()
-                .parse(input, &mut Ast::new(), lexer)
+                .parse(input, &mut AstBuilder::new(), lexer)
                 .unwrap();
             black_box(object)
         })

--- a/cynic-parser/src/ast.rs
+++ b/cynic-parser/src/ast.rs
@@ -5,8 +5,10 @@ use indexmap::IndexSet;
 
 pub(crate) mod ids;
 mod reader;
+mod span;
 
 pub use reader::{AstReader, Definition, ValueReader};
+pub use span::Span;
 
 #[derive(Default)]
 pub struct Ast {
@@ -59,6 +61,7 @@ pub struct ObjectDefinition {
     pub fields: Vec<NodeId>,
     pub directives: Vec<DirectiveId>,
     pub implements: Vec<StringId>,
+    pub span: Span,
 }
 
 pub struct FieldDefinition {
@@ -67,12 +70,14 @@ pub struct FieldDefinition {
     pub arguments: Vec<NodeId>,
     pub description: Option<NodeId>,
     pub directives: Vec<DirectiveId>,
+    pub span: Span,
 }
 
 pub struct InputObjectDefinition {
     pub name: StringId,
     pub fields: Vec<NodeId>,
     pub directives: Vec<DirectiveId>,
+    pub span: Span,
 }
 
 pub struct InputValueDefinition {

--- a/cynic-parser/src/ast.rs
+++ b/cynic-parser/src/ast.rs
@@ -142,113 +142,123 @@ pub enum Value {
     Object(Vec<(StringId, ValueId)>),
 }
 
+pub struct AstBuilder {
+    ast: Ast,
+}
+
 // TODO: Don't forget the spans etc.
-// TODO: make this whole impl into a builder that wraps an Ast.
-// Then the default Reader stuff can just go on Ast - much more sensible...
-impl Ast {
+impl AstBuilder {
     pub fn new() -> Self {
-        Ast::default()
+        AstBuilder {
+            ast: Default::default(),
+        }
+    }
+
+    pub fn finish(self) -> Ast {
+        self.ast
     }
 
     pub fn definitions(&mut self, ids: Vec<(Option<NodeId>, NodeId)>) {
         for (description, definition) in ids {
             if let Some(description) = description {
-                self.definition_descriptions.insert(definition, description);
+                self.ast
+                    .definition_descriptions
+                    .insert(definition, description);
             }
-            self.definition_nodes.push(definition);
+            self.ast.definition_nodes.push(definition);
         }
     }
 
     pub fn schema_definition(&mut self, definition: SchemaDefinition) -> NodeId {
-        let definition_id = SchemaDefinitionId(self.schema_definitions.len());
-        self.schema_definitions.push(definition);
+        let definition_id = SchemaDefinitionId(self.ast.schema_definitions.len());
+        self.ast.schema_definitions.push(definition);
 
-        let node_id = NodeId(self.nodes.len());
+        let node_id = NodeId(self.ast.nodes.len());
         let contents = NodeContents::SchemaDefinition(definition_id);
 
-        self.nodes.push(Node { contents });
+        self.ast.nodes.push(Node { contents });
 
         node_id
     }
 
     pub fn object_definition(&mut self, definition: ObjectDefinition) -> NodeId {
-        let definition_id = ObjectDefinitionId(self.object_definitions.len());
-        self.object_definitions.push(definition);
+        let definition_id = ObjectDefinitionId(self.ast.object_definitions.len());
+        self.ast.object_definitions.push(definition);
 
-        let node_id = NodeId(self.nodes.len());
+        let node_id = NodeId(self.ast.nodes.len());
         let contents = NodeContents::ObjectDefiniton(definition_id);
 
-        self.nodes.push(Node { contents });
+        self.ast.nodes.push(Node { contents });
 
         node_id
     }
 
     pub fn field_definition(&mut self, definition: FieldDefinition) -> NodeId {
-        let definition_id = FieldDefinitionId(self.field_definitions.len());
-        self.field_definitions.push(definition);
+        let definition_id = FieldDefinitionId(self.ast.field_definitions.len());
+        self.ast.field_definitions.push(definition);
 
-        let node_id = NodeId(self.nodes.len());
+        let node_id = NodeId(self.ast.nodes.len());
         let contents = NodeContents::FieldDefinition(definition_id);
 
-        self.nodes.push(Node { contents });
+        self.ast.nodes.push(Node { contents });
 
         node_id
     }
 
     pub fn input_object_definition(&mut self, definition: InputObjectDefinition) -> NodeId {
-        let definition_id = InputObjectDefinitionId(self.input_object_definitions.len());
-        self.input_object_definitions.push(definition);
+        let definition_id = InputObjectDefinitionId(self.ast.input_object_definitions.len());
+        self.ast.input_object_definitions.push(definition);
 
-        let node_id = NodeId(self.nodes.len());
+        let node_id = NodeId(self.ast.nodes.len());
         let contents = NodeContents::InputObjectDefiniton(definition_id);
 
-        self.nodes.push(Node { contents });
+        self.ast.nodes.push(Node { contents });
 
         node_id
     }
 
     pub fn input_value_definition(&mut self, definition: InputValueDefinition) -> NodeId {
-        let definition_id = InputValueDefinitionId(self.input_value_definitions.len());
-        self.input_value_definitions.push(definition);
+        let definition_id = InputValueDefinitionId(self.ast.input_value_definitions.len());
+        self.ast.input_value_definitions.push(definition);
 
-        let node_id = NodeId(self.nodes.len());
+        let node_id = NodeId(self.ast.nodes.len());
         let contents = NodeContents::InputValueDefinition(definition_id);
-        self.nodes.push(Node { contents });
+        self.ast.nodes.push(Node { contents });
 
         node_id
     }
 
     pub fn type_reference(&mut self, ty: Type) -> TypeId {
-        let ty_id = TypeId(self.type_references.len());
-        self.type_references.push(ty);
+        let ty_id = TypeId(self.ast.type_references.len());
+        self.ast.type_references.push(ty);
         ty_id
     }
 
     pub fn directive(&mut self, directive: Directive) -> DirectiveId {
-        let id = DirectiveId(self.directives.len());
-        self.directives.push(directive);
+        let id = DirectiveId(self.ast.directives.len());
+        self.ast.directives.push(directive);
         id
     }
 
     pub fn argument(&mut self, argument: Argument) -> ArgumentId {
-        let id = ArgumentId(self.arguments.len());
-        self.arguments.push(argument);
+        let id = ArgumentId(self.ast.arguments.len());
+        self.ast.arguments.push(argument);
         id
     }
 
     pub fn value(&mut self, value: Value) -> ValueId {
-        let id = ValueId(self.values.len());
-        self.values.push(value);
+        let id = ValueId(self.ast.values.len());
+        self.ast.values.push(value);
         id
     }
 
     pub fn string_literal(&mut self, literal: StringLiteral) -> NodeId {
-        let literal_id = StringLiteralId(self.string_literals.len());
-        self.string_literals.push(literal);
+        let literal_id = StringLiteralId(self.ast.string_literals.len());
+        self.ast.string_literals.push(literal);
 
-        let node_id = NodeId(self.nodes.len());
+        let node_id = NodeId(self.ast.nodes.len());
         let contents = NodeContents::StringLiteral(literal_id);
-        self.nodes.push(Node { contents });
+        self.ast.nodes.push(Node { contents });
 
         node_id
     }
@@ -259,7 +269,7 @@ impl Ast {
 
     // TOOD: should this be pub? not sure...
     pub fn intern_string(&mut self, string: &str) -> StringId {
-        let (id, _) = self.strings.insert_full(string.into());
+        let (id, _) = self.ast.strings.insert_full(string.into());
         StringId(id)
     }
 }

--- a/cynic-parser/src/ast/ids.rs
+++ b/cynic-parser/src/ast/ids.rs
@@ -1,8 +1,8 @@
 use crate::Ast;
 
 use super::{
-    Argument, Directive, FieldDefinition, InputObjectDefinition, InputValueDefinition, Node,
-    ObjectDefinition, SchemaDefinition, Type, Value,
+    Argument, AstDefinition, Directive, FieldDefinition, InputObjectDefinition,
+    InputValueDefinition, ObjectDefinition, SchemaDefinition, Type, Value,
 };
 
 pub trait AstId {}
@@ -13,18 +13,20 @@ pub(crate) trait AstLookup<Id> {
     fn lookup(&self, index: Id) -> &Self::Output;
 }
 
+// TODO: NonZeroUsize these?
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-pub struct NodeId(pub(super) usize);
+pub struct DefinitionId(pub(super) usize);
 
-impl AstLookup<NodeId> for Ast {
-    type Output = Node;
+impl AstLookup<DefinitionId> for Ast {
+    type Output = AstDefinition;
 
-    fn lookup(&self, index: NodeId) -> &Self::Output {
-        &self.nodes[index.0]
+    fn lookup(&self, index: DefinitionId) -> &Self::Output {
+        &self.definitions[index.0]
     }
 }
 
-impl AstId for NodeId {}
+impl AstId for DefinitionId {}
 
 #[derive(Clone, Copy)]
 pub struct StringId(pub(super) usize);

--- a/cynic-parser/src/ast/reader.rs
+++ b/cynic-parser/src/ast/reader.rs
@@ -1,8 +1,8 @@
-use crate::Ast;
+use crate::{ast, Ast};
 
 use super::{
     ids::{ArgumentId, AstId, AstLookup, DirectiveId, InputValueDefinitionId, TypeId, ValueId},
-    FieldDefinitionId, InputObjectDefinitionId, NodeContents, ObjectDefinitionId, OperationType,
+    FieldDefinitionId, InputObjectDefinitionId, ObjectDefinitionId, OperationType,
     SchemaDefinitionId, Type, WrappingType,
 };
 
@@ -22,17 +22,11 @@ impl super::Ast {
 
 impl Ast {
     pub fn definitions<'a>(&'a self) -> impl Iterator<Item = Definition<'a>> + 'a {
-        self.definition_nodes
-            .iter()
-            .map(|definition| match self.nodes[definition.0].contents {
-                NodeContents::SchemaDefinition(id) => Definition::Schema(self.read(id)),
-                NodeContents::ObjectDefiniton(id) => Definition::Object(self.read(id)),
-                NodeContents::InputObjectDefiniton(id) => Definition::InputObject(self.read(id)),
-                NodeContents::FieldDefinition(_)
-                | NodeContents::InputValueDefinition(_)
-                | NodeContents::StringLiteral(_) => unreachable!(),
-                NodeContents::Ident(_) => unreachable!(),
-            })
+        self.definitions.iter().map(|definition| match definition {
+            ast::AstDefinition::Schema(id) => Definition::Schema(self.read(*id)),
+            ast::AstDefinition::Object(id) => Definition::Object(self.read(*id)),
+            ast::AstDefinition::InputObject(id) => Definition::InputObject(self.read(*id)),
+        })
     }
 }
 
@@ -70,10 +64,7 @@ impl<'a> AstReader<'a, ObjectDefinitionId> {
             .lookup(self.id)
             .fields
             .iter()
-            .map(|node| match self.ast.lookup(*node).contents {
-                NodeContents::FieldDefinition(id) => self.ast.read(id),
-                _ => unreachable!(),
-            })
+            .map(|id| self.ast.read(*id))
     }
 
     pub fn directives(&self) -> impl Iterator<Item = AstReader<'a, DirectiveId>> + 'a {
@@ -95,10 +86,7 @@ impl<'a> AstReader<'a, InputObjectDefinitionId> {
             .lookup(self.id)
             .fields
             .iter()
-            .map(|node| match self.ast.lookup(*node).contents {
-                NodeContents::InputValueDefinition(id) => self.ast.read(id),
-                _ => unreachable!(),
-            })
+            .map(|id| self.ast.read(*id))
     }
 
     pub fn directives(&self) -> impl Iterator<Item = AstReader<'a, DirectiveId>> + 'a {
@@ -120,12 +108,11 @@ impl<'a> AstReader<'a, FieldDefinitionId> {
     }
 
     pub fn arguments(&self) -> impl Iterator<Item = AstReader<'a, InputValueDefinitionId>> {
-        self.ast.lookup(self.id).arguments.iter().map(|node| {
-            match self.ast.lookup(*node).contents {
-                NodeContents::InputValueDefinition(id) => self.ast.read(id),
-                _ => unreachable!(),
-            }
-        })
+        self.ast
+            .lookup(self.id)
+            .arguments
+            .iter()
+            .map(|id| self.ast.read(*id))
     }
 
     pub fn directives(&self) -> impl Iterator<Item = AstReader<'a, DirectiveId>> + 'a {

--- a/cynic-parser/src/ast/span.rs
+++ b/cynic-parser/src/ast/span.rs
@@ -1,0 +1,10 @@
+pub struct Span {
+    start: usize,
+    end: usize,
+}
+
+impl Span {
+    pub fn new(start: usize, end: usize) -> Self {
+        Self { start, end }
+    }
+}

--- a/cynic-parser/src/lib.rs
+++ b/cynic-parser/src/lib.rs
@@ -8,19 +8,19 @@ pub use lexer::Lexer;
 pub use schema::ObjectDefinitionParser;
 
 // TODO: Make this more senseible
-pub use ast::Ast;
+pub use ast::{Ast, AstBuilder};
 
 lalrpop_mod!(pub schema);
 
 pub fn parse_type_system_document(input: &str) -> Ast {
     let lexer = lexer::Lexer::new(input);
-    let mut ast = Ast::new();
+    let mut ast = AstBuilder::new();
 
     schema::TypeSystemDocumentParser::new()
         .parse(input, &mut ast, lexer)
         .expect("TODO: error handling");
 
-    ast
+    ast.finish()
 }
 
 #[cfg(test)]

--- a/cynic-parser/src/printer.rs
+++ b/cynic-parser/src/printer.rs
@@ -15,15 +15,11 @@ impl crate::Ast {
         let allocator = BoxAllocator;
 
         let builder = allocator
-            .concat(
-                self.reader()
-                    .definitions()
-                    .map(|definition| match definition {
-                        Definition::Schema(schema) => NodeDisplay(schema).pretty(&allocator),
-                        Definition::Object(object) => NodeDisplay(object).pretty(&allocator),
-                        Definition::InputObject(object) => NodeDisplay(object).pretty(&allocator),
-                    }),
-            )
+            .concat(self.definitions().map(|definition| match definition {
+                Definition::Schema(schema) => NodeDisplay(schema).pretty(&allocator),
+                Definition::Object(object) => NodeDisplay(object).pretty(&allocator),
+                Definition::InputObject(object) => NodeDisplay(object).pretty(&allocator),
+            }))
             .pretty(&allocator);
 
         #[allow(clippy::needless_borrow)] // This doesn't work without the borrow :|

--- a/cynic-parser/src/printer.rs
+++ b/cynic-parser/src/printer.rs
@@ -7,7 +7,7 @@ use crate::ast::{
         ArgumentId, DirectiveId, FieldDefinitionId, InputObjectDefinitionId,
         InputValueDefinitionId, ObjectDefinitionId, SchemaDefinitionId, TypeId, ValueId,
     },
-    AstReader, Definition,
+    AstDefinition, AstReader, Definition,
 };
 
 impl crate::Ast {

--- a/cynic-parser/src/schema.lalrpop
+++ b/cynic-parser/src/schema.lalrpop
@@ -4,7 +4,7 @@ use crate::lexer;
 
 use crate::ast::{*, ids::*};
 
-grammar<'input>(input: &'input str, ast: &mut Ast);
+grammar<'input>(input: &'input str, ast: &mut AstBuilder);
 
 pub TypeSystemDocument: () = {
     <defs:DefinitionAndDescription+> => ast.definitions(defs),

--- a/cynic-parser/src/schema.lalrpop
+++ b/cynic-parser/src/schema.lalrpop
@@ -7,14 +7,14 @@ use crate::ast::{*, ids::*};
 grammar<'input>(input: &'input str, ast: &mut AstBuilder);
 
 pub TypeSystemDocument: () = {
-    <defs:DefinitionAndDescription+> => ast.definitions(defs),
+    <defs:DefinitionAndDescription+> => ast.definition_descriptions(defs),
 }
 
-pub DefinitionAndDescription: (Option<NodeId>, NodeId) = {
+pub DefinitionAndDescription: (Option<StringId>, DefinitionId) = {
     <description:StringValue?> <def:TypeSystemDefinition> => (description, def)
 }
 
-pub TypeSystemDefinition: NodeId = {
+pub TypeSystemDefinition: DefinitionId = {
     <def:SchemaDefinition> => ast.schema_definition(def),
     <def:ObjectDefinition> => ast.object_definition(def),
     <def:InputObjectDefinition> => ast.input_object_definition(def)
@@ -62,11 +62,11 @@ ImplementItem: StringId = {
     "&" <name:NamedType> => name,
 }
 
-FieldsDefinition: Vec<NodeId> = {
+FieldsDefinition: Vec<FieldDefinitionId> = {
     "{" <fields:FieldDefinition+> "}" => fields
 };
 
-FieldDefinition: NodeId = {
+FieldDefinition: FieldDefinitionId = {
     <start:@L>
         <description:StringValue?>
         <name:Name>
@@ -79,12 +79,12 @@ FieldDefinition: NodeId = {
             ty,
             arguments: arguments.unwrap_or_default(),
             description,
-            directives
+            directives,
             span: Span::new(start,end)
         })
 };
 
-ArgumentsDefinition: Vec<NodeId> = {
+ArgumentsDefinition: Vec<InputValueDefinitionId> = {
     "(" <arguments:InputValueDefinition+> ")" => arguments,
 };
 
@@ -97,16 +97,16 @@ pub InputObjectDefinition: InputObjectDefinition = {
     => InputObjectDefinition {
         name,
         directives,
-        fields: fields.unwrap_or_default()
+        fields: fields.unwrap_or_default(),
         span: Span::new(start,end)
     }
 };
 
-InputFieldsDefinition: Vec<NodeId> = {
+InputFieldsDefinition: Vec<InputValueDefinitionId> = {
     "{" <fields:InputValueDefinition+> "}" => fields
 };
 
-InputValueDefinition: NodeId =
+InputValueDefinition: InputValueDefinitionId=
     <start:@L>
         <description:StringValue?>
         <name:Name> ":" <ty:Type> <default:DefaultValue?>
@@ -116,7 +116,7 @@ InputValueDefinition: NodeId =
         ast.input_value_definition(InputValueDefinition {
             name,
             ty,
-            description
+            description,
             directives,
             default,
             span: Span::new(start, end)
@@ -164,14 +164,12 @@ ObjectField: (StringId, ValueId) = {
     <name:Name> ":" <value:Value> => (name, value)
 }
 
-StringValue: NodeId = {
+StringValue: StringId = {
     <s:StringLiteral> => {
-        let id = ast.intern_string(s);
-        ast.string_literal(StringLiteral::Normal(id))
+        ast.intern_string(s)
     },
     <s:BlockStringLiteral> => {
-        let id = ast.intern_string(s);
-        ast.string_literal(StringLiteral::Block(id))
+        ast.intern_string(s)
     },
 }
 
@@ -198,7 +196,6 @@ Argument: ArgumentId = {
     <name:Name> ":" <value:Value> => ast.argument(Argument { <> }),
 }
 
-// TODO: Make this NodeId probably...
 Ident: &'input str = {
     <s:RawIdent> => s,
     schema => "schema",

--- a/cynic-parser/src/schema.lalrpop
+++ b/cynic-parser/src/schema.lalrpop
@@ -32,11 +32,18 @@ pub RootOperationTypeDefinition: RootOperationTypeDefinition = {
 }
 
 pub ObjectDefinition: ObjectDefinition = {
-    ty <name:Name> <implements:ImplementsInterfaces?> <directives:Directive*> <fields:FieldsDefinition?> => ObjectDefinition {
+    <start:@L> ty
+        <name:Name>
+        <implements:ImplementsInterfaces?>
+        <directives:Directive*>
+        <fields:FieldsDefinition?>
+        <end:@R>
+    => ObjectDefinition {
         name,
         directives,
         implements: implements.unwrap_or_default(),
-        fields: fields.unwrap_or_default ()
+        fields: fields.unwrap_or_default(),
+        span: Span::new(start,end)
     }
 };
 
@@ -60,13 +67,20 @@ FieldsDefinition: Vec<NodeId> = {
 };
 
 FieldDefinition: NodeId = {
-    <description:StringValue?> <name:Name> <arguments:ArgumentsDefinition?> ":" <ty:Type> <directives:Directive*> =>
+    <start:@L>
+        <description:StringValue?>
+        <name:Name>
+        <arguments:ArgumentsDefinition?> ":" <ty:Type>
+        <directives:Directive*>
+        <end:@R>
+    =>
         ast.field_definition(FieldDefinition {
             name,
             ty,
             arguments: arguments.unwrap_or_default(),
             description,
             directives
+            span: Span::new(start,end)
         })
 };
 
@@ -75,10 +89,16 @@ ArgumentsDefinition: Vec<NodeId> = {
 };
 
 pub InputObjectDefinition: InputObjectDefinition = {
-    input <name:Name> <directives:Directive*> <fields:InputFieldsDefinition?> => InputObjectDefinition {
+    <start:@L> input
+        <name:Name>
+        <directives:Directive*>
+        <fields:InputFieldsDefinition?>
+        <end:@R>
+    => InputObjectDefinition {
         name,
         directives,
         fields: fields.unwrap_or_default()
+        span: Span::new(start,end)
     }
 };
 
@@ -87,8 +107,20 @@ InputFieldsDefinition: Vec<NodeId> = {
 };
 
 InputValueDefinition: NodeId =
-    <description:StringValue?> <name:Name> ":" <ty:Type> <default:DefaultValue?> <directives:Directive*> =>
-        ast.input_value_definition(InputValueDefinition { <> });
+    <start:@L>
+        <description:StringValue?>
+        <name:Name> ":" <ty:Type> <default:DefaultValue?>
+        <directives:Directive*>
+        <end:@R>
+    =>
+        ast.input_value_definition(InputValueDefinition {
+            name,
+            ty,
+            description
+            directives,
+            default,
+            span: Span::new(start, end)
+        });
 
 DefaultValue: ValueId = {
     "=" <v:Value> => v


### PR DESCRIPTION
- Removed the `Node` abstraction
- Tested reading spans in a few places.
- Split `AstBuilder` out of the main `Ast` struct.