### PR TITLE
Remove needless `black_box` from benchmarks

### DIFF
--- a/cynic-parser/benches/executable.rs
+++ b/cynic-parser/benches/executable.rs
@@ -12,8 +12,7 @@ const QUERY: &str = include_str!("../tests/executables/kitchen-sink.graphql");
 
 #[divan::bench]
 fn cynic_parser() -> cynic_parser::ExecutableDocument {
-    let parsed = cynic_parser::parse_executable_document(QUERY).unwrap();
-    divan::black_box(parsed)
+    cynic_parser::parse_executable_document(QUERY).unwrap()
 }
 
 #[divan::bench(
@@ -26,19 +25,15 @@ fn graphql_parser<T>() -> graphql_parser::query::Document<'static, T>
 where
     T: graphql_parser::query::Text<'static>,
 {
-    let parsed = graphql_parser::parse_query(QUERY).unwrap();
-    divan::black_box(parsed)
+    graphql_parser::parse_query(QUERY).unwrap()
 }
 
 #[divan::bench]
 fn async_graphql_parser() -> async_graphql_parser::types::ExecutableDocument {
-    let parsed = async_graphql_parser::parse_query(QUERY).unwrap();
-    divan::black_box(parsed)
+    async_graphql_parser::parse_query(QUERY).unwrap()
 }
 
 #[divan::bench]
 fn apollo_parser() -> apollo_parser::SyntaxTree {
-    let parser = apollo_parser::Parser::new(QUERY);
-    let cst = parser.parse();
-    divan::black_box(cst)
+    apollo_parser::Parser::new(QUERY).parse()
 }

--- a/cynic-parser/benches/schema.rs
+++ b/cynic-parser/benches/schema.rs
@@ -12,8 +12,7 @@ const GITHUB_SCHEMA: &str = include_str!("../../schemas/github.graphql");
 
 #[divan::bench]
 fn cynic_parser() -> cynic_parser::TypeSystemDocument {
-    let parsed = cynic_parser::parse_type_system_document(GITHUB_SCHEMA).unwrap();
-    divan::black_box(parsed)
+    cynic_parser::parse_type_system_document(GITHUB_SCHEMA).unwrap()
 }
 
 #[divan::bench(
@@ -26,19 +25,15 @@ fn graphql_parser<T>() -> graphql_parser::schema::Document<'static, T>
 where
     T: graphql_parser::query::Text<'static>,
 {
-    let parsed = graphql_parser::parse_schema(GITHUB_SCHEMA).unwrap();
-    divan::black_box(parsed)
+    graphql_parser::parse_schema(GITHUB_SCHEMA).unwrap()
 }
 
 #[divan::bench]
 fn async_graphql_parser() -> async_graphql_parser::types::ServiceDocument {
-    let parsed = async_graphql_parser::parse_schema(GITHUB_SCHEMA).unwrap();
-    divan::black_box(parsed)
+    async_graphql_parser::parse_schema(GITHUB_SCHEMA).unwrap()
 }
 
 #[divan::bench]
 fn apollo_parser() -> apollo_parser::SyntaxTree {
-    let parser = apollo_parser::Parser::new(GITHUB_SCHEMA);
-    let cst = parser.parse();
-    divan::black_box(cst)
+    apollo_parser::Parser::new(GITHUB_SCHEMA).parse()
 }


### PR DESCRIPTION
Thanks for using Divan! I go around seeing how folks use it and noticed that your benchmark code could be improved a bit. 🙂

#### Why are we making this change?

Divan applies `black_box` to returned values, making it unnecessary to use in the benchmark body.

#### What effects does this change have?

This simplifies benchmarks.