### PR TITLE
snapshot test the introspection query

### DIFF
--- a/cynic-introspection/src/query.rs
+++ b/cynic-introspection/src/query.rs
@@ -207,3 +207,17 @@ pub enum TypeKind {
 
 #[cynic::schema("introspection")]
 pub(crate) mod schema {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn snapshot_test_query() {
+        use cynic::QueryBuilder;
+
+        let operation = IntrospectionQuery::build(());
+
+        insta::assert_snapshot!(operation.query);
+    }
+}

--- a/cynic-introspection/src/snapshots/cynic_introspection__query__tests__snapshot_test_query.snap
+++ b/cynic-introspection/src/snapshots/cynic_introspection__query__tests__snapshot_test_query.snap
@@ -1,0 +1,174 @@
+---
+source: cynic-introspection/src/query.rs
+expression: operation.query
+---
+query IntrospectionQuery {
+  __schema {
+    queryType {
+      name
+    }
+    mutationType {
+      name
+    }
+    subscriptionType {
+      name
+    }
+    types {
+      kind
+      name
+      description
+      fields(includeDeprecated: true) {
+        name
+        description
+        args {
+          name
+          description
+          type {
+            kind
+            name
+            ofType {
+              kind
+              name
+              ofType {
+                kind
+                name
+                ofType {
+                  kind
+                  name
+                  ofType {
+                    kind
+                    name
+                    ofType {
+                      kind
+                      name
+                      ofType {
+                        kind
+                        name
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+          defaultValue
+        }
+        type {
+          kind
+          name
+          ofType {
+            kind
+            name
+            ofType {
+              kind
+              name
+              ofType {
+                kind
+                name
+                ofType {
+                  kind
+                  name
+                  ofType {
+                    kind
+                    name
+                    ofType {
+                      kind
+                      name
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+        isDeprecated
+        deprecationReason
+      }
+      inputFields {
+        name
+        description
+        type {
+          kind
+          name
+          ofType {
+            kind
+            name
+            ofType {
+              kind
+              name
+              ofType {
+                kind
+                name
+                ofType {
+                  kind
+                  name
+                  ofType {
+                    kind
+                    name
+                    ofType {
+                      kind
+                      name
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+        defaultValue
+      }
+      interfaces {
+        name
+      }
+      enumValues(includeDeprecated: true) {
+        name
+        description
+        isDeprecated
+        deprecationReason
+      }
+      possibleTypes {
+        name
+      }
+    }
+    directives {
+      name
+      description
+      args {
+        name
+        description
+        type {
+          kind
+          name
+          ofType {
+            kind
+            name
+            ofType {
+              kind
+              name
+              ofType {
+                kind
+                name
+                ofType {
+                  kind
+                  name
+                  ofType {
+                    kind
+                    name
+                    ofType {
+                      kind
+                      name
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+        defaultValue
+      }
+      locations
+    }
+  }
+}
+
+


### PR DESCRIPTION
It's good to double check on any changes that happen in the query, and it's nice to have somewhere to copy the query from should you need to run it manually.