### PR TITLE
feat: infer bounds for generic nested query fragments

### DIFF
--- a/cynic-codegen/src/fragment_derive/fragment_impl.rs
+++ b/cynic-codegen/src/fragment_derive/fragment_impl.rs
@@ -1,3 +1,6 @@
+use darling::usage::{GenericsExt, Purpose, UsesTypeParams};
+use syn::{parse_quote, Token, WhereClause};
+
 use {
     proc_macro2::{Span, TokenStream},
     quote::{quote, quote_spanned},
@@ -28,6 +31,7 @@ pub struct FragmentImpl<'schema, 'a> {
     variables_fields: syn::Type,
     graphql_type_name: String,
     schema_type_path: syn::Path,
+    additional_where: Option<syn::WhereClause>,
 }
 
 #[allow(clippy::large_enum_variant)]
@@ -83,6 +87,14 @@ impl<'schema, 'a: 'schema> FragmentImpl<'schema, 'a> {
         let variables_fields = variables_fields_path(variables);
         let variables_fields = variables_fields.as_ref();
 
+        let additional_where = additional_where_clause(
+            generics,
+            fields,
+            schema,
+            &field_module_path,
+            variables_fields,
+        );
+
         let selections = fields
             .iter()
             .map(|(field, schema_field)| {
@@ -111,6 +123,7 @@ impl<'schema, 'a: 'schema> FragmentImpl<'schema, 'a> {
             variables_fields,
             graphql_type_name: graphql_type_name.to_string(),
             schema_type_path,
+            additional_where,
         })
     }
 }
@@ -167,6 +180,69 @@ fn process_field<'a>(
     }))
 }
 
+fn additional_where_clause(
+    generics: &syn::Generics,
+    fields: &[(FragmentDeriveField, Option<Field<'_>>)],
+    schema: &Schema<'_, Unvalidated>,
+    field_module_path: &syn::Path,
+    variables_fields: Option<&syn::Path>,
+) -> Option<WhereClause> {
+    let all_params = generics.declared_type_params();
+    if all_params.is_empty() {
+        return None;
+    }
+    let options = Purpose::BoundImpl.into();
+
+    let mut predicates: Vec<syn::WherePredicate> = vec![];
+
+    for (field, schema_field) in fields {
+        let Some(schema_field) = schema_field else {
+            continue;
+        };
+        let inner_type = schema_field.field_type.inner_type(schema);
+        if !inner_type.is_composite() {
+            // We only care about generics on composite types for now
+            continue;
+        }
+        if *field.spread || *field.flatten {
+            // We could probably support these, but I don't want to figure it out right now.
+            // Leave it to the user to provide these bounds
+            continue;
+        }
+        if field.ty.uses_type_params(&options, &all_params).is_empty() {
+            // If this field uses no type params we skip it
+            continue;
+        }
+
+        let ty = &field.ty;
+        let marker_ty = schema_field.marker_ident().to_path(field_module_path);
+        predicates.push(parse_quote! {
+            #ty: cynic::QueryFragment<SchemaType = <#marker_ty as cynic::schema::Field>::Type>
+        });
+        match variables_fields {
+            Some(variables_fields) => {
+                predicates.push(parse_quote! {
+                    #variables_fields: cynic::queries::VariableMatch<<#ty as cynic::QueryFragment>::VariablesFields>
+                });
+            }
+            None => {
+                predicates.push(parse_quote! {
+                    (): cynic::queries::VariableMatch<<#ty as cynic::QueryFragment>::VariablesFields>
+                });
+            }
+        }
+    }
+
+    if predicates.is_empty() {
+        return None;
+    }
+
+    Some(WhereClause {
+        where_token: <Token![where]>::default(),
+        predicates: predicates.into_iter().collect(),
+    })
+}
+
 impl quote::ToTokens for FragmentImpl<'_, '_> {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         use quote::TokenStreamExt;
@@ -178,6 +254,17 @@ impl quote::ToTokens for FragmentImpl<'_, '_> {
         let schema_type = &self.schema_type_path;
         let fragment_name = proc_macro2::Literal::string(&target_struct.to_string());
         let (impl_generics, ty_generics, where_clause) = self.generics.split_for_impl();
+
+        let where_clause = match (where_clause, &self.additional_where) {
+            (None, None) => None,
+            (Some(lhs), None) => Some(quote! { #lhs }),
+            (None, Some(rhs)) => Some(quote! { #rhs }),
+            (Some(lhs), Some(rhs)) => {
+                let mut new = lhs.clone();
+                new.predicates.extend(rhs.predicates.clone());
+                Some(quote! { #new })
+            }
+        };
 
         tokens.append_all(quote! {
             #[automatically_derived]
@@ -383,6 +470,13 @@ impl quote::ToTokens for SpreadSelection {
 }
 
 impl OutputType<'_> {
+    fn is_composite(&self) -> bool {
+        matches!(
+            self,
+            OutputType::Object(_) | OutputType::Interface(_) | OutputType::Union(_)
+        )
+    }
+
     fn as_kind(&self) -> FieldKind {
         match self {
             OutputType::Scalar(_) => FieldKind::Scalar,

--- a/cynic-codegen/tests/snapshots/use_schema__simple.graphql.snap
+++ b/cynic-codegen/tests/snapshots/use_schema__simple.graphql.snap
@@ -5,6 +5,10 @@ expression: "format_code(format!(\"{}\", tokens))"
 impl cynic::schema::QueryRoot for Query {}
 pub struct AnInputType;
 impl cynic::schema::InputObjectMarker for AnInputType {}
+pub struct DateTime {}
+impl cynic::schema::NamedType for DateTime {
+    const NAME: &'static ::core::primitive::str = "DateTime";
+}
 pub struct Dessert {}
 pub struct JSON {}
 impl cynic::schema::NamedType for JSON {
@@ -180,6 +184,14 @@ pub mod __fields {
         }
         impl cynic::schema::HasField<json> for super::super::TestStruct {
             type Type = Option<super::super::JSON>;
+        }
+        pub struct date;
+        impl cynic::schema::Field for date {
+            type Type = Option<super::super::DateTime>;
+            const NAME: &'static ::core::primitive::str = "date";
+        }
+        impl cynic::schema::HasField<date> for super::super::TestStruct {
+            type Type = Option<super::super::DateTime>;
         }
         pub struct __typename;
         impl cynic::schema::Field for __typename {

--- a/cynic-parser/tests/snapshots/actual_schemas__simple__snapshot.snap
+++ b/cynic-parser/tests/snapshots/actual_schemas__simple__snapshot.snap
@@ -4,6 +4,8 @@ expression: parsed.to_sdl()
 ---
 scalar JSON
 
+scalar DateTime
+
 type Query {
   testStruct: TestStruct
   myUnion: MyUnionType
@@ -17,6 +19,7 @@ type TestStruct {
   optNested: Nested
   dessert: Dessert
   json: JSON
+  date: DateTime
 }
 
 union MyUnionType = Nested | TestStruct

--- a/cynic/tests/generics_simple.rs
+++ b/cynic/tests/generics_simple.rs
@@ -62,3 +62,58 @@ fn test_generic_in_response() {
 
     "###);
 }
+
+#[derive(cynic::QueryFragment, PartialEq, Debug)]
+#[cynic(
+    schema_path = "../schemas/simple.graphql",
+    graphql_type = "Query",
+    variables = "TestArgs"
+)]
+struct GenericInResponseWithoutBounds<T> {
+    test_struct: Option<T>,
+}
+
+#[test]
+fn test_generic_in_response_without_bounds() {
+    use cynic::QueryBuilder;
+
+    let operation =
+        GenericInResponseWithoutBounds::<TestStruct>::build(TestArgs { a_str: Some("1") });
+
+    insta::assert_snapshot!(operation.query, @r###"
+    query GenericInResponseWithoutBounds($aStr: String) {
+      testStruct {
+        fieldOne(x: 1, y: $aStr)
+      }
+    }
+
+    "###);
+}
+
+#[derive(cynic::QueryFragment, PartialEq, Debug)]
+#[cynic(schema_path = "../schemas/simple.graphql", graphql_type = "TestStruct")]
+struct TestStructWithoutArgs {
+    field_one: String,
+}
+
+#[derive(cynic::QueryFragment, PartialEq, Debug)]
+#[cynic(schema_path = "../schemas/simple.graphql", graphql_type = "Query")]
+struct GenericInResponseWithoutBoundsOrArgs<T> {
+    test_struct: Option<T>,
+}
+
+#[test]
+fn test_generic_in_response_without_bounds_or_args() {
+    use cynic::QueryBuilder;
+
+    let operation = GenericInResponseWithoutBoundsOrArgs::<TestStructWithoutArgs>::build(());
+
+    insta::assert_snapshot!(operation.query, @r###"
+    query GenericInResponseWithoutBoundsOrArgs {
+      testStruct {
+        fieldOne
+      }
+    }
+
+    "###);
+}

--- a/schemas/simple.graphql
+++ b/schemas/simple.graphql
@@ -1,4 +1,5 @@
 scalar JSON
+scalar DateTime
 
 type Query {
   testStruct: TestStruct
@@ -13,6 +14,7 @@ type TestStruct {
   optNested: Nested
   dessert: Dessert
   json: JSON
+  date: DateTime
 }
 
 union MyUnionType = Nested | TestStruct


### PR DESCRIPTION
#### Why are we making this change?

Support for generic parameters in QueryFragment (and elsewhere) was added in v3.0.0.  In #708 a user asked how to do this, and I explained that it required two where bounds to be added by hand.  I wasn't entirely happy with this: although it makes sense, it's annoyingly verbose and the `VariablesFields` bound is particularly non-obvious.

#### What effects does this change have?

This updates the QueryFragment impl to try and infer these bounds when generic parameters are declared on the struct and used on a field that we know is a composite type.

I've not bothered to do the same for scalar or enum fields at present.  They also require bounds, but I think they're less useful and I don't want to put the effort in today.  Can revisit this if any users complain.

Fixes #708 
Fixes #709