### PR TITLE
fix: better type kind mismatch errors

### DIFF
--- a/cynic-codegen/src/schema/mod.rs
+++ b/cynic-codegen/src/schema/mod.rs
@@ -128,8 +128,8 @@ impl std::fmt::Display for SchemaError {
                 found,
             } => write!(
                 f,
-                "Expected type `{}` to be a {} but it was a {}",
-                name, expected, found
+                "The type `{}` is a {} in the GraphQL schema but is being used where we expect a {}",
+                name, found, expected,
             ),
             Self::InvalidTypeInSchema { name, details } => {
                 write!(f, "Invalid schema when validating `{}`: {}", name, details)


### PR DESCRIPTION
A user ran into this particular error message and it wasn't clear to them what their mistake was.  This change hopefully makes things clearer.