### PR TITLE
generate executable ast in cynic-parser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 .DS_Store
 
 .envrc
+
+output

--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,3 @@
 .DS_Store
 
 .envrc
-
-output

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -235,6 +235,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 
 [[package]]
+name = "ast-generator"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "cynic-parser",
+ "indexmap 2.1.0",
+ "indoc",
+ "itertools 0.12.1",
+ "proc-macro2",
+ "quote",
+ "xshell",
+]
+
+[[package]]
 name = "async-channel"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2098,6 +2112,15 @@ name = "itertools"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
 dependencies = [
  "either",
 ]
@@ -4449,6 +4472,21 @@ checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
 ]
+
+[[package]]
+name = "xshell"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2107fe03e558353b4c71ad7626d58ed82efaf56c54134228608893c77023ad"
+dependencies = [
+ "xshell-macros",
+]
+
+[[package]]
+name = "xshell-macros"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e2c411759b501fb9501aac2b1b2d287a6e93e5bdcf13c25306b23e1b716dd0e"
 
 [[package]]
 name = "yaml-rust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,8 @@ members = [
     "schemas/github",
     "tests/querygen-compile-run",
     "tests/ui-tests",
-    "cynic-parser"
+    "cynic-parser",
+    "cynic-parser/ast-generator"
 ]
 exclude = ["cynic-parser/parser-generator"]
 resolver = "2"

--- a/cynic-parser/ast-generator/.gitignore
+++ b/cynic-parser/ast-generator/.gitignore
@@ -1,0 +1,2 @@
+/target
+/Cargo.lock

--- a/cynic-parser/ast-generator/.gitignore
+++ b/cynic-parser/ast-generator/.gitignore
@@ -1,2 +1,4 @@
 /target
 /Cargo.lock
+
+output/**

--- a/cynic-parser/ast-generator/Cargo.toml
+++ b/cynic-parser/ast-generator/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "ast-generator"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+anyhow = "1"
+indexmap = "2"
+indoc = "2"
+itertools = "0.12"
+proc-macro2 = "1"
+quote = "1"
+xshell = "0.2"
+
+cynic-parser.path = "../"
+cynic-parser.features = ["report"]

--- a/cynic-parser/ast-generator/domain/executable.graphql
+++ b/cynic-parser/ast-generator/domain/executable.graphql
@@ -1,0 +1,59 @@
+scalar String
+
+scalar OperationType @inline
+
+# Think this one should be done by hand
+# as it doesnt exist in storage.
+# union ExecutableDefinition = OperationDefintion | FragmentDefinition
+
+type OperationDefinition @file(name: "operation") {
+  operation_type: OperationType
+  name: String!
+  variable_definitions: [VariableDefinition]
+  directives: [Directive]
+  selection_set: [Selection]
+}
+
+type FragmentDefinition @file(name: "fragment") {
+  name: String!
+  type_condition: String
+  directives: [Directive]
+  selection_set: [Selection]
+}
+
+union Selection = FieldSelection | InlineFragment | FragmentSpread
+
+type FieldSelection {
+  alias: String
+  name: String!
+  arguments: [Argument]
+  directives: [Directive]
+  selection_set: [Selection]
+}
+
+type InlineFragment {
+  type_condition: String
+  directives: [Directive]
+  selection_set: [Selection]
+}
+
+type FragmentSpread {
+  fragment_name: String!
+  directives: [Directive]
+}
+
+type Directive {
+  name: String!
+  value: Value!
+}
+
+type Argument {
+  name: String!
+  value: Value!
+}
+
+type VariableDefinition
+
+scalar Type
+
+type Value

--- a/cynic-parser/ast-generator/domain/executable.graphql
+++ b/cynic-parser/ast-generator/domain/executable.graphql
@@ -7,8 +7,8 @@ scalar OperationType @inline
 # union ExecutableDefinition = OperationDefintion | FragmentDefinition
 
 type OperationDefinition @file(name: "operation") {
-  operation_type: OperationType
-  name: String!
+  operation_type: OperationType!
+  name: String
   variable_definitions: [VariableDefinition]
   directives: [Directive]
   selection_set: [Selection]
@@ -21,9 +21,12 @@ type FragmentDefinition @file(name: "fragment") {
   selection_set: [Selection]
 }
 
-union Selection = FieldSelection | InlineFragment | FragmentSpread
+union Selection @file(name: "selections") =
+    FieldSelection
+  | InlineFragment
+  | FragmentSpread
 
-type FieldSelection {
+type FieldSelection @file(name: "selections") {
   alias: String
   name: String!
   arguments: [Argument]
@@ -31,28 +34,33 @@ type FieldSelection {
   selection_set: [Selection]
 }
 
-type InlineFragment {
+type InlineFragment @file(name: "selections") {
   type_condition: String
   directives: [Directive]
   selection_set: [Selection]
 }
 
-type FragmentSpread {
+type FragmentSpread @file(name: "selections") {
   fragment_name: String!
   directives: [Directive]
 }
 
-type Directive {
+type Directive @file(name: "directive") {
+  name: String!
+  arguments: [Argument]
+}
+
+type Argument @file(name: "argument") {
   name: String!
   value: Value!
 }
 
-type Argument {
+type VariableDefinition @file(name: "variable") {
   name: String!
-  value: Value!
+  ty: Type!
+  default_value: Value
+  directives: [Directive]
 }
-
-type VariableDefinition
 
 scalar Type
 

--- a/cynic-parser/ast-generator/domain/executable.graphql
+++ b/cynic-parser/ast-generator/domain/executable.graphql
@@ -64,4 +64,4 @@ type VariableDefinition @file(name: "variable") {
 
 scalar Type
 
-type Value
+scalar Value @file(name: "value")

--- a/cynic-parser/ast-generator/domain/executable.graphql
+++ b/cynic-parser/ast-generator/domain/executable.graphql
@@ -62,6 +62,6 @@ type VariableDefinition @file(name: "variable") {
   directives: [Directive]
 }
 
-scalar Type
+scalar Type @file(name: "types")
 
 scalar Value @file(name: "value")

--- a/cynic-parser/ast-generator/domain/executable.graphql
+++ b/cynic-parser/ast-generator/domain/executable.graphql
@@ -16,7 +16,7 @@ type OperationDefinition @file(name: "operation") {
 
 type FragmentDefinition @file(name: "fragment") {
   name: String!
-  type_condition: String
+  type_condition: String!
   directives: [Directive]
   selection_set: [Selection]
 }

--- a/cynic-parser/ast-generator/domain/executable.graphql
+++ b/cynic-parser/ast-generator/domain/executable.graphql
@@ -1,10 +1,7 @@
-scalar String
+# Defines most of the executable AST.
+# The ast-generator reads this file and uses it to generate a ton of boilerplate
 
-scalar OperationType @inline
-
-# Think this one should be done by hand
-# as it doesnt exist in storage.
-# union ExecutableDefinition = OperationDefintion | FragmentDefinition
+# TODO: Generate ExecutableDefinition (it's totally possible I think)
 
 type OperationDefinition @file(name: "operation") {
   operation_type: OperationType!
@@ -62,6 +59,15 @@ type VariableDefinition @file(name: "variable") {
   directives: [Directive]
 }
 
-scalar Type @file(name: "types")
+# OperationType is marked as @inline which means it just gets
+# stored inside records instead of getting IDs & records.
+scalar OperationType @inline
 
+# Type & Value are kind of special cases that aren't worth automating
+# so we make them scalars and implement them by hand
+scalar Type @file(name: "types")
 scalar Value @file(name: "value")
+
+# String is built in, but easier to implement stuff if its just in the .graphql file
+# It is also special cased a bit in the rust code
+scalar String

--- a/cynic-parser/ast-generator/src/exts.rs
+++ b/cynic-parser/ast-generator/src/exts.rs
@@ -1,13 +1,22 @@
 use cynic_parser::type_system::{readers::ScalarDefinition, TypeDefinition};
+use quote::quote;
 
 pub trait ScalarExt {
     fn is_inline(&self) -> bool;
+    fn reader_fn_override(&self) -> Option<proc_macro2::TokenStream>;
 }
 
 impl ScalarExt for ScalarDefinition<'_> {
     fn is_inline(&self) -> bool {
         self.directives()
             .any(|directive| directive.name() == "inline")
+    }
+
+    fn reader_fn_override(&self) -> Option<proc_macro2::TokenStream> {
+        if self.name() == "String" {
+            return Some(quote! { &'a str });
+        }
+        None
     }
 }
 

--- a/cynic-parser/ast-generator/src/exts.rs
+++ b/cynic-parser/ast-generator/src/exts.rs
@@ -1,0 +1,25 @@
+use cynic_parser::type_system::{readers::ScalarDefinition, TypeDefinition};
+
+pub trait ScalarExt {
+    fn is_inline(&self) -> bool;
+}
+
+impl ScalarExt for ScalarDefinition<'_> {
+    fn is_inline(&self) -> bool {
+        self.directives()
+            .any(|directive| directive.name() == "inline")
+    }
+}
+
+pub trait FileDirectiveExt<'a> {
+    fn file_name(&self) -> &'a str;
+}
+
+impl<'a> FileDirectiveExt<'a> for TypeDefinition<'a> {
+    fn file_name(&self) -> &'a str {
+        self.directives()
+            .find(|directive| directive.name() == "file")
+            .and_then(|directive| directive.arguments().next()?.value().as_str())
+            .unwrap_or(self.name())
+    }
+}

--- a/cynic-parser/ast-generator/src/file.rs
+++ b/cynic-parser/ast-generator/src/file.rs
@@ -1,0 +1,88 @@
+use std::collections::{BTreeSet, HashSet};
+
+use cynic_parser::type_system::TypeDefinition;
+use proc_macro2::{Ident, Span};
+use quote::quote;
+
+use crate::{
+    exts::{FileDirectiveExt, ScalarExt},
+    format_code,
+    idents::IdIdent,
+};
+
+#[derive(Clone, Debug, PartialEq, PartialOrd, Ord, Eq)]
+pub struct EntityRef {
+    module_name: String,
+    name: String,
+    has_id: bool,
+}
+
+impl EntityRef {
+    pub fn new(ty: TypeDefinition<'_>) -> Option<Self> {
+        match ty {
+            TypeDefinition::Scalar(scalar) if scalar.is_inline() => None,
+            TypeDefinition::Scalar(scalar) => Some(EntityRef {
+                module_name: ty.file_name().to_string(),
+                name: ty.name().to_string(),
+                has_id: true,
+            }),
+            TypeDefinition::Object(_) => Some(EntityRef {
+                module_name: ty.file_name().to_string(),
+                name: ty.name().to_string(),
+                has_id: true,
+            }),
+            TypeDefinition::Union(_) => Some(EntityRef {
+                module_name: ty.file_name().to_string(),
+                name: ty.name().to_string(),
+                has_id: true,
+            }),
+            _ => unimplemented!(),
+        }
+    }
+}
+
+pub struct EntityOutput {
+    pub requires: BTreeSet<EntityRef>,
+    pub id: EntityRef,
+    pub contents: String,
+}
+
+pub fn imports(
+    mut requires: BTreeSet<EntityRef>,
+    current_file_entities: Vec<EntityRef>,
+) -> anyhow::Result<String> {
+    for id in &current_file_entities {
+        requires.remove(id);
+    }
+
+    let reader_imports = requires
+        .iter()
+        .map(|entity| {
+            let module_name = Ident::new(&entity.module_name, Span::call_site());
+            let entity_name = Ident::new(&entity.name, Span::call_site());
+            quote! { #module_name::#entity_name, }
+        })
+        .collect::<Vec<_>>();
+
+    let id_imports = requires
+        .iter()
+        .chain(current_file_entities.iter())
+        .map(|entity| IdIdent(&entity.name))
+        .map(|id| {
+            quote! { #id, }
+        })
+        .collect::<Vec<_>>();
+
+    format_code(quote! {
+        #[allow(unused_import)]
+        use crate::{
+            common::{IdRange, OperationType},
+            AstLookup,
+        };
+
+        use super::{
+            #(#reader_imports)*
+            ids::{#(#id_imports)*}
+        };
+    })
+}

--- a/cynic-parser/ast-generator/src/file.rs
+++ b/cynic-parser/ast-generator/src/file.rs
@@ -51,6 +51,7 @@ pub struct EntityOutput {
 pub fn imports(
     mut requires: BTreeSet<EntityRef>,
     current_file_entities: Vec<EntityRef>,
+    id_trait: &str,
 ) -> anyhow::Result<String> {
     for id in &current_file_entities {
         requires.remove(id);
@@ -74,6 +75,8 @@ pub fn imports(
         })
         .collect::<Vec<_>>();
 
+    let id_trait = Ident::new(id_trait, Span::call_site());
+
     format_code(quote! {
         #[allow(unused_imports)]
         use crate::{
@@ -85,7 +88,8 @@ pub fn imports(
 
         use super::{
             #(#reader_imports)*
-            ids::{#(#id_imports)*}
+            ids::{#(#id_imports)*},
+            ReadContext, #id_trait
         };
     })
 }

--- a/cynic-parser/ast-generator/src/file.rs
+++ b/cynic-parser/ast-generator/src/file.rs
@@ -80,6 +80,8 @@ pub fn imports(
             common::{IdRange, OperationType},
             AstLookup,
         };
+        #[allow(unused_imports)]
+        use super::ids::StringId;
 
         use super::{
             #(#reader_imports)*

--- a/cynic-parser/ast-generator/src/file.rs
+++ b/cynic-parser/ast-generator/src/file.rs
@@ -21,6 +21,7 @@ impl EntityRef {
     pub fn new(ty: TypeDefinition<'_>) -> Option<Self> {
         match ty {
             TypeDefinition::Scalar(scalar) if scalar.is_inline() => None,
+            TypeDefinition::Scalar(scalar) if scalar.reader_fn_override().is_some() => None,
             TypeDefinition::Scalar(_) => Some(EntityRef {
                 module_name: ty.file_name().to_string(),
                 name: ty.name().to_string(),
@@ -74,7 +75,7 @@ pub fn imports(
         .collect::<Vec<_>>();
 
     format_code(quote! {
-        #[allow(unused_import)]
+        #[allow(unused_imports)]
         use crate::{
             common::{IdRange, OperationType},
             AstLookup,

--- a/cynic-parser/ast-generator/src/file.rs
+++ b/cynic-parser/ast-generator/src/file.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeSet, HashSet};
+use std::collections::BTreeSet;
 
 use cynic_parser::type_system::TypeDefinition;
 use proc_macro2::{Ident, Span};
@@ -21,7 +21,7 @@ impl EntityRef {
     pub fn new(ty: TypeDefinition<'_>) -> Option<Self> {
         match ty {
             TypeDefinition::Scalar(scalar) if scalar.is_inline() => None,
-            TypeDefinition::Scalar(scalar) => Some(EntityRef {
+            TypeDefinition::Scalar(_) => Some(EntityRef {
                 module_name: ty.file_name().to_string(),
                 name: ty.name().to_string(),
                 has_id: true,

--- a/cynic-parser/ast-generator/src/idents.rs
+++ b/cynic-parser/ast-generator/src/idents.rs
@@ -1,0 +1,13 @@
+use proc_macro2::{Ident, Span};
+use quote::{quote, TokenStreamExt};
+
+#[derive(Clone, Copy)]
+pub struct IdIdent<'a>(pub &'a str);
+
+impl quote::ToTokens for IdIdent<'_> {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        let ident = Ident::new(&format!("{}Id", self.0), Span::call_site());
+
+        tokens.append_all(quote! { #ident })
+    }
+}

--- a/cynic-parser/ast-generator/src/main.rs
+++ b/cynic-parser/ast-generator/src/main.rs
@@ -1,0 +1,87 @@
+mod idents;
+mod object;
+
+use indexmap::IndexMap;
+use itertools::Itertools;
+use proc_macro2::{Ident, Span};
+use quote::{quote, TokenStreamExt};
+use std::{collections::HashMap, ops::Deref};
+
+use cynic_parser::type_system::{
+    readers::{FieldDefinition, ObjectDefinition},
+    Definition, TypeDefinition,
+};
+
+use crate::idents::IdIdent;
+
+fn main() -> anyhow::Result<()> {
+    eprintln!("{:?}", std::env::current_dir());
+    for module in ["executable", "type_system"] {
+        let document =
+            std::fs::read_to_string("cynic-parser/ast-generator/domain/executable.graphql")?;
+
+        let domain = match cynic_parser::parse_type_system_document(&document) {
+            Ok(domain) => domain,
+            Err(error) => {
+                eprintln!("Error parsing document");
+                eprintln!("{}", error.to_report(&document));
+                return Err(anyhow::anyhow!(""));
+            }
+        };
+
+        let mut model_index = IndexMap::new();
+
+        for definition in domain.definitions() {
+            match definition {
+                Definition::Type(ty) => {
+                    model_index.insert(ty.name(), ty);
+                }
+                _ => anyhow::bail!("unsupported definition"),
+            }
+        }
+
+        let outputs = model_index
+            .iter()
+            .map(|(name, model)| {
+                let output = match model {
+                    TypeDefinition::Object(object) => object::object_output(*object, &model_index)?,
+                    TypeDefinition::Scalar(_) => {
+                        return Ok(None);
+                    }
+                    TypeDefinition::Union(_) => {
+                        // TODO
+                        return Ok(None);
+                    }
+                    _ => anyhow::bail!("unsupported definition"),
+                };
+
+                let file_name = model
+                    .directives()
+                    .find(|directive| directive.name() == "file")
+                    .and_then(|directive| directive.arguments().next()?.value().as_str())
+                    .unwrap_or(name);
+
+                Ok(Some((file_name, output)))
+            })
+            .filter_map(Result::transpose)
+            .collect::<Result<Vec<(_, _)>, _>>()
+            .unwrap()
+            .into_iter()
+            .into_group_map();
+
+        for (name, output) in outputs {
+            println!("Output for {name}:\n\n{output}\n\n");
+        }
+    }
+
+    Ok(())
+}
+
+fn format_code(text: impl ToString) -> anyhow::Result<String> {
+    use xshell::{cmd, Shell};
+    let sh = Shell::new()?;
+
+    let stdout = cmd!(sh, "rustfmt").stdin(&text.to_string()).read()?;
+
+    Ok(stdout)
+}

--- a/cynic-parser/ast-generator/src/main.rs
+++ b/cynic-parser/ast-generator/src/main.rs
@@ -2,6 +2,7 @@ mod exts;
 mod file;
 mod idents;
 mod object;
+mod union;
 
 use indexmap::IndexMap;
 use indoc::formatdoc;
@@ -44,17 +45,14 @@ fn main() -> anyhow::Result<()> {
         }
 
         let outputs = model_index
-            .iter()
-            .map(|(name, model)| {
+            .values()
+            .map(|model| {
                 let output = match model {
                     TypeDefinition::Object(object) => object::object_output(*object, &model_index)?,
                     TypeDefinition::Scalar(_) => {
                         return Ok(None);
                     }
-                    TypeDefinition::Union(_) => {
-                        // TODO
-                        return Ok(None);
-                    }
+                    TypeDefinition::Union(union) => union::union_output(*union, &model_index)?,
                     _ => anyhow::bail!("unsupported definition"),
                 };
 

--- a/cynic-parser/ast-generator/src/main.rs
+++ b/cynic-parser/ast-generator/src/main.rs
@@ -66,7 +66,11 @@ fn main() -> anyhow::Result<()> {
                 .collect();
             let current_entities = output.iter().map(|entity| entity.id.clone()).collect();
 
-            let imports = imports(requires, current_entities).unwrap();
+            let id_trait = match module {
+                "executable" => "ExecutableId",
+                _ => todo!(),
+            };
+            let imports = imports(requires, current_entities, id_trait).unwrap();
 
             let doc = formatdoc!(
                 r#"

--- a/cynic-parser/ast-generator/src/main.rs
+++ b/cynic-parser/ast-generator/src/main.rs
@@ -14,9 +14,10 @@ use crate::{exts::FileDirectiveExt, file::imports};
 
 fn main() -> anyhow::Result<()> {
     eprintln!("{:?}", std::env::current_dir());
-    for module in ["executable", "type_system"] {
-        let document =
-            std::fs::read_to_string("cynic-parser/ast-generator/domain/executable.graphql")?;
+    for module in ["executable"] {
+        let document = std::fs::read_to_string(format!(
+            "cynic-parser/ast-generator/domain/{module}.graphql"
+        ))?;
 
         let domain = match cynic_parser::parse_type_system_document(&document) {
             Ok(domain) => domain,
@@ -79,7 +80,11 @@ fn main() -> anyhow::Result<()> {
                     .join("\n\n")
             );
 
-            std::fs::write(format!("output/{file_name}.rs"), doc).unwrap();
+            std::fs::write(
+                format!("cynic-parser/ast-generator/output/{module}/{file_name}.rs"),
+                doc,
+            )
+            .unwrap();
         }
     }
 

--- a/cynic-parser/ast-generator/src/main.rs
+++ b/cynic-parser/ast-generator/src/main.rs
@@ -72,17 +72,18 @@ fn main() -> anyhow::Result<()> {
             };
             let imports = imports(requires, current_entities, id_trait).unwrap();
 
-            let doc = formatdoc!(
+            let doc = format_code(formatdoc!(
                 r#"
                 {imports}
 
                 {}
-            "#,
+                "#,
                 output
                     .into_iter()
                     .map(|entity| entity.contents)
                     .join("\n\n")
-            );
+            ))
+            .unwrap();
 
             std::fs::write(
                 format!("cynic-parser/ast-generator/output/{module}/{file_name}.rs"),

--- a/cynic-parser/ast-generator/src/main.rs
+++ b/cynic-parser/ast-generator/src/main.rs
@@ -7,16 +7,10 @@ mod union;
 use indexmap::IndexMap;
 use indoc::formatdoc;
 use itertools::Itertools;
-use proc_macro2::{Ident, Span};
-use quote::{quote, TokenStreamExt};
-use std::{collections::HashMap, ops::Deref};
 
-use cynic_parser::type_system::{
-    readers::{FieldDefinition, ObjectDefinition},
-    Definition, TypeDefinition,
-};
+use cynic_parser::type_system::{Definition, TypeDefinition};
 
-use crate::{exts::FileDirectiveExt, file::imports, idents::IdIdent};
+use crate::{exts::FileDirectiveExt, file::imports};
 
 fn main() -> anyhow::Result<()> {
     eprintln!("{:?}", std::env::current_dir());

--- a/cynic-parser/ast-generator/src/main.rs
+++ b/cynic-parser/ast-generator/src/main.rs
@@ -69,8 +69,8 @@ fn main() -> anyhow::Result<()> {
             .into_iter()
             .into_group_map();
 
-        for (name, output) in outputs {
-            println!("Output for {name}:\n\n{output}\n\n");
+        for (file_name, output) in outputs {
+            std::fs::write(format!("output/{file_name}.rs"), output.join("\n\n")).unwrap();
         }
     }
 

--- a/cynic-parser/ast-generator/src/object.rs
+++ b/cynic-parser/ast-generator/src/object.rs
@@ -39,7 +39,6 @@ pub fn object_output(
     let record_fields = edges.iter().copied().map(ObjectField);
     let reader_functions = edges.iter().copied().map(ReaderFunction);
 
-    // TODO: Split these up and format individually
     let record = format_code(quote! {
         pub struct #record_name {
             #(#record_fields),*

--- a/cynic-parser/ast-generator/src/object.rs
+++ b/cynic-parser/ast-generator/src/object.rs
@@ -145,8 +145,8 @@ impl quote::ToTokens for ReaderFunction<'_> {
                     .directives()
                     .any(|directive| directive.name() == "inline") =>
             {
-                // For now I'm not generating scalar accessors, will revisit
-                return;
+                // I'm assuming inline scalars are copy here.
+                quote! { #target_type }
             }
             TypeDefinition::Object(_) | TypeDefinition::Union(_) | TypeDefinition::Scalar(_)
                 if self.0.field.ty().is_list() =>
@@ -172,8 +172,12 @@ impl quote::ToTokens for ReaderFunction<'_> {
                     .directives()
                     .any(|directive| directive.name() == "inline") =>
             {
-                // For now I'm not generating scalar accessors, will revisit
-                return;
+                // I'm assuming inline scalars are copy here.
+                quote! {
+                    let document = self.0.document;
+
+                    document.lookup(self.0.id).#field_name
+                }
             }
             TypeDefinition::Object(_) | TypeDefinition::Union(_) | TypeDefinition::Scalar(_)
                 if self.0.field.ty().is_list() =>
@@ -204,7 +208,7 @@ impl quote::ToTokens for ReaderFunction<'_> {
         };
 
         tokens.append_all(quote! {
-            fn #field_name(&self) -> #ty {
+            pub fn #field_name(&self) -> #ty {
                 #body
             }
         });

--- a/cynic-parser/ast-generator/src/object.rs
+++ b/cynic-parser/ast-generator/src/object.rs
@@ -42,6 +42,7 @@ pub fn object_output(
     })?;
 
     let reader = format_code(quote! {
+        #[derive(Clone, Copy)]
         pub struct #reader_name<'a>(ReadContext<'a, #id_name>);
     })?;
 
@@ -58,7 +59,7 @@ pub fn object_output(
     })?;
 
     let from_impl = format_code(quote! {
-        impl <'a> From<ReadContext<'a, #id_name>> for FieldSelection<'a> {
+        impl <'a> From<ReadContext<'a, #id_name>> for #reader_name<'a> {
             fn from(value: ReadContext<'a, #id_name>) -> Self {
                 Self(value)
             }
@@ -126,7 +127,7 @@ impl quote::ToTokens for ObjectField<'_> {
         };
 
         tokens.append_all(quote! {
-            #field_name: #ty
+            pub #field_name: #ty
         });
     }
 }

--- a/cynic-parser/ast-generator/src/object.rs
+++ b/cynic-parser/ast-generator/src/object.rs
@@ -1,0 +1,211 @@
+use indexmap::IndexMap;
+use proc_macro2::{Ident, Span};
+use quote::{quote, TokenStreamExt};
+
+use cynic_parser::type_system::{
+    readers::{FieldDefinition, ObjectDefinition},
+    TypeDefinition,
+};
+
+use crate::{format_code, idents::IdIdent};
+
+pub fn object_output(
+    object: ObjectDefinition<'_>,
+    model_index: &IndexMap<&str, TypeDefinition<'_>>,
+) -> anyhow::Result<String> {
+    let record_name = Ident::new(&format!("{}Record", object.name()), Span::call_site());
+    let reader_name = Ident::new(object.name(), Span::call_site());
+    let id_name = IdIdent(object.name());
+
+    let edges = object
+        .fields()
+        .map(|field| -> anyhow::Result<FieldEdge> {
+            Ok(FieldEdge {
+                container: object,
+                field,
+                target: *model_index
+                    .get(field.ty().name())
+                    .ok_or_else(|| anyhow::anyhow!("Could not find type {}", field.ty().name()))?,
+            })
+        })
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap();
+
+    let record_fields = edges.iter().copied().map(ObjectField);
+    let reader_functions = edges.iter().copied().map(ReaderFunction);
+
+    // TODO: Split these up and format individually
+    let record = format_code(quote! {
+        pub struct #record_name {
+            #(#record_fields),*
+        }
+    })?;
+
+    let reader = format_code(quote! {
+        pub struct #reader_name<'a>(ReadContext<'a, #id_name>);
+    })?;
+
+    let reader_impl = format_code(quote! {
+        impl <'a> #reader_name<'a> {
+            #(#reader_functions)*
+        }
+    })?;
+
+    let executable_id = format_code(quote! {
+        impl ExecutableId for #id_name {
+            type Reader<'a> = #reader_name<'a>;
+        }
+    })?;
+
+    let from_impl = format_code(quote! {
+        impl <'a> From<ReadContext<'a, #id_name>> for FieldSelection<'a> {
+            fn from(value: ReadContext<'a, #id_name>) -> Self {
+                Self(value)
+            }
+        }
+    })?;
+
+    Ok(indoc::formatdoc!(
+        r#"
+        {record}
+
+        {reader}
+
+        {reader_impl}
+
+        {executable_id}
+
+        {from_impl}
+    "#
+    ))
+}
+
+#[derive(Clone, Copy)]
+pub struct FieldEdge<'a> {
+    container: ObjectDefinition<'a>,
+    field: FieldDefinition<'a>,
+    target: TypeDefinition<'a>,
+}
+
+pub struct ObjectField<'a>(FieldEdge<'a>);
+
+impl quote::ToTokens for ObjectField<'_> {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        let field_name = Ident::new(self.0.field.name(), Span::call_site());
+
+        let target_id = IdIdent(self.0.target.name());
+        let ty = match self.0.target {
+            TypeDefinition::Scalar(scalar)
+                if scalar
+                    .directives()
+                    .any(|directive| directive.name() == "inline") =>
+            {
+                let ident = Ident::new(self.0.target.name(), Span::call_site());
+                if self.0.field.ty().is_non_null() {
+                    quote! { #ident }
+                } else {
+                    quote! { Option<#ident> }
+                }
+            }
+            TypeDefinition::Object(_) | TypeDefinition::Union(_) | TypeDefinition::Scalar(_)
+                if self.0.field.ty().is_list() =>
+            {
+                quote! {
+                    IdRange<#target_id>
+                }
+            }
+            TypeDefinition::Object(_) | TypeDefinition::Union(_) | TypeDefinition::Scalar(_)
+                if self.0.field.ty().is_non_null() =>
+            {
+                quote! { #target_id }
+            }
+            TypeDefinition::Object(_) | TypeDefinition::Union(_) | TypeDefinition::Scalar(_) => {
+                quote! { Option<#target_id> }
+            }
+            _ => unimplemented!("No support for this target type"),
+        };
+
+        tokens.append_all(quote! {
+            #field_name: #ty
+        });
+    }
+}
+
+pub struct ReaderFunction<'a>(FieldEdge<'a>);
+
+impl quote::ToTokens for ReaderFunction<'_> {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        let field_name = Ident::new(self.0.field.name(), Span::call_site());
+        let target_type = Ident::new(self.0.target.name(), Span::call_site());
+
+        let ty = match self.0.target {
+            TypeDefinition::Scalar(scalar)
+                if scalar
+                    .directives()
+                    .any(|directive| directive.name() == "inline") =>
+            {
+                // For now I'm not generating scalar accessors, will revisit
+                return;
+            }
+            TypeDefinition::Object(_) | TypeDefinition::Union(_) | TypeDefinition::Scalar(_)
+                if self.0.field.ty().is_list() =>
+            {
+                quote! {
+                    impl ExactSizeIterator<Item = #target_type<'a>>
+                }
+            }
+            TypeDefinition::Object(_) | TypeDefinition::Union(_) | TypeDefinition::Scalar(_)
+                if self.0.field.ty().is_non_null() =>
+            {
+                quote! { #target_type<'a> }
+            }
+            TypeDefinition::Object(_) | TypeDefinition::Union(_) | TypeDefinition::Scalar(_) => {
+                quote! { Option<#target_type<'a>> }
+            }
+            _ => unimplemented!("No support for this target type"),
+        };
+
+        let body = match self.0.target {
+            TypeDefinition::Scalar(scalar)
+                if scalar
+                    .directives()
+                    .any(|directive| directive.name() == "inline") =>
+            {
+                // For now I'm not generating scalar accessors, will revisit
+                return;
+            }
+            TypeDefinition::Object(_) | TypeDefinition::Union(_) | TypeDefinition::Scalar(_)
+                if self.0.field.ty().is_list() =>
+            {
+                quote! {
+                    let document = self.0.document;
+
+                    document.lookup(self.0.id).#field_name.iter().map(|id| document.read(id))
+                }
+            }
+            TypeDefinition::Object(_) | TypeDefinition::Union(_) | TypeDefinition::Scalar(_)
+                if self.0.field.ty().is_non_null() =>
+            {
+                quote! {
+                    let document = self.0.document;
+
+                    document.read(document.lookup(self.0.id).#field_name)
+                }
+            }
+            TypeDefinition::Object(_) | TypeDefinition::Union(_) | TypeDefinition::Scalar(_) => {
+                quote! {
+                    let document = self.0.document;
+
+                    document.lookup(self.0.id).#field_name.map(|id| document.read(id))
+                }
+            }
+            _ => unimplemented!("No support for this target type"),
+        };
+
+        tokens.append_all(quote! {
+            fn #field_name(&self) -> #ty {
+                #body
+            }
+        });
+    }
+}

--- a/cynic-parser/ast-generator/src/union.rs
+++ b/cynic-parser/ast-generator/src/union.rs
@@ -2,13 +2,9 @@ use indexmap::IndexMap;
 use proc_macro2::{Ident, Span};
 use quote::{quote, TokenStreamExt};
 
-use cynic_parser::type_system::{
-    readers::{FieldDefinition, ObjectDefinition, UnionDefinition},
-    TypeDefinition,
-};
+use cynic_parser::type_system::{readers::UnionDefinition, TypeDefinition};
 
 use crate::{
-    exts::ScalarExt,
     file::{EntityOutput, EntityRef},
     format_code,
     idents::IdIdent,
@@ -133,7 +129,6 @@ impl quote::ToTokens for FromBranch<'_> {
         );
         let this_reader = Ident::new(self.0.container.name(), Span::call_site());
         let variant_name = Ident::new(self.0.target.name(), Span::call_site());
-        let reader = Ident::new(self.0.target.name(), Span::call_site());
 
         tokens.append_all(quote! {
             #this_record::#variant_name(id) => #this_reader::#variant_name(id)

--- a/cynic-parser/ast-generator/src/union.rs
+++ b/cynic-parser/ast-generator/src/union.rs
@@ -131,7 +131,7 @@ impl quote::ToTokens for FromBranch<'_> {
         let variant_name = Ident::new(self.0.target.name(), Span::call_site());
 
         tokens.append_all(quote! {
-            #this_record::#variant_name(id) => #this_reader::#variant_name(id)
+            #this_record::#variant_name(id) => #this_reader::#variant_name(value.document.read(*id))
         });
     }
 }

--- a/cynic-parser/ast-generator/src/union.rs
+++ b/cynic-parser/ast-generator/src/union.rs
@@ -1,0 +1,142 @@
+use indexmap::IndexMap;
+use proc_macro2::{Ident, Span};
+use quote::{quote, TokenStreamExt};
+
+use cynic_parser::type_system::{
+    readers::{FieldDefinition, ObjectDefinition, UnionDefinition},
+    TypeDefinition,
+};
+
+use crate::{
+    exts::ScalarExt,
+    file::{EntityOutput, EntityRef},
+    format_code,
+    idents::IdIdent,
+};
+
+pub fn union_output(
+    object: UnionDefinition<'_>,
+    model_index: &IndexMap<&str, TypeDefinition<'_>>,
+) -> anyhow::Result<EntityOutput> {
+    let record_name = Ident::new(&format!("{}Record", object.name()), Span::call_site());
+    let reader_name = Ident::new(object.name(), Span::call_site());
+    let id_name = IdIdent(object.name());
+
+    let edges = object
+        .members()
+        .map(|ty| -> anyhow::Result<TypeEdge> {
+            Ok(TypeEdge {
+                container: object,
+                target: *model_index
+                    .get(ty)
+                    .ok_or_else(|| anyhow::anyhow!("Could not find type {ty}"))?,
+            })
+        })
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap();
+
+    let record_variants = edges.iter().copied().map(RecordVariant);
+    let reader_variants = edges.iter().copied().map(ReaderVariant);
+    let from_branches = edges.iter().copied().map(FromBranch);
+
+    let record = format_code(quote! {
+        pub enum #record_name {
+            #(#record_variants),*
+        }
+    })?;
+
+    let reader = format_code(quote! {
+        #[derive(Clone, Copy)]
+        pub enum #reader_name<'a> {
+            #(#reader_variants),*
+        }
+    })?;
+
+    let executable_id = format_code(quote! {
+        impl ExecutableId for #id_name {
+            type Reader<'a> = #reader_name<'a>;
+        }
+    })?;
+
+    let from_impl = format_code(quote! {
+        impl <'a> From<ReadContext<'a, #id_name>> for #reader_name<'a> {
+            fn from(value: ReadContext<'a, #id_name>) -> Self {
+                match value.document.lookup(value.id) {
+                    #(#from_branches),*
+                }
+            }
+        }
+    })?;
+
+    let contents = indoc::formatdoc!(
+        r#"
+        {record}
+
+        {reader}
+
+        {executable_id}
+
+        {from_impl}
+    "#
+    );
+
+    Ok(EntityOutput {
+        requires: edges
+            .iter()
+            .copied()
+            .filter_map(|edge| EntityRef::new(edge.target))
+            .collect(),
+        id: EntityRef::new(TypeDefinition::Union(object)).unwrap(),
+        contents,
+    })
+}
+
+#[derive(Clone, Copy)]
+pub struct TypeEdge<'a> {
+    container: UnionDefinition<'a>,
+    target: TypeDefinition<'a>,
+}
+
+pub struct RecordVariant<'a>(TypeEdge<'a>);
+
+impl quote::ToTokens for RecordVariant<'_> {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        let variant_name = Ident::new(self.0.target.name(), Span::call_site());
+        let id = IdIdent(self.0.target.name());
+
+        tokens.append_all(quote! {
+            #variant_name(#id)
+        });
+    }
+}
+
+pub struct ReaderVariant<'a>(TypeEdge<'a>);
+
+impl quote::ToTokens for ReaderVariant<'_> {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        let variant_name = Ident::new(self.0.target.name(), Span::call_site());
+        let reader = Ident::new(self.0.target.name(), Span::call_site());
+
+        tokens.append_all(quote! {
+            #variant_name(#reader<'a>)
+        });
+    }
+}
+
+pub struct FromBranch<'a>(TypeEdge<'a>);
+
+impl quote::ToTokens for FromBranch<'_> {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        let this_record = Ident::new(
+            &format!("{}Record", self.0.container.name()),
+            Span::call_site(),
+        );
+        let this_reader = Ident::new(self.0.container.name(), Span::call_site());
+        let variant_name = Ident::new(self.0.target.name(), Span::call_site());
+        let reader = Ident::new(self.0.target.name(), Span::call_site());
+
+        tokens.append_all(quote! {
+            #this_record::#variant_name(id) => #this_reader::#variant_name(id)
+        });
+    }
+}

--- a/cynic-parser/parser-generator/Cargo.toml
+++ b/cynic-parser/parser-generator/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "parser-generator"
 version = "0.1.0"
+publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/cynic-parser/src/errors/report.rs
+++ b/cynic-parser/src/errors/report.rs
@@ -75,6 +75,8 @@ impl Error {
     }
 }
 
+impl std::error::Error for Report<'_> {}
+
 impl fmt::Display for Report<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut output = Vec::<u8>::new();

--- a/cynic-parser/src/executable/argument.rs
+++ b/cynic-parser/src/executable/argument.rs
@@ -1,9 +1,14 @@
-use crate::AstLookup;
-
+#[allow(unused_imports)]
+use super::ids::StringId;
 use super::{
-    ids::{ArgumentId, StringId, ValueId},
+    ids::{ArgumentId, ValueId},
     value::Value,
     ExecutableId, ReadContext,
+};
+#[allow(unused_imports)]
+use crate::{
+    common::{IdRange, OperationType},
+    AstLookup,
 };
 
 pub struct ArgumentRecord {
@@ -19,11 +24,9 @@ impl<'a> Argument<'a> {
         let ast = &self.0.document;
         ast.lookup(ast.lookup(self.0.id).name)
     }
-
     pub fn value(&self) -> Value<'a> {
-        let ast = &self.0.document;
-
-        ast.read(ast.lookup(self.0.id).value)
+        let document = self.0.document;
+        document.read(document.lookup(self.0.id).value)
     }
 }
 
@@ -36,3 +39,4 @@ impl<'a> From<ReadContext<'a, ArgumentId>> for Argument<'a> {
         Self(value)
     }
 }
+

--- a/cynic-parser/src/executable/argument.rs
+++ b/cynic-parser/src/executable/argument.rs
@@ -39,4 +39,3 @@ impl<'a> From<ReadContext<'a, ArgumentId>> for Argument<'a> {
         Self(value)
     }
 }
-

--- a/cynic-parser/src/executable/definition.rs
+++ b/cynic-parser/src/executable/definition.rs
@@ -20,14 +20,10 @@ pub enum ExecutableDefinition<'a> {
 
 impl super::ExecutableDocument {
     pub fn definitions(&self) -> impl ExactSizeIterator<Item = ExecutableDefinition<'_>> {
-        self.definitions.iter().map(|record| match record {
-            ExecutableDefinitionRecord::Operation(id) => {
-                ExecutableDefinition::Operation(self.read(*id))
-            }
-            ExecutableDefinitionRecord::Fragment(id) => {
-                ExecutableDefinition::Fragment(self.read(*id))
-            }
-        })
+        self.definitions
+            .iter()
+            .enumerate()
+            .map(|(i, _)| self.read(ExecutableDefinitionId::new(i)))
     }
 
     pub fn operations(&self) -> impl Iterator<Item = OperationDefinition<'_>> {

--- a/cynic-parser/src/executable/directive.rs
+++ b/cynic-parser/src/executable/directive.rs
@@ -43,4 +43,3 @@ impl<'a> From<ReadContext<'a, DirectiveId>> for Directive<'a> {
         Self(value)
     }
 }
-

--- a/cynic-parser/src/executable/directive.rs
+++ b/cynic-parser/src/executable/directive.rs
@@ -1,9 +1,14 @@
-use crate::{common::IdRange, AstLookup};
-
+#[allow(unused_imports)]
+use super::ids::StringId;
 use super::{
     argument::Argument,
-    ids::{ArgumentId, DirectiveId, StringId},
+    ids::{ArgumentId, DirectiveId},
     ExecutableId, ReadContext,
+};
+#[allow(unused_imports)]
+use crate::{
+    common::{IdRange, OperationType},
+    AstLookup,
 };
 
 pub struct DirectiveRecord {
@@ -17,17 +22,15 @@ pub struct Directive<'a>(ReadContext<'a, DirectiveId>);
 impl<'a> Directive<'a> {
     pub fn name(&self) -> &'a str {
         let ast = &self.0.document;
-
         ast.lookup(ast.lookup(self.0.id).name)
     }
-
     pub fn arguments(&self) -> impl ExactSizeIterator<Item = Argument<'a>> {
-        let ast = &self.0.document;
-
-        ast.lookup(self.0.id)
+        let document = self.0.document;
+        document
+            .lookup(self.0.id)
             .arguments
             .iter()
-            .map(|id| ast.read(id))
+            .map(|id| document.read(id))
     }
 }
 
@@ -40,3 +43,4 @@ impl<'a> From<ReadContext<'a, DirectiveId>> for Directive<'a> {
         Self(value)
     }
 }
+

--- a/cynic-parser/src/executable/fragment.rs
+++ b/cynic-parser/src/executable/fragment.rs
@@ -58,4 +58,3 @@ impl<'a> From<ReadContext<'a, FragmentDefinitionId>> for FragmentDefinition<'a> 
         Self(value)
     }
 }
-

--- a/cynic-parser/src/executable/fragment.rs
+++ b/cynic-parser/src/executable/fragment.rs
@@ -1,10 +1,15 @@
-use crate::{common::IdRange, AstLookup};
-
+#[allow(unused_imports)]
+use super::ids::StringId;
 use super::{
     directive::Directive,
-    ids::{DirectiveId, FragmentDefinitionId, SelectionId, StringId},
+    ids::{DirectiveId, FragmentDefinitionId, SelectionId},
     selections::Selection,
     ExecutableId, ReadContext,
+};
+#[allow(unused_imports)]
+use crate::{
+    common::{IdRange, OperationType},
+    AstLookup,
 };
 
 pub struct FragmentDefinitionRecord {
@@ -22,28 +27,25 @@ impl<'a> FragmentDefinition<'a> {
         let ast = &self.0.document;
         ast.lookup(ast.lookup(self.0.id).name)
     }
-
     pub fn type_condition(&self) -> &'a str {
         let ast = &self.0.document;
         ast.lookup(ast.lookup(self.0.id).type_condition)
     }
-
     pub fn directives(&self) -> impl ExactSizeIterator<Item = Directive<'a>> {
-        self.0
-            .document
+        let document = self.0.document;
+        document
             .lookup(self.0.id)
             .directives
             .iter()
-            .map(|id| self.0.document.read(id))
+            .map(|id| document.read(id))
     }
-
     pub fn selection_set(&self) -> impl ExactSizeIterator<Item = Selection<'a>> {
-        self.0
-            .document
+        let document = self.0.document;
+        document
             .lookup(self.0.id)
             .selection_set
             .iter()
-            .map(|id| self.0.document.read(id))
+            .map(|id| document.read(id))
     }
 }
 
@@ -56,3 +58,4 @@ impl<'a> From<ReadContext<'a, FragmentDefinitionId>> for FragmentDefinition<'a> 
         Self(value)
     }
 }
+

--- a/cynic-parser/src/executable/operation.rs
+++ b/cynic-parser/src/executable/operation.rs
@@ -1,14 +1,16 @@
-use crate::{
-    common::{IdRange, OperationType},
-    AstLookup,
-};
-
+#[allow(unused_imports)]
+use super::ids::StringId;
 use super::{
     directive::Directive,
-    ids::{DirectiveId, OperationDefinitionId, SelectionId, StringId, VariableDefinitionId},
+    ids::{DirectiveId, OperationDefinitionId, SelectionId, VariableDefinitionId},
     selections::Selection,
     variable::VariableDefinition,
     ExecutableId, ReadContext,
+};
+#[allow(unused_imports)]
+use crate::{
+    common::{IdRange, OperationType},
+    AstLookup,
 };
 
 pub struct OperationDefinitionRecord {
@@ -24,40 +26,39 @@ pub struct OperationDefinition<'a>(ReadContext<'a, OperationDefinitionId>);
 
 impl<'a> OperationDefinition<'a> {
     pub fn operation_type(&self) -> OperationType {
-        let ast = self.0.document;
-        ast.lookup(self.0.id).operation_type
+        let document = self.0.document;
+        document.lookup(self.0.id).operation_type
     }
-
     pub fn name(&self) -> Option<&'a str> {
-        let ast = self.0.document;
-        ast.lookup(self.0.id).name.map(|id| ast.lookup(id))
+        let document = self.0.document;
+        document
+            .lookup(self.0.id)
+            .name
+            .map(|id| document.lookup(id))
     }
-
     pub fn variable_definitions(&self) -> impl ExactSizeIterator<Item = VariableDefinition<'a>> {
-        self.0
-            .document
+        let document = self.0.document;
+        document
             .lookup(self.0.id)
             .variable_definitions
             .iter()
-            .map(|id| self.0.document.read(id))
+            .map(|id| document.read(id))
     }
-
     pub fn directives(&self) -> impl ExactSizeIterator<Item = Directive<'a>> {
-        self.0
-            .document
+        let document = self.0.document;
+        document
             .lookup(self.0.id)
             .directives
             .iter()
-            .map(|id| self.0.document.read(id))
+            .map(|id| document.read(id))
     }
-
     pub fn selection_set(&self) -> impl ExactSizeIterator<Item = Selection<'a>> {
-        self.0
-            .document
+        let document = self.0.document;
+        document
             .lookup(self.0.id)
             .selection_set
             .iter()
-            .map(|id| self.0.document.read(id))
+            .map(|id| document.read(id))
     }
 }
 
@@ -70,3 +71,4 @@ impl<'a> From<ReadContext<'a, OperationDefinitionId>> for OperationDefinition<'a
         Self(value)
     }
 }
+

--- a/cynic-parser/src/executable/operation.rs
+++ b/cynic-parser/src/executable/operation.rs
@@ -71,4 +71,3 @@ impl<'a> From<ReadContext<'a, OperationDefinitionId>> for OperationDefinition<'a
         Self(value)
     }
 }
-

--- a/cynic-parser/src/executable/operation.rs
+++ b/cynic-parser/src/executable/operation.rs
@@ -24,12 +24,12 @@ pub struct OperationDefinition<'a>(ReadContext<'a, OperationDefinitionId>);
 
 impl<'a> OperationDefinition<'a> {
     pub fn operation_type(&self) -> OperationType {
-        let ast = &self.0.document;
+        let ast = self.0.document;
         ast.lookup(self.0.id).operation_type
     }
 
     pub fn name(&self) -> Option<&'a str> {
-        let ast = &self.0.document;
+        let ast = self.0.document;
         ast.lookup(self.0.id).name.map(|id| ast.lookup(id))
     }
 

--- a/cynic-parser/src/executable/selections.rs
+++ b/cynic-parser/src/executable/selections.rs
@@ -1,13 +1,17 @@
-use crate::{common::IdRange, AstLookup};
-
+#[allow(unused_imports)]
+use super::ids::StringId;
 use super::{
     argument::Argument,
     directive::Directive,
     ids::{
         ArgumentId, DirectiveId, FieldSelectionId, FragmentSpreadId, InlineFragmentId, SelectionId,
-        StringId,
     },
     ExecutableId, ReadContext,
+};
+#[allow(unused_imports)]
+use crate::{
+    common::{IdRange, OperationType},
+    AstLookup,
 };
 
 pub enum SelectionRecord {
@@ -16,27 +20,9 @@ pub enum SelectionRecord {
     FragmentSpread(FragmentSpreadId),
 }
 
-pub struct FieldSelectionRecord {
-    pub alias: Option<StringId>,
-    pub name: StringId,
-    pub arguments: IdRange<ArgumentId>,
-    pub directives: IdRange<DirectiveId>,
-    pub selection_set: IdRange<SelectionId>,
-}
-
-pub struct InlineFragmentRecord {
-    pub type_condition: Option<StringId>,
-    pub directives: IdRange<DirectiveId>,
-    pub selection_set: IdRange<SelectionId>,
-}
-
-pub struct FragmentSpreadRecord {
-    pub fragment_name: StringId,
-    pub directives: IdRange<DirectiveId>,
-}
-
+#[derive(Clone, Copy)]
 pub enum Selection<'a> {
-    Field(FieldSelection<'a>),
+    FieldSelection(FieldSelection<'a>),
     InlineFragment(InlineFragment<'a>),
     FragmentSpread(FragmentSpread<'a>),
 }
@@ -48,7 +34,9 @@ impl ExecutableId for SelectionId {
 impl<'a> From<ReadContext<'a, SelectionId>> for Selection<'a> {
     fn from(value: ReadContext<'a, SelectionId>) -> Self {
         match value.document.lookup(value.id) {
-            SelectionRecord::FieldSelection(id) => Selection::Field(value.document.read(*id)),
+            SelectionRecord::FieldSelection(id) => {
+                Selection::FieldSelection(value.document.read(*id))
+            }
             SelectionRecord::InlineFragment(id) => {
                 Selection::InlineFragment(value.document.read(*id))
             }
@@ -59,49 +47,53 @@ impl<'a> From<ReadContext<'a, SelectionId>> for Selection<'a> {
     }
 }
 
+
+pub struct FieldSelectionRecord {
+    pub alias: Option<StringId>,
+    pub name: StringId,
+    pub arguments: IdRange<ArgumentId>,
+    pub directives: IdRange<DirectiveId>,
+    pub selection_set: IdRange<SelectionId>,
+}
+
 #[derive(Clone, Copy)]
 pub struct FieldSelection<'a>(ReadContext<'a, FieldSelectionId>);
 
 impl<'a> FieldSelection<'a> {
     pub fn alias(&self) -> Option<&'a str> {
-        self.0
-            .document
+        let document = self.0.document;
+        document
             .lookup(self.0.id)
             .alias
-            .map(|id| self.0.document.lookup(id))
+            .map(|id| document.lookup(id))
     }
-
     pub fn name(&self) -> &'a str {
-        self.0
-            .document
-            .lookup(self.0.document.lookup(self.0.id).name)
-    }
-
-    pub fn arguments(&self) -> impl ExactSizeIterator<Item = Argument<'a>> {
         let ast = &self.0.document;
-
-        ast.lookup(self.0.id)
+        ast.lookup(ast.lookup(self.0.id).name)
+    }
+    pub fn arguments(&self) -> impl ExactSizeIterator<Item = Argument<'a>> {
+        let document = self.0.document;
+        document
+            .lookup(self.0.id)
             .arguments
             .iter()
-            .map(|id| ast.read(id))
+            .map(|id| document.read(id))
     }
-
     pub fn directives(&self) -> impl ExactSizeIterator<Item = Directive<'a>> {
-        self.0
-            .document
+        let document = self.0.document;
+        document
             .lookup(self.0.id)
             .directives
             .iter()
-            .map(|id| self.0.document.read(id))
+            .map(|id| document.read(id))
     }
-
     pub fn selection_set(&self) -> impl ExactSizeIterator<Item = Selection<'a>> {
-        self.0
-            .document
+        let document = self.0.document;
+        document
             .lookup(self.0.id)
             .selection_set
             .iter()
-            .map(|id| self.0.document.read(id))
+            .map(|id| document.read(id))
     }
 }
 
@@ -115,33 +107,39 @@ impl<'a> From<ReadContext<'a, FieldSelectionId>> for FieldSelection<'a> {
     }
 }
 
+
+pub struct InlineFragmentRecord {
+    pub type_condition: Option<StringId>,
+    pub directives: IdRange<DirectiveId>,
+    pub selection_set: IdRange<SelectionId>,
+}
+
 #[derive(Clone, Copy)]
 pub struct InlineFragment<'a>(ReadContext<'a, InlineFragmentId>);
 
 impl<'a> InlineFragment<'a> {
     pub fn type_condition(&self) -> Option<&'a str> {
-        let ast = &self.0.document;
-        ast.lookup(self.0.id)
+        let document = self.0.document;
+        document
+            .lookup(self.0.id)
             .type_condition
-            .map(|id| ast.lookup(id))
+            .map(|id| document.lookup(id))
     }
-
     pub fn directives(&self) -> impl ExactSizeIterator<Item = Directive<'a>> {
-        self.0
-            .document
+        let document = self.0.document;
+        document
             .lookup(self.0.id)
             .directives
             .iter()
-            .map(|id| self.0.document.read(id))
+            .map(|id| document.read(id))
     }
-
     pub fn selection_set(&self) -> impl ExactSizeIterator<Item = Selection<'a>> {
-        self.0
-            .document
+        let document = self.0.document;
+        document
             .lookup(self.0.id)
             .selection_set
             .iter()
-            .map(|id| self.0.document.read(id))
+            .map(|id| document.read(id))
     }
 }
 
@@ -155,23 +153,27 @@ impl<'a> From<ReadContext<'a, InlineFragmentId>> for InlineFragment<'a> {
     }
 }
 
+
+pub struct FragmentSpreadRecord {
+    pub fragment_name: StringId,
+    pub directives: IdRange<DirectiveId>,
+}
+
 #[derive(Clone, Copy)]
 pub struct FragmentSpread<'a>(ReadContext<'a, FragmentSpreadId>);
 
 impl<'a> FragmentSpread<'a> {
     pub fn fragment_name(&self) -> &'a str {
-        self.0
-            .document
-            .lookup(self.0.document.lookup(self.0.id).fragment_name)
+        let ast = &self.0.document;
+        ast.lookup(ast.lookup(self.0.id).fragment_name)
     }
-
     pub fn directives(&self) -> impl ExactSizeIterator<Item = Directive<'a>> {
-        self.0
-            .document
+        let document = self.0.document;
+        document
             .lookup(self.0.id)
             .directives
             .iter()
-            .map(|id| self.0.document.read(id))
+            .map(|id| document.read(id))
     }
 }
 
@@ -184,3 +186,4 @@ impl<'a> From<ReadContext<'a, FragmentSpreadId>> for FragmentSpread<'a> {
         Self(value)
     }
 }
+

--- a/cynic-parser/src/executable/selections.rs
+++ b/cynic-parser/src/executable/selections.rs
@@ -11,7 +11,7 @@ use super::{
 };
 
 pub enum SelectionRecord {
-    Field(FieldSelectionId),
+    FieldSelection(FieldSelectionId),
     InlineFragment(InlineFragmentId),
     FragmentSpread(FragmentSpreadId),
 }
@@ -48,7 +48,7 @@ impl ExecutableId for SelectionId {
 impl<'a> From<ReadContext<'a, SelectionId>> for Selection<'a> {
     fn from(value: ReadContext<'a, SelectionId>) -> Self {
         match value.document.lookup(value.id) {
-            SelectionRecord::Field(id) => Selection::Field(value.document.read(*id)),
+            SelectionRecord::FieldSelection(id) => Selection::Field(value.document.read(*id)),
             SelectionRecord::InlineFragment(id) => {
                 Selection::InlineFragment(value.document.read(*id))
             }

--- a/cynic-parser/src/executable/selections.rs
+++ b/cynic-parser/src/executable/selections.rs
@@ -47,7 +47,6 @@ impl<'a> From<ReadContext<'a, SelectionId>> for Selection<'a> {
     }
 }
 
-
 pub struct FieldSelectionRecord {
     pub alias: Option<StringId>,
     pub name: StringId,
@@ -107,7 +106,6 @@ impl<'a> From<ReadContext<'a, FieldSelectionId>> for FieldSelection<'a> {
     }
 }
 
-
 pub struct InlineFragmentRecord {
     pub type_condition: Option<StringId>,
     pub directives: IdRange<DirectiveId>,
@@ -153,7 +151,6 @@ impl<'a> From<ReadContext<'a, InlineFragmentId>> for InlineFragment<'a> {
     }
 }
 
-
 pub struct FragmentSpreadRecord {
     pub fragment_name: StringId,
     pub directives: IdRange<DirectiveId>,
@@ -186,4 +183,3 @@ impl<'a> From<ReadContext<'a, FragmentSpreadId>> for FragmentSpread<'a> {
         Self(value)
     }
 }
-

--- a/cynic-parser/src/executable/variable.rs
+++ b/cynic-parser/src/executable/variable.rs
@@ -58,4 +58,3 @@ impl<'a> From<ReadContext<'a, VariableDefinitionId>> for VariableDefinition<'a> 
         Self(value)
     }
 }
-

--- a/cynic-parser/src/executable/variable.rs
+++ b/cynic-parser/src/executable/variable.rs
@@ -1,11 +1,16 @@
-use crate::{common::IdRange, AstLookup};
-
+#[allow(unused_imports)]
+use super::ids::StringId;
 use super::{
     directive::Directive,
-    ids::{DirectiveId, StringId, TypeId, ValueId, VariableDefinitionId},
+    ids::{DirectiveId, TypeId, ValueId, VariableDefinitionId},
     types::Type,
     value::Value,
     ExecutableId, ReadContext,
+};
+#[allow(unused_imports)]
+use crate::{
+    common::{IdRange, OperationType},
+    AstLookup,
 };
 
 pub struct VariableDefinitionRecord {
@@ -21,30 +26,26 @@ pub struct VariableDefinition<'a>(ReadContext<'a, VariableDefinitionId>);
 impl<'a> VariableDefinition<'a> {
     pub fn name(&self) -> &'a str {
         let ast = &self.0.document;
-
         ast.lookup(ast.lookup(self.0.id).name)
     }
-
     pub fn ty(&self) -> Type<'a> {
-        let ast = &self.0.document;
-        ast.read(ast.lookup(self.0.id).ty)
+        let document = self.0.document;
+        document.read(document.lookup(self.0.id).ty)
     }
-
     pub fn default_value(&self) -> Option<Value<'a>> {
-        let ast = &self.0.document;
-
-        ast.lookup(self.0.id)
+        let document = self.0.document;
+        document
+            .lookup(self.0.id)
             .default_value
-            .map(|id| self.0.document.read(id))
+            .map(|id| document.read(id))
     }
-
     pub fn directives(&self) -> impl ExactSizeIterator<Item = Directive<'a>> {
-        self.0
-            .document
+        let document = self.0.document;
+        document
             .lookup(self.0.id)
             .directives
             .iter()
-            .map(|id| self.0.document.read(id))
+            .map(|id| document.read(id))
     }
 }
 
@@ -57,3 +58,4 @@ impl<'a> From<ReadContext<'a, VariableDefinitionId>> for VariableDefinition<'a> 
         Self(value)
     }
 }
+

--- a/cynic-parser/src/parser/executable.lalrpop
+++ b/cynic-parser/src/parser/executable.lalrpop
@@ -81,7 +81,7 @@ Selection: SelectionRecord = {
     <alias:Alias?> <name:Name> <arguments:Arguments?> <directives:Directives> <selection_set:SelectionSet?> => {
         let selection_set = selection_set.unwrap_or_default();
         let arguments = arguments.map(|args| ast.arguments(args)).unwrap_or_default();
-        SelectionRecord::Field(
+        SelectionRecord::FieldSelection(
             ast.field_selection(FieldSelectionRecord {
                 <>
             })

--- a/cynic-parser/src/parser/executable.rs
+++ b/cynic-parser/src/parser/executable.rs
@@ -1,5 +1,5 @@
 // auto-generated: "lalrpop 0.20.0"
-// sha3: 08c754fe6dffbd7e3b3919f55eff9d7ea855a65d3a7cea10e782098565a47755
+// sha3: 1f33caee019cede583b4a420743c12e9657283866c75db08d26eb01b72735da7
 use crate::lexer;
 use crate::{
     common::{
@@ -5847,7 +5847,7 @@ fn __action14<'input>(
         let arguments = arguments
             .map(|args| ast.arguments(args))
             .unwrap_or_default();
-        SelectionRecord::Field(ast.field_selection(FieldSelectionRecord {
+        SelectionRecord::FieldSelection(ast.field_selection(FieldSelectionRecord {
             alias,
             name,
             arguments,

--- a/cynic-parser/src/printing/executable.rs
+++ b/cynic-parser/src/printing/executable.rs
@@ -197,7 +197,7 @@ impl<'a> Pretty<'a, Allocator<'a>> for SelectionSetDisplay<'a> {
 impl<'a> Pretty<'a, Allocator<'a>> for NodeDisplay<Selection<'a>> {
     fn pretty(self, allocator: &'a Allocator<'a>) -> pretty::DocBuilder<'a, Allocator<'a>, ()> {
         match self.0 {
-            Selection::Field(field) => {
+            Selection::FieldSelection(field) => {
                 let mut alias_pretty = allocator.nil();
                 if let Some(alias) = field.alias() {
                     alias_pretty = allocator

--- a/cynic-parser/src/type_system/readers/definitions.rs
+++ b/cynic-parser/src/type_system/readers/definitions.rs
@@ -1,7 +1,7 @@
 use super::{
     directives::DirectiveDefinition, enums::EnumDefinition, input_objects::InputObjectDefinition,
     interfaces::InterfaceDefinition, objects::ObjectDefinition, scalars::ScalarDefinition,
-    schemas::SchemaDefinition, unions::UnionDefinition,
+    schemas::SchemaDefinition, unions::UnionDefinition, Directive,
 };
 
 #[derive(Clone, Copy)]
@@ -33,5 +33,18 @@ impl<'a> TypeDefinition<'a> {
             TypeDefinition::Enum(inner) => inner.name(),
             TypeDefinition::InputObject(inner) => inner.name(),
         }
+    }
+
+    pub fn directives(&self) -> impl ExactSizeIterator<Item = Directive<'a>> + 'a {
+        let rv: Box<dyn ExactSizeIterator<Item = Directive<'a>> + 'a> = match self {
+            TypeDefinition::Scalar(inner) => Box::new(inner.directives()),
+            TypeDefinition::Object(inner) => Box::new(inner.directives()),
+            TypeDefinition::Interface(inner) => Box::new(inner.directives()),
+            TypeDefinition::Union(inner) => Box::new(inner.directives()),
+            TypeDefinition::Enum(inner) => Box::new(inner.directives()),
+            TypeDefinition::InputObject(inner) => Box::new(inner.directives()),
+        };
+
+        rv
     }
 }

--- a/cynic-parser/src/type_system/readers/types.rs
+++ b/cynic-parser/src/type_system/readers/types.rs
@@ -12,6 +12,14 @@ impl<'a> Type<'a> {
             .lookup(self.0.document.lookup(self.0.id).name)
     }
 
+    pub fn is_list(&self) -> bool {
+        self.wrappers().any(|wrapper| wrapper == WrappingType::List)
+    }
+
+    pub fn is_non_null(&self) -> bool {
+        self.wrappers().next() == Some(WrappingType::NonNull)
+    }
+
     /// The wrapper types from the outermost to innermost
     pub fn wrappers(&self) -> impl Iterator<Item = WrappingType> + 'a {
         self.0.document.lookup(self.0.id).wrappers.iter()

--- a/cynic-parser/src/type_system/readers/values.rs
+++ b/cynic-parser/src/type_system/readers/values.rs
@@ -19,6 +19,15 @@ pub enum ValueReader<'a> {
     Object(Vec<(&'a str, ValueReader<'a>)>),
 }
 
+impl<'a> ValueReader<'a> {
+    pub fn as_str(&self) -> Option<&'a str> {
+        match self {
+            Self::String(inner) => Some(inner),
+            _ => None,
+        }
+    }
+}
+
 impl TypeSystemId for ValueId {
     type Reader<'a> = ValueReader<'a>;
 }


### PR DESCRIPTION
#### Why are we making this change?

The cynic-parser AST has a lot of fairly boilerplatey code in it.  Each type we store needs a record, a reader, some mechanical functions on the reader that hook up to the underlying data and a few other bits & pieces.

Maintaining all this by hand is going to be a lot of work, particularly if I want to make sweeping changes (which I do in the type_system - I want to re-arrange it completely).

#### What effects does this change have?

This adds an ast-generator crate that uses the parser to parse a type system that defines the executable AST.  We then use this to generate all the records & readers for that AST.  Also acts as a nice dogfood of the parser.