### PR TITLE
Adding Debug to Operation struct

### DIFF
--- a/cynic/src/operation/mod.rs
+++ b/cynic/src/operation/mod.rs
@@ -15,6 +15,7 @@ pub use builder::{OperationBuildError, OperationBuilder};
 ///
 /// This contains a GraphQL query string and variable HashMap.  It can be
 /// serialized into JSON with `serde::Serialize` and sent to a remote server.
+#[derive(Debug)]
 pub struct Operation<QueryFragment, Variables = ()> {
     /// The graphql query string that will be sent to the server
     pub query: String,


### PR DESCRIPTION
#### Why are we making this change?

When instrumenting functions using `#[tracing::instrument]` the parameters need to implement `Debug`. 

#### What effects does this change have?

Derives `Debug` for the `Operation` struct
