### PR TITLE
Make TypeSystemDocument::definitions() return an ExactSizeIterator

### DIFF
--- a/cynic-parser/src/type_system/mod.rs
+++ b/cynic-parser/src/type_system/mod.rs
@@ -174,7 +174,7 @@ impl super::TypeSystemDocument {
 }
 
 impl TypeSystemDocument {
-    pub fn definitions(&self) -> impl Iterator<Item = Definition<'_>> + '_ {
+    pub fn definitions(&self) -> impl ExactSizeIterator<Item = Definition<'_>> + '_ {
         self.definitions.iter().map(|definition| match definition {
             DefinitionRecord::Schema(id) => Definition::Schema(self.read(*id)),
             DefinitionRecord::Scalar(id) => {


### PR DESCRIPTION
To expand possibilities by just changing the function signature.
