### PR TITLE
chore: disable rust builds on draft release PRs

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,6 +17,7 @@ env:
 
 jobs:
   build-rust:
+    if: (!startsWith(github.ref, 'refs/heads/release-plz')) || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
 
     steps:

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -4,6 +4,9 @@ changelog_update = false
 git_release_enable = false
 git_tag_enable = false
 
+# create the release PR in draft to avoid running CI till we're ready
+pr_draft = true
+
 [[package]]
 name = "cynic"
 


### PR DESCRIPTION
I'm doing a lot of work right now that I won't be releasing immediately. There's no point in running CI on the release branch for every merge I do.