### PR TITLE
chore: bump MSRV to 1.72

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ homepage = "https://cynic-rs.dev"
 repository = "https://github.com/obmarg/cynic"
 license = "MPL-2.0"
 version = "3.6.1"
-rust-version = "1.69"
+rust-version = "1.72"
 
 [workspace.dependencies]
 cynic-parser = { path = "cynic-parser", version = "0.2.6" }


### PR DESCRIPTION
I've been running 1.72 on CI for ages, and a number of deps already don't support 1.69, so seems like we haven't actually supported 1.69 for some time.