### PR TITLE
Fix a bunch of unused warnings

### DIFF
--- a/cynic-codegen/src/fragment_derive/arguments/mod.rs
+++ b/cynic-codegen/src/fragment_derive/arguments/mod.rs
@@ -9,10 +9,7 @@ use crate::{
     schema::{Schema, Unvalidated},
 };
 
-pub use self::{
-    output::Output,
-    parsing::{arguments_from_field_attrs, FieldArgument},
-};
+pub use self::{output::Output, parsing::arguments_from_field_attrs};
 
 pub fn process_arguments<'a>(
     schema: &'a Schema<'a, Unvalidated>,

--- a/cynic-querygen/src/query_parsing/parser.rs
+++ b/cynic-querygen/src/query_parsing/parser.rs
@@ -1,5 +1,5 @@
-// Alias all the graphql_parser query types so we don't have to specify generic parameters
-// everywhere
+// Alias all the graphql_parser query types so we don't have to specify generic
+// parameters everywhere
 pub type Document<'a> = graphql_parser::query::Document<'a, &'a str>;
 pub type Definition<'a> = graphql_parser::query::Definition<'a, &'a str>;
 pub type FragmentDefinition<'a> = graphql_parser::query::FragmentDefinition<'a, &'a str>;
@@ -9,5 +9,3 @@ pub type Selection<'a> = graphql_parser::query::Selection<'a, &'a str>;
 pub type TypeCondition<'a> = graphql_parser::query::TypeCondition<'a, &'a str>;
 pub type Value<'a> = graphql_parser::query::Value<'a, &'a str>;
 pub type VariableDefinition<'a> = graphql_parser::query::VariableDefinition<'a, &'a str>;
-
-pub use graphql_parser::query::ParseError;

--- a/cynic-querygen/src/schema/mod.rs
+++ b/cynic-querygen/src/schema/mod.rs
@@ -4,6 +4,7 @@ mod type_index;
 mod type_refs;
 
 pub use fields::*;
+#[cfg(test)]
 pub use parser::Document;
 pub use type_index::{GraphPath, TypeIndex};
 pub use type_refs::{InputTypeRef, InterfaceTypeRef, OutputTypeRef, TypeRef};


### PR DESCRIPTION
Tried to start working on a PR but my VSCode reported some of warnings with the current code.

It looks like Rust has recently improved their unused code diagnosis, where before if something was `pub` but unused within the crate and *not reexported outside of the crate* it wouldn't show the warning, and now it does.