### PR TITLE
Fix some problems around recursive queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ## Unreleased - xxxx-xx-xx
 
+### Changes
+
+- If you accidentally write a recursive query without the `recurse` attribute
+  you'll now get a panic suggesting to use `recurse`.  This may cause false
+  positives if you're writing a particularly large query - users should raise
+  an issue if I've picked a number that's too low.
+
+### Bug Fixes
+
+- The `recurse` attribute now works if an `InlineFragments` derive is used in
+  the recursive path.
+
 ## v3.4.1 - 2024-01-22
 
 ### Bug Fixes

--- a/cynic/src/queries/ast.rs
+++ b/cynic/src/queries/ast.rs
@@ -132,11 +132,15 @@ impl std::fmt::Display for Selection {
                 write!(f, "{}", field_selection.children)
             }
             Selection::InlineFragment(inline_fragment) => {
-                write!(f, "...")?;
-                if let Some(on_type) = inline_fragment.on_clause {
-                    write!(f, " on {}", on_type)?;
+                // Don't print any empty fragments - this can happen in recursive queries...
+                if !inline_fragment.children.selections.is_empty() {
+                    write!(f, "...")?;
+                    if let Some(on_type) = inline_fragment.on_clause {
+                        write!(f, " on {}", on_type)?;
+                    }
+                    write!(f, "{}", inline_fragment.children)?;
                 }
-                write!(f, "{}", inline_fragment.children)
+                Ok(())
             }
         }
     }

--- a/cynic/tests/test-schema.graphql
+++ b/cynic/tests/test-schema.graphql
@@ -33,6 +33,9 @@ type Author implements Node {
   # A nonsense self referential field
   # Don't think this would make sense usually, but it's useful for testing.
   me: Author!
+
+  # an even more nonsense self referential field
+  sillyMe: PostOrAuthor!
 }
 
 type EmptyType {


### PR DESCRIPTION
1. The recurse directive was not working properly if there was an `InlineFragments` in the recursive path.
2. Impose a maximum query depth of 4096 and panic if that's exceeded rather than leaving it to a stack overflow.  Hopefully that's enough for people though if not I can bump it up.
3. Fixed an issue where we could end up accidentally printing an empty inline fragment.

Fixes #838