### PR TITLE
chore: run cargo fmt in parser-generator

### DIFF
--- a/cynic-parser/parser-generator/src/main.rs
+++ b/cynic-parser/parser-generator/src/main.rs
@@ -4,4 +4,11 @@ fn main() {
         .set_out_dir("../src/parser")
         .process()
         .unwrap();
+
+    for input in ["../src/parser/executable.rs", "../src/parser/schema.rs"] {
+        std::process::Command::new("cargo")
+            .args(["fmt", "--", input])
+            .spawn()
+            .ok();
+    }
 }


### PR DESCRIPTION
I have been doing this manually for ages, far better to automate it.