### PR TITLE
fix: blank lines between things with docstrings

### DIFF
--- a/cynic-parser/src/printing/type_system.rs
+++ b/cynic-parser/src/printing/type_system.rs
@@ -379,8 +379,6 @@ impl<'a> Pretty<'a, Allocator<'a>> for NodeDisplay<EnumDefinition<'a>> {
                     allocator
                         .hardline()
                         .append(FieldSequence::new(values))
-                        // allocator
-                        //     .intersperse(values.into_iter().map(NodeDisplay), allocator.hardline())
                         .nest(2),
                 )
                 .append(allocator.hardline())

--- a/cynic-parser/src/printing/type_system.rs
+++ b/cynic-parser/src/printing/type_system.rs
@@ -1,6 +1,11 @@
+mod argument_sequence;
+mod field_sequence;
+
 use pretty::{DocAllocator, Pretty};
 
 use crate::type_system::*;
+
+use self::{argument_sequence::ArgumentSequence, field_sequence::FieldSequence};
 
 use super::escape_string;
 
@@ -181,17 +186,15 @@ impl<'a> Pretty<'a, Allocator<'a>> for NodeDisplay<ObjectDefinition<'a>> {
             );
         }
 
-        let mut fields = self.0.fields().peekable();
-        if fields.peek().is_some() {
+        let fields = self.0.fields();
+        if fields.len() != 0 {
             builder = builder
                 .append(allocator.space())
                 .append(allocator.text("{"))
                 .append(
                     allocator
                         .hardline()
-                        .append(
-                            allocator.intersperse(fields.map(NodeDisplay), allocator.hardline()),
-                        )
+                        .append(FieldSequence::new(fields))
                         .nest(2),
                 )
                 .append(allocator.hardline())
@@ -217,14 +220,12 @@ impl<'a> Pretty<'a, Allocator<'a>> for NodeDisplay<FieldDefinition<'a>> {
 
         let mut arguments_pretty = allocator.nil();
 
-        let mut arguments = self.0.arguments().peekable();
+        let arguments = self.0.arguments();
 
-        if arguments.peek().is_some() {
+        if arguments.len() != 0 {
             arguments_pretty = allocator
                 .line_()
-                .append(
-                    allocator.intersperse(arguments.map(NodeDisplay), comma_or_newline(allocator)),
-                )
+                .append(ArgumentSequence::new(arguments))
                 .nest(2)
                 .append(allocator.line_())
                 .parens()
@@ -283,17 +284,16 @@ impl<'a> Pretty<'a, Allocator<'a>> for NodeDisplay<InterfaceDefinition<'a>> {
             );
         }
 
-        let mut fields = self.0.fields().peekable();
-        if fields.peek().is_some() {
+        let fields = self.0.fields();
+        if fields.len() != 0 {
             builder = builder
                 .append(allocator.space())
                 .append(allocator.text("{"))
-                .append(allocator.hardline())
-                .append(allocator.text("  "))
                 .append(
                     allocator
-                        .intersperse(fields.map(NodeDisplay), allocator.hardline())
-                        .align(),
+                        .hardline()
+                        .append(FieldSequence::new(fields))
+                        .nest(2),
                 )
                 .append(allocator.hardline())
                 .append(allocator.text("}"));
@@ -438,17 +438,15 @@ impl<'a> Pretty<'a, Allocator<'a>> for NodeDisplay<InputObjectDefinition<'a>> {
             );
         }
 
-        let mut fields = self.0.fields().peekable();
-        if fields.peek().is_some() {
+        let fields = self.0.fields();
+        if fields.len() != 0 {
             builder = builder
                 .append(allocator.space())
                 .append(allocator.text("{"))
                 .append(
                     allocator
                         .hardline()
-                        .append(
-                            allocator.intersperse(fields.map(NodeDisplay), allocator.hardline()),
-                        )
+                        .append(FieldSequence::new(fields))
                         .nest(2),
                 )
                 .append(allocator.hardline())
@@ -515,14 +513,12 @@ impl<'a> Pretty<'a, Allocator<'a>> for NodeDisplay<DirectiveDefinition<'a>> {
             .append("@")
             .append(self.0.name());
 
-        let mut arguments = self.0.arguments().peekable();
+        let arguments = self.0.arguments();
 
-        if arguments.peek().is_some() {
+        if arguments.len() != 0 {
             let arguments = allocator
                 .line_()
-                .append(
-                    allocator.intersperse(arguments.map(NodeDisplay), comma_or_newline(allocator)),
-                )
+                .append(ArgumentSequence::new(arguments))
                 .nest(2)
                 .append(allocator.line_())
                 .parens()

--- a/cynic-parser/src/printing/type_system.rs
+++ b/cynic-parser/src/printing/type_system.rs
@@ -369,17 +369,19 @@ impl<'a> Pretty<'a, Allocator<'a>> for NodeDisplay<EnumDefinition<'a>> {
             );
         }
 
-        let values = self.0.values().collect::<Vec<_>>();
+        let values = self.0.values();
 
-        if !values.is_empty() {
+        if values.len() != 0 {
             builder = builder
                 .append(allocator.space())
                 .append(allocator.text("{"))
-                .append(allocator.hardline())
                 .append(
                     allocator
-                        .intersperse(values.into_iter().map(NodeDisplay), allocator.hardline())
-                        .indent(2),
+                        .hardline()
+                        .append(FieldSequence::new(values))
+                        // allocator
+                        //     .intersperse(values.into_iter().map(NodeDisplay), allocator.hardline())
+                        .nest(2),
                 )
                 .append(allocator.hardline())
                 .append(allocator.text("}"));

--- a/cynic-parser/src/printing/type_system/argument_sequence.rs
+++ b/cynic-parser/src/printing/type_system/argument_sequence.rs
@@ -30,9 +30,13 @@ impl<'a> Pretty<'a, Allocator<'a>> for ArgumentSequence<'a> {
         let mut document = allocator.nil();
         for (index, item) in self.iterator {
             if index != 0 {
-                document = document.append(comma_or_newline(allocator));
                 if item.description().is_some() {
+                    // We use a hardcoded `\n` for the first newline here because
+                    // pretty always adds an indent on line but we want this line blank
+                    document = document.append(allocator.text("\n").flat_alt(allocator.text(", ")));
                     document = document.append(allocator.hardline());
+                } else {
+                    document = document.append(allocator.line().flat_alt(allocator.text(", ")));
                 }
             }
             document = document.append(NodeDisplay(item));

--- a/cynic-parser/src/printing/type_system/argument_sequence.rs
+++ b/cynic-parser/src/printing/type_system/argument_sequence.rs
@@ -1,0 +1,42 @@
+use std::iter::Enumerate;
+
+use pretty::{DocAllocator, Pretty};
+
+use super::{comma_or_newline, Allocator, InputValueDefinition, NodeDisplay};
+
+/// A sequence of things with docstrings attached.
+///
+/// This will print each entry with a prefix of:
+/// - first entry gets no prefix
+/// - when no docstring: just a single hardline prefix
+/// - when a docstring: two hardline prefix
+///
+/// This is used for displaying fields (both input fields & output fields)
+/// but arguments should use ArgumentSequence
+pub struct ArgumentSequence<'a> {
+    iterator: Enumerate<crate::type_system::iter::Iter<'a, InputValueDefinition<'a>>>,
+}
+
+impl<'a> ArgumentSequence<'a> {
+    pub fn new(iterator: crate::type_system::iter::Iter<'a, InputValueDefinition<'a>>) -> Self {
+        ArgumentSequence {
+            iterator: iterator.enumerate(),
+        }
+    }
+}
+
+impl<'a> Pretty<'a, Allocator<'a>> for ArgumentSequence<'a> {
+    fn pretty(self, allocator: &'a Allocator<'a>) -> pretty::DocBuilder<'a, Allocator<'a>, ()> {
+        let mut document = allocator.nil();
+        for (index, item) in self.iterator {
+            if index != 0 {
+                document = document.append(comma_or_newline(allocator));
+                if item.description().is_some() {
+                    document = document.append(allocator.hardline());
+                }
+            }
+            document = document.append(NodeDisplay(item));
+        }
+        document
+    }
+}

--- a/cynic-parser/src/printing/type_system/field_sequence.rs
+++ b/cynic-parser/src/printing/type_system/field_sequence.rs
@@ -5,7 +5,8 @@ use pretty::{DocAllocator, Pretty};
 use crate::common::IdOperations;
 
 use super::{
-    iter::IdReader, Allocator, FieldDefinition, InputValueDefinition, NodeDisplay, TypeSystemId,
+    iter::IdReader, Allocator, EnumValueDefinition, FieldDefinition, InputValueDefinition,
+    NodeDisplay, TypeSystemId,
 };
 
 /// A sequence of things with docstrings attached.
@@ -47,6 +48,12 @@ impl DocstringedItem for FieldDefinition<'_> {
 }
 
 impl DocstringedItem for InputValueDefinition<'_> {
+    fn has_docstring(&self) -> bool {
+        self.description().is_some()
+    }
+}
+
+impl DocstringedItem for EnumValueDefinition<'_> {
     fn has_docstring(&self) -> bool {
         self.description().is_some()
     }

--- a/cynic-parser/src/printing/type_system/field_sequence.rs
+++ b/cynic-parser/src/printing/type_system/field_sequence.rs
@@ -64,9 +64,14 @@ where
         let mut document = allocator.nil();
         for (index, item) in self.iterator {
             if index != 0 {
-                document = document.append(allocator.hardline());
                 if item.has_docstring() {
-                    document = document.append(allocator.hardline().nest(-2))
+                    // We use a hardcoded `\n` for the first newline here because
+                    // pretty always adds an indent but we want this line blank
+                    document = document
+                        .append(allocator.text("\n"))
+                        .append(allocator.hardline());
+                } else {
+                    document = document.append(allocator.hardline());
                 }
             }
             document = document.append(NodeDisplay(item));

--- a/cynic-parser/src/printing/type_system/field_sequence.rs
+++ b/cynic-parser/src/printing/type_system/field_sequence.rs
@@ -1,0 +1,76 @@
+use std::iter::Enumerate;
+
+use pretty::{DocAllocator, Pretty};
+
+use crate::common::IdOperations;
+
+use super::{
+    iter::IdReader, Allocator, FieldDefinition, InputValueDefinition, NodeDisplay, TypeSystemId,
+};
+
+/// A sequence of things with docstrings attached.
+///
+/// This will print each entry with a prefix of:
+/// - first entry gets no prefix
+/// - when no docstring: just a single hardline prefix
+/// - when a docstring: two hardline prefix
+///
+/// This is used for displaying fields (both input fields & output fields)
+/// but arguments should use ArgumentSequence
+pub struct FieldSequence<'a, T>
+where
+    T: IdReader,
+{
+    iterator: Enumerate<crate::type_system::iter::Iter<'a, T>>,
+}
+
+impl<'a, T> FieldSequence<'a, T>
+where
+    T: IdReader,
+    T::Id: IdOperations,
+{
+    pub fn new(iterator: crate::type_system::iter::Iter<'a, T>) -> Self {
+        FieldSequence {
+            iterator: iterator.enumerate(),
+        }
+    }
+}
+
+trait DocstringedItem {
+    fn has_docstring(&self) -> bool;
+}
+
+impl DocstringedItem for FieldDefinition<'_> {
+    fn has_docstring(&self) -> bool {
+        self.description().is_some()
+    }
+}
+
+impl DocstringedItem for InputValueDefinition<'_> {
+    fn has_docstring(&self) -> bool {
+        self.description().is_some()
+    }
+}
+
+impl<'a, T> Pretty<'a, Allocator<'a>> for FieldSequence<'a, T>
+where
+    T: DocstringedItem + IdReader,
+    T::Id: IdOperations,
+    // This is a bit much :/
+    <<T as IdReader>::Id as TypeSystemId>::Reader<'a>: DocstringedItem,
+    NodeDisplay<<<T as IdReader>::Id as TypeSystemId>::Reader<'a>>: Pretty<'a, Allocator<'a>>,
+{
+    fn pretty(self, allocator: &'a Allocator<'a>) -> pretty::DocBuilder<'a, Allocator<'a>, ()> {
+        let mut document = allocator.nil();
+        for (index, item) in self.iterator {
+            if index != 0 {
+                document = document.append(allocator.hardline());
+                if item.has_docstring() {
+                    document = document.append(allocator.hardline().nest(-2))
+                }
+            }
+            document = document.append(NodeDisplay(item));
+        }
+        document
+    }
+}

--- a/cynic-parser/tests/snapshots/actual_schemas__github__snapshot.snap
+++ b/cynic-parser/tests/snapshots/actual_schemas__github__snapshot.snap
@@ -24,7 +24,7 @@ directive @possibleTypes(
   Abstract type of accepted global ID
   """
   abstractType: String
-  
+
   """
   Accepted types of global IDs.
   """
@@ -39,7 +39,7 @@ input AbortQueuedMigrationsInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The ID of the organization that is running the migrations.
   """
@@ -54,7 +54,7 @@ type AbortQueuedMigrationsPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   Did the operation succeed?
   """
@@ -69,7 +69,7 @@ input AcceptEnterpriseAdministratorInvitationInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The id of the invitation being accepted
   """
@@ -85,12 +85,12 @@ type AcceptEnterpriseAdministratorInvitationPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The invitation that was accepted.
   """
   invitation: EnterpriseAdministratorInvitation
-  
+
   """
   A message confirming the result of accepting an administrator invitation.
   """
@@ -105,12 +105,12 @@ input AcceptTopicSuggestionInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The name of the suggested topic.
   """
   name: String!
-  
+
   """
   The Node ID of the repository.
   """
@@ -125,7 +125,7 @@ type AcceptTopicSuggestionPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The accepted topic.
   """
@@ -145,17 +145,17 @@ interface Actor {
     """
     size: Int
   ): URI!
-  
+
   """
   The username of the actor.
   """
   login: String!
-  
+
   """
   The HTTP path for this actor.
   """
   resourcePath: URI!
-  
+
   """
   The HTTP URL for this actor.
   """
@@ -170,22 +170,22 @@ type ActorLocation {
   City
   """
   city: String
-  
+
   """
   Country name
   """
   country: String
-  
+
   """
   Country code
   """
   countryCode: String
-  
+
   """
   Region name
   """
   region: String
-  
+
   """
   Region or state code
   """
@@ -218,12 +218,12 @@ input AddAssigneesToAssignableInput {
       concreteTypes: ["Issue", "PullRequest"]
       abstractType: "Assignable"
     )
-  
+
   """
   The id of users to add as assignees.
   """
   assigneeIds: [ID!]! @possibleTypes(concreteTypes: ["User"])
-  
+
   """
   A unique identifier for the client performing the mutation.
   """
@@ -238,7 +238,7 @@ type AddAssigneesToAssignablePayload {
   The item that was assigned.
   """
   assignable: Assignable
-  
+
   """
   A unique identifier for the client performing the mutation.
   """
@@ -253,12 +253,12 @@ input AddCommentInput {
   The contents of the comment.
   """
   body: String!
-  
+
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The Node ID of the subject to modify.
   """
@@ -277,17 +277,17 @@ type AddCommentPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The edge from the subject's comment connection.
   """
   commentEdge: IssueCommentEdge
-  
+
   """
   The subject
   """
   subject: Node
-  
+
   """
   The edge from the subject's timeline connection.
   """
@@ -302,17 +302,17 @@ input AddDiscussionCommentInput {
   The contents of the comment.
   """
   body: String!
-  
+
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The Node ID of the discussion to comment on.
   """
   discussionId: ID! @possibleTypes(concreteTypes: ["Discussion"])
-  
+
   """
   The Node ID of the discussion comment within this discussion to reply to.
   """
@@ -327,7 +327,7 @@ type AddDiscussionCommentPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The newly created discussion comment.
   """
@@ -342,7 +342,7 @@ input AddDiscussionPollVoteInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The Node ID of the discussion poll option to vote for.
   """
@@ -357,7 +357,7 @@ type AddDiscussionPollVotePayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The poll option that a vote was added to.
   """
@@ -372,22 +372,22 @@ input AddEnterpriseOrganizationMemberInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The ID of the enterprise which owns the organization.
   """
   enterpriseId: ID! @possibleTypes(concreteTypes: ["Enterprise"])
-  
+
   """
   The ID of the organization the users will be added to.
   """
   organizationId: ID! @possibleTypes(concreteTypes: ["Organization"])
-  
+
   """
   The role to assign the users in the organization
   """
   role: OrganizationMemberRole
-  
+
   """
   The IDs of the enterprise members to add.
   """
@@ -402,7 +402,7 @@ type AddEnterpriseOrganizationMemberPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The users who were added to the organization.
   """
@@ -417,12 +417,12 @@ input AddEnterpriseSupportEntitlementInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The ID of the Enterprise which the admin belongs to.
   """
   enterpriseId: ID! @possibleTypes(concreteTypes: ["Enterprise"])
-  
+
   """
   The login of a member who will receive the support entitlement.
   """
@@ -437,7 +437,7 @@ type AddEnterpriseSupportEntitlementPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   A message confirming the result of adding the support entitlement.
   """
@@ -452,12 +452,12 @@ input AddLabelsToLabelableInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The ids of the labels to add.
   """
   labelIds: [ID!]! @possibleTypes(concreteTypes: ["Label"])
-  
+
   """
   The id of the labelable object to add labels to.
   """
@@ -476,7 +476,7 @@ type AddLabelsToLabelablePayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The item that was labeled.
   """
@@ -491,7 +491,7 @@ input AddProjectCardInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The content of the card. Must be a member of the ProjectCardItem union
   """
@@ -500,12 +500,12 @@ input AddProjectCardInput {
       concreteTypes: ["Issue", "PullRequest"]
       abstractType: "ProjectCardItem"
     )
-  
+
   """
   The note on the card.
   """
   note: String
-  
+
   """
   The Node ID of the ProjectColumn.
   """
@@ -520,12 +520,12 @@ type AddProjectCardPayload {
   The edge from the ProjectColumn's card connection.
   """
   cardEdge: ProjectCardEdge
-  
+
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The ProjectColumn
   """
@@ -540,12 +540,12 @@ input AddProjectColumnInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The name of the column.
   """
   name: String!
-  
+
   """
   The Node ID of the project.
   """
@@ -560,12 +560,12 @@ type AddProjectColumnPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The edge from the project's column connection.
   """
   columnEdge: ProjectColumnEdge
-  
+
   """
   The project
   """
@@ -580,22 +580,22 @@ input AddProjectV2DraftIssueInput {
   The IDs of the assignees of the draft issue.
   """
   assigneeIds: [ID!] @possibleTypes(concreteTypes: ["User"])
-  
+
   """
   The body of the draft issue.
   """
   body: String
-  
+
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The ID of the Project to add the draft issue to.
   """
   projectId: ID! @possibleTypes(concreteTypes: ["ProjectV2"])
-  
+
   """
   The title of the draft issue. A project item can also be created by providing
   the URL of an Issue or Pull Request if you have access.
@@ -611,7 +611,7 @@ type AddProjectV2DraftIssuePayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The draft issue added to the project.
   """
@@ -626,7 +626,7 @@ input AddProjectV2ItemByIdInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The id of the Issue or Pull Request to add.
   """
@@ -635,7 +635,7 @@ input AddProjectV2ItemByIdInput {
       concreteTypes: ["DraftIssue", "Issue", "PullRequest"]
       abstractType: "ProjectV2ItemContent"
     )
-  
+
   """
   The ID of the Project to add the item to.
   """
@@ -650,7 +650,7 @@ type AddProjectV2ItemByIdPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The item added to the project.
   """
@@ -669,12 +669,12 @@ input AddPullRequestReviewCommentInput {
   **Reason:** We are deprecating the addPullRequestReviewComment mutation
   """
   body: String
-  
+
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The SHA of the commit to comment on.
 
@@ -683,7 +683,7 @@ input AddPullRequestReviewCommentInput {
   **Reason:** We are deprecating the addPullRequestReviewComment mutation
   """
   commitOID: GitObjectID
-  
+
   """
   The comment id to reply to.
 
@@ -692,7 +692,7 @@ input AddPullRequestReviewCommentInput {
   **Reason:** We are deprecating the addPullRequestReviewComment mutation
   """
   inReplyTo: ID @possibleTypes(concreteTypes: ["PullRequestReviewComment"])
-  
+
   """
   The relative path of the file to comment on.
 
@@ -701,7 +701,7 @@ input AddPullRequestReviewCommentInput {
   **Reason:** We are deprecating the addPullRequestReviewComment mutation
   """
   path: String
-  
+
   """
   The line index in the diff to comment on.
 
@@ -710,7 +710,7 @@ input AddPullRequestReviewCommentInput {
   **Reason:** We are deprecating the addPullRequestReviewComment mutation
   """
   position: Int
-  
+
   """
   The node ID of the pull request reviewing
 
@@ -720,7 +720,7 @@ input AddPullRequestReviewCommentInput {
   **Reason:** We are deprecating the addPullRequestReviewComment mutation
   """
   pullRequestId: ID @possibleTypes(concreteTypes: ["PullRequest"])
-  
+
   """
   The Node ID of the review to modify.
 
@@ -740,12 +740,12 @@ type AddPullRequestReviewCommentPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The newly created comment.
   """
   comment: PullRequestReviewComment
-  
+
   """
   The edge from the review's comment connection.
   """
@@ -760,12 +760,12 @@ input AddPullRequestReviewInput {
   The contents of the review body comment.
   """
   body: String
-  
+
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The review line comments.
 
@@ -774,22 +774,22 @@ input AddPullRequestReviewInput {
   **Reason:** We are deprecating comment fields that use diff-relative positioning
   """
   comments: [DraftPullRequestReviewComment]
-  
+
   """
   The commit OID the review pertains to.
   """
   commitOID: GitObjectID
-  
+
   """
   The event to perform on the pull request review.
   """
   event: PullRequestReviewEvent
-  
+
   """
   The Node ID of the pull request to modify.
   """
   pullRequestId: ID! @possibleTypes(concreteTypes: ["PullRequest"])
-  
+
   """
   The review line comment threads.
   """
@@ -804,12 +804,12 @@ type AddPullRequestReviewPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The newly created pull request review.
   """
   pullRequestReview: PullRequestReview
-  
+
   """
   The edge from the pull request's review connection.
   """
@@ -824,48 +824,48 @@ input AddPullRequestReviewThreadInput {
   Body of the thread's first comment.
   """
   body: String!
-  
+
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The line of the blob to which the thread refers, required for line-level
   threads. The end of the line range for multi-line comments.
   """
   line: Int
-  
+
   """
   Path to the file being commented on.
   """
   path: String!
-  
+
   """
   The node ID of the pull request reviewing
   """
   pullRequestId: ID @possibleTypes(concreteTypes: ["PullRequest"])
-  
+
   """
   The Node ID of the review to modify.
   """
   pullRequestReviewId: ID @possibleTypes(concreteTypes: ["PullRequestReview"])
-  
+
   """
   The side of the diff on which the line resides. For multi-line comments, this is the side for the end of the line range.
   """
   side: DiffSide = RIGHT
-  
+
   """
   The first line of the range to which the comment refers.
   """
   startLine: Int
-  
+
   """
   The side of the diff on which the start line resides.
   """
   startSide: DiffSide = RIGHT
-  
+
   """
   The level at which the comments in the corresponding thread are targeted, can be a diff line or a file
   """
@@ -880,7 +880,7 @@ type AddPullRequestReviewThreadPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The newly created thread.
   """
@@ -895,17 +895,17 @@ input AddPullRequestReviewThreadReplyInput {
   The text of the reply.
   """
   body: String!
-  
+
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The Node ID of the pending review to which the reply will belong.
   """
   pullRequestReviewId: ID @possibleTypes(concreteTypes: ["PullRequestReview"])
-  
+
   """
   The Node ID of the thread to which this reply is being written.
   """
@@ -921,7 +921,7 @@ type AddPullRequestReviewThreadReplyPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The newly created reply.
   """
@@ -936,12 +936,12 @@ input AddReactionInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The name of the emoji to react with.
   """
   content: ReactionContent!
-  
+
   """
   The Node ID of the subject to modify.
   """
@@ -972,17 +972,17 @@ type AddReactionPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The reaction object.
   """
   reaction: Reaction
-  
+
   """
   The reaction groups for the subject.
   """
   reactionGroups: [ReactionGroup!]
-  
+
   """
   The reactable subject.
   """
@@ -997,7 +997,7 @@ input AddStarInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The Starrable ID to star.
   """
@@ -1016,7 +1016,7 @@ type AddStarPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The starrable.
   """
@@ -1031,7 +1031,7 @@ input AddUpvoteInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The Node ID of the discussion or comment to upvote.
   """
@@ -1050,7 +1050,7 @@ type AddUpvotePayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The votable subject.
   """
@@ -1065,12 +1065,12 @@ input AddVerifiableDomainInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The URL of the domain
   """
   domain: URI!
-  
+
   """
   The ID of the owner to add the domain to
   """
@@ -1089,7 +1089,7 @@ type AddVerifiableDomainPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The verifiable domain that was added.
   """
@@ -1104,23 +1104,23 @@ type AddedToMergeQueueEvent implements Node {
   Identifies the actor who performed the event.
   """
   actor: Actor
-  
+
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
-  
+
   """
   The user who added this Pull Request to the merge queue
   """
   enqueuer: User
   id: ID!
-  
+
   """
   The merge queue where this pull request was added to.
   """
   mergeQueue: MergeQueue
-  
+
   """
   PullRequest referenced by event.
   """
@@ -1135,28 +1135,28 @@ type AddedToProjectEvent implements Node {
   Identifies the actor who performed the event.
   """
   actor: Actor
-  
+
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
-  
+
   """
   Identifies the primary key from the database.
   """
   databaseId: Int
   id: ID!
-  
+
   """
   Project referenced by event.
   """
   project: Project @preview(toggledBy: "starfox-preview")
-  
+
   """
   Project card referenced by this project event.
   """
   projectCard: ProjectCard @preview(toggledBy: "starfox-preview")
-  
+
   """
   Column name referenced by this project event.
   """
@@ -1171,12 +1171,12 @@ interface AnnouncementBanner {
   The text of the announcement
   """
   announcement: String
-  
+
   """
   The expiration date of the announcement, if any
   """
   announcementExpiresAt: DateTime
-  
+
   """
   Whether the announcement can be dismissed by the user
   """
@@ -1191,18 +1191,18 @@ type App implements Node {
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
-  
+
   """
   Identifies the primary key from the database.
   """
   databaseId: Int
-  
+
   """
   The description of the app.
   """
   description: String
   id: ID!
-  
+
   """
   The IP addresses of the app.
   """
@@ -1211,33 +1211,33 @@ type App implements Node {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for IP allow list entries returned.
     """
     orderBy: IpAllowListEntryOrder = { field: ALLOW_LIST_VALUE, direction: ASC }
   ): IpAllowListEntryConnection!
-  
+
   """
   The hex color code, without the leading '#', for the logo background.
   """
   logoBackgroundColor: String!
-  
+
   """
   A URL pointing to the app's logo.
   """
@@ -1247,22 +1247,22 @@ type App implements Node {
     """
     size: Int
   ): URI!
-  
+
   """
   The name of the app.
   """
   name: String!
-  
+
   """
   A slug based on the name of the app for use in URLs.
   """
   slug: String!
-  
+
   """
   Identifies the date and time when the object was last updated.
   """
   updatedAt: DateTime!
-  
+
   """
   The URL to the app's homepage.
   """
@@ -1277,17 +1277,17 @@ input ApproveDeploymentsInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   Optional comment for approving deployments
   """
   comment: String = ""
-  
+
   """
   The ids of environments to reject deployments
   """
   environmentIds: [ID!]!
-  
+
   """
   The node ID of the workflow run containing the pending deployments.
   """
@@ -1302,7 +1302,7 @@ type ApproveDeploymentsPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The affected deployments.
   """
@@ -1317,7 +1317,7 @@ input ApproveVerifiableDomainInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The ID of the verifiable domain to approve.
   """
@@ -1332,7 +1332,7 @@ type ApproveVerifiableDomainPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The verifiable domain that was approved.
   """
@@ -1347,12 +1347,12 @@ input ArchiveProjectV2ItemInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The ID of the ProjectV2Item to archive.
   """
   itemId: ID! @possibleTypes(concreteTypes: ["ProjectV2Item"])
-  
+
   """
   The ID of the Project to archive the item from.
   """
@@ -1367,7 +1367,7 @@ type ArchiveProjectV2ItemPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The item archived from the project.
   """
@@ -1382,7 +1382,7 @@ input ArchiveRepositoryInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The ID of the repository to mark as archived.
   """
@@ -1397,7 +1397,7 @@ type ArchiveRepositoryPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The repository that was marked as archived.
   """
@@ -1416,17 +1416,17 @@ interface Assignable {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
@@ -1442,23 +1442,23 @@ type AssignedEvent implements Node {
   Identifies the actor who performed the event.
   """
   actor: Actor
-  
+
   """
   Identifies the assignable associated with the event.
   """
   assignable: Assignable!
-  
+
   """
   Identifies the user or mannequin that was assigned.
   """
   assignee: Assignee
-  
+
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
   id: ID!
-  
+
   """
   Identifies the user who was assigned.
   """
@@ -1481,62 +1481,62 @@ interface AuditEntry {
   The action name
   """
   action: String!
-  
+
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
-  
+
   """
   The IP address of the actor
   """
   actorIp: String
-  
+
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
-  
+
   """
   The username of the user who initiated the action
   """
   actorLogin: String
-  
+
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
-  
+
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
-  
+
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
-  
+
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
-  
+
   """
   The user affected by the action
   """
   user: User
-  
+
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
-  
+
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
-  
+
   """
   The HTTP URL for the user.
   """
@@ -1556,7 +1556,7 @@ input AuditLogOrder {
   The ordering direction.
   """
   direction: OrderDirection
-  
+
   """
   The field to order Audit Logs by.
   """
@@ -1581,28 +1581,28 @@ type AutoMergeDisabledEvent implements Node {
   Identifies the actor who performed the event.
   """
   actor: Actor
-  
+
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
-  
+
   """
   The user who disabled auto-merge for this Pull Request
   """
   disabler: User
   id: ID!
-  
+
   """
   PullRequest referenced by event
   """
   pullRequest: PullRequest
-  
+
   """
   The reason auto-merge was disabled
   """
   reason: String
-  
+
   """
   The reason_code relating to why auto-merge was disabled
   """
@@ -1617,18 +1617,18 @@ type AutoMergeEnabledEvent implements Node {
   Identifies the actor who performed the event.
   """
   actor: Actor
-  
+
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
-  
+
   """
   The user who enabled auto-merge for this Pull Request
   """
   enabler: User
   id: ID!
-  
+
   """
   PullRequest referenced by event.
   """
@@ -1643,35 +1643,35 @@ type AutoMergeRequest {
   The email address of the author of this auto-merge request.
   """
   authorEmail: String
-  
+
   """
   The commit message of the auto-merge request. If a merge queue is required by
   the base branch, this value will be set by the merge queue when merging.
   """
   commitBody: String
-  
+
   """
   The commit title of the auto-merge request. If a merge queue is required by
   the base branch, this value will be set by the merge queue when merging
   """
   commitHeadline: String
-  
+
   """
   When was this auto-merge request was enabled.
   """
   enabledAt: DateTime
-  
+
   """
   The actor who created the auto-merge request.
   """
   enabledBy: Actor
-  
+
   """
   The merge method of the auto-merge request. If a merge queue is required by
   the base branch, this value will be set by the merge queue when merging.
   """
   mergeMethod: PullRequestMergeMethod!
-  
+
   """
   The pull request that this auto-merge request is set against.
   """
@@ -1686,18 +1686,18 @@ type AutoRebaseEnabledEvent implements Node {
   Identifies the actor who performed the event.
   """
   actor: Actor
-  
+
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
-  
+
   """
   The user who enabled auto-merge (rebase) for this Pull Request
   """
   enabler: User
   id: ID!
-  
+
   """
   PullRequest referenced by event.
   """
@@ -1712,18 +1712,18 @@ type AutoSquashEnabledEvent implements Node {
   Identifies the actor who performed the event.
   """
   actor: Actor
-  
+
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
-  
+
   """
   The user who enabled auto-merge (squash) for this Pull Request
   """
   enabler: User
   id: ID!
-  
+
   """
   PullRequest referenced by event.
   """
@@ -1738,23 +1738,23 @@ type AutomaticBaseChangeFailedEvent implements Node {
   Identifies the actor who performed the event.
   """
   actor: Actor
-  
+
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
   id: ID!
-  
+
   """
   The new base for this PR
   """
   newBase: String!
-  
+
   """
   The old base for this PR
   """
   oldBase: String!
-  
+
   """
   PullRequest referenced by event.
   """
@@ -1769,23 +1769,23 @@ type AutomaticBaseChangeSucceededEvent implements Node {
   Identifies the actor who performed the event.
   """
   actor: Actor
-  
+
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
   id: ID!
-  
+
   """
   The new base for this PR
   """
   newBase: String!
-  
+
   """
   The old base for this PR
   """
   oldBase: String!
-  
+
   """
   PullRequest referenced by event.
   """
@@ -1805,28 +1805,28 @@ type BaseRefChangedEvent implements Node {
   Identifies the actor who performed the event.
   """
   actor: Actor
-  
+
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
-  
+
   """
   Identifies the name of the base ref for the pull request after it was changed.
   """
   currentRefName: String!
-  
+
   """
   Identifies the primary key from the database.
   """
   databaseId: Int
   id: ID!
-  
+
   """
   Identifies the name of the base ref for the pull request before it was changed.
   """
   previousRefName: String!
-  
+
   """
   PullRequest referenced by event.
   """
@@ -1841,18 +1841,18 @@ type BaseRefDeletedEvent implements Node {
   Identifies the actor who performed the event.
   """
   actor: Actor
-  
+
   """
   Identifies the name of the Ref associated with the `base_ref_deleted` event.
   """
   baseRefName: String
-  
+
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
   id: ID!
-  
+
   """
   PullRequest referenced by event.
   """
@@ -1867,28 +1867,28 @@ type BaseRefForcePushedEvent implements Node {
   Identifies the actor who performed the event.
   """
   actor: Actor
-  
+
   """
   Identifies the after commit SHA for the 'base_ref_force_pushed' event.
   """
   afterCommit: Commit
-  
+
   """
   Identifies the before commit SHA for the 'base_ref_force_pushed' event.
   """
   beforeCommit: Commit
-  
+
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
   id: ID!
-  
+
   """
   PullRequest referenced by event.
   """
   pullRequest: PullRequest!
-  
+
   """
   Identifies the fully qualified ref name for the 'base_ref_force_pushed' event.
   """
@@ -1922,17 +1922,17 @@ type BlameRange {
   range's change.
   """
   age: Int!
-  
+
   """
   Identifies the line author
   """
   commit: Commit!
-  
+
   """
   The ending line for the range
   """
   endingLine: Int!
-  
+
   """
   The starting line for the range
   """
@@ -1947,43 +1947,43 @@ type Blob implements GitObject & Node {
   An abbreviated version of the Git object ID
   """
   abbreviatedOid: String!
-  
+
   """
   Byte size of Blob object
   """
   byteSize: Int!
-  
+
   """
   The HTTP path for this Git object
   """
   commitResourcePath: URI!
-  
+
   """
   The HTTP URL for this Git object
   """
   commitUrl: URI!
   id: ID!
-  
+
   """
   Indicates whether the Blob is binary or text. Returns null if unable to determine the encoding.
   """
   isBinary: Boolean
-  
+
   """
   Indicates whether the contents is truncated
   """
   isTruncated: Boolean!
-  
+
   """
   The Git object ID
   """
   oid: GitObjectID!
-  
+
   """
   The Repository the Git object belongs to
   """
   repository: Repository!
-  
+
   """
   UTF8 text data or null if the Blob is binary
   """
@@ -2003,33 +2003,33 @@ type Bot implements Actor & Node & UniformResourceLocatable {
     """
     size: Int
   ): URI!
-  
+
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
-  
+
   """
   Identifies the primary key from the database.
   """
   databaseId: Int
   id: ID!
-  
+
   """
   The username of the actor.
   """
   login: String!
-  
+
   """
   The HTTP path for this bot
   """
   resourcePath: URI!
-  
+
   """
   Identifies the date and time when the object was last updated.
   """
   updatedAt: DateTime!
-  
+
   """
   The HTTP URL for this bot
   """
@@ -2049,17 +2049,17 @@ type BranchNamePatternParameters {
   How this rule will appear to users.
   """
   name: String
-  
+
   """
   If true, the rule will fail if the pattern matches.
   """
   negate: Boolean!
-  
+
   """
   The operator to use for matching.
   """
   operator: String!
-  
+
   """
   The pattern to match with.
   """
@@ -2074,17 +2074,17 @@ input BranchNamePatternParametersInput {
   How this rule will appear to users.
   """
   name: String
-  
+
   """
   If true, the rule will fail if the pattern matches.
   """
   negate: Boolean
-  
+
   """
   The operator to use for matching.
   """
   operator: String!
-  
+
   """
   The pattern to match with.
   """
@@ -2099,17 +2099,17 @@ type BranchProtectionRule implements Node {
   Can this branch be deleted.
   """
   allowsDeletions: Boolean!
-  
+
   """
   Are force pushes allowed on this branch.
   """
   allowsForcePushes: Boolean!
-  
+
   """
   Is branch creation a protected operation.
   """
   blocksCreations: Boolean!
-  
+
   """
   A list of conflicts matching branches protection rule and other branch protection rules
   """
@@ -2118,23 +2118,23 @@ type BranchProtectionRule implements Node {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): BranchProtectionRuleConflictConnection!
-  
+
   """
   A list of actors able to force push for this branch protection rule.
   """
@@ -2143,23 +2143,23 @@ type BranchProtectionRule implements Node {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): BypassForcePushAllowanceConnection!
-  
+
   """
   A list of actors able to bypass PRs for this branch protection rule.
   """
@@ -2168,55 +2168,55 @@ type BranchProtectionRule implements Node {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): BypassPullRequestAllowanceConnection!
-  
+
   """
   The actor who created this branch protection rule.
   """
   creator: Actor
-  
+
   """
   Identifies the primary key from the database.
   """
   databaseId: Int
-  
+
   """
   Will new commits pushed to matching branches dismiss pull request review approvals.
   """
   dismissesStaleReviews: Boolean!
   id: ID!
-  
+
   """
   Can admins overwrite branch protection.
   """
   isAdminEnforced: Boolean!
-  
+
   """
   Whether users can pull changes from upstream when the branch is locked. Set to
   `true` to allow fork syncing. Set to `false` to prevent fork syncing.
   """
   lockAllowsFetchAndMerge: Boolean!
-  
+
   """
   Whether to set the branch as read-only. If this is true, users will not be able to push to the branch.
   """
   lockBranch: Boolean!
-  
+
   """
   Repository refs that are protected by this rule
   """
@@ -2225,33 +2225,33 @@ type BranchProtectionRule implements Node {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Filters refs with query on name
     """
     query: String
   ): RefConnection!
-  
+
   """
   Identifies the protection rule pattern.
   """
   pattern: String!
-  
+
   """
   A list push allowances for this branch protection rule.
   """
@@ -2260,103 +2260,103 @@ type BranchProtectionRule implements Node {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): PushAllowanceConnection!
-  
+
   """
   The repository associated with this branch protection rule.
   """
   repository: Repository
-  
+
   """
   Whether the most recent push must be approved by someone other than the person who pushed it
   """
   requireLastPushApproval: Boolean!
-  
+
   """
   Number of approving reviews required to update matching branches.
   """
   requiredApprovingReviewCount: Int
-  
+
   """
   List of required deployment environments that must be deployed successfully to update matching branches
   """
   requiredDeploymentEnvironments: [String]
-  
+
   """
   List of required status check contexts that must pass for commits to be accepted to matching branches.
   """
   requiredStatusCheckContexts: [String]
-  
+
   """
   List of required status checks that must pass for commits to be accepted to matching branches.
   """
   requiredStatusChecks: [RequiredStatusCheckDescription!]
-  
+
   """
   Are approving reviews required to update matching branches.
   """
   requiresApprovingReviews: Boolean!
-  
+
   """
   Are reviews from code owners required to update matching branches.
   """
   requiresCodeOwnerReviews: Boolean!
-  
+
   """
   Are commits required to be signed.
   """
   requiresCommitSignatures: Boolean!
-  
+
   """
   Are conversations required to be resolved before merging.
   """
   requiresConversationResolution: Boolean!
-  
+
   """
   Does this branch require deployment to specific environments before merging
   """
   requiresDeployments: Boolean!
-  
+
   """
   Are merge commits prohibited from being pushed to this branch.
   """
   requiresLinearHistory: Boolean!
-  
+
   """
   Are status checks required to update matching branches.
   """
   requiresStatusChecks: Boolean!
-  
+
   """
   Are branches required to be up to date before merging.
   """
   requiresStrictStatusChecks: Boolean!
-  
+
   """
   Is pushing to matching branches restricted.
   """
   restrictsPushes: Boolean!
-  
+
   """
   Is dismissal of pull request reviews restricted.
   """
   restrictsReviewDismissals: Boolean!
-  
+
   """
   A list review dismissal allowances for this branch protection rule.
   """
@@ -2365,17 +2365,17 @@ type BranchProtectionRule implements Node {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
@@ -2391,12 +2391,12 @@ type BranchProtectionRuleConflict {
   Identifies the branch protection rule.
   """
   branchProtectionRule: BranchProtectionRule
-  
+
   """
   Identifies the conflicting branch protection rule.
   """
   conflictingBranchProtectionRule: BranchProtectionRule
-  
+
   """
   Identifies the branch ref that has conflicting rules
   """
@@ -2411,17 +2411,17 @@ type BranchProtectionRuleConflictConnection {
   A list of edges.
   """
   edges: [BranchProtectionRuleConflictEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [BranchProtectionRuleConflict]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -2436,7 +2436,7 @@ type BranchProtectionRuleConflictEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -2451,17 +2451,17 @@ type BranchProtectionRuleConnection {
   A list of edges.
   """
   edges: [BranchProtectionRuleEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [BranchProtectionRule]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -2476,7 +2476,7 @@ type BranchProtectionRuleEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -2492,7 +2492,7 @@ input BulkSponsorship {
   The amount to pay to the sponsorable in US dollars. Valid values: 1-12000.
   """
   amount: Int!
-  
+
   """
   The ID of the user or organization who is receiving the sponsorship. Required if sponsorableLogin is not given.
   """
@@ -2501,7 +2501,7 @@ input BulkSponsorship {
       concreteTypes: ["Organization", "User"]
       abstractType: "Sponsorable"
     )
-  
+
   """
   The username of the user or organization who is receiving the sponsorship. Required if sponsorableId is not given.
   """
@@ -2521,7 +2521,7 @@ type BypassForcePushAllowance implements Node {
   The actor that can force push.
   """
   actor: BranchActorAllowanceActor
-  
+
   """
   Identifies the branch protection rule associated with the allowed user, team, or app.
   """
@@ -2537,17 +2537,17 @@ type BypassForcePushAllowanceConnection {
   A list of edges.
   """
   edges: [BypassForcePushAllowanceEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [BypassForcePushAllowance]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -2562,7 +2562,7 @@ type BypassForcePushAllowanceEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -2577,7 +2577,7 @@ type BypassPullRequestAllowance implements Node {
   The actor that can bypass.
   """
   actor: BranchActorAllowanceActor
-  
+
   """
   Identifies the branch protection rule associated with the allowed user, team, or app.
   """
@@ -2593,17 +2593,17 @@ type BypassPullRequestAllowanceConnection {
   A list of edges.
   """
   edges: [BypassPullRequestAllowanceEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [BypassPullRequestAllowance]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -2618,7 +2618,7 @@ type BypassPullRequestAllowanceEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -2633,7 +2633,7 @@ type CVSS {
   The CVSS score associated with this advisory
   """
   score: Float!
-  
+
   """
   The CVSS vector string associated with this advisory
   """
@@ -2648,13 +2648,13 @@ type CWE implements Node {
   The id of the CWE
   """
   cweId: String!
-  
+
   """
   A detailed description of this CWE
   """
   description: String!
   id: ID!
-  
+
   """
   The name of this CWE
   """
@@ -2669,17 +2669,17 @@ type CWEConnection {
   A list of edges.
   """
   edges: [CWEEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [CWE]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -2694,7 +2694,7 @@ type CWEEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -2709,7 +2709,7 @@ input CancelEnterpriseAdminInvitationInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The Node ID of the pending enterprise administrator invitation.
   """
@@ -2725,12 +2725,12 @@ type CancelEnterpriseAdminInvitationPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The invitation that was canceled.
   """
   invitation: EnterpriseAdministratorInvitation
-  
+
   """
   A message confirming the result of canceling an administrator invitation.
   """
@@ -2745,7 +2745,7 @@ input CancelSponsorshipInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The ID of the user or organization who is acting as the sponsor, paying for
   the sponsorship. Required if sponsorLogin is not given.
@@ -2755,13 +2755,13 @@ input CancelSponsorshipInput {
       concreteTypes: ["Organization", "User"]
       abstractType: "Sponsor"
     )
-  
+
   """
   The username of the user or organization who is acting as the sponsor, paying
   for the sponsorship. Required if sponsorId is not given.
   """
   sponsorLogin: String
-  
+
   """
   The ID of the user or organization who is receiving the sponsorship. Required if sponsorableLogin is not given.
   """
@@ -2770,7 +2770,7 @@ input CancelSponsorshipInput {
       concreteTypes: ["Organization", "User"]
       abstractType: "Sponsorable"
     )
-  
+
   """
   The username of the user or organization who is receiving the sponsorship. Required if sponsorableId is not given.
   """
@@ -2785,7 +2785,7 @@ type CancelSponsorshipPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The tier that was being used at the time of cancellation.
   """
@@ -2800,27 +2800,27 @@ input ChangeUserStatusInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The emoji to represent your status. Can either be a native Unicode emoji or an emoji name with colons, e.g., :grinning:.
   """
   emoji: String
-  
+
   """
   If set, the user status will not be shown after this date.
   """
   expiresAt: DateTime
-  
+
   """
   Whether this status should indicate you are not fully available on GitHub, e.g., you are away.
   """
   limitedAvailability: Boolean = false
-  
+
   """
   A short description of your current status.
   """
   message: String
-  
+
   """
   The ID of the organization whose members will be allowed to see the status. If
   omitted, the status will be publicly visible.
@@ -2836,7 +2836,7 @@ type ChangeUserStatusPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   Your updated status.
   """
@@ -2851,37 +2851,37 @@ type CheckAnnotation {
   The annotation's severity level.
   """
   annotationLevel: CheckAnnotationLevel
-  
+
   """
   The path to the file that this annotation was made on.
   """
   blobUrl: URI!
-  
+
   """
   Identifies the primary key from the database.
   """
   databaseId: Int
-  
+
   """
   The position of this annotation.
   """
   location: CheckAnnotationSpan!
-  
+
   """
   The annotation's message.
   """
   message: String!
-  
+
   """
   The path that this annotation was made on.
   """
   path: String!
-  
+
   """
   Additional information about the annotation.
   """
   rawDetails: String
-  
+
   """
   The annotation's title
   """
@@ -2896,17 +2896,17 @@ type CheckAnnotationConnection {
   A list of edges.
   """
   edges: [CheckAnnotationEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [CheckAnnotation]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -2921,27 +2921,27 @@ input CheckAnnotationData {
   Represents an annotation's information level
   """
   annotationLevel: CheckAnnotationLevel!
-  
+
   """
   The location of the annotation
   """
   location: CheckAnnotationRange!
-  
+
   """
   A short description of the feedback for these lines of code.
   """
   message: String!
-  
+
   """
   The path of the file to add an annotation to.
   """
   path: String!
-  
+
   """
   Details about this annotation.
   """
   rawDetails: String
-  
+
   """
   The title that represents the annotation.
   """
@@ -2956,7 +2956,7 @@ type CheckAnnotationEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -2989,7 +2989,7 @@ type CheckAnnotationPosition {
   Column number (1 indexed).
   """
   column: Int
-  
+
   """
   Line number (1 indexed).
   """
@@ -3004,17 +3004,17 @@ input CheckAnnotationRange {
   The ending column of the range.
   """
   endColumn: Int
-  
+
   """
   The ending line of the range.
   """
   endLine: Int!
-  
+
   """
   The starting column of the range.
   """
   startColumn: Int
-  
+
   """
   The starting line of the range.
   """
@@ -3029,7 +3029,7 @@ type CheckAnnotationSpan {
   End position (inclusive).
   """
   end: CheckAnnotationPosition!
-  
+
   """
   Start position (inclusive).
   """
@@ -3090,59 +3090,59 @@ type CheckRun implements Node & RequirableByPullRequest & UniformResourceLocatab
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): CheckAnnotationConnection
-  
+
   """
   The check suite that this run is a part of.
   """
   checkSuite: CheckSuite!
-  
+
   """
   Identifies the date and time when the check run was completed.
   """
   completedAt: DateTime
-  
+
   """
   The conclusion of the check run.
   """
   conclusion: CheckConclusionState
-  
+
   """
   Identifies the primary key from the database.
   """
   databaseId: Int
-  
+
   """
   The corresponding deployment for this job, if any
   """
   deployment: Deployment
-  
+
   """
   The URL from which to find full details of the check run on the integrator's site.
   """
   detailsUrl: URI
-  
+
   """
   A reference for the check run on the integrator's system.
   """
   externalId: String
   id: ID!
-  
+
   """
   Whether this is required to pass before merging for a specific pull request.
   """
@@ -3151,48 +3151,48 @@ type CheckRun implements Node & RequirableByPullRequest & UniformResourceLocatab
     The id of the pull request this is required for
     """
     pullRequestId: ID
-    
+
     """
     The number of the pull request this is required for
     """
     pullRequestNumber: Int
   ): Boolean!
-  
+
   """
   The name of the check for this check run.
   """
   name: String!
-  
+
   """
   Information about a pending deployment, if any, in this check run
   """
   pendingDeploymentRequest: DeploymentRequest
-  
+
   """
   The permalink to the check run summary.
   """
   permalink: URI!
-  
+
   """
   The repository associated with this check run.
   """
   repository: Repository!
-  
+
   """
   The HTTP path for this check run.
   """
   resourcePath: URI!
-  
+
   """
   Identifies the date and time when the check run was started.
   """
   startedAt: DateTime
-  
+
   """
   The current status of the check run.
   """
   status: CheckStatusState!
-  
+
   """
   The check run's steps
   """
@@ -3201,43 +3201,43 @@ type CheckRun implements Node & RequirableByPullRequest & UniformResourceLocatab
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Step number
     """
     number: Int
   ): CheckStepConnection
-  
+
   """
   A string representing the check run's summary
   """
   summary: String
-  
+
   """
   A string representing the check run's text
   """
   text: String
-  
+
   """
   A string representing the check run
   """
   title: String
-  
+
   """
   The HTTP URL for this check run.
   """
@@ -3252,12 +3252,12 @@ input CheckRunAction {
   A short explanation of what this action would do.
   """
   description: String!
-  
+
   """
   A reference for the action on the integrator's system.
   """
   identifier: String!
-  
+
   """
   The text to be displayed on a button in the web UI.
   """
@@ -3272,17 +3272,17 @@ type CheckRunConnection {
   A list of edges.
   """
   edges: [CheckRunEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [CheckRun]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -3297,7 +3297,7 @@ type CheckRunEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -3312,27 +3312,27 @@ input CheckRunFilter {
   Filters the check runs created by this application ID.
   """
   appId: Int
-  
+
   """
   Filters the check runs by this name.
   """
   checkName: String
-  
+
   """
   Filters the check runs by this type.
   """
   checkType: CheckRunType
-  
+
   """
   Filters the check runs by these conclusions.
   """
   conclusions: [CheckConclusionState!]
-  
+
   """
   Filters the check runs by this status. Superceded by statuses.
   """
   status: CheckStatusState
-  
+
   """
   Filters the check runs by this status. Overrides status.
   """
@@ -3347,22 +3347,22 @@ input CheckRunOutput {
   The annotations that are made as part of the check run.
   """
   annotations: [CheckAnnotationData!]
-  
+
   """
   Images attached to the check run output displayed in the GitHub pull request UI.
   """
   images: [CheckRunOutputImage!]
-  
+
   """
   The summary of the check run (supports Commonmark).
   """
   summary: String!
-  
+
   """
   The details of the check run (supports Commonmark).
   """
   text: String
-  
+
   """
   A title to provide for this check run.
   """
@@ -3377,12 +3377,12 @@ input CheckRunOutputImage {
   The alternative text for the image.
   """
   alt: String!
-  
+
   """
   A short image description.
   """
   caption: String
-  
+
   """
   The full URL of the image.
   """
@@ -3459,7 +3459,7 @@ type CheckRunStateCount {
   The number of check runs with this state.
   """
   count: Int!
-  
+
   """
   The state of a check run.
   """
@@ -3518,37 +3518,37 @@ type CheckStep {
   Identifies the date and time when the check step was completed.
   """
   completedAt: DateTime
-  
+
   """
   The conclusion of the check step.
   """
   conclusion: CheckConclusionState
-  
+
   """
   A reference for the check step on the integrator's system.
   """
   externalId: String
-  
+
   """
   The step's name.
   """
   name: String!
-  
+
   """
   The index of the step in the list of steps of the parent check run.
   """
   number: Int!
-  
+
   """
   Number of seconds to completion.
   """
   secondsToCompletion: Int
-  
+
   """
   Identifies the date and time when the check step was started.
   """
   startedAt: DateTime
-  
+
   """
   The current status of the check step.
   """
@@ -3563,17 +3563,17 @@ type CheckStepConnection {
   A list of edges.
   """
   edges: [CheckStepEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [CheckStep]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -3588,7 +3588,7 @@ type CheckStepEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -3603,12 +3603,12 @@ type CheckSuite implements Node {
   The GitHub App which created this check suite.
   """
   app: App
-  
+
   """
   The name of the branch for this check suite.
   """
   branch: Ref
-  
+
   """
   The check runs associated with a check suite.
   """
@@ -3617,54 +3617,54 @@ type CheckSuite implements Node {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Filters the check runs by this type.
     """
     filterBy: CheckRunFilter
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): CheckRunConnection
-  
+
   """
   The commit for this check suite
   """
   commit: Commit!
-  
+
   """
   The conclusion of this check suite.
   """
   conclusion: CheckConclusionState
-  
+
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
-  
+
   """
   The user who triggered the check suite.
   """
   creator: User
-  
+
   """
   Identifies the primary key from the database.
   """
   databaseId: Int
   id: ID!
-  
+
   """
   A list of open pull requests matching the check suite.
   """
@@ -3673,78 +3673,78 @@ type CheckSuite implements Node {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     The base ref name to filter the pull requests by.
     """
     baseRefName: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     The head ref name to filter the pull requests by.
     """
     headRefName: String
-    
+
     """
     A list of label names to filter the pull requests by.
     """
     labels: [String!]
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for pull requests returned from the connection.
     """
     orderBy: IssueOrder
-    
+
     """
     A list of states to filter the pull requests by.
     """
     states: [PullRequestState!]
   ): PullRequestConnection
-  
+
   """
   The push that triggered this check suite.
   """
   push: Push
-  
+
   """
   The repository associated with this check suite.
   """
   repository: Repository!
-  
+
   """
   The HTTP path for this check suite
   """
   resourcePath: URI!
-  
+
   """
   The status of this check suite.
   """
   status: CheckStatusState!
-  
+
   """
   Identifies the date and time when the object was last updated.
   """
   updatedAt: DateTime!
-  
+
   """
   The HTTP URL for this check suite
   """
   url: URI!
-  
+
   """
   The workflow run associated with this check suite.
   """
@@ -3759,7 +3759,7 @@ input CheckSuiteAutoTriggerPreference {
   The node ID of the application that owns the check suite.
   """
   appId: ID!
-  
+
   """
   Set to `true` to enable automatic creation of CheckSuite events upon pushes to the repository.
   """
@@ -3774,17 +3774,17 @@ type CheckSuiteConnection {
   A list of edges.
   """
   edges: [CheckSuiteEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [CheckSuite]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -3799,7 +3799,7 @@ type CheckSuiteEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -3814,7 +3814,7 @@ input CheckSuiteFilter {
   Filters the check suites created by this application ID.
   """
   appId: Int
-  
+
   """
   Filters the check suites by this name.
   """
@@ -3834,7 +3834,7 @@ input ClearLabelsFromLabelableInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The id of the labelable object to clear the labels from.
   """
@@ -3853,7 +3853,7 @@ type ClearLabelsFromLabelablePayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The item that was unlabeled.
   """
@@ -3868,7 +3868,7 @@ input ClearProjectV2ItemFieldValueInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The ID of the field to be cleared.
   """
@@ -3881,12 +3881,12 @@ input ClearProjectV2ItemFieldValueInput {
       ]
       abstractType: "ProjectV2FieldConfiguration"
     )
-  
+
   """
   The ID of the item to be cleared.
   """
   itemId: ID! @possibleTypes(concreteTypes: ["ProjectV2Item"])
-  
+
   """
   The ID of the Project.
   """
@@ -3901,7 +3901,7 @@ type ClearProjectV2ItemFieldValuePayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The updated item.
   """
@@ -3916,32 +3916,32 @@ input CloneProjectInput {
   The description of the project.
   """
   body: String
-  
+
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   Whether or not to clone the source project's workflows.
   """
   includeWorkflows: Boolean!
-  
+
   """
   The name of the project.
   """
   name: String!
-  
+
   """
   The visibility of the project, defaults to false (private).
   """
   public: Boolean
-  
+
   """
   The source project to clone.
   """
   sourceId: ID! @possibleTypes(concreteTypes: ["Project"])
-  
+
   """
   The owner ID to create the project under.
   """
@@ -3960,12 +3960,12 @@ type CloneProjectPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The id of the JobStatus for populating cloned fields.
   """
   jobStatusId: String
-  
+
   """
   The new cloned project.
   """
@@ -3980,23 +3980,23 @@ input CloneTemplateRepositoryInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   A short description of the new repository.
   """
   description: String
-  
+
   """
   Whether to copy all branches from the template to the new repository. Defaults
   to copying only the default branch of the template.
   """
   includeAllBranches: Boolean = false
-  
+
   """
   The name of the new repository.
   """
   name: String!
-  
+
   """
   The ID of the owner for the new repository.
   """
@@ -4005,12 +4005,12 @@ input CloneTemplateRepositoryInput {
       concreteTypes: ["Organization", "User"]
       abstractType: "RepositoryOwner"
     )
-  
+
   """
   The Node ID of the template repository.
   """
   repositoryId: ID! @possibleTypes(concreteTypes: ["Repository"])
-  
+
   """
   Indicates the repository's visibility level.
   """
@@ -4025,7 +4025,7 @@ type CloneTemplateRepositoryPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The new repository.
   """
@@ -4040,17 +4040,17 @@ interface Closable {
   Indicates if the object is closed (definition of closed may depend on type)
   """
   closed: Boolean!
-  
+
   """
   Identifies the date and time when the object was closed.
   """
   closedAt: DateTime
-  
+
   """
   Indicates if the object can be closed by the viewer.
   """
   viewerCanClose: Boolean!
-  
+
   """
   Indicates if the object can be reopened by the viewer.
   """
@@ -4065,12 +4065,12 @@ input CloseDiscussionInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   ID of the discussion to be closed.
   """
   discussionId: ID! @possibleTypes(concreteTypes: ["Discussion"])
-  
+
   """
   The reason why the discussion is being closed.
   """
@@ -4085,7 +4085,7 @@ type CloseDiscussionPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The discussion that was closed.
   """
@@ -4100,12 +4100,12 @@ input CloseIssueInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   ID of the issue to be closed.
   """
   issueId: ID! @possibleTypes(concreteTypes: ["Issue"])
-  
+
   """
   The reason the issue is to be closed.
   """
@@ -4120,7 +4120,7 @@ type CloseIssuePayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The issue that was closed.
   """
@@ -4135,7 +4135,7 @@ input ClosePullRequestInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   ID of the pull request to be closed.
   """
@@ -4150,7 +4150,7 @@ type ClosePullRequestPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The pull request that was closed.
   """
@@ -4165,33 +4165,33 @@ type ClosedEvent implements Node & UniformResourceLocatable {
   Identifies the actor who performed the event.
   """
   actor: Actor
-  
+
   """
   Object that was closed.
   """
   closable: Closable!
-  
+
   """
   Object which triggered the creation of this event.
   """
   closer: Closer
-  
+
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
   id: ID!
-  
+
   """
   The HTTP path for this closed event.
   """
   resourcePath: URI!
-  
+
   """
   The reason the issue state was changed to closed.
   """
   stateReason: IssueStateReason
-  
+
   """
   The HTTP URL for this closed event.
   """
@@ -4212,22 +4212,22 @@ type CodeOfConduct implements Node {
   """
   body: String
   id: ID!
-  
+
   """
   The key for the Code of Conduct
   """
   key: String!
-  
+
   """
   The formal name of the Code of Conduct
   """
   name: String!
-  
+
   """
   The HTTP path for this Code of Conduct
   """
   resourcePath: URI
-  
+
   """
   The HTTP URL for this Code of Conduct
   """
@@ -4260,63 +4260,63 @@ interface Comment {
   The actor who authored the comment.
   """
   author: Actor
-  
+
   """
   Author's association with the subject of the comment.
   """
   authorAssociation: CommentAuthorAssociation!
-  
+
   """
   The body as Markdown.
   """
   body: String!
-  
+
   """
   The body rendered to HTML.
   """
   bodyHTML: HTML!
-  
+
   """
   The body rendered to text.
   """
   bodyText: String!
-  
+
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
-  
+
   """
   Check if this comment was created via an email reply.
   """
   createdViaEmail: Boolean!
-  
+
   """
   The actor who edited the comment.
   """
   editor: Actor
   id: ID!
-  
+
   """
   Check if this comment was edited and includes an edit with the creation data
   """
   includesCreatedEdit: Boolean!
-  
+
   """
   The moment the editor made the last edit
   """
   lastEditedAt: DateTime
-  
+
   """
   Identifies when the comment was published at.
   """
   publishedAt: DateTime
-  
+
   """
   Identifies the date and time when the object was last updated.
   """
   updatedAt: DateTime!
-  
+
   """
   A list of edits to this content.
   """
@@ -4325,23 +4325,23 @@ interface Comment {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): UserContentEditConnection
-  
+
   """
   Did the viewer author this comment.
   """
@@ -4428,17 +4428,17 @@ type CommentDeletedEvent implements Node {
   Identifies the actor who performed the event.
   """
   actor: Actor
-  
+
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
-  
+
   """
   Identifies the primary key from the database.
   """
   databaseId: Int
-  
+
   """
   The user who authored the deleted comment.
   """
@@ -4454,12 +4454,12 @@ type Commit implements GitObject & Node & Subscribable & UniformResourceLocatabl
   An abbreviated version of the Git object ID
   """
   abbreviatedOid: String!
-  
+
   """
   The number of additions in this commit.
   """
   additions: Int!
-  
+
   """
   The merged Pull Request that introduced the commit to the repository. If the
   commit is not present in the default branch, additionally returns open Pull
@@ -4470,43 +4470,43 @@ type Commit implements GitObject & Node & Subscribable & UniformResourceLocatabl
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for pull requests.
     """
     orderBy: PullRequestOrder = { field: CREATED_AT, direction: ASC }
   ): PullRequestConnection
-  
+
   """
   Authorship details of the commit.
   """
   author: GitActor
-  
+
   """
   Check if the committer and the author match.
   """
   authoredByCommitter: Boolean!
-  
+
   """
   The datetime when this commit was authored.
   """
   authoredDate: DateTime!
-  
+
   """
   The list of authors for this commit based on the git author and the Co-authored-by
   message trailer. The git author will always be first.
@@ -4516,23 +4516,23 @@ type Commit implements GitObject & Node & Subscribable & UniformResourceLocatabl
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): GitActorConnection!
-  
+
   """
   Fetches `git blame` information.
   """
@@ -4542,7 +4542,7 @@ type Commit implements GitObject & Node & Subscribable & UniformResourceLocatabl
     """
     path: String!
   ): Blame!
-  
+
   """
   We recommend using the `changedFilesIfAvailable` field instead of
   `changedFiles`, as `changedFiles` will cause your request to return an error
@@ -4552,14 +4552,14 @@ type Commit implements GitObject & Node & Subscribable & UniformResourceLocatabl
     @deprecated(
       reason: "`changedFiles` will be removed. Use `changedFilesIfAvailable` instead. Removal on 2023-01-01 UTC."
     )
-  
+
   """
   The number of changed files in this commit. If GitHub is unable to calculate
   the number of changed files (for example due to a timeout), this will return
   `null`. We recommend using this field instead of `changedFiles`.
   """
   changedFilesIfAvailable: Int
-  
+
   """
   The check suites associated with a commit.
   """
@@ -4568,28 +4568,28 @@ type Commit implements GitObject & Node & Subscribable & UniformResourceLocatabl
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Filters the check suites by this type.
     """
     filterBy: CheckSuiteFilter
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): CheckSuiteConnection
-  
+
   """
   Comments made on the commit.
   """
@@ -4598,53 +4598,53 @@ type Commit implements GitObject & Node & Subscribable & UniformResourceLocatabl
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): CommitCommentConnection!
-  
+
   """
   The HTTP path for this Git object
   """
   commitResourcePath: URI!
-  
+
   """
   The HTTP URL for this Git object
   """
   commitUrl: URI!
-  
+
   """
   The datetime when this commit was committed.
   """
   committedDate: DateTime!
-  
+
   """
   Check if committed via GitHub web UI.
   """
   committedViaWeb: Boolean!
-  
+
   """
   Committer details of the commit.
   """
   committer: GitActor
-  
+
   """
   The number of deletions in this commit.
   """
   deletions: Int!
-  
+
   """
   The deployments associated with a commit.
   """
@@ -4653,33 +4653,33 @@ type Commit implements GitObject & Node & Subscribable & UniformResourceLocatabl
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Environments to list deployments for
     """
     environments: [String!]
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for deployments returned from the connection.
     """
     orderBy: DeploymentOrder = { field: CREATED_AT, direction: ASC }
   ): DeploymentConnection
-  
+
   """
   The tree entry representing the file located at the given path.
   """
@@ -4689,7 +4689,7 @@ type Commit implements GitObject & Node & Subscribable & UniformResourceLocatabl
     """
     path: String!
   ): TreeEntry
-  
+
   """
   The linear commit history starting from (and including) this commit, in the same order as `git log`.
   """
@@ -4698,79 +4698,79 @@ type Commit implements GitObject & Node & Subscribable & UniformResourceLocatabl
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     If non-null, filters history to only show commits with matching authorship.
     """
     author: CommitAuthor
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     If non-null, filters history to only show commits touching files under this path.
     """
     path: String
-    
+
     """
     Allows specifying a beginning time or date for fetching commits.
     """
     since: GitTimestamp
-    
+
     """
     Allows specifying an ending time or date for fetching commits.
     """
     until: GitTimestamp
   ): CommitHistoryConnection!
   id: ID!
-  
+
   """
   The Git commit message
   """
   message: String!
-  
+
   """
   The Git commit message body
   """
   messageBody: String!
-  
+
   """
   The commit message body rendered to HTML.
   """
   messageBodyHTML: HTML!
-  
+
   """
   The Git commit message headline
   """
   messageHeadline: String!
-  
+
   """
   The commit message headline rendered to HTML.
   """
   messageHeadlineHTML: HTML!
-  
+
   """
   The Git object ID
   """
   oid: GitObjectID!
-  
+
   """
   The organization this commit was made on behalf of.
   """
   onBehalfOf: Organization
-  
+
   """
   The parents of a commit.
   """
@@ -4779,23 +4779,23 @@ type Commit implements GitObject & Node & Subscribable & UniformResourceLocatabl
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): CommitConnection!
-  
+
   """
   The datetime when this commit was pushed.
   """
@@ -4803,32 +4803,32 @@ type Commit implements GitObject & Node & Subscribable & UniformResourceLocatabl
     @deprecated(
       reason: "`pushedDate` is no longer supported. Removal on 2023-07-01 UTC."
     )
-  
+
   """
   The Repository this commit belongs to
   """
   repository: Repository!
-  
+
   """
   The HTTP path for this commit
   """
   resourcePath: URI!
-  
+
   """
   Commit signing information, if present.
   """
   signature: GitSignature
-  
+
   """
   Status information for this commit
   """
   status: Status
-  
+
   """
   Check and Status rollup information for this commit.
   """
   statusCheckRollup: StatusCheckRollup
-  
+
   """
   Returns a list of all submodules in this repository as of this Commit parsed from the .gitmodules file.
   """
@@ -4837,59 +4837,59 @@ type Commit implements GitObject & Node & Subscribable & UniformResourceLocatabl
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): SubmoduleConnection!
-  
+
   """
   Returns a URL to download a tarball archive for a repository.
   Note: For private repositories, these links are temporary and expire after five minutes.
   """
   tarballUrl: URI!
-  
+
   """
   Commit's root Tree
   """
   tree: Tree!
-  
+
   """
   The HTTP path for the tree of this commit
   """
   treeResourcePath: URI!
-  
+
   """
   The HTTP URL for the tree of this commit
   """
   treeUrl: URI!
-  
+
   """
   The HTTP URL for this commit
   """
   url: URI!
-  
+
   """
   Check if the viewer is able to change their subscription status for the repository.
   """
   viewerCanSubscribe: Boolean!
-  
+
   """
   Identifies if the viewer is watching, not watching, or ignoring the subscribable entity.
   """
   viewerSubscription: SubscriptionState
-  
+
   """
   Returns a URL to download a zipball archive for a repository.
   Note: For private repositories, these links are temporary and expire after five minutes.
@@ -4905,7 +4905,7 @@ input CommitAuthor {
   Email addresses to filter by. Commits authored by any of the specified email addresses will be returned.
   """
   emails: [String!]
-  
+
   """
   ID of a User to filter by. If non-null, only commits authored by this user
   will be returned. This field takes precedence over emails.
@@ -4921,17 +4921,17 @@ type CommitAuthorEmailPatternParameters {
   How this rule will appear to users.
   """
   name: String
-  
+
   """
   If true, the rule will fail if the pattern matches.
   """
   negate: Boolean!
-  
+
   """
   The operator to use for matching.
   """
   operator: String!
-  
+
   """
   The pattern to match with.
   """
@@ -4946,17 +4946,17 @@ input CommitAuthorEmailPatternParametersInput {
   How this rule will appear to users.
   """
   name: String
-  
+
   """
   If true, the rule will fail if the pattern matches.
   """
   negate: Boolean
-  
+
   """
   The operator to use for matching.
   """
   operator: String!
-  
+
   """
   The pattern to match with.
   """
@@ -4971,95 +4971,95 @@ type CommitComment implements Comment & Deletable & Minimizable & Node & Reactab
   The actor who authored the comment.
   """
   author: Actor
-  
+
   """
   Author's association with the subject of the comment.
   """
   authorAssociation: CommentAuthorAssociation!
-  
+
   """
   Identifies the comment body.
   """
   body: String!
-  
+
   """
   The body rendered to HTML.
   """
   bodyHTML: HTML!
-  
+
   """
   The body rendered to text.
   """
   bodyText: String!
-  
+
   """
   Identifies the commit associated with the comment, if the commit exists.
   """
   commit: Commit
-  
+
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
-  
+
   """
   Check if this comment was created via an email reply.
   """
   createdViaEmail: Boolean!
-  
+
   """
   Identifies the primary key from the database.
   """
   databaseId: Int
-  
+
   """
   The actor who edited the comment.
   """
   editor: Actor
   id: ID!
-  
+
   """
   Check if this comment was edited and includes an edit with the creation data
   """
   includesCreatedEdit: Boolean!
-  
+
   """
   Returns whether or not a comment has been minimized.
   """
   isMinimized: Boolean!
-  
+
   """
   The moment the editor made the last edit
   """
   lastEditedAt: DateTime
-  
+
   """
   Returns why the comment was minimized. One of `abuse`, `off-topic`,
   `outdated`, `resolved`, `duplicate` and `spam`. Note that the case and
   formatting of these values differs from the inputs to the `MinimizeComment` mutation.
   """
   minimizedReason: String
-  
+
   """
   Identifies the file path associated with the comment.
   """
   path: String
-  
+
   """
   Identifies the line position associated with the comment.
   """
   position: Int
-  
+
   """
   Identifies when the comment was published at.
   """
   publishedAt: DateTime
-  
+
   """
   A list of reactions grouped by content left on the subject.
   """
   reactionGroups: [ReactionGroup!]
-  
+
   """
   A list of Reactions left on the Issue.
   """
@@ -5068,53 +5068,53 @@ type CommitComment implements Comment & Deletable & Minimizable & Node & Reactab
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Allows filtering Reactions by emoji.
     """
     content: ReactionContent
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Allows specifying the order in which reactions are returned.
     """
     orderBy: ReactionOrder
   ): ReactionConnection!
-  
+
   """
   The repository associated with this node.
   """
   repository: Repository!
-  
+
   """
   The HTTP path permalink for this commit comment.
   """
   resourcePath: URI!
-  
+
   """
   Identifies the date and time when the object was last updated.
   """
   updatedAt: DateTime!
-  
+
   """
   The HTTP URL permalink for this commit comment.
   """
   url: URI!
-  
+
   """
   A list of edits to this content.
   """
@@ -5123,48 +5123,48 @@ type CommitComment implements Comment & Deletable & Minimizable & Node & Reactab
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): UserContentEditConnection
-  
+
   """
   Check if the current viewer can delete this object.
   """
   viewerCanDelete: Boolean!
-  
+
   """
   Check if the current viewer can minimize this object.
   """
   viewerCanMinimize: Boolean!
-  
+
   """
   Can user react to this subject
   """
   viewerCanReact: Boolean!
-  
+
   """
   Check if the current viewer can update this object.
   """
   viewerCanUpdate: Boolean!
-  
+
   """
   Reasons why the current viewer can not update this comment.
   """
   viewerCannotUpdateReasons: [CommentCannotUpdateReason!]!
-  
+
   """
   Did the viewer author this comment.
   """
@@ -5179,17 +5179,17 @@ type CommitCommentConnection {
   A list of edges.
   """
   edges: [CommitCommentEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [CommitComment]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -5204,7 +5204,7 @@ type CommitCommentEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -5223,39 +5223,39 @@ type CommitCommentThread implements Node & RepositoryNode {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): CommitCommentConnection!
-  
+
   """
   The commit the comments were made on.
   """
   commit: Commit
   id: ID!
-  
+
   """
   The file the comments were made on.
   """
   path: String
-  
+
   """
   The position in the diff for the commit that the comment was made on.
   """
   position: Int
-  
+
   """
   The repository associated with this node.
   """
@@ -5270,17 +5270,17 @@ type CommitConnection {
   A list of edges.
   """
   edges: [CommitEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [Commit]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -5295,7 +5295,7 @@ input CommitContributionOrder {
   The ordering direction.
   """
   direction: OrderDirection!
-  
+
   """
   The field by which to order commit contributions.
   """
@@ -5328,38 +5328,38 @@ type CommitContributionsByRepository {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for commit contributions returned from the connection.
     """
     orderBy: CommitContributionOrder = { field: OCCURRED_AT, direction: DESC }
   ): CreatedCommitContributionConnection!
-  
+
   """
   The repository in which the commits were made.
   """
   repository: Repository!
-  
+
   """
   The HTTP path for the user's commits to the repository in this time range.
   """
   resourcePath: URI!
-  
+
   """
   The HTTP URL for the user's commits to the repository in this time range.
   """
@@ -5374,7 +5374,7 @@ type CommitEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -5389,17 +5389,17 @@ type CommitHistoryConnection {
   A list of edges.
   """
   edges: [CommitEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [Commit]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -5414,7 +5414,7 @@ input CommitMessage {
   The body of the message.
   """
   body: String
-  
+
   """
   The headline of the message.
   """
@@ -5429,17 +5429,17 @@ type CommitMessagePatternParameters {
   How this rule will appear to users.
   """
   name: String
-  
+
   """
   If true, the rule will fail if the pattern matches.
   """
   negate: Boolean!
-  
+
   """
   The operator to use for matching.
   """
   operator: String!
-  
+
   """
   The pattern to match with.
   """
@@ -5454,17 +5454,17 @@ input CommitMessagePatternParametersInput {
   How this rule will appear to users.
   """
   name: String
-  
+
   """
   If true, the rule will fail if the pattern matches.
   """
   negate: Boolean
-  
+
   """
   The operator to use for matching.
   """
   operator: String!
-  
+
   """
   The pattern to match with.
   """
@@ -5499,12 +5499,12 @@ input CommittableBranch {
   The unqualified name of the branch to append the commit to.
   """
   branchName: String
-  
+
   """
   The Node ID of the Ref to be updated.
   """
   id: ID
-  
+
   """
   The nameWithOwner of the repository to commit to.
   """
@@ -5519,17 +5519,17 @@ type CommitterEmailPatternParameters {
   How this rule will appear to users.
   """
   name: String
-  
+
   """
   If true, the rule will fail if the pattern matches.
   """
   negate: Boolean!
-  
+
   """
   The operator to use for matching.
   """
   operator: String!
-  
+
   """
   The pattern to match with.
   """
@@ -5544,17 +5544,17 @@ input CommitterEmailPatternParametersInput {
   How this rule will appear to users.
   """
   name: String
-  
+
   """
   If true, the rule will fail if the pattern matches.
   """
   negate: Boolean
-  
+
   """
   The operator to use for matching.
   """
   operator: String!
-  
+
   """
   The pattern to match with.
   """
@@ -5569,17 +5569,17 @@ type Comparison implements Node {
   The number of commits ahead of the base branch.
   """
   aheadBy: Int!
-  
+
   """
   The base revision of this comparison.
   """
   baseTarget: GitObject!
-  
+
   """
   The number of commits behind the base branch.
   """
   behindBy: Int!
-  
+
   """
   The commits which compose this comparison.
   """
@@ -5588,29 +5588,29 @@ type Comparison implements Node {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): ComparisonCommitConnection!
-  
+
   """
   The head revision of this comparison.
   """
   headTarget: GitObject!
   id: ID!
-  
+
   """
   The status of this comparison.
   """
@@ -5625,22 +5625,22 @@ type ComparisonCommitConnection {
   The total count of authors and co-authors across all commits.
   """
   authorCount: Int!
-  
+
   """
   A list of edges.
   """
   edges: [CommitEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [Commit]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -5677,23 +5677,23 @@ type ConnectedEvent implements Node {
   Identifies the actor who performed the event.
   """
   actor: Actor
-  
+
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
   id: ID!
-  
+
   """
   Reference originated in a different repository.
   """
   isCrossRepository: Boolean!
-  
+
   """
   Issue or pull request that made the reference.
   """
   source: ReferencedSubject!
-  
+
   """
   Issue or pull request which was connected.
   """
@@ -5708,12 +5708,12 @@ type ContributingGuidelines {
   The body of the Contributing Guidelines.
   """
   body: String
-  
+
   """
   The HTTP path for the Contributing Guidelines.
   """
   resourcePath: URI
-  
+
   """
   The HTTP URL for the Contributing Guidelines.
   """
@@ -5730,22 +5730,22 @@ interface Contribution {
   longer access.
   """
   isRestricted: Boolean!
-  
+
   """
   When this contribution was made.
   """
   occurredAt: DateTime!
-  
+
   """
   The HTTP path for this contribution.
   """
   resourcePath: URI!
-  
+
   """
   The HTTP URL for this contribution.
   """
   url: URI!
-  
+
   """
   The user who made this contribution.
   """
@@ -5760,22 +5760,22 @@ type ContributionCalendar {
   A list of hex color codes used in this calendar. The darker the color, the more contributions it represents.
   """
   colors: [String!]!
-  
+
   """
   Determine if the color set was chosen because it's currently Halloween.
   """
   isHalloween: Boolean!
-  
+
   """
   A list of the months of contributions in this calendar.
   """
   months: [ContributionCalendarMonth!]!
-  
+
   """
   The count of total contributions in the calendar.
   """
   totalContributions: Int!
-  
+
   """
   A list of the weeks of contributions in this calendar.
   """
@@ -5790,23 +5790,23 @@ type ContributionCalendarDay {
   The hex color code that represents how many contributions were made on this day compared to others in the calendar.
   """
   color: String!
-  
+
   """
   How many contributions were made by the user on this day.
   """
   contributionCount: Int!
-  
+
   """
   Indication of contributions, relative to other days. Can be used to indicate
   which color to represent this day on a calendar.
   """
   contributionLevel: ContributionLevel!
-  
+
   """
   The day this square represents.
   """
   date: Date!
-  
+
   """
   A number representing which day of the week this square represents, e.g., 1 is Monday.
   """
@@ -5821,17 +5821,17 @@ type ContributionCalendarMonth {
   The date of the first day of this month.
   """
   firstDay: Date!
-  
+
   """
   The name of the month.
   """
   name: String!
-  
+
   """
   How many weeks started in this month.
   """
   totalWeeks: Int!
-  
+
   """
   The year the month occurred in.
   """
@@ -5846,7 +5846,7 @@ type ContributionCalendarWeek {
   The days of contributions in this week.
   """
   contributionDays: [ContributionCalendarDay!]!
-  
+
   """
   The date of the earliest square in this week.
   """
@@ -5902,33 +5902,33 @@ type ContributionsCollection {
     """
     maxRepositories: Int = 25
   ): [CommitContributionsByRepository!]!
-  
+
   """
   A calendar of this user's contributions on GitHub.
   """
   contributionCalendar: ContributionCalendar!
-  
+
   """
   The years the user has been making contributions with the most recent year first.
   """
   contributionYears: [Int!]!
-  
+
   """
   Determine if this collection's time span ends in the current month.
   """
   doesEndInCurrentMonth: Boolean!
-  
+
   """
   The date of the first restricted contribution the user made in this time
   period. Can only be non-null when the user has enabled private contribution counts.
   """
   earliestRestrictedContributionDate: Date
-  
+
   """
   The ending date and time of this collection.
   """
   endedAt: DateTime!
-  
+
   """
   The first issue the user opened on GitHub. This will be null if that issue was
   opened outside the collection's time range and ignoreTimeRange is false. If
@@ -5936,7 +5936,7 @@ type ContributionsCollection {
   a RestrictedContribution will be returned.
   """
   firstIssueContribution: CreatedIssueOrRestrictedContribution
-  
+
   """
   The first pull request the user opened on GitHub. This will be null if that
   pull request was opened outside the collection's time range and
@@ -5944,7 +5944,7 @@ type ContributionsCollection {
   has opted to show private contributions, a RestrictedContribution will be returned.
   """
   firstPullRequestContribution: CreatedPullRequestOrRestrictedContribution
-  
+
   """
   The first repository the user created on GitHub. This will be null if that
   first repository was created outside the collection's time range and
@@ -5952,29 +5952,29 @@ type ContributionsCollection {
   RestrictedContribution is returned.
   """
   firstRepositoryContribution: CreatedRepositoryOrRestrictedContribution
-  
+
   """
   Does the user have any more activity in the timeline that occurred prior to the collection's time range?
   """
   hasActivityInThePast: Boolean!
-  
+
   """
   Determine if there are any contributions in this collection.
   """
   hasAnyContributions: Boolean!
-  
+
   """
   Determine if the user made any contributions in this time frame whose details
   are not visible because they were made in a private repository. Can only be
   true if the user enabled private contribution counts.
   """
   hasAnyRestrictedContributions: Boolean!
-  
+
   """
   Whether or not the collector's time span is all within the same day.
   """
   isSingleDay: Boolean!
-  
+
   """
   A list of issues the user opened.
   """
@@ -5983,38 +5983,38 @@ type ContributionsCollection {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Should the user's first issue ever be excluded from the result.
     """
     excludeFirst: Boolean = false
-    
+
     """
     Should the user's most commented issue be excluded from the result.
     """
     excludePopular: Boolean = false
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for contributions returned from the connection.
     """
     orderBy: ContributionOrder = { direction: DESC }
   ): CreatedIssueContributionConnection!
-  
+
   """
   Issue contributions made by the user, grouped by repository.
   """
@@ -6023,54 +6023,54 @@ type ContributionsCollection {
     Should the user's first issue ever be excluded from the result.
     """
     excludeFirst: Boolean = false
-    
+
     """
     Should the user's most commented issue be excluded from the result.
     """
     excludePopular: Boolean = false
-    
+
     """
     How many repositories should be included.
     """
     maxRepositories: Int = 25
   ): [IssueContributionsByRepository!]!
-  
+
   """
   When the user signed up for GitHub. This will be null if that sign up date
   falls outside the collection's time range and ignoreTimeRange is false.
   """
   joinedGitHubContribution: JoinedGitHubContribution
-  
+
   """
   The date of the most recent restricted contribution the user made in this time
   period. Can only be non-null when the user has enabled private contribution counts.
   """
   latestRestrictedContributionDate: Date
-  
+
   """
   When this collection's time range does not include any activity from the user, use this
   to get a different collection from an earlier time range that does have activity.
   """
   mostRecentCollectionWithActivity: ContributionsCollection
-  
+
   """
   Returns a different contributions collection from an earlier time range than this one
   that does not have any contributions.
   """
   mostRecentCollectionWithoutActivity: ContributionsCollection
-  
+
   """
   The issue the user opened on GitHub that received the most comments in the specified
   time frame.
   """
   popularIssueContribution: CreatedIssueContribution
-  
+
   """
   The pull request the user opened on GitHub that received the most comments in the
   specified time frame.
   """
   popularPullRequestContribution: CreatedPullRequestContribution
-  
+
   """
   Pull request contributions made by the user.
   """
@@ -6079,38 +6079,38 @@ type ContributionsCollection {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Should the user's first pull request ever be excluded from the result.
     """
     excludeFirst: Boolean = false
-    
+
     """
     Should the user's most commented pull request be excluded from the result.
     """
     excludePopular: Boolean = false
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for contributions returned from the connection.
     """
     orderBy: ContributionOrder = { direction: DESC }
   ): CreatedPullRequestContributionConnection!
-  
+
   """
   Pull request contributions made by the user, grouped by repository.
   """
@@ -6119,18 +6119,18 @@ type ContributionsCollection {
     Should the user's first pull request ever be excluded from the result.
     """
     excludeFirst: Boolean = false
-    
+
     """
     Should the user's most commented pull request be excluded from the result.
     """
     excludePopular: Boolean = false
-    
+
     """
     How many repositories should be included.
     """
     maxRepositories: Int = 25
   ): [PullRequestContributionsByRepository!]!
-  
+
   """
   Pull request review contributions made by the user. Returns the most recently
   submitted review for each PR reviewed by the user.
@@ -6140,28 +6140,28 @@ type ContributionsCollection {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for contributions returned from the connection.
     """
     orderBy: ContributionOrder = { direction: DESC }
   ): CreatedPullRequestReviewContributionConnection!
-  
+
   """
   Pull request review contributions made by the user, grouped by repository.
   """
@@ -6171,7 +6171,7 @@ type ContributionsCollection {
     """
     maxRepositories: Int = 25
   ): [PullRequestReviewContributionsByRepository!]!
-  
+
   """
   A list of repositories owned by the user that the user created in this time range.
   """
@@ -6180,49 +6180,49 @@ type ContributionsCollection {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Should the user's first repository ever be excluded from the result.
     """
     excludeFirst: Boolean = false
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for contributions returned from the connection.
     """
     orderBy: ContributionOrder = { direction: DESC }
   ): CreatedRepositoryContributionConnection!
-  
+
   """
   A count of contributions made by the user that the viewer cannot access. Only
   non-zero when the user has chosen to share their private contribution counts.
   """
   restrictedContributionsCount: Int!
-  
+
   """
   The beginning date and time of this collection.
   """
   startedAt: DateTime!
-  
+
   """
   How many commits were made by the user in this time span.
   """
   totalCommitContributions: Int!
-  
+
   """
   How many issues the user opened.
   """
@@ -6231,13 +6231,13 @@ type ContributionsCollection {
     Should the user's first issue ever be excluded from this count.
     """
     excludeFirst: Boolean = false
-    
+
     """
     Should the user's most commented issue be excluded from this count.
     """
     excludePopular: Boolean = false
   ): Int!
-  
+
   """
   How many pull requests the user opened.
   """
@@ -6246,23 +6246,23 @@ type ContributionsCollection {
     Should the user's first pull request ever be excluded from this count.
     """
     excludeFirst: Boolean = false
-    
+
     """
     Should the user's most commented pull request be excluded from this count.
     """
     excludePopular: Boolean = false
   ): Int!
-  
+
   """
   How many pull request reviews the user left.
   """
   totalPullRequestReviewContributions: Int!
-  
+
   """
   How many different repositories the user committed to.
   """
   totalRepositoriesWithContributedCommits: Int!
-  
+
   """
   How many different repositories the user opened issues in.
   """
@@ -6271,18 +6271,18 @@ type ContributionsCollection {
     Should the user's first issue ever be excluded from this count.
     """
     excludeFirst: Boolean = false
-    
+
     """
     Should the user's most commented issue be excluded from this count.
     """
     excludePopular: Boolean = false
   ): Int!
-  
+
   """
   How many different repositories the user left pull request reviews in.
   """
   totalRepositoriesWithContributedPullRequestReviews: Int!
-  
+
   """
   How many different repositories the user opened pull requests in.
   """
@@ -6291,13 +6291,13 @@ type ContributionsCollection {
     Should the user's first pull request ever be excluded from this count.
     """
     excludeFirst: Boolean = false
-    
+
     """
     Should the user's most commented pull request be excluded from this count.
     """
     excludePopular: Boolean = false
   ): Int!
-  
+
   """
   How many repositories the user created.
   """
@@ -6307,7 +6307,7 @@ type ContributionsCollection {
     """
     excludeFirst: Boolean = false
   ): Int!
-  
+
   """
   The user who made the contributions in this collection.
   """
@@ -6322,22 +6322,22 @@ input ConvertProjectCardNoteToIssueInput {
   The body of the newly created issue.
   """
   body: String
-  
+
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The ProjectCard ID to convert.
   """
   projectCardId: ID! @possibleTypes(concreteTypes: ["ProjectCard"])
-  
+
   """
   The ID of the repository to create the issue in.
   """
   repositoryId: ID! @possibleTypes(concreteTypes: ["Repository"])
-  
+
   """
   The title of the newly created issue. Defaults to the card's note text.
   """
@@ -6352,7 +6352,7 @@ type ConvertProjectCardNoteToIssuePayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The updated ProjectCard.
   """
@@ -6367,7 +6367,7 @@ input ConvertPullRequestToDraftInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   ID of the pull request to convert to draft
   """
@@ -6382,7 +6382,7 @@ type ConvertPullRequestToDraftPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The pull request that is now a draft.
   """
@@ -6397,23 +6397,23 @@ type ConvertToDraftEvent implements Node & UniformResourceLocatable {
   Identifies the actor who performed the event.
   """
   actor: Actor
-  
+
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
   id: ID!
-  
+
   """
   PullRequest referenced by event.
   """
   pullRequest: PullRequest!
-  
+
   """
   The HTTP path for this convert to draft event.
   """
   resourcePath: URI!
-  
+
   """
   The HTTP URL for this convert to draft event.
   """
@@ -6428,28 +6428,28 @@ type ConvertedNoteToIssueEvent implements Node {
   Identifies the actor who performed the event.
   """
   actor: Actor
-  
+
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
-  
+
   """
   Identifies the primary key from the database.
   """
   databaseId: Int
   id: ID!
-  
+
   """
   Project referenced by event.
   """
   project: Project @preview(toggledBy: "starfox-preview")
-  
+
   """
   Project card referenced by this project event.
   """
   projectCard: ProjectCard @preview(toggledBy: "starfox-preview")
-  
+
   """
   Column name referenced by this project event.
   """
@@ -6464,12 +6464,12 @@ type ConvertedToDiscussionEvent implements Node {
   Identifies the actor who performed the event.
   """
   actor: Actor
-  
+
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
-  
+
   """
   The discussion that the issue was converted into.
   """
@@ -6485,12 +6485,12 @@ input CopyProjectV2Input {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   Include draft issues in the new project
   """
   includeDraftIssues: Boolean = false
-  
+
   """
   The owner ID of the new project.
   """
@@ -6499,12 +6499,12 @@ input CopyProjectV2Input {
       concreteTypes: ["Organization", "User"]
       abstractType: "OrganizationOrUser"
     )
-  
+
   """
   The ID of the source Project to copy.
   """
   projectId: ID! @possibleTypes(concreteTypes: ["ProjectV2"])
-  
+
   """
   The title of the project.
   """
@@ -6519,7 +6519,7 @@ type CopyProjectV2Payload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The copied project.
   """
@@ -6534,7 +6534,7 @@ input CreateAttributionInvitationInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The Node ID of the owner scoping the reattributable data.
   """
@@ -6542,7 +6542,7 @@ input CreateAttributionInvitationInput {
     @possibleTypes(
       concreteTypes: ["Bot", "Enterprise", "Mannequin", "Organization", "User"]
     )
-  
+
   """
   The Node ID of the account owning the data to reattribute.
   """
@@ -6550,7 +6550,7 @@ input CreateAttributionInvitationInput {
     @possibleTypes(
       concreteTypes: ["Bot", "Enterprise", "Mannequin", "Organization", "User"]
     )
-  
+
   """
   The Node ID of the account which may claim the data.
   """
@@ -6568,17 +6568,17 @@ type CreateAttributionInvitationPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The owner scoping the reattributable data.
   """
   owner: Organization
-  
+
   """
   The account owning the data to reattribute.
   """
   source: Claimable
-  
+
   """
   The account which may claim the data.
   """
@@ -6593,143 +6593,143 @@ input CreateBranchProtectionRuleInput {
   Can this branch be deleted.
   """
   allowsDeletions: Boolean
-  
+
   """
   Are force pushes allowed on this branch.
   """
   allowsForcePushes: Boolean
-  
+
   """
   Is branch creation a protected operation.
   """
   blocksCreations: Boolean
-  
+
   """
   A list of User, Team, or App IDs allowed to bypass force push targeting matching branches.
   """
   bypassForcePushActorIds: [ID!]
-  
+
   """
   A list of User, Team, or App IDs allowed to bypass pull requests targeting matching branches.
   """
   bypassPullRequestActorIds: [ID!]
-  
+
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   Will new commits pushed to matching branches dismiss pull request review approvals.
   """
   dismissesStaleReviews: Boolean
-  
+
   """
   Can admins overwrite branch protection.
   """
   isAdminEnforced: Boolean
-  
+
   """
   Whether users can pull changes from upstream when the branch is locked. Set to
   `true` to allow fork syncing. Set to `false` to prevent fork syncing.
   """
   lockAllowsFetchAndMerge: Boolean
-  
+
   """
   Whether to set the branch as read-only. If this is true, users will not be able to push to the branch.
   """
   lockBranch: Boolean
-  
+
   """
   The glob-like pattern used to determine matching branches.
   """
   pattern: String!
-  
+
   """
   A list of User, Team, or App IDs allowed to push to matching branches.
   """
   pushActorIds: [ID!]
-  
+
   """
   The global relay id of the repository in which a new branch protection rule should be created in.
   """
   repositoryId: ID! @possibleTypes(concreteTypes: ["Repository"])
-  
+
   """
   Whether the most recent push must be approved by someone other than the person who pushed it
   """
   requireLastPushApproval: Boolean
-  
+
   """
   Number of approving reviews required to update matching branches.
   """
   requiredApprovingReviewCount: Int
-  
+
   """
   The list of required deployment environments
   """
   requiredDeploymentEnvironments: [String!]
-  
+
   """
   List of required status check contexts that must pass for commits to be accepted to matching branches.
   """
   requiredStatusCheckContexts: [String!]
-  
+
   """
   The list of required status checks
   """
   requiredStatusChecks: [RequiredStatusCheckInput!]
-  
+
   """
   Are approving reviews required to update matching branches.
   """
   requiresApprovingReviews: Boolean
-  
+
   """
   Are reviews from code owners required to update matching branches.
   """
   requiresCodeOwnerReviews: Boolean
-  
+
   """
   Are commits required to be signed.
   """
   requiresCommitSignatures: Boolean
-  
+
   """
   Are conversations required to be resolved before merging.
   """
   requiresConversationResolution: Boolean
-  
+
   """
   Are successful deployments required before merging.
   """
   requiresDeployments: Boolean
-  
+
   """
   Are merge commits prohibited from being pushed to this branch.
   """
   requiresLinearHistory: Boolean
-  
+
   """
   Are status checks required to update matching branches.
   """
   requiresStatusChecks: Boolean
-  
+
   """
   Are branches required to be up to date before merging.
   """
   requiresStrictStatusChecks: Boolean
-  
+
   """
   Is pushing to matching branches restricted.
   """
   restrictsPushes: Boolean
-  
+
   """
   Is dismissal of pull request reviews restricted.
   """
   restrictsReviewDismissals: Boolean
-  
+
   """
   A list of User, Team, or App IDs allowed to dismiss reviews on pull requests targeting matching branches.
   """
@@ -6744,7 +6744,7 @@ type CreateBranchProtectionRulePayload {
   The newly created BranchProtectionRule.
   """
   branchProtectionRule: BranchProtectionRule
-  
+
   """
   A unique identifier for the client performing the mutation.
   """
@@ -6759,57 +6759,57 @@ input CreateCheckRunInput {
   Possible further actions the integrator can perform, which a user may trigger.
   """
   actions: [CheckRunAction!]
-  
+
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The time that the check run finished.
   """
   completedAt: DateTime
-  
+
   """
   The final conclusion of the check.
   """
   conclusion: CheckConclusionState
-  
+
   """
   The URL of the integrator's site that has the full details of the check.
   """
   detailsUrl: URI
-  
+
   """
   A reference for the run on the integrator's system.
   """
   externalId: String
-  
+
   """
   The SHA of the head commit.
   """
   headSha: GitObjectID!
-  
+
   """
   The name of the check.
   """
   name: String!
-  
+
   """
   Descriptive details about the run.
   """
   output: CheckRunOutput
-  
+
   """
   The node ID of the repository.
   """
   repositoryId: ID! @possibleTypes(concreteTypes: ["Repository"])
-  
+
   """
   The time that the check run began.
   """
   startedAt: DateTime
-  
+
   """
   The current status.
   """
@@ -6824,7 +6824,7 @@ type CreateCheckRunPayload {
   The newly created check run.
   """
   checkRun: CheckRun
-  
+
   """
   A unique identifier for the client performing the mutation.
   """
@@ -6839,12 +6839,12 @@ input CreateCheckSuiteInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The SHA of the head commit.
   """
   headSha: GitObjectID!
-  
+
   """
   The Node ID of the repository.
   """
@@ -6859,7 +6859,7 @@ type CreateCheckSuitePayload {
   The newly created check suite.
   """
   checkSuite: CheckSuite
-  
+
   """
   A unique identifier for the client performing the mutation.
   """
@@ -6874,22 +6874,22 @@ input CreateCommitOnBranchInput {
   The Ref to be updated.  Must be a branch.
   """
   branch: CommittableBranch!
-  
+
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The git commit oid expected at the head of the branch prior to the commit
   """
   expectedHeadOid: GitObjectID!
-  
+
   """
   A description of changes to files in this commit.
   """
   fileChanges: FileChanges
-  
+
   """
   The commit message the be included with the commit.
   """
@@ -6904,12 +6904,12 @@ type CreateCommitOnBranchPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The new commit.
   """
   commit: Commit
-  
+
   """
   The ref which has been updated to point to the new commit.
   """
@@ -6924,43 +6924,43 @@ input CreateDeploymentInput @preview(toggledBy: "flash-preview") {
   Attempt to automatically merge the default branch into the requested ref, defaults to true.
   """
   autoMerge: Boolean = true
-  
+
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   Short description of the deployment.
   """
   description: String = ""
-  
+
   """
   Name for the target deployment environment.
   """
   environment: String = "production"
-  
+
   """
   JSON payload with extra information about the deployment.
   """
   payload: String = "{}"
-  
+
   """
   The node ID of the ref to be deployed.
   """
   refId: ID! @possibleTypes(concreteTypes: ["Ref"])
-  
+
   """
   The node ID of the repository.
   """
   repositoryId: ID! @possibleTypes(concreteTypes: ["Repository"])
-  
+
   """
   The status contexts to verify against commit status checks. To bypass required
   contexts, pass an empty array. Defaults to all unique contexts.
   """
   requiredContexts: [String!]
-  
+
   """
   Specifies a task to execute.
   """
@@ -6975,12 +6975,12 @@ type CreateDeploymentPayload @preview(toggledBy: "flash-preview") {
   True if the default branch has been auto-merged into the deployment ref.
   """
   autoMerged: Boolean
-  
+
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The new deployment.
   """
@@ -6997,39 +6997,39 @@ input CreateDeploymentStatusInput @preview(toggledBy: "flash-preview") {
   status's deployment.
   """
   autoInactive: Boolean = true
-  
+
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The node ID of the deployment.
   """
   deploymentId: ID! @possibleTypes(concreteTypes: ["Deployment"])
-  
+
   """
   A short description of the status. Maximum length of 140 characters.
   """
   description: String = ""
-  
+
   """
   If provided, updates the environment of the deploy. Otherwise, does not modify the environment.
   """
   environment: String
-  
+
   """
   Sets the URL for accessing your environment.
   """
   environmentUrl: String = ""
-  
+
   """
   The log URL to associate with this status.       This URL should contain
   output to keep the user updated while the task is running       or serve as
   historical information for what happened in the deployment.
   """
   logUrl: String = ""
-  
+
   """
   The state of the deployment.
   """
@@ -7044,7 +7044,7 @@ type CreateDeploymentStatusPayload @preview(toggledBy: "flash-preview") {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The new deployment status.
   """
@@ -7059,22 +7059,22 @@ input CreateDiscussionInput {
   The body of the discussion.
   """
   body: String!
-  
+
   """
   The id of the discussion category to associate with this discussion.
   """
   categoryId: ID! @possibleTypes(concreteTypes: ["DiscussionCategory"])
-  
+
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The id of the repository on which to create the discussion.
   """
   repositoryId: ID! @possibleTypes(concreteTypes: ["Repository"])
-  
+
   """
   The title of the discussion.
   """
@@ -7089,7 +7089,7 @@ type CreateDiscussionPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The discussion that was just created.
   """
@@ -7104,27 +7104,27 @@ input CreateEnterpriseOrganizationInput {
   The logins for the administrators of the new organization.
   """
   adminLogins: [String!]!
-  
+
   """
   The email used for sending billing receipts.
   """
   billingEmail: String!
-  
+
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The ID of the enterprise owning the new organization.
   """
   enterpriseId: ID! @possibleTypes(concreteTypes: ["Enterprise"])
-  
+
   """
   The login of the new organization.
   """
   login: String!
-  
+
   """
   The profile name of the new organization.
   """
@@ -7139,12 +7139,12 @@ type CreateEnterpriseOrganizationPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The enterprise that owns the created organization.
   """
   enterprise: Enterprise
-  
+
   """
   The organization that was created.
   """
@@ -7159,12 +7159,12 @@ input CreateEnvironmentInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The name of the environment.
   """
   name: String!
-  
+
   """
   The node ID of the repository.
   """
@@ -7179,7 +7179,7 @@ type CreateEnvironmentPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The new or existing environment.
   """
@@ -7194,22 +7194,22 @@ input CreateIpAllowListEntryInput {
   An IP address or range of addresses in CIDR notation.
   """
   allowListValue: String!
-  
+
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   Whether the IP allow list entry is active when an IP allow list is enabled.
   """
   isActive: Boolean!
-  
+
   """
   An optional name for the IP allow list entry.
   """
   name: String
-  
+
   """
   The ID of the owner for which to create the new IP allow list entry.
   """
@@ -7228,7 +7228,7 @@ type CreateIpAllowListEntryPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The IP allow list entry that was created.
   """
@@ -7243,42 +7243,42 @@ input CreateIssueInput {
   The Node ID for the user assignee for this issue.
   """
   assigneeIds: [ID!] @possibleTypes(concreteTypes: ["User"])
-  
+
   """
   The body for the issue description.
   """
   body: String
-  
+
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The name of an issue template in the repository, assigns labels and assignees from the template to the issue
   """
   issueTemplate: String
-  
+
   """
   An array of Node IDs of labels for this issue.
   """
   labelIds: [ID!] @possibleTypes(concreteTypes: ["Label"])
-  
+
   """
   The Node ID of the milestone for this issue.
   """
   milestoneId: ID @possibleTypes(concreteTypes: ["Milestone"])
-  
+
   """
   An array of Node IDs for projects associated with this issue.
   """
   projectIds: [ID!] @possibleTypes(concreteTypes: ["Project"])
-  
+
   """
   The Node ID of the repository.
   """
   repositoryId: ID! @possibleTypes(concreteTypes: ["Repository"])
-  
+
   """
   The title for the issue.
   """
@@ -7293,7 +7293,7 @@ type CreateIssuePayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The new issue.
   """
@@ -7308,22 +7308,22 @@ input CreateLabelInput @preview(toggledBy: "bane-preview") {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   A 6 character hex code, without the leading #, identifying the color of the label.
   """
   color: String!
-  
+
   """
   A brief description of the label, such as its purpose.
   """
   description: String
-  
+
   """
   The name of the label.
   """
   name: String!
-  
+
   """
   The Node ID of the repository.
   """
@@ -7338,7 +7338,7 @@ type CreateLabelPayload @preview(toggledBy: "bane-preview") {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The new label.
   """
@@ -7353,22 +7353,22 @@ input CreateLinkedBranchInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   ID of the issue to link to.
   """
   issueId: ID! @possibleTypes(concreteTypes: ["Issue"])
-  
+
   """
   The name of the new branch. Defaults to issue number and title.
   """
   name: String
-  
+
   """
   The commit SHA to base the new branch on.
   """
   oid: GitObjectID!
-  
+
   """
   ID of the repository to create the branch in. Defaults to the issue repository.
   """
@@ -7383,12 +7383,12 @@ type CreateLinkedBranchPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The issue that was linked to.
   """
   issue: Issue
-  
+
   """
   The new branch issue reference.
   """
@@ -7403,32 +7403,32 @@ input CreateMigrationSourceInput {
   The migration source access token.
   """
   accessToken: String
-  
+
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The GitHub personal access token of the user importing to the target repository.
   """
   githubPat: String
-  
+
   """
   The migration source name.
   """
   name: String!
-  
+
   """
   The ID of the organization that will own the migration source.
   """
   ownerId: ID! @possibleTypes(concreteTypes: ["Organization"])
-  
+
   """
   The migration source type.
   """
   type: MigrationSourceType!
-  
+
   """
   The migration source URL, for example `https://github.com` or `https://monalisa.ghe.com`.
   """
@@ -7443,7 +7443,7 @@ type CreateMigrationSourcePayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The created migration source.
   """
@@ -7458,17 +7458,17 @@ input CreateProjectInput {
   The description of project.
   """
   body: String
-  
+
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The name of project.
   """
   name: String!
-  
+
   """
   The owner ID to create the project under.
   """
@@ -7477,12 +7477,12 @@ input CreateProjectInput {
       concreteTypes: ["Organization", "Repository", "User"]
       abstractType: "ProjectOwner"
     )
-  
+
   """
   A list of repository IDs to create as linked repositories for the project
   """
   repositoryIds: [ID!] @possibleTypes(concreteTypes: ["Repository"])
-  
+
   """
   The name of the GitHub-provided template.
   """
@@ -7497,7 +7497,7 @@ type CreateProjectPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The new project.
   """
@@ -7512,22 +7512,22 @@ input CreateProjectV2FieldInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The data type of the field.
   """
   dataType: ProjectV2CustomFieldType!
-  
+
   """
   The name of the field.
   """
   name: String!
-  
+
   """
   The ID of the Project to create the field in.
   """
   projectId: ID! @possibleTypes(concreteTypes: ["ProjectV2"])
-  
+
   """
   Options for a single select field. At least one value is required if data_type is SINGLE_SELECT
   """
@@ -7542,7 +7542,7 @@ type CreateProjectV2FieldPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The new field.
   """
@@ -7557,7 +7557,7 @@ input CreateProjectV2Input {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The owner ID to create the project under.
   """
@@ -7566,17 +7566,17 @@ input CreateProjectV2Input {
       concreteTypes: ["Organization", "User"]
       abstractType: "OrganizationOrUser"
     )
-  
+
   """
   The repository to link the project to.
   """
   repositoryId: ID @possibleTypes(concreteTypes: ["Repository"])
-  
+
   """
   The team to link the project to. The team will be granted read permissions.
   """
   teamId: ID @possibleTypes(concreteTypes: ["Team"])
-  
+
   """
   The title of the project.
   """
@@ -7591,7 +7591,7 @@ type CreateProjectV2Payload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The new project.
   """
@@ -7608,43 +7608,43 @@ input CreatePullRequestInput {
   to another repository.
   """
   baseRefName: String!
-  
+
   """
   The contents of the pull request.
   """
   body: String
-  
+
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   Indicates whether this pull request should be a draft.
   """
   draft: Boolean = false
-  
+
   """
   The name of the branch where your changes are implemented. For cross-repository pull requests
   in the same network, namespace `head_ref_name` with a user like this: `username:branch`.
   """
   headRefName: String!
-  
+
   """
   The Node ID of the head repository.
   """
   headRepositoryId: ID @possibleTypes(concreteTypes: ["Repository"])
-  
+
   """
   Indicates whether maintainers can modify the pull request.
   """
   maintainerCanModify: Boolean = true
-  
+
   """
   The Node ID of the repository.
   """
   repositoryId: ID! @possibleTypes(concreteTypes: ["Repository"])
-  
+
   """
   The title of the pull request.
   """
@@ -7659,7 +7659,7 @@ type CreatePullRequestPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The new pull request.
   """
@@ -7674,17 +7674,17 @@ input CreateRefInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The fully qualified name of the new Ref (ie: `refs/heads/my_new_branch`).
   """
   name: String!
-  
+
   """
   The GitObjectID that the new Ref shall target. Must point to a commit.
   """
   oid: GitObjectID!
-  
+
   """
   The Node ID of the Repository to create the Ref in.
   """
@@ -7699,7 +7699,7 @@ type CreateRefPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The newly created ref.
   """
@@ -7714,32 +7714,32 @@ input CreateRepositoryInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   A short description of the new repository.
   """
   description: String
-  
+
   """
   Indicates if the repository should have the issues feature enabled.
   """
   hasIssuesEnabled: Boolean = true
-  
+
   """
   Indicates if the repository should have the wiki feature enabled.
   """
   hasWikiEnabled: Boolean = false
-  
+
   """
   The URL for a web page about this repository.
   """
   homepageUrl: URI
-  
+
   """
   The name of the new repository.
   """
   name: String!
-  
+
   """
   The ID of the owner for the new repository.
   """
@@ -7748,19 +7748,19 @@ input CreateRepositoryInput {
       concreteTypes: ["Organization", "User"]
       abstractType: "RepositoryOwner"
     )
-  
+
   """
   When an organization is specified as the owner, this ID identifies the team
   that should be granted access to the new repository.
   """
   teamId: ID @possibleTypes(concreteTypes: ["Team"])
-  
+
   """
   Whether this repository should be marked as a template such that anyone who
   can access it can create new repositories with the same files and directory structure.
   """
   template: Boolean = false
-  
+
   """
   Indicates the repository's visibility level.
   """
@@ -7775,7 +7775,7 @@ type CreateRepositoryPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The new repository.
   """
@@ -7790,32 +7790,32 @@ input CreateRepositoryRulesetInput {
   A list of actors that are allowed to bypass rules in this ruleset.
   """
   bypassActors: [RepositoryRulesetBypassActorInput!]
-  
+
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The set of conditions for this ruleset
   """
   conditions: RepositoryRuleConditionsInput!
-  
+
   """
   The enforcement level for this ruleset
   """
   enforcement: RuleEnforcement!
-  
+
   """
   The name of the ruleset.
   """
   name: String!
-  
+
   """
   The list of rules for this ruleset
   """
   rules: [RepositoryRuleInput!]
-  
+
   """
   The global relay id of the source in which a new ruleset should be created in.
   """
@@ -7824,7 +7824,7 @@ input CreateRepositoryRulesetInput {
       concreteTypes: ["Organization", "Repository"]
       abstractType: "RuleSource"
     )
-  
+
   """
   The target of the ruleset.
   """
@@ -7839,7 +7839,7 @@ type CreateRepositoryRulesetPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The newly created Ruleset.
   """
@@ -7855,12 +7855,12 @@ input CreateSponsorsListingInput {
   Required if fiscalHostLogin is not specified, ignored when fiscalHostLogin is specified.
   """
   billingCountryOrRegionCode: SponsorsCountryOrRegionCode
-  
+
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The email address we should use to contact you about the GitHub Sponsors
   profile being created. This will not be shared publicly. Must be a verified
@@ -7868,7 +7868,7 @@ input CreateSponsorsListingInput {
   sponsorable is yourself. Defaults to your primary email address on file if omitted.
   """
   contactEmail: String
-  
+
   """
   The username of the supported fiscal host's GitHub organization, if you want
   to receive sponsorship payouts through a fiscal host rather than directly to a
@@ -7877,14 +7877,14 @@ input CreateSponsorsListingInput {
   for more information.
   """
   fiscalHostLogin: String
-  
+
   """
   The URL for your profile page on the fiscal host's website, e.g.,
   https://opencollective.com/babel or https://numfocus.org/project/bokeh.
   Required if fiscalHostLogin is specified.
   """
   fiscallyHostedProjectProfileUrl: String
-  
+
   """
   Provide an introduction to serve as the main focus that appears on your GitHub
   Sponsors profile. It's a great opportunity to help potential sponsors learn
@@ -7892,14 +7892,14 @@ input CreateSponsorsListingInput {
   GitHub-flavored Markdown is supported.
   """
   fullDescription: String
-  
+
   """
   The country or region where the sponsorable resides. This is for tax purposes.
   Required if the sponsorable is yourself, ignored when sponsorableLogin
   specifies an organization.
   """
   residenceCountryOrRegionCode: SponsorsCountryOrRegionCode
-  
+
   """
   The username of the organization to create a GitHub Sponsors profile for, if
   desired. Defaults to creating a GitHub Sponsors profile for the authenticated
@@ -7916,7 +7916,7 @@ type CreateSponsorsListingPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The new GitHub Sponsors profile.
   """
@@ -7931,48 +7931,48 @@ input CreateSponsorsTierInput {
   The value of the new tier in US dollars. Valid values: 1-12000.
   """
   amount: Int!
-  
+
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   A description of what this tier is, what perks sponsors might receive, what a sponsorship at this tier means for you, etc.
   """
   description: String!
-  
+
   """
   Whether sponsorships using this tier should happen monthly/yearly or just once.
   """
   isRecurring: Boolean = true
-  
+
   """
   Whether to make the tier available immediately for sponsors to choose.
   Defaults to creating a draft tier that will not be publicly visible.
   """
   publish: Boolean = false
-  
+
   """
   Optional ID of the private repository that sponsors at this tier should gain
   read-only access to. Must be owned by an organization.
   """
   repositoryId: ID @possibleTypes(concreteTypes: ["Repository"])
-  
+
   """
   Optional name of the private repository that sponsors at this tier should gain
   read-only access to. Must be owned by an organization. Necessary if
   repositoryOwnerLogin is given. Will be ignored if repositoryId is given.
   """
   repositoryName: String
-  
+
   """
   Optional login of the organization owner of the private repository that
   sponsors at this tier should gain read-only access to. Necessary if
   repositoryName is given. Will be ignored if repositoryId is given.
   """
   repositoryOwnerLogin: String
-  
+
   """
   The ID of the user or organization who owns the GitHub Sponsors profile.
   Defaults to the current user if omitted and sponsorableLogin is not given.
@@ -7982,13 +7982,13 @@ input CreateSponsorsTierInput {
       concreteTypes: ["Organization", "User"]
       abstractType: "Sponsorable"
     )
-  
+
   """
   The username of the user or organization who owns the GitHub Sponsors profile.
   Defaults to the current user if omitted and sponsorableId is not given.
   """
   sponsorableLogin: String
-  
+
   """
   Optional message new sponsors at this tier will receive.
   """
@@ -8003,7 +8003,7 @@ type CreateSponsorsTierPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The new tier.
   """
@@ -8018,28 +8018,28 @@ input CreateSponsorshipInput {
   The amount to pay to the sponsorable in US dollars. Required if a tierId is not specified. Valid values: 1-12000.
   """
   amount: Int
-  
+
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   Whether the sponsorship should happen monthly/yearly or just this one time. Required if a tierId is not specified.
   """
   isRecurring: Boolean
-  
+
   """
   Specify whether others should be able to see that the sponsor is sponsoring
   the sponsorable. Public visibility still does not reveal which tier is used.
   """
   privacyLevel: SponsorshipPrivacy = PUBLIC
-  
+
   """
   Whether the sponsor should receive email updates from the sponsorable.
   """
   receiveEmails: Boolean = true
-  
+
   """
   The ID of the user or organization who is acting as the sponsor, paying for
   the sponsorship. Required if sponsorLogin is not given.
@@ -8049,13 +8049,13 @@ input CreateSponsorshipInput {
       concreteTypes: ["Organization", "User"]
       abstractType: "Sponsor"
     )
-  
+
   """
   The username of the user or organization who is acting as the sponsor, paying
   for the sponsorship. Required if sponsorId is not given.
   """
   sponsorLogin: String
-  
+
   """
   The ID of the user or organization who is receiving the sponsorship. Required if sponsorableLogin is not given.
   """
@@ -8064,12 +8064,12 @@ input CreateSponsorshipInput {
       concreteTypes: ["Organization", "User"]
       abstractType: "Sponsorable"
     )
-  
+
   """
   The username of the user or organization who is receiving the sponsorship. Required if sponsorableId is not given.
   """
   sponsorableLogin: String
-  
+
   """
   The ID of one of sponsorable's existing tiers to sponsor at. Required if amount is not specified.
   """
@@ -8084,7 +8084,7 @@ type CreateSponsorshipPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The sponsorship that was started.
   """
@@ -8099,24 +8099,24 @@ input CreateSponsorshipsInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   Specify whether others should be able to see that the sponsor is sponsoring
   the sponsorables. Public visibility still does not reveal the dollar value of
   the sponsorship.
   """
   privacyLevel: SponsorshipPrivacy = PUBLIC
-  
+
   """
   Whether the sponsor should receive email updates from the sponsorables.
   """
   receiveEmails: Boolean = false
-  
+
   """
   The username of the user or organization who is acting as the sponsor, paying for the sponsorships.
   """
   sponsorLogin: String!
-  
+
   """
   The list of maintainers to sponsor and for how much apiece.
   """
@@ -8131,7 +8131,7 @@ type CreateSponsorshipsPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The users and organizations who received a sponsorship.
   """
@@ -8152,12 +8152,12 @@ input CreateTeamDiscussionCommentInput {
   **Reason:** The Team Discussions feature is deprecated in favor of Organization Discussions.
   """
   body: String
-  
+
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The ID of the discussion to which the comment belongs. This field is required.
 
@@ -8178,7 +8178,7 @@ type CreateTeamDiscussionCommentPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The new comment.
   """
@@ -8202,12 +8202,12 @@ input CreateTeamDiscussionInput {
   **Reason:** The Team Discussions feature is deprecated in favor of Organization Discussions.
   """
   body: String
-  
+
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   If true, restricts the visibility of this discussion to team members and
   organization admins. If false or not specified, allows any organization member
@@ -8220,7 +8220,7 @@ input CreateTeamDiscussionInput {
   **Reason:** The Team Discussions feature is deprecated in favor of Organization Discussions.
   """
   private: Boolean
-  
+
   """
   The ID of the team to which the discussion belongs. This field is required.
 
@@ -8231,7 +8231,7 @@ input CreateTeamDiscussionInput {
   **Reason:** The Team Discussions feature is deprecated in favor of Organization Discussions.
   """
   teamId: ID @possibleTypes(concreteTypes: ["Team"])
-  
+
   """
   The title of the discussion. This field is required.
 
@@ -8252,7 +8252,7 @@ type CreateTeamDiscussionPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The new discussion.
   """
@@ -8270,34 +8270,34 @@ type CreatedCommitContribution implements Contribution {
   How many commits were made on this day to this repository by the user.
   """
   commitCount: Int!
-  
+
   """
   Whether this contribution is associated with a record you do not have access to. For
   example, your own 'first issue' contribution may have been made on a repository you can no
   longer access.
   """
   isRestricted: Boolean!
-  
+
   """
   When this contribution was made.
   """
   occurredAt: DateTime!
-  
+
   """
   The repository the user made a commit in.
   """
   repository: Repository!
-  
+
   """
   The HTTP path for this contribution.
   """
   resourcePath: URI!
-  
+
   """
   The HTTP URL for this contribution.
   """
   url: URI!
-  
+
   """
   The user who made this contribution.
   """
@@ -8312,17 +8312,17 @@ type CreatedCommitContributionConnection {
   A list of edges.
   """
   edges: [CreatedCommitContributionEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [CreatedCommitContribution]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of commits across days and repositories in the connection.
   """
@@ -8337,7 +8337,7 @@ type CreatedCommitContributionEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -8354,27 +8354,27 @@ type CreatedIssueContribution implements Contribution {
   longer access.
   """
   isRestricted: Boolean!
-  
+
   """
   The issue that was opened.
   """
   issue: Issue!
-  
+
   """
   When this contribution was made.
   """
   occurredAt: DateTime!
-  
+
   """
   The HTTP path for this contribution.
   """
   resourcePath: URI!
-  
+
   """
   The HTTP URL for this contribution.
   """
   url: URI!
-  
+
   """
   The user who made this contribution.
   """
@@ -8389,17 +8389,17 @@ type CreatedIssueContributionConnection {
   A list of edges.
   """
   edges: [CreatedIssueContributionEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [CreatedIssueContribution]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -8414,7 +8414,7 @@ type CreatedIssueContributionEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -8437,27 +8437,27 @@ type CreatedPullRequestContribution implements Contribution {
   longer access.
   """
   isRestricted: Boolean!
-  
+
   """
   When this contribution was made.
   """
   occurredAt: DateTime!
-  
+
   """
   The pull request that was opened.
   """
   pullRequest: PullRequest!
-  
+
   """
   The HTTP path for this contribution.
   """
   resourcePath: URI!
-  
+
   """
   The HTTP URL for this contribution.
   """
   url: URI!
-  
+
   """
   The user who made this contribution.
   """
@@ -8472,17 +8472,17 @@ type CreatedPullRequestContributionConnection {
   A list of edges.
   """
   edges: [CreatedPullRequestContributionEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [CreatedPullRequestContribution]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -8497,7 +8497,7 @@ type CreatedPullRequestContributionEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -8520,37 +8520,37 @@ type CreatedPullRequestReviewContribution implements Contribution {
   longer access.
   """
   isRestricted: Boolean!
-  
+
   """
   When this contribution was made.
   """
   occurredAt: DateTime!
-  
+
   """
   The pull request the user reviewed.
   """
   pullRequest: PullRequest!
-  
+
   """
   The review the user left on the pull request.
   """
   pullRequestReview: PullRequestReview!
-  
+
   """
   The repository containing the pull request that the user reviewed.
   """
   repository: Repository!
-  
+
   """
   The HTTP path for this contribution.
   """
   resourcePath: URI!
-  
+
   """
   The HTTP URL for this contribution.
   """
   url: URI!
-  
+
   """
   The user who made this contribution.
   """
@@ -8565,17 +8565,17 @@ type CreatedPullRequestReviewContributionConnection {
   A list of edges.
   """
   edges: [CreatedPullRequestReviewContributionEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [CreatedPullRequestReviewContribution]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -8590,7 +8590,7 @@ type CreatedPullRequestReviewContributionEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -8607,27 +8607,27 @@ type CreatedRepositoryContribution implements Contribution {
   longer access.
   """
   isRestricted: Boolean!
-  
+
   """
   When this contribution was made.
   """
   occurredAt: DateTime!
-  
+
   """
   The repository that was created.
   """
   repository: Repository!
-  
+
   """
   The HTTP path for this contribution.
   """
   resourcePath: URI!
-  
+
   """
   The HTTP URL for this contribution.
   """
   url: URI!
-  
+
   """
   The user who made this contribution.
   """
@@ -8642,17 +8642,17 @@ type CreatedRepositoryContributionConnection {
   A list of edges.
   """
   edges: [CreatedRepositoryContributionEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [CreatedRepositoryContribution]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -8667,7 +8667,7 @@ type CreatedRepositoryContributionEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -8688,43 +8688,43 @@ type CrossReferencedEvent implements Node & UniformResourceLocatable {
   Identifies the actor who performed the event.
   """
   actor: Actor
-  
+
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
   id: ID!
-  
+
   """
   Reference originated in a different repository.
   """
   isCrossRepository: Boolean!
-  
+
   """
   Identifies when the reference was made.
   """
   referencedAt: DateTime!
-  
+
   """
   The HTTP path for this pull request.
   """
   resourcePath: URI!
-  
+
   """
   Issue or pull request that made the reference.
   """
   source: ReferencedSubject!
-  
+
   """
   Issue or pull request to which the reference was made.
   """
   target: ReferencedSubject!
-  
+
   """
   The HTTP URL for this pull request.
   """
   url: URI!
-  
+
   """
   Checks if the target will be closed when the source is merged.
   """
@@ -8749,17 +8749,17 @@ input DeclineTopicSuggestionInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The name of the suggested topic.
   """
   name: String!
-  
+
   """
   The reason why the suggested topic is declined.
   """
   reason: TopicSuggestionDeclineReason!
-  
+
   """
   The Node ID of the repository.
   """
@@ -8774,7 +8774,7 @@ type DeclineTopicSuggestionPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The declined topic.
   """
@@ -8822,7 +8822,7 @@ input DeleteBranchProtectionRuleInput {
   """
   branchProtectionRuleId: ID!
     @possibleTypes(concreteTypes: ["BranchProtectionRule"])
-  
+
   """
   A unique identifier for the client performing the mutation.
   """
@@ -8847,7 +8847,7 @@ input DeleteDeploymentInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The Node ID of the deployment to be deleted.
   """
@@ -8872,7 +8872,7 @@ input DeleteDiscussionCommentInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The Node id of the discussion comment to delete.
   """
@@ -8887,7 +8887,7 @@ type DeleteDiscussionCommentPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The discussion comment that was just deleted.
   """
@@ -8902,7 +8902,7 @@ input DeleteDiscussionInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The id of the discussion to delete.
   """
@@ -8917,7 +8917,7 @@ type DeleteDiscussionPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The discussion that was just deleted.
   """
@@ -8932,7 +8932,7 @@ input DeleteEnvironmentInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The Node ID of the environment to be deleted.
   """
@@ -8957,7 +8957,7 @@ input DeleteIpAllowListEntryInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The ID of the IP allow list entry to delete.
   """
@@ -8972,7 +8972,7 @@ type DeleteIpAllowListEntryPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The IP allow list entry that was deleted.
   """
@@ -8987,7 +8987,7 @@ input DeleteIssueCommentInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The ID of the comment to delete.
   """
@@ -9012,7 +9012,7 @@ input DeleteIssueInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The ID of the issue to delete.
   """
@@ -9027,7 +9027,7 @@ type DeleteIssuePayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The repository the issue belonged to
   """
@@ -9042,7 +9042,7 @@ input DeleteLabelInput @preview(toggledBy: "bane-preview") {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The Node ID of the label to be deleted.
   """
@@ -9067,7 +9067,7 @@ input DeleteLinkedBranchInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The ID of the linked branch
   """
@@ -9082,7 +9082,7 @@ type DeleteLinkedBranchPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The issue the linked branch was unlinked from.
   """
@@ -9097,7 +9097,7 @@ input DeletePackageVersionInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The ID of the package version to be deleted.
   """
@@ -9112,7 +9112,7 @@ type DeletePackageVersionPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   Whether or not the operation succeeded.
   """
@@ -9127,7 +9127,7 @@ input DeleteProjectCardInput {
   The id of the card to delete.
   """
   cardId: ID! @possibleTypes(concreteTypes: ["ProjectCard"])
-  
+
   """
   A unique identifier for the client performing the mutation.
   """
@@ -9142,12 +9142,12 @@ type DeleteProjectCardPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The column the deleted card was in.
   """
   column: ProjectColumn
-  
+
   """
   The deleted card ID.
   """
@@ -9162,7 +9162,7 @@ input DeleteProjectColumnInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The id of the column to delete.
   """
@@ -9177,12 +9177,12 @@ type DeleteProjectColumnPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The deleted column ID.
   """
   deletedColumnId: ID
-  
+
   """
   The project the deleted column was in.
   """
@@ -9197,7 +9197,7 @@ input DeleteProjectInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The Project ID to update.
   """
@@ -9212,7 +9212,7 @@ type DeleteProjectPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The repository or organization the project was removed from.
   """
@@ -9227,7 +9227,7 @@ input DeleteProjectV2FieldInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The ID of the field to delete.
   """
@@ -9250,7 +9250,7 @@ type DeleteProjectV2FieldPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The deleted field.
   """
@@ -9265,7 +9265,7 @@ input DeleteProjectV2Input {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The ID of the Project to delete.
   """
@@ -9280,12 +9280,12 @@ input DeleteProjectV2ItemInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The ID of the item to be removed.
   """
   itemId: ID! @possibleTypes(concreteTypes: ["ProjectV2Item"])
-  
+
   """
   The ID of the Project from which the item should be removed.
   """
@@ -9300,7 +9300,7 @@ type DeleteProjectV2ItemPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The ID of the deleted item.
   """
@@ -9315,7 +9315,7 @@ type DeleteProjectV2Payload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The deleted Project.
   """
@@ -9330,7 +9330,7 @@ input DeleteProjectV2WorkflowInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The ID of the workflow to be removed.
   """
@@ -9345,12 +9345,12 @@ type DeleteProjectV2WorkflowPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The ID of the deleted workflow.
   """
   deletedWorkflowId: ID
-  
+
   """
   The project the deleted workflow was in.
   """
@@ -9365,7 +9365,7 @@ input DeletePullRequestReviewCommentInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The ID of the comment to delete.
   """
@@ -9380,12 +9380,12 @@ type DeletePullRequestReviewCommentPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The pull request review the deleted comment belonged to.
   """
   pullRequestReview: PullRequestReview
-  
+
   """
   The deleted pull request review comment.
   """
@@ -9400,7 +9400,7 @@ input DeletePullRequestReviewInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The Node ID of the pull request review to delete.
   """
@@ -9415,7 +9415,7 @@ type DeletePullRequestReviewPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The deleted pull request review.
   """
@@ -9430,7 +9430,7 @@ input DeleteRefInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The Node ID of the Ref to be deleted.
   """
@@ -9455,7 +9455,7 @@ input DeleteRepositoryRulesetInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The global relay id of the repository ruleset to be deleted.
   """
@@ -9480,7 +9480,7 @@ input DeleteTeamDiscussionCommentInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The ID of the comment to delete.
   """
@@ -9505,7 +9505,7 @@ input DeleteTeamDiscussionInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The discussion ID to delete.
   """
@@ -9530,7 +9530,7 @@ input DeleteVerifiableDomainInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The ID of the verifiable domain to delete.
   """
@@ -9545,7 +9545,7 @@ type DeleteVerifiableDomainPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The owning account from which the domain was deleted.
   """
@@ -9560,18 +9560,18 @@ type DemilestonedEvent implements Node {
   Identifies the actor who performed the event.
   """
   actor: Actor
-  
+
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
   id: ID!
-  
+
   """
   Identifies the milestone title associated with the 'demilestoned' event.
   """
   milestoneTitle: String!
-  
+
   """
   Object referenced by event.
   """
@@ -9586,12 +9586,12 @@ type DependabotUpdate implements RepositoryNode {
   The error from a dependency update
   """
   error: DependabotUpdateError
-  
+
   """
   The associated pull request
   """
   pullRequest: PullRequest
-  
+
   """
   The repository associated with this node.
   """
@@ -9606,12 +9606,12 @@ type DependabotUpdateError {
   The body of the error
   """
   body: String!
-  
+
   """
   The error code
   """
   errorType: String!
-  
+
   """
   The title of the error
   """
@@ -9626,7 +9626,7 @@ type DependencyGraphDependency @preview(toggledBy: "hawkgirl-preview") {
   Does the dependency itself have dependencies?
   """
   hasDependencies: Boolean!
-  
+
   """
   The original name of the package, as it appears in the manifest.
   """
@@ -9634,22 +9634,22 @@ type DependencyGraphDependency @preview(toggledBy: "hawkgirl-preview") {
     @deprecated(
       reason: "`packageLabel` will be removed. Use normalized `packageName` field instead. Removal on 2022-10-01 UTC."
     )
-  
+
   """
   The dependency package manager
   """
   packageManager: String
-  
+
   """
   The name of the package in the canonical form used by the package manager.
   """
   packageName: String!
-  
+
   """
   The repository containing the package
   """
   repository: Repository
-  
+
   """
   The dependency version requirements
   """
@@ -9665,17 +9665,17 @@ type DependencyGraphDependencyConnection
   A list of edges.
   """
   edges: [DependencyGraphDependencyEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [DependencyGraphDependency]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -9690,7 +9690,7 @@ type DependencyGraphDependencyEdge @preview(toggledBy: "hawkgirl-preview") {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -9756,7 +9756,7 @@ type DependencyGraphManifest implements Node
   Path to view the manifest file blob
   """
   blobPath: String!
-  
+
   """
   A list of manifest dependencies
   """
@@ -9765,44 +9765,44 @@ type DependencyGraphManifest implements Node
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): DependencyGraphDependencyConnection
-  
+
   """
   The number of dependencies listed in the manifest
   """
   dependenciesCount: Int
-  
+
   """
   Is the manifest too big to parse?
   """
   exceedsMaxSize: Boolean!
-  
+
   """
   Fully qualified manifest filename
   """
   filename: String!
   id: ID!
-  
+
   """
   Were we able to parse the manifest?
   """
   parseable: Boolean!
-  
+
   """
   The repository containing the manifest
   """
@@ -9817,17 +9817,17 @@ type DependencyGraphManifestConnection @preview(toggledBy: "hawkgirl-preview") {
   A list of edges.
   """
   edges: [DependencyGraphManifestEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [DependencyGraphManifest]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -9842,7 +9842,7 @@ type DependencyGraphManifestEdge @preview(toggledBy: "hawkgirl-preview") {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -9858,22 +9858,22 @@ type DeployKey implements Node {
   """
   createdAt: DateTime!
   id: ID!
-  
+
   """
   The deploy key.
   """
   key: String!
-  
+
   """
   Whether or not the deploy key is read only.
   """
   readOnly: Boolean!
-  
+
   """
   The deploy key title.
   """
   title: String!
-  
+
   """
   Whether or not the deploy key has been verified.
   """
@@ -9888,17 +9888,17 @@ type DeployKeyConnection {
   A list of edges.
   """
   edges: [DeployKeyEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [DeployKey]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -9913,7 +9913,7 @@ type DeployKeyEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -9928,28 +9928,28 @@ type DeployedEvent implements Node {
   Identifies the actor who performed the event.
   """
   actor: Actor
-  
+
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
-  
+
   """
   Identifies the primary key from the database.
   """
   databaseId: Int
-  
+
   """
   The deployment associated with the 'deployed' event.
   """
   deployment: Deployment!
   id: ID!
-  
+
   """
   PullRequest referenced by event.
   """
   pullRequest: PullRequest!
-  
+
   """
   The ref associated with the 'deployed' event.
   """
@@ -9964,73 +9964,73 @@ type Deployment implements Node {
   Identifies the commit sha of the deployment.
   """
   commit: Commit
-  
+
   """
   Identifies the oid of the deployment commit, even if the commit has been deleted.
   """
   commitOid: String!
-  
+
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
-  
+
   """
   Identifies the actor who triggered the deployment.
   """
   creator: Actor!
-  
+
   """
   Identifies the primary key from the database.
   """
   databaseId: Int
-  
+
   """
   The deployment description.
   """
   description: String
-  
+
   """
   The latest environment to which this deployment was made.
   """
   environment: String
   id: ID!
-  
+
   """
   The latest environment to which this deployment was made.
   """
   latestEnvironment: String
-  
+
   """
   The latest status of this deployment.
   """
   latestStatus: DeploymentStatus
-  
+
   """
   The original environment to which this deployment was made.
   """
   originalEnvironment: String
-  
+
   """
   Extra information that a deployment system might need.
   """
   payload: String
-  
+
   """
   Identifies the Ref of the deployment, if the deployment was created by ref.
   """
   ref: Ref
-  
+
   """
   Identifies the repository associated with the deployment.
   """
   repository: Repository!
-  
+
   """
   The current state of the deployment.
   """
   state: DeploymentState
-  
+
   """
   A list of statuses associated with the deployment.
   """
@@ -10039,28 +10039,28 @@ type Deployment implements Node {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): DeploymentStatusConnection
-  
+
   """
   The deployment task.
   """
   task: String
-  
+
   """
   Identifies the date and time when the object was last updated.
   """
@@ -10075,17 +10075,17 @@ type DeploymentConnection {
   A list of edges.
   """
   edges: [DeploymentEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [Deployment]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -10100,7 +10100,7 @@ type DeploymentEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -10115,18 +10115,18 @@ type DeploymentEnvironmentChangedEvent implements Node {
   Identifies the actor who performed the event.
   """
   actor: Actor
-  
+
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
-  
+
   """
   The deployment status that updated the deployment environment.
   """
   deploymentStatus: DeploymentStatus!
   id: ID!
-  
+
   """
   PullRequest referenced by event.
   """
@@ -10141,7 +10141,7 @@ input DeploymentOrder {
   The ordering direction.
   """
   direction: OrderDirection!
-  
+
   """
   The field to order deployments by.
   """
@@ -10166,7 +10166,7 @@ type DeploymentProtectionRule {
   Identifies the primary key from the database.
   """
   databaseId: Int
-  
+
   """
   The teams or users that can review the deployment
   """
@@ -10175,28 +10175,28 @@ type DeploymentProtectionRule {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): DeploymentReviewerConnection!
-  
+
   """
   The timeout in minutes for this protection rule.
   """
   timeout: Int!
-  
+
   """
   The type of protection rule.
   """
@@ -10211,17 +10211,17 @@ type DeploymentProtectionRuleConnection {
   A list of edges.
   """
   edges: [DeploymentProtectionRuleEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [DeploymentProtectionRule]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -10236,7 +10236,7 @@ type DeploymentProtectionRuleEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -10265,12 +10265,12 @@ type DeploymentRequest {
   Whether or not the current user can approve the deployment
   """
   currentUserCanApprove: Boolean!
-  
+
   """
   The target environment of the deployment
   """
   environment: Environment!
-  
+
   """
   The teams or users that can review the deployment
   """
@@ -10279,28 +10279,28 @@ type DeploymentRequest {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): DeploymentReviewerConnection!
-  
+
   """
   The wait timer in minutes configured in the environment
   """
   waitTimer: Int!
-  
+
   """
   The wait timer in minutes configured in the environment
   """
@@ -10315,17 +10315,17 @@ type DeploymentRequestConnection {
   A list of edges.
   """
   edges: [DeploymentRequestEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [DeploymentRequest]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -10340,7 +10340,7 @@ type DeploymentRequestEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -10355,12 +10355,12 @@ type DeploymentReview implements Node {
   The comment the user left.
   """
   comment: String!
-  
+
   """
   Identifies the primary key from the database.
   """
   databaseId: Int
-  
+
   """
   The environments approved or rejected
   """
@@ -10369,29 +10369,29 @@ type DeploymentReview implements Node {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): EnvironmentConnection!
   id: ID!
-  
+
   """
   The decision of the user.
   """
   state: DeploymentReviewState!
-  
+
   """
   The user that reviewed the deployment.
   """
@@ -10406,17 +10406,17 @@ type DeploymentReviewConnection {
   A list of edges.
   """
   edges: [DeploymentReviewEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [DeploymentReview]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -10431,7 +10431,7 @@ type DeploymentReviewEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -10465,17 +10465,17 @@ type DeploymentReviewerConnection {
   A list of edges.
   """
   edges: [DeploymentReviewerEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [DeploymentReviewer]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -10490,7 +10490,7 @@ type DeploymentReviewerEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -10555,43 +10555,43 @@ type DeploymentStatus implements Node {
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
-  
+
   """
   Identifies the actor who triggered the deployment.
   """
   creator: Actor!
-  
+
   """
   Identifies the deployment associated with status.
   """
   deployment: Deployment!
-  
+
   """
   Identifies the description of the deployment.
   """
   description: String
-  
+
   """
   Identifies the environment of the deployment at the time of this deployment status
   """
   environment: String @preview(toggledBy: "flash-preview")
-  
+
   """
   Identifies the environment URL of the deployment.
   """
   environmentUrl: URI
   id: ID!
-  
+
   """
   Identifies the log URL of the deployment.
   """
   logUrl: URI
-  
+
   """
   Identifies the current state of the deployment.
   """
   state: DeploymentStatusState!
-  
+
   """
   Identifies the date and time when the object was last updated.
   """
@@ -10606,17 +10606,17 @@ type DeploymentStatusConnection {
   A list of edges.
   """
   edges: [DeploymentStatusEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [DeploymentStatus]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -10631,7 +10631,7 @@ type DeploymentStatusEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -10684,7 +10684,7 @@ input DequeuePullRequestInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The ID of the pull request to be dequeued.
   """
@@ -10699,7 +10699,7 @@ type DequeuePullRequestPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The merge queue entry of the dequeued pull request.
   """
@@ -10728,7 +10728,7 @@ input DisablePullRequestAutoMergeInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   ID of the pull request to disable auto merge on.
   """
@@ -10743,12 +10743,12 @@ type DisablePullRequestAutoMergePayload {
   Identifies the actor who performed the event.
   """
   actor: Actor
-  
+
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The pull request auto merge was disabled on.
   """
@@ -10763,23 +10763,23 @@ type DisconnectedEvent implements Node {
   Identifies the actor who performed the event.
   """
   actor: Actor
-  
+
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
   id: ID!
-  
+
   """
   Reference originated in a different repository.
   """
   isCrossRepository: Boolean!
-  
+
   """
   Issue or pull request from which the issue was disconnected.
   """
   source: ReferencedSubject!
-  
+
   """
   Issue or pull request which was disconnected.
   """
@@ -10794,62 +10794,62 @@ type Discussion implements Closable & Comment & Deletable & Labelable & Lockable
   Reason that the conversation was locked.
   """
   activeLockReason: LockReason
-  
+
   """
   The comment chosen as this discussion's answer, if any.
   """
   answer: DiscussionComment
-  
+
   """
   The time when a user chose this discussion's answer, if answered.
   """
   answerChosenAt: DateTime
-  
+
   """
   The user who chose this discussion's answer, if answered.
   """
   answerChosenBy: Actor
-  
+
   """
   The actor who authored the comment.
   """
   author: Actor
-  
+
   """
   Author's association with the subject of the comment.
   """
   authorAssociation: CommentAuthorAssociation!
-  
+
   """
   The main text of the discussion post.
   """
   body: String!
-  
+
   """
   The body rendered to HTML.
   """
   bodyHTML: HTML!
-  
+
   """
   The body rendered to text.
   """
   bodyText: String!
-  
+
   """
   The category for this discussion.
   """
   category: DiscussionCategory!
-  
+
   """
   Indicates if the object is closed (definition of closed may depend on type)
   """
   closed: Boolean!
-  
+
   """
   Identifies the date and time when the object was closed.
   """
   closedAt: DateTime
-  
+
   """
   The replies to the discussion.
   """
@@ -10858,54 +10858,54 @@ type Discussion implements Closable & Comment & Deletable & Labelable & Lockable
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): DiscussionCommentConnection!
-  
+
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
-  
+
   """
   Check if this comment was created via an email reply.
   """
   createdViaEmail: Boolean!
-  
+
   """
   Identifies the primary key from the database.
   """
   databaseId: Int
-  
+
   """
   The actor who edited the comment.
   """
   editor: Actor
   id: ID!
-  
+
   """
   Check if this comment was edited and includes an edit with the creation data
   """
   includesCreatedEdit: Boolean!
-  
+
   """
   Only return answered/unanswered discussions
   """
   isAnswered: Boolean
-  
+
   """
   A list of labels associated with the object.
   """
@@ -10914,58 +10914,58 @@ type Discussion implements Closable & Comment & Deletable & Labelable & Lockable
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for labels returned from the connection.
     """
     orderBy: LabelOrder = { field: CREATED_AT, direction: ASC }
   ): LabelConnection
-  
+
   """
   The moment the editor made the last edit
   """
   lastEditedAt: DateTime
-  
+
   """
   `true` if the object is locked
   """
   locked: Boolean!
-  
+
   """
   The number identifying this discussion within the repository.
   """
   number: Int!
-  
+
   """
   The poll associated with this discussion, if one exists.
   """
   poll: DiscussionPoll
-  
+
   """
   Identifies when the comment was published at.
   """
   publishedAt: DateTime
-  
+
   """
   A list of reactions grouped by content left on the subject.
   """
   reactionGroups: [ReactionGroup!]
-  
+
   """
   A list of Reactions left on the Issue.
   """
@@ -10974,68 +10974,68 @@ type Discussion implements Closable & Comment & Deletable & Labelable & Lockable
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Allows filtering Reactions by emoji.
     """
     content: ReactionContent
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Allows specifying the order in which reactions are returned.
     """
     orderBy: ReactionOrder
   ): ReactionConnection!
-  
+
   """
   The repository associated with this node.
   """
   repository: Repository!
-  
+
   """
   The path for this discussion.
   """
   resourcePath: URI!
-  
+
   """
   Identifies the reason for the discussion's state.
   """
   stateReason: DiscussionStateReason
-  
+
   """
   The title of this discussion.
   """
   title: String!
-  
+
   """
   Identifies the date and time when the object was last updated.
   """
   updatedAt: DateTime!
-  
+
   """
   Number of upvotes that this subject has received.
   """
   upvoteCount: Int!
-  
+
   """
   The URL for this discussion.
   """
   url: URI!
-  
+
   """
   A list of edits to this content.
   """
@@ -11044,68 +11044,68 @@ type Discussion implements Closable & Comment & Deletable & Labelable & Lockable
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): UserContentEditConnection
-  
+
   """
   Indicates if the object can be closed by the viewer.
   """
   viewerCanClose: Boolean!
-  
+
   """
   Check if the current viewer can delete this object.
   """
   viewerCanDelete: Boolean!
-  
+
   """
   Can user react to this subject
   """
   viewerCanReact: Boolean!
-  
+
   """
   Indicates if the object can be reopened by the viewer.
   """
   viewerCanReopen: Boolean!
-  
+
   """
   Check if the viewer is able to change their subscription status for the repository.
   """
   viewerCanSubscribe: Boolean!
-  
+
   """
   Check if the current viewer can update this object.
   """
   viewerCanUpdate: Boolean!
-  
+
   """
   Whether or not the current user can add or remove an upvote on this subject.
   """
   viewerCanUpvote: Boolean!
-  
+
   """
   Did the viewer author this comment.
   """
   viewerDidAuthor: Boolean!
-  
+
   """
   Whether or not the current user has already upvoted this subject.
   """
   viewerHasUpvoted: Boolean!
-  
+
   """
   Identifies if the viewer is watching, not watching, or ignoring the subscribable entity.
   """
@@ -11120,43 +11120,43 @@ type DiscussionCategory implements Node & RepositoryNode {
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
-  
+
   """
   A description of this category.
   """
   description: String
-  
+
   """
   An emoji representing this category.
   """
   emoji: String!
-  
+
   """
   This category's emoji rendered as HTML.
   """
   emojiHTML: HTML!
   id: ID!
-  
+
   """
   Whether or not discussions in this category support choosing an answer with the markDiscussionCommentAsAnswer mutation.
   """
   isAnswerable: Boolean!
-  
+
   """
   The name of this category.
   """
   name: String!
-  
+
   """
   The repository associated with this node.
   """
   repository: Repository!
-  
+
   """
   The slug of this category.
   """
   slug: String!
-  
+
   """
   Identifies the date and time when the object was last updated.
   """
@@ -11171,17 +11171,17 @@ type DiscussionCategoryConnection {
   A list of edges.
   """
   edges: [DiscussionCategoryEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [DiscussionCategory]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -11196,7 +11196,7 @@ type DiscussionCategoryEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -11229,95 +11229,95 @@ type DiscussionComment implements Comment & Deletable & Minimizable & Node & Rea
   The actor who authored the comment.
   """
   author: Actor
-  
+
   """
   Author's association with the subject of the comment.
   """
   authorAssociation: CommentAuthorAssociation!
-  
+
   """
   The body as Markdown.
   """
   body: String!
-  
+
   """
   The body rendered to HTML.
   """
   bodyHTML: HTML!
-  
+
   """
   The body rendered to text.
   """
   bodyText: String!
-  
+
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
-  
+
   """
   Check if this comment was created via an email reply.
   """
   createdViaEmail: Boolean!
-  
+
   """
   Identifies the primary key from the database.
   """
   databaseId: Int
-  
+
   """
   The time when this replied-to comment was deleted
   """
   deletedAt: DateTime
-  
+
   """
   The discussion this comment was created in
   """
   discussion: Discussion
-  
+
   """
   The actor who edited the comment.
   """
   editor: Actor
   id: ID!
-  
+
   """
   Check if this comment was edited and includes an edit with the creation data
   """
   includesCreatedEdit: Boolean!
-  
+
   """
   Has this comment been chosen as the answer of its discussion?
   """
   isAnswer: Boolean!
-  
+
   """
   Returns whether or not a comment has been minimized.
   """
   isMinimized: Boolean!
-  
+
   """
   The moment the editor made the last edit
   """
   lastEditedAt: DateTime
-  
+
   """
   Returns why the comment was minimized. One of `abuse`, `off-topic`,
   `outdated`, `resolved`, `duplicate` and `spam`. Note that the case and
   formatting of these values differs from the inputs to the `MinimizeComment` mutation.
   """
   minimizedReason: String
-  
+
   """
   Identifies when the comment was published at.
   """
   publishedAt: DateTime
-  
+
   """
   A list of reactions grouped by content left on the subject.
   """
   reactionGroups: [ReactionGroup!]
-  
+
   """
   A list of Reactions left on the Issue.
   """
@@ -11326,33 +11326,33 @@ type DiscussionComment implements Comment & Deletable & Minimizable & Node & Rea
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Allows filtering Reactions by emoji.
     """
     content: ReactionContent
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Allows specifying the order in which reactions are returned.
     """
     orderBy: ReactionOrder
   ): ReactionConnection!
-  
+
   """
   The threaded replies to this comment.
   """
@@ -11361,48 +11361,48 @@ type DiscussionComment implements Comment & Deletable & Minimizable & Node & Rea
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): DiscussionCommentConnection!
-  
+
   """
   The discussion comment this comment is a reply to
   """
   replyTo: DiscussionComment
-  
+
   """
   The path for this discussion comment.
   """
   resourcePath: URI!
-  
+
   """
   Identifies the date and time when the object was last updated.
   """
   updatedAt: DateTime!
-  
+
   """
   Number of upvotes that this subject has received.
   """
   upvoteCount: Int!
-  
+
   """
   The URL for this discussion comment.
   """
   url: URI!
-  
+
   """
   A list of edits to this content.
   """
@@ -11411,68 +11411,68 @@ type DiscussionComment implements Comment & Deletable & Minimizable & Node & Rea
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): UserContentEditConnection
-  
+
   """
   Check if the current viewer can delete this object.
   """
   viewerCanDelete: Boolean!
-  
+
   """
   Can the current user mark this comment as an answer?
   """
   viewerCanMarkAsAnswer: Boolean!
-  
+
   """
   Check if the current viewer can minimize this object.
   """
   viewerCanMinimize: Boolean!
-  
+
   """
   Can user react to this subject
   """
   viewerCanReact: Boolean!
-  
+
   """
   Can the current user unmark this comment as an answer?
   """
   viewerCanUnmarkAsAnswer: Boolean!
-  
+
   """
   Check if the current viewer can update this object.
   """
   viewerCanUpdate: Boolean!
-  
+
   """
   Whether or not the current user can add or remove an upvote on this subject.
   """
   viewerCanUpvote: Boolean!
-  
+
   """
   Reasons why the current viewer can not update this comment.
   """
   viewerCannotUpdateReasons: [CommentCannotUpdateReason!]!
-  
+
   """
   Did the viewer author this comment.
   """
   viewerDidAuthor: Boolean!
-  
+
   """
   Whether or not the current user has already upvoted this subject.
   """
@@ -11487,17 +11487,17 @@ type DiscussionCommentConnection {
   A list of edges.
   """
   edges: [DiscussionCommentEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [DiscussionComment]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -11512,7 +11512,7 @@ type DiscussionCommentEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -11527,17 +11527,17 @@ type DiscussionConnection {
   A list of edges.
   """
   edges: [DiscussionEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [Discussion]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -11552,7 +11552,7 @@ type DiscussionEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -11567,7 +11567,7 @@ input DiscussionOrder {
   The direction in which to order discussions by the specified field.
   """
   direction: OrderDirection!
-  
+
   """
   The field by which to order discussions.
   """
@@ -11597,7 +11597,7 @@ type DiscussionPoll implements Node {
   """
   discussion: Discussion
   id: ID!
-  
+
   """
   The options for this poll.
   """
@@ -11606,44 +11606,44 @@ type DiscussionPoll implements Node {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     How to order the options for the discussion poll.
     """
     orderBy: DiscussionPollOptionOrder = { field: AUTHORED_ORDER, direction: ASC
     }
   ): DiscussionPollOptionConnection
-  
+
   """
   The question that is being asked by this poll.
   """
   question: String!
-  
+
   """
   The total number of votes that have been cast for this poll.
   """
   totalVoteCount: Int!
-  
+
   """
   Indicates if the viewer has permission to vote in this poll.
   """
   viewerCanVote: Boolean!
-  
+
   """
   Indicates if the viewer has voted for any option in this poll.
   """
@@ -11655,22 +11655,22 @@ An option for a discussion poll.
 """
 type DiscussionPollOption implements Node {
   id: ID!
-  
+
   """
   The text for this option.
   """
   option: String!
-  
+
   """
   The discussion poll that this option belongs to.
   """
   poll: DiscussionPoll
-  
+
   """
   The total number of votes that have been cast for this option.
   """
   totalVoteCount: Int!
-  
+
   """
   Indicates if the viewer has voted for this option in the poll.
   """
@@ -11685,17 +11685,17 @@ type DiscussionPollOptionConnection {
   A list of edges.
   """
   edges: [DiscussionPollOptionEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [DiscussionPollOption]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -11710,7 +11710,7 @@ type DiscussionPollOptionEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -11725,7 +11725,7 @@ input DiscussionPollOptionOrder {
   The ordering direction.
   """
   direction: OrderDirection!
-  
+
   """
   The field to order poll options by.
   """
@@ -11790,12 +11790,12 @@ input DismissPullRequestReviewInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The contents of the pull request review dismissal message.
   """
   message: String!
-  
+
   """
   The Node ID of the pull request review to modify.
   """
@@ -11810,7 +11810,7 @@ type DismissPullRequestReviewPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The dismissed pull request review.
   """
@@ -11851,12 +11851,12 @@ input DismissRepositoryVulnerabilityAlertInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The reason the Dependabot alert is being dismissed.
   """
   dismissReason: DismissReason!
-  
+
   """
   The Dependabot alert ID to dismiss.
   """
@@ -11872,7 +11872,7 @@ type DismissRepositoryVulnerabilityAlertPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The Dependabot alert that was dismissed
   """
@@ -11891,49 +11891,49 @@ type DraftIssue implements Node {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): UserConnection!
-  
+
   """
   The body of the draft issue.
   """
   body: String!
-  
+
   """
   The body of the draft issue rendered to HTML.
   """
   bodyHTML: HTML!
-  
+
   """
   The body of the draft issue rendered to text.
   """
   bodyText: String!
-  
+
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
-  
+
   """
   The actor who created this draft issue.
   """
   creator: Actor
   id: ID!
-  
+
   """
   List of items linked with the draft issue (currently draft issue can be linked to only one item).
   """
@@ -11942,23 +11942,23 @@ type DraftIssue implements Node {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): ProjectV2ItemConnection!
-  
+
   """
   Projects that link to this draft issue (currently draft issue can be linked to only one project).
   """
@@ -11967,28 +11967,28 @@ type DraftIssue implements Node {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): ProjectV2Connection!
-  
+
   """
   The title of the draft issue
   """
   title: String!
-  
+
   """
   Identifies the date and time when the object was last updated.
   """
@@ -12003,12 +12003,12 @@ input DraftPullRequestReviewComment {
   Body of the comment to leave.
   """
   body: String!
-  
+
   """
   Path to the file being commented on.
   """
   path: String!
-  
+
   """
   Position in the file to leave a comment on.
   """
@@ -12023,27 +12023,27 @@ input DraftPullRequestReviewThread {
   Body of the comment to leave.
   """
   body: String!
-  
+
   """
   The line of the blob to which the thread refers. The end of the line range for multi-line comments.
   """
   line: Int!
-  
+
   """
   Path to the file being commented on.
   """
   path: String!
-  
+
   """
   The side of the diff on which the line resides. For multi-line comments, this is the side for the end of the line range.
   """
   side: DiffSide = RIGHT
-  
+
   """
   The first line of the range to which the comment refers.
   """
   startLine: Int
-  
+
   """
   The side of the diff on which the start line resides.
   """
@@ -12058,37 +12058,37 @@ input EnablePullRequestAutoMergeInput {
   The email address to associate with this merge.
   """
   authorEmail: String
-  
+
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   Commit body to use for the commit when the PR is mergable; if omitted, a
   default message will be used. NOTE: when merging with a merge queue any input
   value for commit message is ignored.
   """
   commitBody: String
-  
+
   """
   Commit headline to use for the commit when the PR is mergable; if omitted, a
   default message will be used. NOTE: when merging with a merge queue any input
   value for commit headline is ignored.
   """
   commitHeadline: String
-  
+
   """
   The expected head OID of the pull request.
   """
   expectedHeadOid: GitObjectID
-  
+
   """
   The merge method to use. If omitted, defaults to `MERGE`. NOTE: when merging
   with a merge queue any input value for merge method is ignored.
   """
   mergeMethod: PullRequestMergeMethod = MERGE
-  
+
   """
   ID of the pull request to enable auto-merge on.
   """
@@ -12103,12 +12103,12 @@ type EnablePullRequestAutoMergePayload {
   Identifies the actor who performed the event.
   """
   actor: Actor
-  
+
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The pull request auto-merge was enabled on.
   """
@@ -12123,17 +12123,17 @@ input EnqueuePullRequestInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The expected head OID of the pull request.
   """
   expectedHeadOid: GitObjectID
-  
+
   """
   Add the pull request to the front of the queue.
   """
   jump: Boolean
-  
+
   """
   The ID of the pull request to enqueue.
   """
@@ -12148,7 +12148,7 @@ type EnqueuePullRequestPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The merge queue entry for the enqueued pull request.
   """
@@ -12163,17 +12163,17 @@ type Enterprise implements AnnouncementBanner & Node {
   The text of the announcement
   """
   announcement: String
-  
+
   """
   The expiration date of the announcement, if any
   """
   announcementExpiresAt: DateTime
-  
+
   """
   Whether the announcement can be dismissed by the user
   """
   announcementUserDismissible: Boolean
-  
+
   """
   A URL pointing to the enterprise's public avatar.
   """
@@ -12183,38 +12183,38 @@ type Enterprise implements AnnouncementBanner & Node {
     """
     size: Int
   ): URI!
-  
+
   """
   Enterprise billing information visible to enterprise billing managers.
   """
   billingInfo: EnterpriseBillingInfo
-  
+
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
-  
+
   """
   Identifies the primary key from the database.
   """
   databaseId: Int
-  
+
   """
   The description of the enterprise.
   """
   description: String
-  
+
   """
   The description of the enterprise as HTML.
   """
   descriptionHTML: HTML!
   id: ID!
-  
+
   """
   The location of the enterprise.
   """
   location: String
-  
+
   """
   A list of users who are members of this enterprise.
   """
@@ -12223,59 +12223,59 @@ type Enterprise implements AnnouncementBanner & Node {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Only return members within the selected GitHub Enterprise deployment
     """
     deployment: EnterpriseUserDeployment
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Only return members with this two-factor authentication status. Does not
     include members who only have an account on a GitHub Enterprise Server instance.
     """
     hasTwoFactorEnabled: Boolean = null
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for members returned from the connection.
     """
     orderBy: EnterpriseMemberOrder = { field: LOGIN, direction: ASC }
-    
+
     """
     Only return members within the organizations with these logins
     """
     organizationLogins: [String!]
-    
+
     """
     The search string to look for.
     """
     query: String
-    
+
     """
     The role of the user in the enterprise organization or server.
     """
     role: EnterpriseUserAccountMembershipRole
   ): EnterpriseMemberConnection!
-  
+
   """
   The name of the enterprise.
   """
   name: String!
-  
+
   """
   A list of organizations that belong to this enterprise.
   """
@@ -12284,64 +12284,64 @@ type Enterprise implements AnnouncementBanner & Node {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for organizations returned from the connection.
     """
     orderBy: OrganizationOrder = { field: LOGIN, direction: ASC }
-    
+
     """
     The search string to look for.
     """
     query: String
-    
+
     """
     The viewer's role in an organization.
     """
     viewerOrganizationRole: RoleInOrganization
   ): OrganizationConnection!
-  
+
   """
   Enterprise information visible to enterprise owners or enterprise owners'
   personal access tokens (classic) with read:enterprise or admin:enterprise scope.
   """
   ownerInfo: EnterpriseOwnerInfo
-  
+
   """
   The HTTP path for this enterprise.
   """
   resourcePath: URI!
-  
+
   """
   The URL-friendly identifier for the enterprise.
   """
   slug: String!
-  
+
   """
   The HTTP URL for this enterprise.
   """
   url: URI!
-  
+
   """
   Is the current viewer an admin of this enterprise?
   """
   viewerIsAdmin: Boolean!
-  
+
   """
   The URL of the enterprise website.
   """
@@ -12356,17 +12356,17 @@ type EnterpriseAdministratorConnection {
   A list of edges.
   """
   edges: [EnterpriseAdministratorEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [User]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -12381,12 +12381,12 @@ type EnterpriseAdministratorEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
   node: User
-  
+
   """
   The role of the administrator.
   """
@@ -12401,28 +12401,28 @@ type EnterpriseAdministratorInvitation implements Node {
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
-  
+
   """
   The email of the person who was invited to the enterprise.
   """
   email: String
-  
+
   """
   The enterprise the invitation is for.
   """
   enterprise: Enterprise!
   id: ID!
-  
+
   """
   The user who was invited to the enterprise.
   """
   invitee: User
-  
+
   """
   The user who created the invitation.
   """
   inviter: User
-  
+
   """
   The invitee's pending role in the enterprise (owner or billing_manager).
   """
@@ -12437,17 +12437,17 @@ type EnterpriseAdministratorInvitationConnection {
   A list of edges.
   """
   edges: [EnterpriseAdministratorInvitationEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [EnterpriseAdministratorInvitation]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -12462,7 +12462,7 @@ type EnterpriseAdministratorInvitationEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -12477,7 +12477,7 @@ input EnterpriseAdministratorInvitationOrder {
   The ordering direction.
   """
   direction: OrderDirection!
-  
+
   """
   The field to order enterprise administrator invitations by.
   """
@@ -12546,12 +12546,12 @@ interface EnterpriseAuditEntryData {
   The HTTP path for this enterprise.
   """
   enterpriseResourcePath: URI
-  
+
   """
   The slug of the enterprise.
   """
   enterpriseSlug: String
-  
+
   """
   The HTTP URL for this enterprise.
   """
@@ -12566,47 +12566,47 @@ type EnterpriseBillingInfo {
   The number of licenseable users/emails across the enterprise.
   """
   allLicensableUsersCount: Int!
-  
+
   """
   The number of data packs used by all organizations owned by the enterprise.
   """
   assetPacks: Int!
-  
+
   """
   The bandwidth quota in GB for all organizations owned by the enterprise.
   """
   bandwidthQuota: Float!
-  
+
   """
   The bandwidth usage in GB for all organizations owned by the enterprise.
   """
   bandwidthUsage: Float!
-  
+
   """
   The bandwidth usage as a percentage of the bandwidth quota.
   """
   bandwidthUsagePercentage: Int!
-  
+
   """
   The storage quota in GB for all organizations owned by the enterprise.
   """
   storageQuota: Float!
-  
+
   """
   The storage usage in GB for all organizations owned by the enterprise.
   """
   storageUsage: Float!
-  
+
   """
   The storage usage as a percentage of the storage quota.
   """
   storageUsagePercentage: Int!
-  
+
   """
   The number of available licenses across all owned organizations based on the unique number of billable users.
   """
   totalAvailableLicenses: Int!
-  
+
   """
   The total number of licenses allocated.
   """
@@ -12621,17 +12621,17 @@ type EnterpriseConnection {
   A list of edges.
   """
   edges: [EnterpriseEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [Enterprise]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -12672,7 +12672,7 @@ type EnterpriseEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -12719,22 +12719,22 @@ type EnterpriseFailedInvitationConnection {
   A list of edges.
   """
   edges: [EnterpriseFailedInvitationEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [OrganizationInvitation]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
   totalCount: Int!
-  
+
   """
   Identifies the total count of unique users in the connection.
   """
@@ -12749,7 +12749,7 @@ type EnterpriseFailedInvitationEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -12766,12 +12766,12 @@ type EnterpriseIdentityProvider implements Node {
   The digest algorithm used to sign SAML requests for the identity provider.
   """
   digestMethod: SamlDigestAlgorithm
-  
+
   """
   The enterprise this identity provider belongs to.
   """
   enterprise: Enterprise
-  
+
   """
   ExternalIdentities provisioned by this identity provider.
   """
@@ -12780,59 +12780,59 @@ type EnterpriseIdentityProvider implements Node {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Filter to external identities with the users login
     """
     login: String
-    
+
     """
     Filter to external identities with valid org membership only
     """
     membersOnly: Boolean
-    
+
     """
     Filter to external identities with the users userName/NameID attribute
     """
     userName: String
   ): ExternalIdentityConnection!
   id: ID!
-  
+
   """
   The x509 certificate used by the identity provider to sign assertions and responses.
   """
   idpCertificate: X509Certificate
-  
+
   """
   The Issuer Entity ID for the SAML identity provider.
   """
   issuer: String
-  
+
   """
   Recovery codes that can be used by admins to access the enterprise if the identity provider is unavailable.
   """
   recoveryCodes: [String!]
-  
+
   """
   The signature algorithm used to sign SAML requests for the identity provider.
   """
   signatureMethod: SamlSignatureAlgorithm
-  
+
   """
   The URL endpoint for the identity provider's SAML SSO.
   """
@@ -12852,17 +12852,17 @@ type EnterpriseMemberConnection {
   A list of edges.
   """
   edges: [EnterpriseMemberEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [EnterpriseMember]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -12877,7 +12877,7 @@ type EnterpriseMemberEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -12892,7 +12892,7 @@ input EnterpriseMemberOrder {
   The ordering direction.
   """
   direction: OrderDirection!
-  
+
   """
   The field to order enterprise members by.
   """
@@ -12983,7 +12983,7 @@ input EnterpriseOrder {
   The ordering direction.
   """
   direction: OrderDirection!
-  
+
   """
   The field to order enterprises by.
   """
@@ -13008,17 +13008,17 @@ type EnterpriseOrganizationMembershipConnection {
   A list of edges.
   """
   edges: [EnterpriseOrganizationMembershipEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [Organization]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -13033,12 +13033,12 @@ type EnterpriseOrganizationMembershipEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
   node: Organization
-  
+
   """
   The role of the user in the enterprise membership.
   """
@@ -13053,17 +13053,17 @@ type EnterpriseOutsideCollaboratorConnection {
   A list of edges.
   """
   edges: [EnterpriseOutsideCollaboratorEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [User]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -13078,12 +13078,12 @@ type EnterpriseOutsideCollaboratorEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
   node: User
-  
+
   """
   The enterprise organization repositories this user is a member of.
   """
@@ -13092,22 +13092,22 @@ type EnterpriseOutsideCollaboratorEdge {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for repositories.
     """
@@ -13128,48 +13128,48 @@ type EnterpriseOwnerInfo {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Only return administrators with this two-factor authentication status.
     """
     hasTwoFactorEnabled: Boolean = null
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for administrators returned from the connection.
     """
     orderBy: EnterpriseMemberOrder = { field: LOGIN, direction: ASC }
-    
+
     """
     Only return members within the organizations with these logins
     """
     organizationLogins: [String!]
-    
+
     """
     The search string to look for.
     """
     query: String
-    
+
     """
     The role to filter by.
     """
     role: EnterpriseAdministratorRole
   ): EnterpriseAdministratorConnection!
-  
+
   """
   A list of users in the enterprise who currently have two-factor authentication disabled.
   """
@@ -13178,33 +13178,33 @@ type EnterpriseOwnerInfo {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): UserConnection!
-  
+
   """
   Whether or not affiliated users with two-factor authentication disabled exist in the enterprise.
   """
   affiliatedUsersWithTwoFactorDisabledExist: Boolean!
-  
+
   """
   The setting value for whether private repository forking is enabled for repositories in organizations in this enterprise.
   """
   allowPrivateRepositoryForkingSetting: EnterpriseEnabledDisabledSettingValue!
-  
+
   """
   A list of enterprise organizations configured with the provided private repository forking setting value.
   """
@@ -13213,43 +13213,43 @@ type EnterpriseOwnerInfo {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for organizations with this setting.
     """
     orderBy: OrganizationOrder = { field: LOGIN, direction: ASC }
-    
+
     """
     The setting value to find organizations for.
     """
     value: Boolean!
   ): OrganizationConnection!
-  
+
   """
   The value for the allow private repository forking policy on the enterprise.
   """
   allowPrivateRepositoryForkingSettingPolicyValue: EnterpriseAllowPrivateRepositoryForkingPolicyValue
-  
+
   """
   The setting value for base repository permissions for organizations in this enterprise.
   """
   defaultRepositoryPermissionSetting: EnterpriseDefaultRepositoryPermissionSettingValue!
-  
+
   """
   A list of enterprise organizations configured with the provided base repository permission.
   """
@@ -13258,33 +13258,33 @@ type EnterpriseOwnerInfo {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for organizations with this setting.
     """
     orderBy: OrganizationOrder = { field: LOGIN, direction: ASC }
-    
+
     """
     The permission to find organizations for.
     """
     value: DefaultRepositoryPermissionField!
   ): OrganizationConnection!
-  
+
   """
   A list of domains owned by the enterprise. Visible to enterprise owners or
   enterprise owners' personal access tokens (classic) with admin:enterprise scope.
@@ -13294,38 +13294,38 @@ type EnterpriseOwnerInfo {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Filter whether or not the domain is approved.
     """
     isApproved: Boolean = null
-    
+
     """
     Filter whether or not the domain is verified.
     """
     isVerified: Boolean = null
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for verifiable domains returned.
     """
     orderBy: VerifiableDomainOrder = { field: DOMAIN, direction: ASC }
   ): VerifiableDomainConnection!
-  
+
   """
   Enterprise Server installations owned by the enterprise.
   """
@@ -13334,34 +13334,34 @@ type EnterpriseOwnerInfo {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Whether or not to only return installations discovered via GitHub Connect.
     """
     connectedOnly: Boolean = false
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for Enterprise Server installations returned.
     """
     orderBy: EnterpriseServerInstallationOrder = {
     field: HOST_NAME, direction: ASC }
   ): EnterpriseServerInstallationConnection!
-  
+
   """
   A list of failed invitations in the enterprise.
   """
@@ -13370,33 +13370,33 @@ type EnterpriseOwnerInfo {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     The search string to look for.
     """
     query: String
   ): EnterpriseFailedInvitationConnection!
-  
+
   """
   The setting value for whether the enterprise has an IP allow list enabled.
   """
   ipAllowListEnabledSetting: IpAllowListEnabledSettingValue!
-  
+
   """
   The IP addresses that are allowed to access resources owned by the enterprise.
   Visible to enterprise owners or enterprise owners' personal access tokens
@@ -13407,49 +13407,49 @@ type EnterpriseOwnerInfo {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for IP allow list entries returned.
     """
     orderBy: IpAllowListEntryOrder = { field: ALLOW_LIST_VALUE, direction: ASC }
   ): IpAllowListEntryConnection!
-  
+
   """
   The setting value for whether the enterprise has IP allow list configuration for installed GitHub Apps enabled.
   """
   ipAllowListForInstalledAppsEnabledSetting: IpAllowListForInstalledAppsEnabledSettingValue!
-  
+
   """
   Whether or not the base repository permission is currently being updated.
   """
   isUpdatingDefaultRepositoryPermission: Boolean!
-  
+
   """
   Whether the two-factor authentication requirement is currently being enforced.
   """
   isUpdatingTwoFactorRequirement: Boolean!
-  
+
   """
   The setting value for whether organization members with admin permissions on a
   repository can change repository visibility.
   """
   membersCanChangeRepositoryVisibilitySetting: EnterpriseEnabledDisabledSettingValue!
-  
+
   """
   A list of enterprise organizations configured with the provided can change repository visibility setting value.
   """
@@ -13458,53 +13458,53 @@ type EnterpriseOwnerInfo {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for organizations with this setting.
     """
     orderBy: OrganizationOrder = { field: LOGIN, direction: ASC }
-    
+
     """
     The setting value to find organizations for.
     """
     value: Boolean!
   ): OrganizationConnection!
-  
+
   """
   The setting value for whether members of organizations in the enterprise can create internal repositories.
   """
   membersCanCreateInternalRepositoriesSetting: Boolean
-  
+
   """
   The setting value for whether members of organizations in the enterprise can create private repositories.
   """
   membersCanCreatePrivateRepositoriesSetting: Boolean
-  
+
   """
   The setting value for whether members of organizations in the enterprise can create public repositories.
   """
   membersCanCreatePublicRepositoriesSetting: Boolean
-  
+
   """
   The setting value for whether members of organizations in the enterprise can create repositories.
   """
   membersCanCreateRepositoriesSetting: EnterpriseMembersCanCreateRepositoriesSettingValue
-  
+
   """
   A list of enterprise organizations configured with the provided repository creation setting value.
   """
@@ -13513,38 +13513,38 @@ type EnterpriseOwnerInfo {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for organizations with this setting.
     """
     orderBy: OrganizationOrder = { field: LOGIN, direction: ASC }
-    
+
     """
     The setting to find organizations for.
     """
     value: OrganizationMembersCanCreateRepositoriesSettingValue!
   ): OrganizationConnection!
-  
+
   """
   The setting value for whether members with admin permissions for repositories can delete issues.
   """
   membersCanDeleteIssuesSetting: EnterpriseEnabledDisabledSettingValue!
-  
+
   """
   A list of enterprise organizations configured with the provided members can delete issues setting value.
   """
@@ -13553,38 +13553,38 @@ type EnterpriseOwnerInfo {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for organizations with this setting.
     """
     orderBy: OrganizationOrder = { field: LOGIN, direction: ASC }
-    
+
     """
     The setting value to find organizations for.
     """
     value: Boolean!
   ): OrganizationConnection!
-  
+
   """
   The setting value for whether members with admin permissions for repositories can delete or transfer repositories.
   """
   membersCanDeleteRepositoriesSetting: EnterpriseEnabledDisabledSettingValue!
-  
+
   """
   A list of enterprise organizations configured with the provided members can delete repositories setting value.
   """
@@ -13593,38 +13593,38 @@ type EnterpriseOwnerInfo {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for organizations with this setting.
     """
     orderBy: OrganizationOrder = { field: LOGIN, direction: ASC }
-    
+
     """
     The setting value to find organizations for.
     """
     value: Boolean!
   ): OrganizationConnection!
-  
+
   """
   The setting value for whether members of organizations in the enterprise can invite outside collaborators.
   """
   membersCanInviteCollaboratorsSetting: EnterpriseEnabledDisabledSettingValue!
-  
+
   """
   A list of enterprise organizations configured with the provided members can invite collaborators setting value.
   """
@@ -13633,43 +13633,43 @@ type EnterpriseOwnerInfo {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for organizations with this setting.
     """
     orderBy: OrganizationOrder = { field: LOGIN, direction: ASC }
-    
+
     """
     The setting value to find organizations for.
     """
     value: Boolean!
   ): OrganizationConnection!
-  
+
   """
   Indicates whether members of this enterprise's organizations can purchase additional services for those organizations.
   """
   membersCanMakePurchasesSetting: EnterpriseMembersCanMakePurchasesSettingValue!
-  
+
   """
   The setting value for whether members with admin permissions for repositories can update protected branches.
   """
   membersCanUpdateProtectedBranchesSetting: EnterpriseEnabledDisabledSettingValue!
-  
+
   """
   A list of enterprise organizations configured with the provided members can update protected branches setting value.
   """
@@ -13678,38 +13678,38 @@ type EnterpriseOwnerInfo {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for organizations with this setting.
     """
     orderBy: OrganizationOrder = { field: LOGIN, direction: ASC }
-    
+
     """
     The setting value to find organizations for.
     """
     value: Boolean!
   ): OrganizationConnection!
-  
+
   """
   The setting value for whether members can view dependency insights.
   """
   membersCanViewDependencyInsightsSetting: EnterpriseEnabledDisabledSettingValue!
-  
+
   """
   A list of enterprise organizations configured with the provided members can view dependency insights setting value.
   """
@@ -13718,48 +13718,48 @@ type EnterpriseOwnerInfo {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for organizations with this setting.
     """
     orderBy: OrganizationOrder = { field: LOGIN, direction: ASC }
-    
+
     """
     The setting value to find organizations for.
     """
     value: Boolean!
   ): OrganizationConnection!
-  
+
   """
   Indicates if email notification delivery for this enterprise is restricted to verified or approved domains.
   """
   notificationDeliveryRestrictionEnabledSetting: NotificationRestrictionSettingValue!
-  
+
   """
   The OIDC Identity Provider for the enterprise.
   """
   oidcProvider: OIDCProvider
-  
+
   """
   The setting value for whether organization projects are enabled for organizations in this enterprise.
   """
   organizationProjectsSetting: EnterpriseEnabledDisabledSettingValue!
-  
+
   """
   A list of enterprise organizations configured with the provided organization projects setting value.
   """
@@ -13768,33 +13768,33 @@ type EnterpriseOwnerInfo {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for organizations with this setting.
     """
     orderBy: OrganizationOrder = { field: LOGIN, direction: ASC }
-    
+
     """
     The setting value to find organizations for.
     """
     value: Boolean!
   ): OrganizationConnection!
-  
+
   """
   A list of outside collaborators across the repositories in the enterprise.
   """
@@ -13803,53 +13803,53 @@ type EnterpriseOwnerInfo {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Only return outside collaborators with this two-factor authentication status.
     """
     hasTwoFactorEnabled: Boolean = null
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     The login of one specific outside collaborator.
     """
     login: String
-    
+
     """
     Ordering options for outside collaborators returned from the connection.
     """
     orderBy: EnterpriseMemberOrder = { field: LOGIN, direction: ASC }
-    
+
     """
     Only return outside collaborators within the organizations with these logins
     """
     organizationLogins: [String!]
-    
+
     """
     The search string to look for.
     """
     query: String
-    
+
     """
     Only return outside collaborators on repositories with this visibility.
     """
     visibility: RepositoryVisibility
   ): EnterpriseOutsideCollaboratorConnection!
-  
+
   """
   A list of pending administrator invitations for the enterprise.
   """
@@ -13858,39 +13858,39 @@ type EnterpriseOwnerInfo {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for pending enterprise administrator invitations returned from the connection.
     """
     orderBy: EnterpriseAdministratorInvitationOrder = {
     field: CREATED_AT, direction: DESC }
-    
+
     """
     The search string to look for.
     """
     query: String
-    
+
     """
     The role to filter by.
     """
     role: EnterpriseAdministratorRole
   ): EnterpriseAdministratorInvitationConnection!
-  
+
   """
   A list of pending collaborator invitations across the repositories in the enterprise.
   """
@@ -13899,33 +13899,33 @@ type EnterpriseOwnerInfo {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for pending repository collaborator invitations returned from the connection.
     """
     orderBy: RepositoryInvitationOrder = { field: CREATED_AT, direction: DESC }
-    
+
     """
     The search string to look for.
     """
     query: String
   ): RepositoryInvitationConnection!
-  
+
   """
   A list of pending member invitations for organizations in the enterprise.
   """
@@ -13934,43 +13934,43 @@ type EnterpriseOwnerInfo {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Only return invitations matching this invitation source
     """
     invitationSource: OrganizationInvitationSource
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Only return invitations within the organizations with these logins
     """
     organizationLogins: [String!]
-    
+
     """
     The search string to look for.
     """
     query: String
   ): EnterprisePendingMemberInvitationConnection!
-  
+
   """
   The setting value for whether repository projects are enabled in this enterprise.
   """
   repositoryProjectsSetting: EnterpriseEnabledDisabledSettingValue!
-  
+
   """
   A list of enterprise organizations configured with the provided repository projects setting value.
   """
@@ -13979,38 +13979,38 @@ type EnterpriseOwnerInfo {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for organizations with this setting.
     """
     orderBy: OrganizationOrder = { field: LOGIN, direction: ASC }
-    
+
     """
     The setting value to find organizations for.
     """
     value: Boolean!
   ): OrganizationConnection!
-  
+
   """
   The SAML Identity Provider for the enterprise.
   """
   samlIdentityProvider: EnterpriseIdentityProvider
-  
+
   """
   A list of enterprise organizations configured with the SAML single sign-on setting value.
   """
@@ -14019,33 +14019,33 @@ type EnterpriseOwnerInfo {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for organizations with this setting.
     """
     orderBy: OrganizationOrder = { field: LOGIN, direction: ASC }
-    
+
     """
     The setting value to find organizations for.
     """
     value: IdentityProviderConfigurationState!
   ): OrganizationConnection!
-  
+
   """
   A list of members with a support entitlement.
   """
@@ -14054,33 +14054,33 @@ type EnterpriseOwnerInfo {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for support entitlement users returned from the connection.
     """
     orderBy: EnterpriseMemberOrder = { field: LOGIN, direction: ASC }
   ): EnterpriseMemberConnection!
-  
+
   """
   The setting value for whether team discussions are enabled for organizations in this enterprise.
   """
   teamDiscussionsSetting: EnterpriseEnabledDisabledSettingValue!
-  
+
   """
   A list of enterprise organizations configured with the provided team discussions setting value.
   """
@@ -14089,38 +14089,38 @@ type EnterpriseOwnerInfo {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for organizations with this setting.
     """
     orderBy: OrganizationOrder = { field: LOGIN, direction: ASC }
-    
+
     """
     The setting value to find organizations for.
     """
     value: Boolean!
   ): OrganizationConnection!
-  
+
   """
   The setting value for whether the enterprise requires two-factor authentication for its organizations and users.
   """
   twoFactorRequiredSetting: EnterpriseEnabledSettingValue!
-  
+
   """
   A list of enterprise organizations configured with the two-factor authentication setting value.
   """
@@ -14129,27 +14129,27 @@ type EnterpriseOwnerInfo {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for organizations with this setting.
     """
     orderBy: OrganizationOrder = { field: LOGIN, direction: ASC }
-    
+
     """
     The setting value to find organizations for.
     """
@@ -14165,22 +14165,22 @@ type EnterprisePendingMemberInvitationConnection {
   A list of edges.
   """
   edges: [EnterprisePendingMemberInvitationEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [OrganizationInvitation]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
   totalCount: Int!
-  
+
   """
   Identifies the total count of unique users in the connection.
   """
@@ -14195,7 +14195,7 @@ type EnterprisePendingMemberInvitationEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -14207,17 +14207,17 @@ A subset of repository information queryable from an enterprise.
 """
 type EnterpriseRepositoryInfo implements Node {
   id: ID!
-  
+
   """
   Identifies if the repository is private or internal.
   """
   isPrivate: Boolean!
-  
+
   """
   The repository's name.
   """
   name: String!
-  
+
   """
   The repository's name with owner.
   """
@@ -14232,17 +14232,17 @@ type EnterpriseRepositoryInfoConnection {
   A list of edges.
   """
   edges: [EnterpriseRepositoryInfoEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [EnterpriseRepositoryInfo]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -14257,7 +14257,7 @@ type EnterpriseRepositoryInfoEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -14272,28 +14272,28 @@ type EnterpriseServerInstallation implements Node {
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
-  
+
   """
   The customer name to which the Enterprise Server installation belongs.
   """
   customerName: String!
-  
+
   """
   The host name of the Enterprise Server installation.
   """
   hostName: String!
   id: ID!
-  
+
   """
   Whether or not the installation is connected to an Enterprise Server installation via GitHub Connect.
   """
   isConnected: Boolean!
-  
+
   """
   Identifies the date and time when the object was last updated.
   """
   updatedAt: DateTime!
-  
+
   """
   User accounts on this Enterprise Server installation.
   """
@@ -14302,28 +14302,28 @@ type EnterpriseServerInstallation implements Node {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for Enterprise Server user accounts returned from the connection.
     """
     orderBy: EnterpriseServerUserAccountOrder = { field: LOGIN, direction: ASC }
   ): EnterpriseServerUserAccountConnection!
-  
+
   """
   User accounts uploads for the Enterprise Server installation.
   """
@@ -14332,22 +14332,22 @@ type EnterpriseServerInstallation implements Node {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for Enterprise Server user accounts uploads returned from the connection.
     """
@@ -14364,17 +14364,17 @@ type EnterpriseServerInstallationConnection {
   A list of edges.
   """
   edges: [EnterpriseServerInstallationEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [EnterpriseServerInstallation]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -14389,7 +14389,7 @@ type EnterpriseServerInstallationEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -14404,17 +14404,17 @@ type EnterpriseServerInstallationMembershipConnection {
   A list of edges.
   """
   edges: [EnterpriseServerInstallationMembershipEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [EnterpriseServerInstallation]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -14429,12 +14429,12 @@ type EnterpriseServerInstallationMembershipEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
   node: EnterpriseServerInstallation
-  
+
   """
   The role of the user in the enterprise membership.
   """
@@ -14449,7 +14449,7 @@ input EnterpriseServerInstallationOrder {
   The ordering direction.
   """
   direction: OrderDirection!
-  
+
   """
   The field to order Enterprise Server installations by.
   """
@@ -14482,7 +14482,7 @@ type EnterpriseServerUserAccount implements Node {
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
-  
+
   """
   User emails belonging to this user account.
   """
@@ -14491,60 +14491,60 @@ type EnterpriseServerUserAccount implements Node {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for Enterprise Server user account emails returned from the connection.
     """
     orderBy: EnterpriseServerUserAccountEmailOrder = {
     field: EMAIL, direction: ASC }
   ): EnterpriseServerUserAccountEmailConnection!
-  
+
   """
   The Enterprise Server installation on which this user account exists.
   """
   enterpriseServerInstallation: EnterpriseServerInstallation!
   id: ID!
-  
+
   """
   Whether the user account is a site administrator on the Enterprise Server installation.
   """
   isSiteAdmin: Boolean!
-  
+
   """
   The login of the user account on the Enterprise Server installation.
   """
   login: String!
-  
+
   """
   The profile name of the user account on the Enterprise Server installation.
   """
   profileName: String
-  
+
   """
   The date and time when the user account was created on the Enterprise Server installation.
   """
   remoteCreatedAt: DateTime!
-  
+
   """
   The ID of the user account on the Enterprise Server installation.
   """
   remoteUserId: Int!
-  
+
   """
   Identifies the date and time when the object was last updated.
   """
@@ -14559,17 +14559,17 @@ type EnterpriseServerUserAccountConnection {
   A list of edges.
   """
   edges: [EnterpriseServerUserAccountEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [EnterpriseServerUserAccount]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -14584,7 +14584,7 @@ type EnterpriseServerUserAccountEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -14599,23 +14599,23 @@ type EnterpriseServerUserAccountEmail implements Node {
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
-  
+
   """
   The email address.
   """
   email: String!
   id: ID!
-  
+
   """
   Indicates whether this is the primary email of the associated user account.
   """
   isPrimary: Boolean!
-  
+
   """
   Identifies the date and time when the object was last updated.
   """
   updatedAt: DateTime!
-  
+
   """
   The user account to which the email belongs.
   """
@@ -14630,17 +14630,17 @@ type EnterpriseServerUserAccountEmailConnection {
   A list of edges.
   """
   edges: [EnterpriseServerUserAccountEmailEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [EnterpriseServerUserAccountEmail]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -14655,7 +14655,7 @@ type EnterpriseServerUserAccountEmailEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -14670,7 +14670,7 @@ input EnterpriseServerUserAccountEmailOrder {
   The ordering direction.
   """
   direction: OrderDirection!
-  
+
   """
   The field to order emails by.
   """
@@ -14695,7 +14695,7 @@ input EnterpriseServerUserAccountOrder {
   The ordering direction.
   """
   direction: OrderDirection!
-  
+
   """
   The field to order user accounts by.
   """
@@ -14724,28 +14724,28 @@ type EnterpriseServerUserAccountsUpload implements Node {
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
-  
+
   """
   The enterprise to which this upload belongs.
   """
   enterprise: Enterprise!
-  
+
   """
   The Enterprise Server installation for which this upload was generated.
   """
   enterpriseServerInstallation: EnterpriseServerInstallation!
   id: ID!
-  
+
   """
   The name of the file uploaded.
   """
   name: String!
-  
+
   """
   The synchronization state of the upload
   """
   syncState: EnterpriseServerUserAccountsUploadSyncState!
-  
+
   """
   Identifies the date and time when the object was last updated.
   """
@@ -14760,17 +14760,17 @@ type EnterpriseServerUserAccountsUploadConnection {
   A list of edges.
   """
   edges: [EnterpriseServerUserAccountsUploadEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [EnterpriseServerUserAccountsUpload]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -14785,7 +14785,7 @@ type EnterpriseServerUserAccountsUploadEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -14800,7 +14800,7 @@ input EnterpriseServerUserAccountsUploadOrder {
   The ordering direction.
   """
   direction: OrderDirection!
-  
+
   """
   The field to order user accounts uploads by.
   """
@@ -14848,17 +14848,17 @@ type EnterpriseUserAccount implements Actor & Node {
     """
     size: Int
   ): URI!
-  
+
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
-  
+
   """
   The enterprise in which this user account exists.
   """
   enterprise: Enterprise!
-  
+
   """
   A list of Enterprise Server installations this user is a member of.
   """
@@ -14867,50 +14867,50 @@ type EnterpriseUserAccount implements Actor & Node {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for installations returned from the connection.
     """
     orderBy: EnterpriseServerInstallationOrder = {
     field: HOST_NAME, direction: ASC }
-    
+
     """
     The search string to look for.
     """
     query: String
-    
+
     """
     The role of the user in the installation.
     """
     role: EnterpriseUserAccountMembershipRole
   ): EnterpriseServerInstallationMembershipConnection!
   id: ID!
-  
+
   """
   An identifier for the enterprise user account, a login or email address
   """
   login: String!
-  
+
   """
   The name of the enterprise user account
   """
   name: String
-  
+
   """
   A list of enterprise organizations this user is a member of.
   """
@@ -14919,53 +14919,53 @@ type EnterpriseUserAccount implements Actor & Node {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for organizations returned from the connection.
     """
     orderBy: OrganizationOrder = { field: LOGIN, direction: ASC }
-    
+
     """
     The search string to look for.
     """
     query: String
-    
+
     """
     The role of the user in the enterprise organization.
     """
     role: EnterpriseUserAccountMembershipRole
   ): EnterpriseOrganizationMembershipConnection!
-  
+
   """
   The HTTP path for this user.
   """
   resourcePath: URI!
-  
+
   """
   Identifies the date and time when the object was last updated.
   """
   updatedAt: DateTime!
-  
+
   """
   The HTTP URL for this user.
   """
   url: URI!
-  
+
   """
   The user within the enterprise.
   """
@@ -15014,12 +15014,12 @@ type Environment implements Node {
   """
   databaseId: Int
   id: ID!
-  
+
   """
   The name of the environment
   """
   name: String!
-  
+
   """
   The protection rules defined for this environment
   """
@@ -15028,17 +15028,17 @@ type Environment implements Node {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
@@ -15054,17 +15054,17 @@ type EnvironmentConnection {
   A list of edges.
   """
   edges: [EnvironmentEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [Environment]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -15079,7 +15079,7 @@ type EnvironmentEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -15104,7 +15104,7 @@ input Environments {
   The direction in which to order environments by the specified field.
   """
   direction: OrderDirection!
-  
+
   """
   The field to order environments by.
   """
@@ -15126,22 +15126,22 @@ type ExternalIdentity implements Node {
   """
   guid: String!
   id: ID!
-  
+
   """
   Organization invitation for this SCIM-provisioned external identity
   """
   organizationInvitation: OrganizationInvitation
-  
+
   """
   SAML Identity attributes
   """
   samlIdentity: ExternalIdentitySamlAttributes
-  
+
   """
   SCIM Identity attributes
   """
   scimIdentity: ExternalIdentityScimAttributes
-  
+
   """
   User linked to this external identity. Will be NULL if this identity has not been claimed by an organization member.
   """
@@ -15156,12 +15156,12 @@ type ExternalIdentityAttribute {
   The attribute metadata as JSON
   """
   metadata: String
-  
+
   """
   The attribute name
   """
   name: String!
-  
+
   """
   The attribute value
   """
@@ -15176,17 +15176,17 @@ type ExternalIdentityConnection {
   A list of edges.
   """
   edges: [ExternalIdentityEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [ExternalIdentity]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -15201,7 +15201,7 @@ type ExternalIdentityEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -15216,32 +15216,32 @@ type ExternalIdentitySamlAttributes {
   SAML Identity attributes
   """
   attributes: [ExternalIdentityAttribute!]!
-  
+
   """
   The emails associated with the SAML identity
   """
   emails: [UserEmailMetadata!]
-  
+
   """
   Family name of the SAML identity
   """
   familyName: String
-  
+
   """
   Given name of the SAML identity
   """
   givenName: String
-  
+
   """
   The groups linked to this identity in IDP
   """
   groups: [String!]
-  
+
   """
   The NameID of the SAML identity
   """
   nameId: String
-  
+
   """
   The userName of the SAML identity
   """
@@ -15256,22 +15256,22 @@ type ExternalIdentityScimAttributes {
   The emails associated with the SCIM identity
   """
   emails: [UserEmailMetadata!]
-  
+
   """
   Family name of the SCIM identity
   """
   familyName: String
-  
+
   """
   Given name of the SCIM identity
   """
   givenName: String
-  
+
   """
   The groups linked to this identity in IDP
   """
   groups: [String!]
-  
+
   """
   The userName of the SCIM identity
   """
@@ -15287,7 +15287,7 @@ input FileAddition {
   The base64 encoded contents of the file
   """
   contents: Base64String!
-  
+
   """
   The path in the repository where the file will be located
   """
@@ -15414,7 +15414,7 @@ input FileChanges {
   File to add or change.
   """
   additions: [FileAddition!] = []
-  
+
   """
   Files to delete.
   """
@@ -15457,7 +15457,7 @@ input FollowOrganizationInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   ID of the organization to follow.
   """
@@ -15472,7 +15472,7 @@ type FollowOrganizationPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The organization that was followed.
   """
@@ -15487,7 +15487,7 @@ input FollowUserInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   ID of the user to follow.
   """
@@ -15502,7 +15502,7 @@ type FollowUserPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The user that was followed.
   """
@@ -15517,17 +15517,17 @@ type FollowerConnection {
   A list of edges.
   """
   edges: [UserEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [User]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -15542,17 +15542,17 @@ type FollowingConnection {
   A list of edges.
   """
   edges: [UserEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [User]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -15567,7 +15567,7 @@ type FundingLink {
   The funding platform this link is for.
   """
   platform: FundingPlatform!
-  
+
   """
   The configured URL for this funding link.
   """
@@ -15632,7 +15632,7 @@ type GenericHovercardContext implements HovercardContext {
   A string describing this context
   """
   message: String!
-  
+
   """
   An octicon to accompany this context
   """
@@ -15651,33 +15651,33 @@ type Gist implements Node & Starrable & UniformResourceLocatable {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): GistCommentConnection!
-  
+
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
-  
+
   """
   The gist description.
   """
   description: String
-  
+
   """
   The files in this gist.
   """
@@ -15686,13 +15686,13 @@ type Gist implements Node & Starrable & UniformResourceLocatable {
     The maximum number of files to return.
     """
     limit: Int = 10
-    
+
     """
     The oid of the files to return
     """
     oid: GitObjectID
   ): [GistFile]
-  
+
   """
   A list of forks associated with the gist
   """
@@ -15701,64 +15701,64 @@ type Gist implements Node & Starrable & UniformResourceLocatable {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for gists returned from the connection
     """
     orderBy: GistOrder
   ): GistConnection!
   id: ID!
-  
+
   """
   Identifies if the gist is a fork.
   """
   isFork: Boolean!
-  
+
   """
   Whether the gist is public or not.
   """
   isPublic: Boolean!
-  
+
   """
   The gist name.
   """
   name: String!
-  
+
   """
   The gist owner.
   """
   owner: RepositoryOwner
-  
+
   """
   Identifies when the gist was last pushed to.
   """
   pushedAt: DateTime
-  
+
   """
   The HTML path to this resource.
   """
   resourcePath: URI!
-  
+
   """
   Returns a count of how many stargazers there are on this object
   """
   stargazerCount: Int!
-  
+
   """
   A list of users who have starred this starrable.
   """
@@ -15767,38 +15767,38 @@ type Gist implements Node & Starrable & UniformResourceLocatable {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Order for connection
     """
     orderBy: StarOrder
   ): StargazerConnection!
-  
+
   """
   Identifies the date and time when the object was last updated.
   """
   updatedAt: DateTime!
-  
+
   """
   The HTTP URL for this Gist.
   """
   url: URI!
-  
+
   """
   Returns a boolean indicating whether the viewing user has starred this starrable.
   """
@@ -15813,85 +15813,85 @@ type GistComment implements Comment & Deletable & Minimizable & Node & Updatable
   The actor who authored the comment.
   """
   author: Actor
-  
+
   """
   Author's association with the gist.
   """
   authorAssociation: CommentAuthorAssociation!
-  
+
   """
   Identifies the comment body.
   """
   body: String!
-  
+
   """
   The body rendered to HTML.
   """
   bodyHTML: HTML!
-  
+
   """
   The body rendered to text.
   """
   bodyText: String!
-  
+
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
-  
+
   """
   Check if this comment was created via an email reply.
   """
   createdViaEmail: Boolean!
-  
+
   """
   Identifies the primary key from the database.
   """
   databaseId: Int
-  
+
   """
   The actor who edited the comment.
   """
   editor: Actor
-  
+
   """
   The associated gist.
   """
   gist: Gist!
   id: ID!
-  
+
   """
   Check if this comment was edited and includes an edit with the creation data
   """
   includesCreatedEdit: Boolean!
-  
+
   """
   Returns whether or not a comment has been minimized.
   """
   isMinimized: Boolean!
-  
+
   """
   The moment the editor made the last edit
   """
   lastEditedAt: DateTime
-  
+
   """
   Returns why the comment was minimized. One of `abuse`, `off-topic`,
   `outdated`, `resolved`, `duplicate` and `spam`. Note that the case and
   formatting of these values differs from the inputs to the `MinimizeComment` mutation.
   """
   minimizedReason: String
-  
+
   """
   Identifies when the comment was published at.
   """
   publishedAt: DateTime
-  
+
   """
   Identifies the date and time when the object was last updated.
   """
   updatedAt: DateTime!
-  
+
   """
   A list of edits to this content.
   """
@@ -15900,43 +15900,43 @@ type GistComment implements Comment & Deletable & Minimizable & Node & Updatable
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): UserContentEditConnection
-  
+
   """
   Check if the current viewer can delete this object.
   """
   viewerCanDelete: Boolean!
-  
+
   """
   Check if the current viewer can minimize this object.
   """
   viewerCanMinimize: Boolean!
-  
+
   """
   Check if the current viewer can update this object.
   """
   viewerCanUpdate: Boolean!
-  
+
   """
   Reasons why the current viewer can not update this comment.
   """
   viewerCannotUpdateReasons: [CommentCannotUpdateReason!]!
-  
+
   """
   Did the viewer author this comment.
   """
@@ -15951,17 +15951,17 @@ type GistCommentConnection {
   A list of edges.
   """
   edges: [GistCommentEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [GistComment]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -15976,7 +15976,7 @@ type GistCommentEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -15991,17 +15991,17 @@ type GistConnection {
   A list of edges.
   """
   edges: [GistEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [Gist]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -16016,7 +16016,7 @@ type GistEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -16031,42 +16031,42 @@ type GistFile {
   The file name encoded to remove characters that are invalid in URL paths.
   """
   encodedName: String
-  
+
   """
   The gist file encoding.
   """
   encoding: String
-  
+
   """
   The file extension from the file name.
   """
   extension: String
-  
+
   """
   Indicates if this file is an image.
   """
   isImage: Boolean!
-  
+
   """
   Whether the file's contents were truncated.
   """
   isTruncated: Boolean!
-  
+
   """
   The programming language this file is written in.
   """
   language: Language
-  
+
   """
   The gist file name.
   """
   name: String
-  
+
   """
   The gist file size in bytes.
   """
   size: Int
-  
+
   """
   UTF8 text data or null if the file is binary
   """
@@ -16086,7 +16086,7 @@ input GistOrder {
   The ordering direction.
   """
   direction: OrderDirection!
-  
+
   """
   The field to order repositories by.
   """
@@ -16142,22 +16142,22 @@ type GitActor {
     """
     size: Int
   ): URI!
-  
+
   """
   The timestamp of the Git action (authoring or committing).
   """
   date: GitTimestamp
-  
+
   """
   The email in the Git commit.
   """
   email: String
-  
+
   """
   The name in the Git commit.
   """
   name: String
-  
+
   """
   The GitHub user corresponding to the email field. Null if no such user exists.
   """
@@ -16172,17 +16172,17 @@ type GitActorConnection {
   A list of edges.
   """
   edges: [GitActorEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [GitActor]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -16197,7 +16197,7 @@ type GitActorEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -16212,32 +16212,32 @@ type GitHubMetadata {
   Returns a String that's a SHA of `github-services`
   """
   gitHubServicesSha: GitObjectID!
-  
+
   """
   IP addresses that users connect to for git operations
   """
   gitIpAddresses: [String!]
-  
+
   """
   IP addresses that GitHub Enterprise Importer uses for outbound connections
   """
   githubEnterpriseImporterIpAddresses: [String!]
-  
+
   """
   IP addresses that service hooks are sent from
   """
   hookIpAddresses: [String!]
-  
+
   """
   IP addresses that the importer connects from
   """
   importerIpAddresses: [String!]
-  
+
   """
   Whether or not users are verified
   """
   isPasswordAuthenticationVerifiable: Boolean!
-  
+
   """
   IP addresses for GitHub Pages' A records
   """
@@ -16252,23 +16252,23 @@ interface GitObject {
   An abbreviated version of the Git object ID
   """
   abbreviatedOid: String!
-  
+
   """
   The HTTP path for this Git object
   """
   commitResourcePath: URI!
-  
+
   """
   The HTTP URL for this Git object
   """
   commitUrl: URI!
   id: ID!
-  
+
   """
   The Git object ID
   """
   oid: GitObjectID!
-  
+
   """
   The Repository the Git object belongs to
   """
@@ -16298,33 +16298,33 @@ interface GitSignature {
   Email used to sign this object.
   """
   email: String!
-  
+
   """
   True if the signature is valid and verified by GitHub.
   """
   isValid: Boolean!
-  
+
   """
   Payload for GPG signing object. Raw ODB object without the signature header.
   """
   payload: String!
-  
+
   """
   ASCII-armored signature header from object.
   """
   signature: String!
-  
+
   """
   GitHub user corresponding to the email signing this commit.
   """
   signer: User
-  
+
   """
   The state of this signature. `VALID` if signature is valid and verified by
   GitHub, otherwise represents reason why signature is considered invalid.
   """
   state: GitSignatureState!
-  
+
   """
   True if the signature was made with GitHub's signing key.
   """
@@ -16418,38 +16418,38 @@ type GpgSignature implements GitSignature {
   Email used to sign this object.
   """
   email: String!
-  
+
   """
   True if the signature is valid and verified by GitHub.
   """
   isValid: Boolean!
-  
+
   """
   Hex-encoded ID of the key that signed this object.
   """
   keyId: String
-  
+
   """
   Payload for GPG signing object. Raw ODB object without the signature header.
   """
   payload: String!
-  
+
   """
   ASCII-armored signature header from object.
   """
   signature: String!
-  
+
   """
   GitHub user corresponding to the email signing this commit.
   """
   signer: User
-  
+
   """
   The state of this signature. `VALID` if signature is valid and verified by
   GitHub, otherwise represents reason why signature is considered invalid.
   """
   state: GitSignatureState!
-  
+
   """
   True if the signature was made with GitHub's signing key.
   """
@@ -16464,12 +16464,12 @@ input GrantEnterpriseOrganizationsMigratorRoleInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The ID of the enterprise to which all organizations managed by it will be granted the migrator role.
   """
   enterpriseId: ID! @possibleTypes(concreteTypes: ["Enterprise"])
-  
+
   """
   The login of the user to grant the migrator role
   """
@@ -16484,7 +16484,7 @@ type GrantEnterpriseOrganizationsMigratorRolePayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The organizations that had the migrator role applied to for the given user.
   """
@@ -16493,17 +16493,17 @@ type GrantEnterpriseOrganizationsMigratorRolePayload {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
@@ -16519,17 +16519,17 @@ input GrantMigratorRoleInput {
   The user login or Team slug to grant the migrator role.
   """
   actor: String!
-  
+
   """
   Specifies the type of the actor, can be either USER or TEAM.
   """
   actorType: ActorType!
-  
+
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The ID of the organization that the user/team belongs to.
   """
@@ -16544,7 +16544,7 @@ type GrantMigratorRolePayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   Did the operation succeed?
   """
@@ -16564,23 +16564,23 @@ type HeadRefDeletedEvent implements Node {
   Identifies the actor who performed the event.
   """
   actor: Actor
-  
+
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
-  
+
   """
   Identifies the Ref associated with the `head_ref_deleted` event.
   """
   headRef: Ref
-  
+
   """
   Identifies the name of the Ref associated with the `head_ref_deleted` event.
   """
   headRefName: String!
   id: ID!
-  
+
   """
   PullRequest referenced by event.
   """
@@ -16595,28 +16595,28 @@ type HeadRefForcePushedEvent implements Node {
   Identifies the actor who performed the event.
   """
   actor: Actor
-  
+
   """
   Identifies the after commit SHA for the 'head_ref_force_pushed' event.
   """
   afterCommit: Commit
-  
+
   """
   Identifies the before commit SHA for the 'head_ref_force_pushed' event.
   """
   beforeCommit: Commit
-  
+
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
   id: ID!
-  
+
   """
   PullRequest referenced by event.
   """
   pullRequest: PullRequest!
-  
+
   """
   Identifies the fully qualified ref name for the 'head_ref_force_pushed' event.
   """
@@ -16631,13 +16631,13 @@ type HeadRefRestoredEvent implements Node {
   Identifies the actor who performed the event.
   """
   actor: Actor
-  
+
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
   id: ID!
-  
+
   """
   PullRequest referenced by event.
   """
@@ -16662,7 +16662,7 @@ interface HovercardContext {
   A string describing this context
   """
   message: String!
-  
+
   """
   An octicon to accompany this context
   """
@@ -16695,27 +16695,27 @@ input ImportProjectInput {
   The description of Project.
   """
   body: String
-  
+
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   A list of columns containing issues and pull requests.
   """
   columnImports: [ProjectColumnImport!]!
-  
+
   """
   The name of Project.
   """
   name: String!
-  
+
   """
   The name of the Organization or User to create the Project under.
   """
   ownerName: String!
-  
+
   """
   Whether the Project is public or not.
   """
@@ -16730,7 +16730,7 @@ type ImportProjectPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The new Project!
   """
@@ -16745,22 +16745,22 @@ input InviteEnterpriseAdminInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The email of the person to invite as an administrator.
   """
   email: String
-  
+
   """
   The ID of the enterprise to which you want to invite an administrator.
   """
   enterpriseId: ID! @possibleTypes(concreteTypes: ["Enterprise"])
-  
+
   """
   The login of a user to invite as an administrator.
   """
   invitee: String
-  
+
   """
   The role of the administrator.
   """
@@ -16775,7 +16775,7 @@ type InviteEnterpriseAdminPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The created enterprise administrator invitation.
   """
@@ -16804,28 +16804,28 @@ type IpAllowListEntry implements Node {
   A single IP address or range of IP addresses in CIDR notation.
   """
   allowListValue: String!
-  
+
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
   id: ID!
-  
+
   """
   Whether the entry is currently active.
   """
   isActive: Boolean!
-  
+
   """
   The name of the IP allow list entry.
   """
   name: String
-  
+
   """
   The owner of the IP allow list entry.
   """
   owner: IpAllowListOwner!
-  
+
   """
   Identifies the date and time when the object was last updated.
   """
@@ -16840,17 +16840,17 @@ type IpAllowListEntryConnection {
   A list of edges.
   """
   edges: [IpAllowListEntryEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [IpAllowListEntry]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -16865,7 +16865,7 @@ type IpAllowListEntryEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -16880,7 +16880,7 @@ input IpAllowListEntryOrder {
   The ordering direction.
   """
   direction: OrderDirection!
-  
+
   """
   The field to order IP allow list entries by.
   """
@@ -16928,7 +16928,7 @@ type Issue implements Assignable & Closable & Comment & Deletable & Labelable & 
   Reason that the conversation was locked.
   """
   activeLockReason: LockReason
-  
+
   """
   A list of Users assigned to this object.
   """
@@ -16937,68 +16937,68 @@ type Issue implements Assignable & Closable & Comment & Deletable & Labelable & 
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): UserConnection!
-  
+
   """
   The actor who authored the comment.
   """
   author: Actor
-  
+
   """
   Author's association with the subject of the comment.
   """
   authorAssociation: CommentAuthorAssociation!
-  
+
   """
   Identifies the body of the issue.
   """
   body: String!
-  
+
   """
   The body rendered to HTML.
   """
   bodyHTML: HTML!
-  
+
   """
   The http path for this issue body
   """
   bodyResourcePath: URI!
-  
+
   """
   Identifies the body of the issue rendered to text.
   """
   bodyText: String!
-  
+
   """
   The http URL for this issue body
   """
   bodyUrl: URI!
-  
+
   """
   Indicates if the object is closed (definition of closed may depend on type)
   """
   closed: Boolean!
-  
+
   """
   Identifies the date and time when the object was closed.
   """
   closedAt: DateTime
-  
+
   """
   A list of comments associated with the Issue.
   """
@@ -17007,53 +17007,53 @@ type Issue implements Assignable & Closable & Comment & Deletable & Labelable & 
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for issue comments returned from the connection.
     """
     orderBy: IssueCommentOrder
   ): IssueCommentConnection!
-  
+
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
-  
+
   """
   Check if this comment was created via an email reply.
   """
   createdViaEmail: Boolean!
-  
+
   """
   Identifies the primary key from the database.
   """
   databaseId: Int
-  
+
   """
   The actor who edited the comment.
   """
   editor: Actor
-  
+
   """
   Identifies the primary key from the database as a BigInt.
   """
   fullDatabaseId: BigInt
-  
+
   """
   The hovercard information for this issue
   """
@@ -17064,22 +17064,22 @@ type Issue implements Assignable & Closable & Comment & Deletable & Labelable & 
     includeNotificationContexts: Boolean = true
   ): Hovercard!
   id: ID!
-  
+
   """
   Check if this comment was edited and includes an edit with the creation data
   """
   includesCreatedEdit: Boolean!
-  
+
   """
   Indicates whether or not this issue is currently pinned to the repository issues list
   """
   isPinned: Boolean
-  
+
   """
   Is this issue read by the viewer
   """
   isReadByViewer: Boolean
-  
+
   """
   A list of labels associated with the object.
   """
@@ -17088,33 +17088,33 @@ type Issue implements Assignable & Closable & Comment & Deletable & Labelable & 
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for labels returned from the connection.
     """
     orderBy: LabelOrder = { field: CREATED_AT, direction: ASC }
   ): LabelConnection
-  
+
   """
   The moment the editor made the last edit
   """
   lastEditedAt: DateTime
-  
+
   """
   Branches linked to this issue.
   """
@@ -17123,38 +17123,38 @@ type Issue implements Assignable & Closable & Comment & Deletable & Labelable & 
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): LinkedBranchConnection!
-  
+
   """
   `true` if the object is locked
   """
   locked: Boolean!
-  
+
   """
   Identifies the milestone associated with the issue.
   """
   milestone: Milestone
-  
+
   """
   Identifies the issue number.
   """
   number: Int!
-  
+
   """
   A list of Users that are participating in the Issue conversation.
   """
@@ -17163,23 +17163,23 @@ type Issue implements Assignable & Closable & Comment & Deletable & Labelable & 
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): UserConnection!
-  
+
   """
   List of project cards associated with this issue.
   """
@@ -17188,28 +17188,28 @@ type Issue implements Assignable & Closable & Comment & Deletable & Labelable & 
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     A list of archived states to filter the cards by
     """
     archivedStates: [ProjectCardArchivedState] = [ARCHIVED, NOT_ARCHIVED]
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): ProjectCardConnection!
-  
+
   """
   List of project items associated with this issue.
   """
@@ -17218,28 +17218,28 @@ type Issue implements Assignable & Closable & Comment & Deletable & Labelable & 
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Include archived items.
     """
     includeArchived: Boolean = true
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): ProjectV2ItemConnection!
-  
+
   """
   Find a project by number.
   """
@@ -17249,7 +17249,7 @@ type Issue implements Assignable & Closable & Comment & Deletable & Labelable & 
     """
     number: Int!
   ): ProjectV2
-  
+
   """
   A list of projects under the owner.
   """
@@ -17258,43 +17258,43 @@ type Issue implements Assignable & Closable & Comment & Deletable & Labelable & 
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     How to order the returned projects.
     """
     orderBy: ProjectV2Order = { field: NUMBER, direction: DESC }
-    
+
     """
     A project to search for under the the owner.
     """
     query: String
   ): ProjectV2Connection!
-  
+
   """
   Identifies when the comment was published at.
   """
   publishedAt: DateTime
-  
+
   """
   A list of reactions grouped by content left on the subject.
   """
   reactionGroups: [ReactionGroup!]
-  
+
   """
   A list of Reactions left on the Issue.
   """
@@ -17303,53 +17303,53 @@ type Issue implements Assignable & Closable & Comment & Deletable & Labelable & 
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Allows filtering Reactions by emoji.
     """
     content: ReactionContent
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Allows specifying the order in which reactions are returned.
     """
     orderBy: ReactionOrder
   ): ReactionConnection!
-  
+
   """
   The repository associated with this node.
   """
   repository: Repository!
-  
+
   """
   The HTTP path for this issue
   """
   resourcePath: URI!
-  
+
   """
   Identifies the state of the issue.
   """
   state: IssueState!
-  
+
   """
   Identifies the reason for the issue state.
   """
   stateReason: IssueStateReason
-  
+
   """
   A list of events, comments, commits, etc. associated with the issue.
   """
@@ -17358,22 +17358,22 @@ type Issue implements Assignable & Closable & Comment & Deletable & Labelable & 
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Allows filtering timeline events by a `since` timestamp.
     """
@@ -17382,7 +17382,7 @@ type Issue implements Assignable & Closable & Comment & Deletable & Labelable & 
     @deprecated(
       reason: "`timeline` will be removed Use Issue.timelineItems instead. Removal on 2020-10-01 UTC."
     )
-  
+
   """
   A list of events, comments, commits, etc. associated with the issue.
   """
@@ -17391,48 +17391,48 @@ type Issue implements Assignable & Closable & Comment & Deletable & Labelable & 
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Filter timeline items by type.
     """
     itemTypes: [IssueTimelineItemsItemType!]
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Filter timeline items by a `since` timestamp.
     """
     since: DateTime
-    
+
     """
     Skips the first _n_ elements in the list.
     """
     skip: Int
   ): IssueTimelineItemsConnection!
-  
+
   """
   Identifies the issue title.
   """
   title: String!
-  
+
   """
   Identifies the issue title rendered to HTML.
   """
   titleHTML: String!
-  
+
   """
   A list of issues that track this issue
   """
@@ -17441,23 +17441,23 @@ type Issue implements Assignable & Closable & Comment & Deletable & Labelable & 
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): IssueConnection!
-  
+
   """
   A list of issues tracked inside the current issue
   """
@@ -17466,23 +17466,23 @@ type Issue implements Assignable & Closable & Comment & Deletable & Labelable & 
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): IssueConnection!
-  
+
   """
   The number of tracked issues for this issue
   """
@@ -17492,17 +17492,17 @@ type Issue implements Assignable & Closable & Comment & Deletable & Labelable & 
     """
     states: [TrackedIssueStates]
   ): Int!
-  
+
   """
   Identifies the date and time when the object was last updated.
   """
   updatedAt: DateTime!
-  
+
   """
   The HTTP URL for this issue
   """
   url: URI!
-  
+
   """
   A list of edits to this content.
   """
@@ -17511,73 +17511,73 @@ type Issue implements Assignable & Closable & Comment & Deletable & Labelable & 
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): UserContentEditConnection
-  
+
   """
   Indicates if the object can be closed by the viewer.
   """
   viewerCanClose: Boolean!
-  
+
   """
   Check if the current viewer can delete this object.
   """
   viewerCanDelete: Boolean!
-  
+
   """
   Can user react to this subject
   """
   viewerCanReact: Boolean!
-  
+
   """
   Indicates if the object can be reopened by the viewer.
   """
   viewerCanReopen: Boolean!
-  
+
   """
   Check if the viewer is able to change their subscription status for the repository.
   """
   viewerCanSubscribe: Boolean!
-  
+
   """
   Check if the current viewer can update this object.
   """
   viewerCanUpdate: Boolean!
-  
+
   """
   Reasons why the current viewer can not update this comment.
   """
   viewerCannotUpdateReasons: [CommentCannotUpdateReason!]!
-  
+
   """
   Did the viewer author this comment.
   """
   viewerDidAuthor: Boolean!
-  
+
   """
   Identifies if the viewer is watching, not watching, or ignoring the subscribable entity.
   """
   viewerSubscription: SubscriptionState
-  
+
   """
   Identifies the viewer's thread subscription form action.
   """
   viewerThreadSubscriptionFormAction: ThreadSubscriptionFormAction
-  
+
   """
   Identifies the viewer's thread subscription status.
   """
@@ -17606,96 +17606,96 @@ type IssueComment implements Comment & Deletable & Minimizable & Node & Reactabl
   The actor who authored the comment.
   """
   author: Actor
-  
+
   """
   Author's association with the subject of the comment.
   """
   authorAssociation: CommentAuthorAssociation!
-  
+
   """
   The body as Markdown.
   """
   body: String!
-  
+
   """
   The body rendered to HTML.
   """
   bodyHTML: HTML!
-  
+
   """
   The body rendered to text.
   """
   bodyText: String!
-  
+
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
-  
+
   """
   Check if this comment was created via an email reply.
   """
   createdViaEmail: Boolean!
-  
+
   """
   Identifies the primary key from the database.
   """
   databaseId: Int
-  
+
   """
   The actor who edited the comment.
   """
   editor: Actor
-  
+
   """
   Identifies the primary key from the database as a BigInt.
   """
   fullDatabaseId: BigInt
   id: ID!
-  
+
   """
   Check if this comment was edited and includes an edit with the creation data
   """
   includesCreatedEdit: Boolean!
-  
+
   """
   Returns whether or not a comment has been minimized.
   """
   isMinimized: Boolean!
-  
+
   """
   Identifies the issue associated with the comment.
   """
   issue: Issue!
-  
+
   """
   The moment the editor made the last edit
   """
   lastEditedAt: DateTime
-  
+
   """
   Returns why the comment was minimized. One of `abuse`, `off-topic`,
   `outdated`, `resolved`, `duplicate` and `spam`. Note that the case and
   formatting of these values differs from the inputs to the `MinimizeComment` mutation.
   """
   minimizedReason: String
-  
+
   """
   Identifies when the comment was published at.
   """
   publishedAt: DateTime
-  
+
   """
   Returns the pull request associated with the comment, if this comment was made on a
   pull request.
   """
   pullRequest: PullRequest
-  
+
   """
   A list of reactions grouped by content left on the subject.
   """
   reactionGroups: [ReactionGroup!]
-  
+
   """
   A list of Reactions left on the Issue.
   """
@@ -17704,53 +17704,53 @@ type IssueComment implements Comment & Deletable & Minimizable & Node & Reactabl
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Allows filtering Reactions by emoji.
     """
     content: ReactionContent
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Allows specifying the order in which reactions are returned.
     """
     orderBy: ReactionOrder
   ): ReactionConnection!
-  
+
   """
   The repository associated with this node.
   """
   repository: Repository!
-  
+
   """
   The HTTP path for this issue comment
   """
   resourcePath: URI!
-  
+
   """
   Identifies the date and time when the object was last updated.
   """
   updatedAt: DateTime!
-  
+
   """
   The HTTP URL for this issue comment
   """
   url: URI!
-  
+
   """
   A list of edits to this content.
   """
@@ -17759,48 +17759,48 @@ type IssueComment implements Comment & Deletable & Minimizable & Node & Reactabl
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): UserContentEditConnection
-  
+
   """
   Check if the current viewer can delete this object.
   """
   viewerCanDelete: Boolean!
-  
+
   """
   Check if the current viewer can minimize this object.
   """
   viewerCanMinimize: Boolean!
-  
+
   """
   Can user react to this subject
   """
   viewerCanReact: Boolean!
-  
+
   """
   Check if the current viewer can update this object.
   """
   viewerCanUpdate: Boolean!
-  
+
   """
   Reasons why the current viewer can not update this comment.
   """
   viewerCannotUpdateReasons: [CommentCannotUpdateReason!]!
-  
+
   """
   Did the viewer author this comment.
   """
@@ -17815,17 +17815,17 @@ type IssueCommentConnection {
   A list of edges.
   """
   edges: [IssueCommentEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [IssueComment]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -17840,7 +17840,7 @@ type IssueCommentEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -17855,7 +17855,7 @@ input IssueCommentOrder {
   The direction in which to order issue comments by the specified field.
   """
   direction: OrderDirection!
-  
+
   """
   The field in which to order issue comments by.
   """
@@ -17880,17 +17880,17 @@ type IssueConnection {
   A list of edges.
   """
   edges: [IssueEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [Issue]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -17909,28 +17909,28 @@ type IssueContributionsByRepository {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for contributions returned from the connection.
     """
     orderBy: ContributionOrder = { direction: DESC }
   ): CreatedIssueContributionConnection!
-  
+
   """
   The repository in which the issues were opened.
   """
@@ -17945,7 +17945,7 @@ type IssueEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -17961,46 +17961,46 @@ input IssueFilters {
   user, and `*` for issues assigned to any user.
   """
   assignee: String
-  
+
   """
   List issues created by given name.
   """
   createdBy: String
-  
+
   """
   List issues where the list of label names exist on the issue.
   """
   labels: [String!]
-  
+
   """
   List issues where the given name is mentioned in the issue.
   """
   mentioned: String
-  
+
   """
   List issues by given milestone argument. If an string representation of an
   integer is passed, it should refer to a milestone by its database ID. Pass in
   `null` for issues with no milestone, and `*` for issues that are assigned to any milestone.
   """
   milestone: String
-  
+
   """
   List issues by given milestone argument. If an string representation of an
   integer is passed, it should refer to a milestone by its number field. Pass in
   `null` for issues with no milestone, and `*` for issues that are assigned to any milestone.
   """
   milestoneNumber: String
-  
+
   """
   List issues that have been updated at or after the given date.
   """
   since: DateTime
-  
+
   """
   List issues filtered by the list of states given.
   """
   states: [IssueState!]
-  
+
   """
   List issues subscribed to by viewer.
   """
@@ -18020,7 +18020,7 @@ input IssueOrder {
   The direction in which to order issues by the specified field.
   """
   direction: OrderDirection!
-  
+
   """
   The field in which to order issues by.
   """
@@ -18085,7 +18085,7 @@ type IssueTemplate {
   The template purpose.
   """
   about: String
-  
+
   """
   The suggested assignees.
   """
@@ -18094,33 +18094,33 @@ type IssueTemplate {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): UserConnection!
-  
+
   """
   The suggested issue body.
   """
   body: String
-  
+
   """
   The template filename.
   """
   filename: String!
-  
+
   """
   The suggested issue labels
   """
@@ -18129,33 +18129,33 @@ type IssueTemplate {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for labels returned from the connection.
     """
     orderBy: LabelOrder = { field: CREATED_AT, direction: ASC }
   ): LabelConnection
-  
+
   """
   The template name.
   """
   name: String!
-  
+
   """
   The suggested issue title.
   """
@@ -18170,17 +18170,17 @@ type IssueTimelineConnection {
   A list of edges.
   """
   edges: [IssueTimelineItemEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [IssueTimelineItem]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -18218,7 +18218,7 @@ type IssueTimelineItemEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -18268,32 +18268,32 @@ type IssueTimelineItemsConnection {
   A list of edges.
   """
   edges: [IssueTimelineItemsEdge]
-  
+
   """
   Identifies the count of items after applying `before` and `after` filters.
   """
   filteredCount: Int!
-  
+
   """
   A list of nodes.
   """
   nodes: [IssueTimelineItems]
-  
+
   """
   Identifies the count of items after applying `before`/`after` filters and `first`/`last`/`skip` slicing.
   """
   pageCount: Int!
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
   totalCount: Int!
-  
+
   """
   Identifies the date and time when the timeline was last updated.
   """
@@ -18308,7 +18308,7 @@ type IssueTimelineItemsEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -18455,22 +18455,22 @@ type JoinedGitHubContribution implements Contribution {
   longer access.
   """
   isRestricted: Boolean!
-  
+
   """
   When this contribution was made.
   """
   occurredAt: DateTime!
-  
+
   """
   The HTTP path for this contribution.
   """
   resourcePath: URI!
-  
+
   """
   The HTTP URL for this contribution.
   """
   url: URI!
-  
+
   """
   The user who made this contribution.
   """
@@ -18485,23 +18485,23 @@ type Label implements Node {
   Identifies the label color.
   """
   color: String!
-  
+
   """
   Identifies the date and time when the label was created.
   """
   createdAt: DateTime
-  
+
   """
   A brief description of this label.
   """
   description: String
   id: ID!
-  
+
   """
   Indicates whether or not this is a default label.
   """
   isDefault: Boolean!
-  
+
   """
   A list of issues associated with this label.
   """
@@ -18510,48 +18510,48 @@ type Label implements Node {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Filtering options for issues returned from the connection.
     """
     filterBy: IssueFilters
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     A list of label names to filter the pull requests by.
     """
     labels: [String!]
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for issues returned from the connection.
     """
     orderBy: IssueOrder
-    
+
     """
     A list of states to filter the issues by.
     """
     states: [IssueState!]
   ): IssueConnection!
-  
+
   """
   Identifies the label name.
   """
   name: String!
-  
+
   """
   A list of pull requests associated with this label.
   """
@@ -18560,63 +18560,63 @@ type Label implements Node {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     The base ref name to filter the pull requests by.
     """
     baseRefName: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     The head ref name to filter the pull requests by.
     """
     headRefName: String
-    
+
     """
     A list of label names to filter the pull requests by.
     """
     labels: [String!]
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for pull requests returned from the connection.
     """
     orderBy: IssueOrder
-    
+
     """
     A list of states to filter the pull requests by.
     """
     states: [PullRequestState!]
   ): PullRequestConnection!
-  
+
   """
   The repository associated with this label.
   """
   repository: Repository!
-  
+
   """
   The HTTP path for this label.
   """
   resourcePath: URI!
-  
+
   """
   Identifies the date and time when the label was last updated.
   """
   updatedAt: DateTime
-  
+
   """
   The HTTP URL for this label.
   """
@@ -18631,17 +18631,17 @@ type LabelConnection {
   A list of edges.
   """
   edges: [LabelEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [Label]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -18656,7 +18656,7 @@ type LabelEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -18671,7 +18671,7 @@ input LabelOrder {
   The direction in which to order labels by the specified field.
   """
   direction: OrderDirection!
-  
+
   """
   The field in which to order labels by.
   """
@@ -18704,22 +18704,22 @@ interface Labelable {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for labels returned from the connection.
     """
@@ -18735,18 +18735,18 @@ type LabeledEvent implements Node {
   Identifies the actor who performed the event.
   """
   actor: Actor
-  
+
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
   id: ID!
-  
+
   """
   Identifies the label associated with the 'labeled' event.
   """
   label: Label!
-  
+
   """
   Identifies the `Labelable` associated with the event.
   """
@@ -18762,7 +18762,7 @@ type Language implements Node {
   """
   color: String
   id: ID!
-  
+
   """
   The name of the current language.
   """
@@ -18777,22 +18777,22 @@ type LanguageConnection {
   A list of edges.
   """
   edges: [LanguageEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [Language]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
   totalCount: Int!
-  
+
   """
   The total size in bytes of files written in that language.
   """
@@ -18805,7 +18805,7 @@ Represents the language of a repository.
 type LanguageEdge {
   cursor: String!
   node: Language!
-  
+
   """
   The number of bytes of code written in the language.
   """
@@ -18820,7 +18820,7 @@ input LanguageOrder {
   The ordering direction.
   """
   direction: OrderDirection!
-  
+
   """
   The field to order languages by.
   """
@@ -18845,68 +18845,68 @@ type License implements Node {
   The full text of the license
   """
   body: String!
-  
+
   """
   The conditions set by the license
   """
   conditions: [LicenseRule]!
-  
+
   """
   A human-readable description of the license
   """
   description: String
-  
+
   """
   Whether the license should be featured
   """
   featured: Boolean!
-  
+
   """
   Whether the license should be displayed in license pickers
   """
   hidden: Boolean!
   id: ID!
-  
+
   """
   Instructions on how to implement the license
   """
   implementation: String
-  
+
   """
   The lowercased SPDX ID of the license
   """
   key: String!
-  
+
   """
   The limitations set by the license
   """
   limitations: [LicenseRule]!
-  
+
   """
   The license full name specified by <https://spdx.org/licenses>
   """
   name: String!
-  
+
   """
   Customary short name if applicable (e.g, GPLv3)
   """
   nickname: String
-  
+
   """
   The permissions set by the license
   """
   permissions: [LicenseRule]!
-  
+
   """
   Whether the license is a pseudo-license placeholder (e.g., other, no-license)
   """
   pseudoLicense: Boolean!
-  
+
   """
   Short identifier specified by <https://spdx.org/licenses>
   """
   spdxId: String
-  
+
   """
   URL to the license on <https://choosealicense.com>
   """
@@ -18921,12 +18921,12 @@ type LicenseRule {
   A description of the rule
   """
   description: String!
-  
+
   """
   The machine-readable rule key
   """
   key: String!
-  
+
   """
   The human-readable rule label
   """
@@ -18941,12 +18941,12 @@ input LinkProjectV2ToRepositoryInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The ID of the project to link to the repository.
   """
   projectId: ID! @possibleTypes(concreteTypes: ["ProjectV2"])
-  
+
   """
   The ID of the repository to link to the project.
   """
@@ -18961,7 +18961,7 @@ type LinkProjectV2ToRepositoryPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The repository the project is linked to.
   """
@@ -18976,12 +18976,12 @@ input LinkProjectV2ToTeamInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The ID of the project to link to the team.
   """
   projectId: ID! @possibleTypes(concreteTypes: ["ProjectV2"])
-  
+
   """
   The ID of the team to link to the project.
   """
@@ -18996,7 +18996,7 @@ type LinkProjectV2ToTeamPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The team the project is linked to
   """
@@ -19011,12 +19011,12 @@ input LinkRepositoryToProjectInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The ID of the Project to link to a Repository
   """
   projectId: ID! @possibleTypes(concreteTypes: ["Project"])
-  
+
   """
   The ID of the Repository to link to a Project.
   """
@@ -19031,12 +19031,12 @@ type LinkRepositoryToProjectPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The linked Project.
   """
   project: Project
-  
+
   """
   The linked Repository.
   """
@@ -19048,7 +19048,7 @@ A branch linked to an issue.
 """
 type LinkedBranch implements Node {
   id: ID!
-  
+
   """
   The branch's ref.
   """
@@ -19063,17 +19063,17 @@ type LinkedBranchConnection {
   A list of edges.
   """
   edges: [LinkedBranchEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [LinkedBranch]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -19088,7 +19088,7 @@ type LinkedBranchEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -19103,12 +19103,12 @@ input LockLockableInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   A reason for why the item will be locked.
   """
   lockReason: LockReason
-  
+
   """
   ID of the item to be locked.
   """
@@ -19127,12 +19127,12 @@ type LockLockablePayload {
   Identifies the actor who performed the event.
   """
   actor: Actor
-  
+
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The item that was locked.
   """
@@ -19169,7 +19169,7 @@ interface Lockable {
   Reason that the conversation was locked.
   """
   activeLockReason: LockReason
-  
+
   """
   `true` if the object is locked
   """
@@ -19184,18 +19184,18 @@ type LockedEvent implements Node {
   Identifies the actor who performed the event.
   """
   actor: Actor
-  
+
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
   id: ID!
-  
+
   """
   Reason that the conversation was locked (optional).
   """
   lockReason: LockReason
-  
+
   """
   Object that was locked.
   """
@@ -19215,43 +19215,43 @@ type Mannequin implements Actor & Node & UniformResourceLocatable {
     """
     size: Int
   ): URI!
-  
+
   """
   The user that has claimed the data attributed to this mannequin.
   """
   claimant: User
-  
+
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
-  
+
   """
   Identifies the primary key from the database.
   """
   databaseId: Int
-  
+
   """
   The mannequin's email on the source instance.
   """
   email: String
   id: ID!
-  
+
   """
   The username of the actor.
   """
   login: String!
-  
+
   """
   The HTML path to this resource.
   """
   resourcePath: URI!
-  
+
   """
   Identifies the date and time when the object was last updated.
   """
   updatedAt: DateTime!
-  
+
   """
   The URL to this resource.
   """
@@ -19266,17 +19266,17 @@ type MannequinConnection {
   A list of edges.
   """
   edges: [MannequinEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [Mannequin]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -19291,7 +19291,7 @@ type MannequinEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -19306,7 +19306,7 @@ input MannequinOrder {
   The ordering direction.
   """
   direction: OrderDirection!
-  
+
   """
   The field to order mannequins by.
   """
@@ -19335,7 +19335,7 @@ input MarkDiscussionCommentAsAnswerInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The Node ID of the discussion comment to mark as an answer.
   """
@@ -19350,7 +19350,7 @@ type MarkDiscussionCommentAsAnswerPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The discussion that includes the chosen comment.
   """
@@ -19365,12 +19365,12 @@ input MarkFileAsViewedInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The path of the file to mark as viewed
   """
   path: String!
-  
+
   """
   The Node ID of the pull request.
   """
@@ -19385,7 +19385,7 @@ type MarkFileAsViewedPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The updated pull request.
   """
@@ -19400,7 +19400,7 @@ input MarkProjectV2AsTemplateInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The ID of the Project to mark as a template.
   """
@@ -19415,7 +19415,7 @@ type MarkProjectV2AsTemplatePayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The project.
   """
@@ -19430,7 +19430,7 @@ input MarkPullRequestReadyForReviewInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   ID of the pull request to be marked as ready for review.
   """
@@ -19445,7 +19445,7 @@ type MarkPullRequestReadyForReviewPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The pull request that is ready for review.
   """
@@ -19460,23 +19460,23 @@ type MarkedAsDuplicateEvent implements Node {
   Identifies the actor who performed the event.
   """
   actor: Actor
-  
+
   """
   The authoritative issue or pull request which has been duplicated by another.
   """
   canonical: IssueOrPullRequest
-  
+
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
-  
+
   """
   The issue or pull request which has been marked as a duplicate of another.
   """
   duplicate: IssueOrPullRequest
   id: ID!
-  
+
   """
   Canonical and duplicate belong to different repositories.
   """
@@ -19491,38 +19491,38 @@ type MarketplaceCategory implements Node {
   The category's description.
   """
   description: String
-  
+
   """
   The technical description of how apps listed in this category work with GitHub.
   """
   howItWorks: String
   id: ID!
-  
+
   """
   The category's name.
   """
   name: String!
-  
+
   """
   How many Marketplace listings have this as their primary category.
   """
   primaryListingCount: Int!
-  
+
   """
   The HTTP path for this Marketplace category.
   """
   resourcePath: URI!
-  
+
   """
   How many Marketplace listings have this as their secondary category.
   """
   secondaryListingCount: Int!
-  
+
   """
   The short name of the category used in its URL.
   """
   slug: String!
-  
+
   """
   The HTTP URL for this Marketplace category.
   """
@@ -19537,139 +19537,139 @@ type MarketplaceListing implements Node {
   The GitHub App this listing represents.
   """
   app: App
-  
+
   """
   URL to the listing owner's company site.
   """
   companyUrl: URI
-  
+
   """
   The HTTP path for configuring access to the listing's integration or OAuth app
   """
   configurationResourcePath: URI!
-  
+
   """
   The HTTP URL for configuring access to the listing's integration or OAuth app
   """
   configurationUrl: URI!
-  
+
   """
   URL to the listing's documentation.
   """
   documentationUrl: URI
-  
+
   """
   The listing's detailed description.
   """
   extendedDescription: String
-  
+
   """
   The listing's detailed description rendered to HTML.
   """
   extendedDescriptionHTML: HTML!
-  
+
   """
   The listing's introductory description.
   """
   fullDescription: String!
-  
+
   """
   The listing's introductory description rendered to HTML.
   """
   fullDescriptionHTML: HTML!
-  
+
   """
   Does this listing have any plans with a free trial?
   """
   hasPublishedFreeTrialPlans: Boolean!
-  
+
   """
   Does this listing have a terms of service link?
   """
   hasTermsOfService: Boolean!
-  
+
   """
   Whether the creator of the app is a verified org
   """
   hasVerifiedOwner: Boolean!
-  
+
   """
   A technical description of how this app works with GitHub.
   """
   howItWorks: String
-  
+
   """
   The listing's technical description rendered to HTML.
   """
   howItWorksHTML: HTML!
   id: ID!
-  
+
   """
   URL to install the product to the viewer's account or organization.
   """
   installationUrl: URI
-  
+
   """
   Whether this listing's app has been installed for the current viewer
   """
   installedForViewer: Boolean!
-  
+
   """
   Whether this listing has been removed from the Marketplace.
   """
   isArchived: Boolean!
-  
+
   """
   Whether this listing is still an editable draft that has not been submitted
   for review and is not publicly visible in the Marketplace.
   """
   isDraft: Boolean!
-  
+
   """
   Whether the product this listing represents is available as part of a paid plan.
   """
   isPaid: Boolean!
-  
+
   """
   Whether this listing has been approved for display in the Marketplace.
   """
   isPublic: Boolean!
-  
+
   """
   Whether this listing has been rejected by GitHub for display in the Marketplace.
   """
   isRejected: Boolean!
-  
+
   """
   Whether this listing has been approved for unverified display in the Marketplace.
   """
   isUnverified: Boolean!
-  
+
   """
   Whether this draft listing has been submitted for review for approval to be unverified in the Marketplace.
   """
   isUnverifiedPending: Boolean!
-  
+
   """
   Whether this draft listing has been submitted for review from GitHub for approval to be verified in the Marketplace.
   """
   isVerificationPendingFromDraft: Boolean!
-  
+
   """
   Whether this unverified listing has been submitted for review from GitHub for approval to be verified in the Marketplace.
   """
   isVerificationPendingFromUnverified: Boolean!
-  
+
   """
   Whether this listing has been approved for verified display in the Marketplace.
   """
   isVerified: Boolean!
-  
+
   """
   The hex color code, without the leading '#', for the logo background.
   """
   logoBackgroundColor: String!
-  
+
   """
   URL for the listing's logo image.
   """
@@ -19679,143 +19679,143 @@ type MarketplaceListing implements Node {
     """
     size: Int = 400
   ): URI
-  
+
   """
   The listing's full name.
   """
   name: String!
-  
+
   """
   The listing's very short description without a trailing period or ampersands.
   """
   normalizedShortDescription: String!
-  
+
   """
   URL to the listing's detailed pricing.
   """
   pricingUrl: URI
-  
+
   """
   The category that best describes the listing.
   """
   primaryCategory: MarketplaceCategory!
-  
+
   """
   URL to the listing's privacy policy, may return an empty string for listings that do not require a privacy policy URL.
   """
   privacyPolicyUrl: URI!
-  
+
   """
   The HTTP path for the Marketplace listing.
   """
   resourcePath: URI!
-  
+
   """
   The URLs for the listing's screenshots.
   """
   screenshotUrls: [String]!
-  
+
   """
   An alternate category that describes the listing.
   """
   secondaryCategory: MarketplaceCategory
-  
+
   """
   The listing's very short description.
   """
   shortDescription: String!
-  
+
   """
   The short name of the listing used in its URL.
   """
   slug: String!
-  
+
   """
   URL to the listing's status page.
   """
   statusUrl: URI
-  
+
   """
   An email address for support for this listing's app.
   """
   supportEmail: String
-  
+
   """
   Either a URL or an email address for support for this listing's app, may
   return an empty string for listings that do not require a support URL.
   """
   supportUrl: URI!
-  
+
   """
   URL to the listing's terms of service.
   """
   termsOfServiceUrl: URI
-  
+
   """
   The HTTP URL for the Marketplace listing.
   """
   url: URI!
-  
+
   """
   Can the current viewer add plans for this Marketplace listing.
   """
   viewerCanAddPlans: Boolean!
-  
+
   """
   Can the current viewer approve this Marketplace listing.
   """
   viewerCanApprove: Boolean!
-  
+
   """
   Can the current viewer delist this Marketplace listing.
   """
   viewerCanDelist: Boolean!
-  
+
   """
   Can the current viewer edit this Marketplace listing.
   """
   viewerCanEdit: Boolean!
-  
+
   """
   Can the current viewer edit the primary and secondary category of this
   Marketplace listing.
   """
   viewerCanEditCategories: Boolean!
-  
+
   """
   Can the current viewer edit the plans for this Marketplace listing.
   """
   viewerCanEditPlans: Boolean!
-  
+
   """
   Can the current viewer return this Marketplace listing to draft state
   so it becomes editable again.
   """
   viewerCanRedraft: Boolean!
-  
+
   """
   Can the current viewer reject this Marketplace listing by returning it to
   an editable draft state or rejecting it entirely.
   """
   viewerCanReject: Boolean!
-  
+
   """
   Can the current viewer request this listing be reviewed for display in
   the Marketplace as verified.
   """
   viewerCanRequestApproval: Boolean!
-  
+
   """
   Indicates whether the current user has an active subscription to this Marketplace listing.
   """
   viewerHasPurchased: Boolean!
-  
+
   """
   Indicates if the current user has purchased a subscription to this Marketplace listing
   for all of the organizations the user owns.
   """
   viewerHasPurchasedForAllOrganizations: Boolean!
-  
+
   """
   Does the current viewer role allow them to administer this Marketplace listing.
   """
@@ -19830,17 +19830,17 @@ type MarketplaceListingConnection {
   A list of edges.
   """
   edges: [MarketplaceListingEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [MarketplaceListing]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -19855,7 +19855,7 @@ type MarketplaceListingEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -19874,22 +19874,22 @@ interface MemberStatusable {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for user statuses returned from the connection.
     """
@@ -19905,98 +19905,98 @@ type MembersCanDeleteReposClearAuditEntry implements AuditEntry & EnterpriseAudi
   The action name
   """
   action: String!
-  
+
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
-  
+
   """
   The IP address of the actor
   """
   actorIp: String
-  
+
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
-  
+
   """
   The username of the user who initiated the action
   """
   actorLogin: String
-  
+
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
-  
+
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
-  
+
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
-  
+
   """
   The HTTP path for this enterprise.
   """
   enterpriseResourcePath: URI
-  
+
   """
   The slug of the enterprise.
   """
   enterpriseSlug: String
-  
+
   """
   The HTTP URL for this enterprise.
   """
   enterpriseUrl: URI
   id: ID!
-  
+
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
-  
+
   """
   The Organization associated with the Audit Entry.
   """
   organization: Organization
-  
+
   """
   The name of the Organization.
   """
   organizationName: String
-  
+
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
-  
+
   """
   The HTTP URL for the organization
   """
   organizationUrl: URI
-  
+
   """
   The user affected by the action
   """
   user: User
-  
+
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
-  
+
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
-  
+
   """
   The HTTP URL for the user.
   """
@@ -20011,98 +20011,98 @@ type MembersCanDeleteReposDisableAuditEntry implements AuditEntry & EnterpriseAu
   The action name
   """
   action: String!
-  
+
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
-  
+
   """
   The IP address of the actor
   """
   actorIp: String
-  
+
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
-  
+
   """
   The username of the user who initiated the action
   """
   actorLogin: String
-  
+
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
-  
+
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
-  
+
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
-  
+
   """
   The HTTP path for this enterprise.
   """
   enterpriseResourcePath: URI
-  
+
   """
   The slug of the enterprise.
   """
   enterpriseSlug: String
-  
+
   """
   The HTTP URL for this enterprise.
   """
   enterpriseUrl: URI
   id: ID!
-  
+
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
-  
+
   """
   The Organization associated with the Audit Entry.
   """
   organization: Organization
-  
+
   """
   The name of the Organization.
   """
   organizationName: String
-  
+
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
-  
+
   """
   The HTTP URL for the organization
   """
   organizationUrl: URI
-  
+
   """
   The user affected by the action
   """
   user: User
-  
+
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
-  
+
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
-  
+
   """
   The HTTP URL for the user.
   """
@@ -20117,98 +20117,98 @@ type MembersCanDeleteReposEnableAuditEntry implements AuditEntry & EnterpriseAud
   The action name
   """
   action: String!
-  
+
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
-  
+
   """
   The IP address of the actor
   """
   actorIp: String
-  
+
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
-  
+
   """
   The username of the user who initiated the action
   """
   actorLogin: String
-  
+
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
-  
+
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
-  
+
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
-  
+
   """
   The HTTP path for this enterprise.
   """
   enterpriseResourcePath: URI
-  
+
   """
   The slug of the enterprise.
   """
   enterpriseSlug: String
-  
+
   """
   The HTTP URL for this enterprise.
   """
   enterpriseUrl: URI
   id: ID!
-  
+
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
-  
+
   """
   The Organization associated with the Audit Entry.
   """
   organization: Organization
-  
+
   """
   The name of the Organization.
   """
   organizationName: String
-  
+
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
-  
+
   """
   The HTTP URL for the organization
   """
   organizationUrl: URI
-  
+
   """
   The user affected by the action
   """
   user: User
-  
+
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
-  
+
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
-  
+
   """
   The HTTP URL for the user.
   """
@@ -20223,12 +20223,12 @@ type MentionedEvent implements Node {
   Identifies the actor who performed the event.
   """
   actor: Actor
-  
+
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
-  
+
   """
   Identifies the primary key from the database.
   """
@@ -20244,27 +20244,27 @@ input MergeBranchInput {
   The email address to associate with this commit.
   """
   authorEmail: String
-  
+
   """
   The name of the base branch that the provided head will be merged into.
   """
   base: String!
-  
+
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   Message to use for the merge commit. If omitted, a default will be used.
   """
   commitMessage: String
-  
+
   """
   The head to merge into the base branch. This can be a branch name or a commit GitObjectID.
   """
   head: String!
-  
+
   """
   The Node ID of the Repository containing the base branch that will be modified.
   """
@@ -20279,7 +20279,7 @@ type MergeBranchPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The resulting merge Commit.
   """
@@ -20326,32 +20326,32 @@ input MergePullRequestInput {
   The email address to associate with this merge.
   """
   authorEmail: String
-  
+
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   Commit body to use for the merge commit; if omitted, a default message will be used
   """
   commitBody: String
-  
+
   """
   Commit headline to use for the merge commit; if omitted, a default message will be used.
   """
   commitHeadline: String
-  
+
   """
   OID that the pull request head ref must match to allow merge; if omitted, no check is performed.
   """
   expectedHeadOid: GitObjectID
-  
+
   """
   The merge method to use. If omitted, defaults to 'MERGE'
   """
   mergeMethod: PullRequestMergeMethod = MERGE
-  
+
   """
   ID of the pull request to be merged.
   """
@@ -20366,12 +20366,12 @@ type MergePullRequestPayload {
   Identifies the actor who performed the event.
   """
   actor: Actor
-  
+
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The pull request that was merged.
   """
@@ -20386,7 +20386,7 @@ type MergeQueue implements Node {
   The configuration for this merge queue
   """
   configuration: MergeQueueConfiguration
-  
+
   """
   The entries in the queue
   """
@@ -20395,39 +20395,39 @@ type MergeQueue implements Node {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): MergeQueueEntryConnection
   id: ID!
-  
+
   """
   The estimated time in seconds until a newly added entry would be merged
   """
   nextEntryEstimatedTimeToMerge: Int
-  
+
   """
   The repository this merge queue belongs to
   """
   repository: Repository
-  
+
   """
   The HTTP path for this merge queue
   """
   resourcePath: URI!
-  
+
   """
   The HTTP URL for this merge queue
   """
@@ -20442,32 +20442,32 @@ type MergeQueueConfiguration {
   The amount of time in minutes to wait for a check response before considering it a failure.
   """
   checkResponseTimeout: Int
-  
+
   """
   The maximum number of entries to build at once.
   """
   maximumEntriesToBuild: Int
-  
+
   """
   The maximum number of entries to merge at once.
   """
   maximumEntriesToMerge: Int
-  
+
   """
   The merge method to use for this queue.
   """
   mergeMethod: PullRequestMergeMethod
-  
+
   """
   The strategy to use when merging entries.
   """
   mergingStrategy: MergeQueueMergingStrategy
-  
+
   """
   The minimum number of entries required to merge at once.
   """
   minimumEntriesToMerge: Int
-  
+
   """
   The amount of time in minutes to wait before ignoring the minumum number of
   entries in the queue requirement and merging a collection of entries
@@ -20483,53 +20483,53 @@ type MergeQueueEntry implements Node {
   The base commit for this entry
   """
   baseCommit: Commit
-  
+
   """
   The date and time this entry was added to the merge queue
   """
   enqueuedAt: DateTime!
-  
+
   """
   The actor that enqueued this entry
   """
   enqueuer: Actor!
-  
+
   """
   The estimated time in seconds until this entry will be merged
   """
   estimatedTimeToMerge: Int
-  
+
   """
   The head commit for this entry
   """
   headCommit: Commit
   id: ID!
-  
+
   """
   Whether this pull request should jump the queue
   """
   jump: Boolean!
-  
+
   """
   The merge queue that this entry belongs to
   """
   mergeQueue: MergeQueue
-  
+
   """
   The position of this entry in the queue
   """
   position: Int!
-  
+
   """
   The pull request that will be added to a merge group
   """
   pullRequest: PullRequest
-  
+
   """
   Does this pull request need to be deployed on its own
   """
   solo: Boolean!
-  
+
   """
   The state of this entry in the queue
   """
@@ -20544,17 +20544,17 @@ type MergeQueueEntryConnection {
   A list of edges.
   """
   edges: [MergeQueueEntryEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [MergeQueueEntry]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -20569,7 +20569,7 @@ type MergeQueueEntryEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -20682,38 +20682,38 @@ type MergedEvent implements Node & UniformResourceLocatable {
   Identifies the actor who performed the event.
   """
   actor: Actor
-  
+
   """
   Identifies the commit associated with the `merge` event.
   """
   commit: Commit
-  
+
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
   id: ID!
-  
+
   """
   Identifies the Ref associated with the `merge` event.
   """
   mergeRef: Ref
-  
+
   """
   Identifies the name of the Ref associated with the `merge` event.
   """
   mergeRefName: String!
-  
+
   """
   PullRequest referenced by event.
   """
   pullRequest: PullRequest!
-  
+
   """
   The HTTP path for this merged event.
   """
   resourcePath: URI!
-  
+
   """
   The HTTP URL for this merged event.
   """
@@ -20728,48 +20728,48 @@ interface Migration {
   The migration flag to continue on error.
   """
   continueOnError: Boolean!
-  
+
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
-  
+
   """
   Identifies the primary key from the database.
   """
   databaseId: String
-  
+
   """
   The reason the migration failed.
   """
   failureReason: String
   id: ID!
-  
+
   """
   The URL for the migration log (expires 1 day after migration completes).
   """
   migrationLogUrl: URI
-  
+
   """
   The migration source.
   """
   migrationSource: MigrationSource!
-  
+
   """
   The target repository name.
   """
   repositoryName: String!
-  
+
   """
   The migration source URL, for example `https://github.com` or `https://monalisa.ghe.com`.
   """
   sourceUrl: URI!
-  
+
   """
   The migration state.
   """
   state: MigrationState!
-  
+
   """
   The number of warnings encountered for this migration. To review the warnings,
   check the [Migration Log](https://docs.github.com/en/migrations/using-github-enterprise-importer/completing-your-migration-with-github-enterprise-importer/accessing-your-migration-logs-for-github-enterprise-importer).
@@ -20782,17 +20782,17 @@ A GitHub Enterprise Importer (GEI) migration source.
 """
 type MigrationSource implements Node {
   id: ID!
-  
+
   """
   The migration source name.
   """
   name: String!
-  
+
   """
   The migration source type.
   """
   type: MigrationSourceType!
-  
+
   """
   The migration source URL, for example `https://github.com` or `https://monalisa.ghe.com`.
   """
@@ -20859,33 +20859,33 @@ type Milestone implements Closable & Node & UniformResourceLocatable {
   Indicates if the object is closed (definition of closed may depend on type)
   """
   closed: Boolean!
-  
+
   """
   Identifies the date and time when the object was closed.
   """
   closedAt: DateTime
-  
+
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
-  
+
   """
   Identifies the actor who created the milestone.
   """
   creator: Actor
-  
+
   """
   Identifies the description of the milestone.
   """
   description: String
-  
+
   """
   Identifies the due date of the milestone.
   """
   dueOn: DateTime
   id: ID!
-  
+
   """
   A list of issues associated with the milestone.
   """
@@ -20894,53 +20894,53 @@ type Milestone implements Closable & Node & UniformResourceLocatable {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Filtering options for issues returned from the connection.
     """
     filterBy: IssueFilters
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     A list of label names to filter the pull requests by.
     """
     labels: [String!]
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for issues returned from the connection.
     """
     orderBy: IssueOrder
-    
+
     """
     A list of states to filter the issues by.
     """
     states: [IssueState!]
   ): IssueConnection!
-  
+
   """
   Identifies the number of the milestone.
   """
   number: Int!
-  
+
   """
   Identifies the percentage complete for the milestone
   """
   progressPercentage: Float!
-  
+
   """
   A list of pull requests associated with the milestone.
   """
@@ -20949,83 +20949,83 @@ type Milestone implements Closable & Node & UniformResourceLocatable {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     The base ref name to filter the pull requests by.
     """
     baseRefName: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     The head ref name to filter the pull requests by.
     """
     headRefName: String
-    
+
     """
     A list of label names to filter the pull requests by.
     """
     labels: [String!]
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for pull requests returned from the connection.
     """
     orderBy: IssueOrder
-    
+
     """
     A list of states to filter the pull requests by.
     """
     states: [PullRequestState!]
   ): PullRequestConnection!
-  
+
   """
   The repository associated with this milestone.
   """
   repository: Repository!
-  
+
   """
   The HTTP path for this milestone
   """
   resourcePath: URI!
-  
+
   """
   Identifies the state of the milestone.
   """
   state: MilestoneState!
-  
+
   """
   Identifies the title of the milestone.
   """
   title: String!
-  
+
   """
   Identifies the date and time when the object was last updated.
   """
   updatedAt: DateTime!
-  
+
   """
   The HTTP URL for this milestone
   """
   url: URI!
-  
+
   """
   Indicates if the object can be closed by the viewer.
   """
   viewerCanClose: Boolean!
-  
+
   """
   Indicates if the object can be reopened by the viewer.
   """
@@ -21040,17 +21040,17 @@ type MilestoneConnection {
   A list of edges.
   """
   edges: [MilestoneEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [Milestone]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -21065,7 +21065,7 @@ type MilestoneEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -21085,7 +21085,7 @@ input MilestoneOrder {
   The ordering direction.
   """
   direction: OrderDirection!
-  
+
   """
   The field to order milestones by.
   """
@@ -21136,18 +21136,18 @@ type MilestonedEvent implements Node {
   Identifies the actor who performed the event.
   """
   actor: Actor
-  
+
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
   id: ID!
-  
+
   """
   Identifies the milestone title associated with the 'milestoned' event.
   """
   milestoneTitle: String!
-  
+
   """
   Object referenced by event.
   """
@@ -21162,14 +21162,14 @@ interface Minimizable {
   Returns whether or not a comment has been minimized.
   """
   isMinimized: Boolean!
-  
+
   """
   Returns why the comment was minimized. One of `abuse`, `off-topic`,
   `outdated`, `resolved`, `duplicate` and `spam`. Note that the case and
   formatting of these values differs from the inputs to the `MinimizeComment` mutation.
   """
   minimizedReason: String
-  
+
   """
   Check if the current viewer can minimize this object.
   """
@@ -21184,12 +21184,12 @@ input MinimizeCommentInput {
   The classification of comment
   """
   classifier: ReportedContentClassifiers!
-  
+
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The Node ID of the subject to modify.
   """
@@ -21214,7 +21214,7 @@ type MinimizeCommentPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The comment that was minimized.
   """
@@ -21229,17 +21229,17 @@ input MoveProjectCardInput {
   Place the new card after the card with this id. Pass null to place it at the top.
   """
   afterCardId: ID @possibleTypes(concreteTypes: ["ProjectCard"])
-  
+
   """
   The id of the card to move.
   """
   cardId: ID! @possibleTypes(concreteTypes: ["ProjectCard"])
-  
+
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The id of the column to move it into.
   """
@@ -21254,7 +21254,7 @@ type MoveProjectCardPayload {
   The new edge of the moved card.
   """
   cardEdge: ProjectCardEdge
-  
+
   """
   A unique identifier for the client performing the mutation.
   """
@@ -21269,12 +21269,12 @@ input MoveProjectColumnInput {
   Place the new column after the column with this id. Pass null to place it at the front.
   """
   afterColumnId: ID @possibleTypes(concreteTypes: ["ProjectColumn"])
-  
+
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The id of the column to move.
   """
@@ -21289,7 +21289,7 @@ type MoveProjectColumnPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The new edge of the moved column.
   """
@@ -21304,33 +21304,33 @@ type MovedColumnsInProjectEvent implements Node {
   Identifies the actor who performed the event.
   """
   actor: Actor
-  
+
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
-  
+
   """
   Identifies the primary key from the database.
   """
   databaseId: Int
   id: ID!
-  
+
   """
   Column name the issue or pull request was moved from.
   """
   previousProjectColumnName: String! @preview(toggledBy: "starfox-preview")
-  
+
   """
   Project referenced by event.
   """
   project: Project @preview(toggledBy: "starfox-preview")
-  
+
   """
   Project card referenced by this project event.
   """
   projectCard: ProjectCard @preview(toggledBy: "starfox-preview")
-  
+
   """
   Column name the issue or pull request was moved to.
   """
@@ -21350,7 +21350,7 @@ type Mutation {
     """
     input: AbortQueuedMigrationsInput!
   ): AbortQueuedMigrationsPayload
-  
+
   """
   Accepts a pending invitation for a user to become an administrator of an enterprise.
   """
@@ -21360,7 +21360,7 @@ type Mutation {
     """
     input: AcceptEnterpriseAdministratorInvitationInput!
   ): AcceptEnterpriseAdministratorInvitationPayload
-  
+
   """
   Applies a suggested topic to the repository.
   """
@@ -21370,7 +21370,7 @@ type Mutation {
     """
     input: AcceptTopicSuggestionInput!
   ): AcceptTopicSuggestionPayload
-  
+
   """
   Adds assignees to an assignable object.
   """
@@ -21380,7 +21380,7 @@ type Mutation {
     """
     input: AddAssigneesToAssignableInput!
   ): AddAssigneesToAssignablePayload
-  
+
   """
   Adds a comment to an Issue or Pull Request.
   """
@@ -21390,7 +21390,7 @@ type Mutation {
     """
     input: AddCommentInput!
   ): AddCommentPayload
-  
+
   """
   Adds a comment to a Discussion, possibly as a reply to another comment.
   """
@@ -21400,7 +21400,7 @@ type Mutation {
     """
     input: AddDiscussionCommentInput!
   ): AddDiscussionCommentPayload
-  
+
   """
   Vote for an option in a discussion poll.
   """
@@ -21410,7 +21410,7 @@ type Mutation {
     """
     input: AddDiscussionPollVoteInput!
   ): AddDiscussionPollVotePayload
-  
+
   """
   Adds enterprise members to an organization within the enterprise.
   """
@@ -21420,7 +21420,7 @@ type Mutation {
     """
     input: AddEnterpriseOrganizationMemberInput!
   ): AddEnterpriseOrganizationMemberPayload
-  
+
   """
   Adds a support entitlement to an enterprise member.
   """
@@ -21430,7 +21430,7 @@ type Mutation {
     """
     input: AddEnterpriseSupportEntitlementInput!
   ): AddEnterpriseSupportEntitlementPayload
-  
+
   """
   Adds labels to a labelable object.
   """
@@ -21440,7 +21440,7 @@ type Mutation {
     """
     input: AddLabelsToLabelableInput!
   ): AddLabelsToLabelablePayload
-  
+
   """
   Adds a card to a ProjectColumn. Either `contentId` or `note` must be provided but **not** both.
   """
@@ -21450,7 +21450,7 @@ type Mutation {
     """
     input: AddProjectCardInput!
   ): AddProjectCardPayload
-  
+
   """
   Adds a column to a Project.
   """
@@ -21460,7 +21460,7 @@ type Mutation {
     """
     input: AddProjectColumnInput!
   ): AddProjectColumnPayload
-  
+
   """
   Creates a new draft issue and add it to a Project.
   """
@@ -21470,7 +21470,7 @@ type Mutation {
     """
     input: AddProjectV2DraftIssueInput!
   ): AddProjectV2DraftIssuePayload
-  
+
   """
   Links an existing content instance to a Project.
   """
@@ -21480,7 +21480,7 @@ type Mutation {
     """
     input: AddProjectV2ItemByIdInput!
   ): AddProjectV2ItemByIdPayload
-  
+
   """
   Adds a review to a Pull Request.
   """
@@ -21490,7 +21490,7 @@ type Mutation {
     """
     input: AddPullRequestReviewInput!
   ): AddPullRequestReviewPayload
-  
+
   """
   Adds a comment to a review.
   """
@@ -21500,7 +21500,7 @@ type Mutation {
     """
     input: AddPullRequestReviewCommentInput!
   ): AddPullRequestReviewCommentPayload
-  
+
   """
   Adds a new thread to a pending Pull Request Review.
   """
@@ -21510,7 +21510,7 @@ type Mutation {
     """
     input: AddPullRequestReviewThreadInput!
   ): AddPullRequestReviewThreadPayload
-  
+
   """
   Adds a reply to an existing Pull Request Review Thread.
   """
@@ -21520,7 +21520,7 @@ type Mutation {
     """
     input: AddPullRequestReviewThreadReplyInput!
   ): AddPullRequestReviewThreadReplyPayload
-  
+
   """
   Adds a reaction to a subject.
   """
@@ -21530,7 +21530,7 @@ type Mutation {
     """
     input: AddReactionInput!
   ): AddReactionPayload
-  
+
   """
   Adds a star to a Starrable.
   """
@@ -21540,7 +21540,7 @@ type Mutation {
     """
     input: AddStarInput!
   ): AddStarPayload
-  
+
   """
   Add an upvote to a discussion or discussion comment.
   """
@@ -21550,7 +21550,7 @@ type Mutation {
     """
     input: AddUpvoteInput!
   ): AddUpvotePayload
-  
+
   """
   Adds a verifiable domain to an owning account.
   """
@@ -21560,7 +21560,7 @@ type Mutation {
     """
     input: AddVerifiableDomainInput!
   ): AddVerifiableDomainPayload
-  
+
   """
   Approve all pending deployments under one or more environments
   """
@@ -21570,7 +21570,7 @@ type Mutation {
     """
     input: ApproveDeploymentsInput!
   ): ApproveDeploymentsPayload
-  
+
   """
   Approve a verifiable domain for notification delivery.
   """
@@ -21580,7 +21580,7 @@ type Mutation {
     """
     input: ApproveVerifiableDomainInput!
   ): ApproveVerifiableDomainPayload
-  
+
   """
   Archives a ProjectV2Item
   """
@@ -21590,7 +21590,7 @@ type Mutation {
     """
     input: ArchiveProjectV2ItemInput!
   ): ArchiveProjectV2ItemPayload
-  
+
   """
   Marks a repository as archived.
   """
@@ -21600,7 +21600,7 @@ type Mutation {
     """
     input: ArchiveRepositoryInput!
   ): ArchiveRepositoryPayload
-  
+
   """
   Cancels a pending invitation for an administrator to join an enterprise.
   """
@@ -21610,7 +21610,7 @@ type Mutation {
     """
     input: CancelEnterpriseAdminInvitationInput!
   ): CancelEnterpriseAdminInvitationPayload
-  
+
   """
   Cancel an active sponsorship.
   """
@@ -21620,7 +21620,7 @@ type Mutation {
     """
     input: CancelSponsorshipInput!
   ): CancelSponsorshipPayload
-  
+
   """
   Update your status on GitHub.
   """
@@ -21630,7 +21630,7 @@ type Mutation {
     """
     input: ChangeUserStatusInput!
   ): ChangeUserStatusPayload
-  
+
   """
   Clears all labels from a labelable object.
   """
@@ -21640,7 +21640,7 @@ type Mutation {
     """
     input: ClearLabelsFromLabelableInput!
   ): ClearLabelsFromLabelablePayload
-  
+
   """
   This mutation clears the value of a field for an item in a Project. Currently
   only text, number, date, assignees, labels, single-select, iteration and
@@ -21652,7 +21652,7 @@ type Mutation {
     """
     input: ClearProjectV2ItemFieldValueInput!
   ): ClearProjectV2ItemFieldValuePayload
-  
+
   """
   Creates a new project by cloning configuration from an existing project.
   """
@@ -21662,7 +21662,7 @@ type Mutation {
     """
     input: CloneProjectInput!
   ): CloneProjectPayload
-  
+
   """
   Create a new repository with the same files and directory structure as a template repository.
   """
@@ -21672,7 +21672,7 @@ type Mutation {
     """
     input: CloneTemplateRepositoryInput!
   ): CloneTemplateRepositoryPayload
-  
+
   """
   Close a discussion.
   """
@@ -21682,7 +21682,7 @@ type Mutation {
     """
     input: CloseDiscussionInput!
   ): CloseDiscussionPayload
-  
+
   """
   Close an issue.
   """
@@ -21692,7 +21692,7 @@ type Mutation {
     """
     input: CloseIssueInput!
   ): CloseIssuePayload
-  
+
   """
   Close a pull request.
   """
@@ -21702,7 +21702,7 @@ type Mutation {
     """
     input: ClosePullRequestInput!
   ): ClosePullRequestPayload
-  
+
   """
   Convert a project note card to one associated with a newly created issue.
   """
@@ -21712,7 +21712,7 @@ type Mutation {
     """
     input: ConvertProjectCardNoteToIssueInput!
   ): ConvertProjectCardNoteToIssuePayload
-  
+
   """
   Converts a pull request to draft
   """
@@ -21722,7 +21722,7 @@ type Mutation {
     """
     input: ConvertPullRequestToDraftInput!
   ): ConvertPullRequestToDraftPayload
-  
+
   """
   Copy a project.
   """
@@ -21732,7 +21732,7 @@ type Mutation {
     """
     input: CopyProjectV2Input!
   ): CopyProjectV2Payload
-  
+
   """
   Invites a user to claim reattributable data
   """
@@ -21742,7 +21742,7 @@ type Mutation {
     """
     input: CreateAttributionInvitationInput!
   ): CreateAttributionInvitationPayload
-  
+
   """
   Create a new branch protection rule
   """
@@ -21752,7 +21752,7 @@ type Mutation {
     """
     input: CreateBranchProtectionRuleInput!
   ): CreateBranchProtectionRulePayload
-  
+
   """
   Create a check run.
   """
@@ -21762,7 +21762,7 @@ type Mutation {
     """
     input: CreateCheckRunInput!
   ): CreateCheckRunPayload
-  
+
   """
   Create a check suite
   """
@@ -21772,7 +21772,7 @@ type Mutation {
     """
     input: CreateCheckSuiteInput!
   ): CreateCheckSuitePayload
-  
+
   """
   Appends a commit to the given branch as the authenticated user.
 
@@ -21823,7 +21823,7 @@ type Mutation {
     """
     input: CreateCommitOnBranchInput!
   ): CreateCommitOnBranchPayload
-  
+
   """
   Creates a new deployment event.
   """
@@ -21833,7 +21833,7 @@ type Mutation {
     """
     input: CreateDeploymentInput!
   ): CreateDeploymentPayload @preview(toggledBy: "flash-preview")
-  
+
   """
   Create a deployment status.
   """
@@ -21843,7 +21843,7 @@ type Mutation {
     """
     input: CreateDeploymentStatusInput!
   ): CreateDeploymentStatusPayload @preview(toggledBy: "flash-preview")
-  
+
   """
   Create a discussion.
   """
@@ -21853,7 +21853,7 @@ type Mutation {
     """
     input: CreateDiscussionInput!
   ): CreateDiscussionPayload
-  
+
   """
   Creates an organization as part of an enterprise account.
   """
@@ -21863,7 +21863,7 @@ type Mutation {
     """
     input: CreateEnterpriseOrganizationInput!
   ): CreateEnterpriseOrganizationPayload
-  
+
   """
   Creates an environment or simply returns it if already exists.
   """
@@ -21873,7 +21873,7 @@ type Mutation {
     """
     input: CreateEnvironmentInput!
   ): CreateEnvironmentPayload
-  
+
   """
   Creates a new IP allow list entry.
   """
@@ -21883,7 +21883,7 @@ type Mutation {
     """
     input: CreateIpAllowListEntryInput!
   ): CreateIpAllowListEntryPayload
-  
+
   """
   Creates a new issue.
   """
@@ -21893,7 +21893,7 @@ type Mutation {
     """
     input: CreateIssueInput!
   ): CreateIssuePayload
-  
+
   """
   Creates a new label.
   """
@@ -21903,7 +21903,7 @@ type Mutation {
     """
     input: CreateLabelInput!
   ): CreateLabelPayload @preview(toggledBy: "bane-preview")
-  
+
   """
   Create a branch linked to an issue.
   """
@@ -21913,7 +21913,7 @@ type Mutation {
     """
     input: CreateLinkedBranchInput!
   ): CreateLinkedBranchPayload
-  
+
   """
   Creates a GitHub Enterprise Importer (GEI) migration source.
   """
@@ -21923,7 +21923,7 @@ type Mutation {
     """
     input: CreateMigrationSourceInput!
   ): CreateMigrationSourcePayload
-  
+
   """
   Creates a new project.
   """
@@ -21933,7 +21933,7 @@ type Mutation {
     """
     input: CreateProjectInput!
   ): CreateProjectPayload
-  
+
   """
   Creates a new project.
   """
@@ -21943,7 +21943,7 @@ type Mutation {
     """
     input: CreateProjectV2Input!
   ): CreateProjectV2Payload
-  
+
   """
   Create a new project field.
   """
@@ -21953,7 +21953,7 @@ type Mutation {
     """
     input: CreateProjectV2FieldInput!
   ): CreateProjectV2FieldPayload
-  
+
   """
   Create a new pull request
   """
@@ -21963,7 +21963,7 @@ type Mutation {
     """
     input: CreatePullRequestInput!
   ): CreatePullRequestPayload
-  
+
   """
   Create a new Git Ref.
   """
@@ -21973,7 +21973,7 @@ type Mutation {
     """
     input: CreateRefInput!
   ): CreateRefPayload
-  
+
   """
   Create a new repository.
   """
@@ -21983,7 +21983,7 @@ type Mutation {
     """
     input: CreateRepositoryInput!
   ): CreateRepositoryPayload
-  
+
   """
   Create a repository ruleset
   """
@@ -21993,7 +21993,7 @@ type Mutation {
     """
     input: CreateRepositoryRulesetInput!
   ): CreateRepositoryRulesetPayload
-  
+
   """
   Create a GitHub Sponsors profile to allow others to sponsor you or your organization.
   """
@@ -22003,7 +22003,7 @@ type Mutation {
     """
     input: CreateSponsorsListingInput!
   ): CreateSponsorsListingPayload
-  
+
   """
   Create a new payment tier for your GitHub Sponsors profile.
   """
@@ -22013,7 +22013,7 @@ type Mutation {
     """
     input: CreateSponsorsTierInput!
   ): CreateSponsorsTierPayload
-  
+
   """
   Start a new sponsorship of a maintainer in GitHub Sponsors, or reactivate a past sponsorship.
   """
@@ -22023,7 +22023,7 @@ type Mutation {
     """
     input: CreateSponsorshipInput!
   ): CreateSponsorshipPayload
-  
+
   """
   Make many one-time sponsorships for different sponsorable users or
   organizations at once. Can only sponsor those who have a public GitHub
@@ -22035,7 +22035,7 @@ type Mutation {
     """
     input: CreateSponsorshipsInput!
   ): CreateSponsorshipsPayload
-  
+
   """
   Creates a new team discussion.
   """
@@ -22045,7 +22045,7 @@ type Mutation {
     """
     input: CreateTeamDiscussionInput!
   ): CreateTeamDiscussionPayload
-  
+
   """
   Creates a new team discussion comment.
   """
@@ -22055,7 +22055,7 @@ type Mutation {
     """
     input: CreateTeamDiscussionCommentInput!
   ): CreateTeamDiscussionCommentPayload
-  
+
   """
   Rejects a suggested topic for the repository.
   """
@@ -22065,7 +22065,7 @@ type Mutation {
     """
     input: DeclineTopicSuggestionInput!
   ): DeclineTopicSuggestionPayload
-  
+
   """
   Delete a branch protection rule
   """
@@ -22075,7 +22075,7 @@ type Mutation {
     """
     input: DeleteBranchProtectionRuleInput!
   ): DeleteBranchProtectionRulePayload
-  
+
   """
   Deletes a deployment.
   """
@@ -22085,7 +22085,7 @@ type Mutation {
     """
     input: DeleteDeploymentInput!
   ): DeleteDeploymentPayload
-  
+
   """
   Delete a discussion and all of its replies.
   """
@@ -22095,7 +22095,7 @@ type Mutation {
     """
     input: DeleteDiscussionInput!
   ): DeleteDiscussionPayload
-  
+
   """
   Delete a discussion comment. If it has replies, wipe it instead.
   """
@@ -22105,7 +22105,7 @@ type Mutation {
     """
     input: DeleteDiscussionCommentInput!
   ): DeleteDiscussionCommentPayload
-  
+
   """
   Deletes an environment
   """
@@ -22115,7 +22115,7 @@ type Mutation {
     """
     input: DeleteEnvironmentInput!
   ): DeleteEnvironmentPayload
-  
+
   """
   Deletes an IP allow list entry.
   """
@@ -22125,7 +22125,7 @@ type Mutation {
     """
     input: DeleteIpAllowListEntryInput!
   ): DeleteIpAllowListEntryPayload
-  
+
   """
   Deletes an Issue object.
   """
@@ -22135,7 +22135,7 @@ type Mutation {
     """
     input: DeleteIssueInput!
   ): DeleteIssuePayload
-  
+
   """
   Deletes an IssueComment object.
   """
@@ -22145,7 +22145,7 @@ type Mutation {
     """
     input: DeleteIssueCommentInput!
   ): DeleteIssueCommentPayload
-  
+
   """
   Deletes a label.
   """
@@ -22155,7 +22155,7 @@ type Mutation {
     """
     input: DeleteLabelInput!
   ): DeleteLabelPayload @preview(toggledBy: "bane-preview")
-  
+
   """
   Unlink a branch from an issue.
   """
@@ -22165,7 +22165,7 @@ type Mutation {
     """
     input: DeleteLinkedBranchInput!
   ): DeleteLinkedBranchPayload
-  
+
   """
   Delete a package version.
   """
@@ -22175,7 +22175,7 @@ type Mutation {
     """
     input: DeletePackageVersionInput!
   ): DeletePackageVersionPayload @preview(toggledBy: "package-deletes-preview")
-  
+
   """
   Deletes a project.
   """
@@ -22185,7 +22185,7 @@ type Mutation {
     """
     input: DeleteProjectInput!
   ): DeleteProjectPayload
-  
+
   """
   Deletes a project card.
   """
@@ -22195,7 +22195,7 @@ type Mutation {
     """
     input: DeleteProjectCardInput!
   ): DeleteProjectCardPayload
-  
+
   """
   Deletes a project column.
   """
@@ -22205,7 +22205,7 @@ type Mutation {
     """
     input: DeleteProjectColumnInput!
   ): DeleteProjectColumnPayload
-  
+
   """
   Delete a project.
   """
@@ -22215,7 +22215,7 @@ type Mutation {
     """
     input: DeleteProjectV2Input!
   ): DeleteProjectV2Payload
-  
+
   """
   Delete a project field.
   """
@@ -22225,7 +22225,7 @@ type Mutation {
     """
     input: DeleteProjectV2FieldInput!
   ): DeleteProjectV2FieldPayload
-  
+
   """
   Deletes an item from a Project.
   """
@@ -22235,7 +22235,7 @@ type Mutation {
     """
     input: DeleteProjectV2ItemInput!
   ): DeleteProjectV2ItemPayload
-  
+
   """
   Deletes a project workflow.
   """
@@ -22245,7 +22245,7 @@ type Mutation {
     """
     input: DeleteProjectV2WorkflowInput!
   ): DeleteProjectV2WorkflowPayload
-  
+
   """
   Deletes a pull request review.
   """
@@ -22255,7 +22255,7 @@ type Mutation {
     """
     input: DeletePullRequestReviewInput!
   ): DeletePullRequestReviewPayload
-  
+
   """
   Deletes a pull request review comment.
   """
@@ -22265,7 +22265,7 @@ type Mutation {
     """
     input: DeletePullRequestReviewCommentInput!
   ): DeletePullRequestReviewCommentPayload
-  
+
   """
   Delete a Git Ref.
   """
@@ -22275,7 +22275,7 @@ type Mutation {
     """
     input: DeleteRefInput!
   ): DeleteRefPayload
-  
+
   """
   Delete a repository ruleset
   """
@@ -22285,7 +22285,7 @@ type Mutation {
     """
     input: DeleteRepositoryRulesetInput!
   ): DeleteRepositoryRulesetPayload
-  
+
   """
   Deletes a team discussion.
   """
@@ -22295,7 +22295,7 @@ type Mutation {
     """
     input: DeleteTeamDiscussionInput!
   ): DeleteTeamDiscussionPayload
-  
+
   """
   Deletes a team discussion comment.
   """
@@ -22305,7 +22305,7 @@ type Mutation {
     """
     input: DeleteTeamDiscussionCommentInput!
   ): DeleteTeamDiscussionCommentPayload
-  
+
   """
   Deletes a verifiable domain.
   """
@@ -22315,7 +22315,7 @@ type Mutation {
     """
     input: DeleteVerifiableDomainInput!
   ): DeleteVerifiableDomainPayload
-  
+
   """
   Remove a pull request from the merge queue.
   """
@@ -22325,7 +22325,7 @@ type Mutation {
     """
     input: DequeuePullRequestInput!
   ): DequeuePullRequestPayload
-  
+
   """
   Disable auto merge on the given pull request
   """
@@ -22335,7 +22335,7 @@ type Mutation {
     """
     input: DisablePullRequestAutoMergeInput!
   ): DisablePullRequestAutoMergePayload
-  
+
   """
   Dismisses an approved or rejected pull request review.
   """
@@ -22345,7 +22345,7 @@ type Mutation {
     """
     input: DismissPullRequestReviewInput!
   ): DismissPullRequestReviewPayload
-  
+
   """
   Dismisses the Dependabot alert.
   """
@@ -22355,7 +22355,7 @@ type Mutation {
     """
     input: DismissRepositoryVulnerabilityAlertInput!
   ): DismissRepositoryVulnerabilityAlertPayload
-  
+
   """
   Enable the default auto-merge on a pull request.
   """
@@ -22365,7 +22365,7 @@ type Mutation {
     """
     input: EnablePullRequestAutoMergeInput!
   ): EnablePullRequestAutoMergePayload
-  
+
   """
   Add a pull request to the merge queue.
   """
@@ -22375,7 +22375,7 @@ type Mutation {
     """
     input: EnqueuePullRequestInput!
   ): EnqueuePullRequestPayload
-  
+
   """
   Follow an organization.
   """
@@ -22385,7 +22385,7 @@ type Mutation {
     """
     input: FollowOrganizationInput!
   ): FollowOrganizationPayload
-  
+
   """
   Follow a user.
   """
@@ -22395,7 +22395,7 @@ type Mutation {
     """
     input: FollowUserInput!
   ): FollowUserPayload
-  
+
   """
   Grant the migrator role to a user for all organizations under an enterprise account.
   """
@@ -22405,7 +22405,7 @@ type Mutation {
     """
     input: GrantEnterpriseOrganizationsMigratorRoleInput!
   ): GrantEnterpriseOrganizationsMigratorRolePayload
-  
+
   """
   Grant the migrator role to a user or a team.
   """
@@ -22415,7 +22415,7 @@ type Mutation {
     """
     input: GrantMigratorRoleInput!
   ): GrantMigratorRolePayload
-  
+
   """
   Creates a new project by importing columns and a list of issues/PRs.
   """
@@ -22425,7 +22425,7 @@ type Mutation {
     """
     input: ImportProjectInput!
   ): ImportProjectPayload @preview(toggledBy: "slothette-preview")
-  
+
   """
   Invite someone to become an administrator of the enterprise.
   """
@@ -22435,7 +22435,7 @@ type Mutation {
     """
     input: InviteEnterpriseAdminInput!
   ): InviteEnterpriseAdminPayload
-  
+
   """
   Links a project to a repository.
   """
@@ -22445,7 +22445,7 @@ type Mutation {
     """
     input: LinkProjectV2ToRepositoryInput!
   ): LinkProjectV2ToRepositoryPayload
-  
+
   """
   Links a project to a team.
   """
@@ -22455,7 +22455,7 @@ type Mutation {
     """
     input: LinkProjectV2ToTeamInput!
   ): LinkProjectV2ToTeamPayload
-  
+
   """
   Creates a repository link for a project.
   """
@@ -22465,7 +22465,7 @@ type Mutation {
     """
     input: LinkRepositoryToProjectInput!
   ): LinkRepositoryToProjectPayload
-  
+
   """
   Lock a lockable object
   """
@@ -22475,7 +22475,7 @@ type Mutation {
     """
     input: LockLockableInput!
   ): LockLockablePayload
-  
+
   """
   Mark a discussion comment as the chosen answer for discussions in an answerable category.
   """
@@ -22485,7 +22485,7 @@ type Mutation {
     """
     input: MarkDiscussionCommentAsAnswerInput!
   ): MarkDiscussionCommentAsAnswerPayload
-  
+
   """
   Mark a pull request file as viewed
   """
@@ -22495,7 +22495,7 @@ type Mutation {
     """
     input: MarkFileAsViewedInput!
   ): MarkFileAsViewedPayload
-  
+
   """
   Mark a project as a template. Note that only projects which are owned by an Organization can be marked as a template.
   """
@@ -22505,7 +22505,7 @@ type Mutation {
     """
     input: MarkProjectV2AsTemplateInput!
   ): MarkProjectV2AsTemplatePayload
-  
+
   """
   Marks a pull request ready for review.
   """
@@ -22515,7 +22515,7 @@ type Mutation {
     """
     input: MarkPullRequestReadyForReviewInput!
   ): MarkPullRequestReadyForReviewPayload
-  
+
   """
   Merge a head into a branch.
   """
@@ -22525,7 +22525,7 @@ type Mutation {
     """
     input: MergeBranchInput!
   ): MergeBranchPayload
-  
+
   """
   Merge a pull request.
   """
@@ -22535,7 +22535,7 @@ type Mutation {
     """
     input: MergePullRequestInput!
   ): MergePullRequestPayload
-  
+
   """
   Minimizes a comment on an Issue, Commit, Pull Request, or Gist
   """
@@ -22545,7 +22545,7 @@ type Mutation {
     """
     input: MinimizeCommentInput!
   ): MinimizeCommentPayload
-  
+
   """
   Moves a project card to another place.
   """
@@ -22555,7 +22555,7 @@ type Mutation {
     """
     input: MoveProjectCardInput!
   ): MoveProjectCardPayload
-  
+
   """
   Moves a project column to another place.
   """
@@ -22565,7 +22565,7 @@ type Mutation {
     """
     input: MoveProjectColumnInput!
   ): MoveProjectColumnPayload
-  
+
   """
   Pin an issue to a repository
   """
@@ -22575,7 +22575,7 @@ type Mutation {
     """
     input: PinIssueInput!
   ): PinIssuePayload
-  
+
   """
   Publish an existing sponsorship tier that is currently still a draft to a GitHub Sponsors profile.
   """
@@ -22585,7 +22585,7 @@ type Mutation {
     """
     input: PublishSponsorsTierInput!
   ): PublishSponsorsTierPayload
-  
+
   """
   Regenerates the identity provider recovery codes for an enterprise
   """
@@ -22595,7 +22595,7 @@ type Mutation {
     """
     input: RegenerateEnterpriseIdentityProviderRecoveryCodesInput!
   ): RegenerateEnterpriseIdentityProviderRecoveryCodesPayload
-  
+
   """
   Regenerates a verifiable domain's verification token.
   """
@@ -22605,7 +22605,7 @@ type Mutation {
     """
     input: RegenerateVerifiableDomainTokenInput!
   ): RegenerateVerifiableDomainTokenPayload
-  
+
   """
   Reject all pending deployments under one or more environments
   """
@@ -22615,7 +22615,7 @@ type Mutation {
     """
     input: RejectDeploymentsInput!
   ): RejectDeploymentsPayload
-  
+
   """
   Removes assignees from an assignable object.
   """
@@ -22625,7 +22625,7 @@ type Mutation {
     """
     input: RemoveAssigneesFromAssignableInput!
   ): RemoveAssigneesFromAssignablePayload
-  
+
   """
   Removes an administrator from the enterprise.
   """
@@ -22635,7 +22635,7 @@ type Mutation {
     """
     input: RemoveEnterpriseAdminInput!
   ): RemoveEnterpriseAdminPayload
-  
+
   """
   Removes the identity provider from an enterprise
   """
@@ -22645,7 +22645,7 @@ type Mutation {
     """
     input: RemoveEnterpriseIdentityProviderInput!
   ): RemoveEnterpriseIdentityProviderPayload
-  
+
   """
   Removes a user from all organizations within the enterprise
   """
@@ -22655,7 +22655,7 @@ type Mutation {
     """
     input: RemoveEnterpriseMemberInput!
   ): RemoveEnterpriseMemberPayload
-  
+
   """
   Removes an organization from the enterprise
   """
@@ -22665,7 +22665,7 @@ type Mutation {
     """
     input: RemoveEnterpriseOrganizationInput!
   ): RemoveEnterpriseOrganizationPayload
-  
+
   """
   Removes a support entitlement from an enterprise member.
   """
@@ -22675,7 +22675,7 @@ type Mutation {
     """
     input: RemoveEnterpriseSupportEntitlementInput!
   ): RemoveEnterpriseSupportEntitlementPayload
-  
+
   """
   Removes labels from a Labelable object.
   """
@@ -22685,7 +22685,7 @@ type Mutation {
     """
     input: RemoveLabelsFromLabelableInput!
   ): RemoveLabelsFromLabelablePayload
-  
+
   """
   Removes outside collaborator from all repositories in an organization.
   """
@@ -22695,7 +22695,7 @@ type Mutation {
     """
     input: RemoveOutsideCollaboratorInput!
   ): RemoveOutsideCollaboratorPayload
-  
+
   """
   Removes a reaction from a subject.
   """
@@ -22705,7 +22705,7 @@ type Mutation {
     """
     input: RemoveReactionInput!
   ): RemoveReactionPayload
-  
+
   """
   Removes a star from a Starrable.
   """
@@ -22715,7 +22715,7 @@ type Mutation {
     """
     input: RemoveStarInput!
   ): RemoveStarPayload
-  
+
   """
   Remove an upvote to a discussion or discussion comment.
   """
@@ -22725,7 +22725,7 @@ type Mutation {
     """
     input: RemoveUpvoteInput!
   ): RemoveUpvotePayload
-  
+
   """
   Reopen a discussion.
   """
@@ -22735,7 +22735,7 @@ type Mutation {
     """
     input: ReopenDiscussionInput!
   ): ReopenDiscussionPayload
-  
+
   """
   Reopen a issue.
   """
@@ -22745,7 +22745,7 @@ type Mutation {
     """
     input: ReopenIssueInput!
   ): ReopenIssuePayload
-  
+
   """
   Reopen a pull request.
   """
@@ -22755,7 +22755,7 @@ type Mutation {
     """
     input: ReopenPullRequestInput!
   ): ReopenPullRequestPayload
-  
+
   """
   Set review requests on a pull request.
   """
@@ -22765,7 +22765,7 @@ type Mutation {
     """
     input: RequestReviewsInput!
   ): RequestReviewsPayload
-  
+
   """
   Rerequests an existing check suite.
   """
@@ -22775,7 +22775,7 @@ type Mutation {
     """
     input: RerequestCheckSuiteInput!
   ): RerequestCheckSuitePayload
-  
+
   """
   Marks a review thread as resolved.
   """
@@ -22785,7 +22785,7 @@ type Mutation {
     """
     input: ResolveReviewThreadInput!
   ): ResolveReviewThreadPayload
-  
+
   """
   Retire a published payment tier from your GitHub Sponsors profile so it cannot be used to start new sponsorships.
   """
@@ -22795,7 +22795,7 @@ type Mutation {
     """
     input: RetireSponsorsTierInput!
   ): RetireSponsorsTierPayload
-  
+
   """
   Create a pull request that reverts the changes from a merged pull request.
   """
@@ -22805,7 +22805,7 @@ type Mutation {
     """
     input: RevertPullRequestInput!
   ): RevertPullRequestPayload
-  
+
   """
   Revoke the migrator role to a user for all organizations under an enterprise account.
   """
@@ -22815,7 +22815,7 @@ type Mutation {
     """
     input: RevokeEnterpriseOrganizationsMigratorRoleInput!
   ): RevokeEnterpriseOrganizationsMigratorRolePayload
-  
+
   """
   Revoke the migrator role from a user or a team.
   """
@@ -22825,7 +22825,7 @@ type Mutation {
     """
     input: RevokeMigratorRoleInput!
   ): RevokeMigratorRolePayload
-  
+
   """
   Creates or updates the identity provider for an enterprise.
   """
@@ -22835,7 +22835,7 @@ type Mutation {
     """
     input: SetEnterpriseIdentityProviderInput!
   ): SetEnterpriseIdentityProviderPayload
-  
+
   """
   Set an organization level interaction limit for an organization's public repositories.
   """
@@ -22845,7 +22845,7 @@ type Mutation {
     """
     input: SetOrganizationInteractionLimitInput!
   ): SetOrganizationInteractionLimitPayload
-  
+
   """
   Sets an interaction limit setting for a repository.
   """
@@ -22855,7 +22855,7 @@ type Mutation {
     """
     input: SetRepositoryInteractionLimitInput!
   ): SetRepositoryInteractionLimitPayload
-  
+
   """
   Set a user level interaction limit for an user's public repositories.
   """
@@ -22865,7 +22865,7 @@ type Mutation {
     """
     input: SetUserInteractionLimitInput!
   ): SetUserInteractionLimitPayload
-  
+
   """
   Starts a GitHub Enterprise Importer organization migration.
   """
@@ -22875,7 +22875,7 @@ type Mutation {
     """
     input: StartOrganizationMigrationInput!
   ): StartOrganizationMigrationPayload
-  
+
   """
   Starts a GitHub Enterprise Importer (GEI) repository migration.
   """
@@ -22885,7 +22885,7 @@ type Mutation {
     """
     input: StartRepositoryMigrationInput!
   ): StartRepositoryMigrationPayload
-  
+
   """
   Submits a pending pull request review.
   """
@@ -22895,7 +22895,7 @@ type Mutation {
     """
     input: SubmitPullRequestReviewInput!
   ): SubmitPullRequestReviewPayload
-  
+
   """
   Transfer an organization from one enterprise to another enterprise.
   """
@@ -22905,7 +22905,7 @@ type Mutation {
     """
     input: TransferEnterpriseOrganizationInput!
   ): TransferEnterpriseOrganizationPayload
-  
+
   """
   Transfer an issue to a different repository
   """
@@ -22915,7 +22915,7 @@ type Mutation {
     """
     input: TransferIssueInput!
   ): TransferIssuePayload
-  
+
   """
   Unarchives a ProjectV2Item
   """
@@ -22925,7 +22925,7 @@ type Mutation {
     """
     input: UnarchiveProjectV2ItemInput!
   ): UnarchiveProjectV2ItemPayload
-  
+
   """
   Unarchives a repository.
   """
@@ -22935,7 +22935,7 @@ type Mutation {
     """
     input: UnarchiveRepositoryInput!
   ): UnarchiveRepositoryPayload
-  
+
   """
   Unfollow an organization.
   """
@@ -22945,7 +22945,7 @@ type Mutation {
     """
     input: UnfollowOrganizationInput!
   ): UnfollowOrganizationPayload
-  
+
   """
   Unfollow a user.
   """
@@ -22955,7 +22955,7 @@ type Mutation {
     """
     input: UnfollowUserInput!
   ): UnfollowUserPayload
-  
+
   """
   Unlinks a project from a repository.
   """
@@ -22965,7 +22965,7 @@ type Mutation {
     """
     input: UnlinkProjectV2FromRepositoryInput!
   ): UnlinkProjectV2FromRepositoryPayload
-  
+
   """
   Unlinks a project to a team.
   """
@@ -22975,7 +22975,7 @@ type Mutation {
     """
     input: UnlinkProjectV2FromTeamInput!
   ): UnlinkProjectV2FromTeamPayload
-  
+
   """
   Deletes a repository link from a project.
   """
@@ -22985,7 +22985,7 @@ type Mutation {
     """
     input: UnlinkRepositoryFromProjectInput!
   ): UnlinkRepositoryFromProjectPayload
-  
+
   """
   Unlock a lockable object
   """
@@ -22995,7 +22995,7 @@ type Mutation {
     """
     input: UnlockLockableInput!
   ): UnlockLockablePayload
-  
+
   """
   Unmark a discussion comment as the chosen answer for discussions in an answerable category.
   """
@@ -23005,7 +23005,7 @@ type Mutation {
     """
     input: UnmarkDiscussionCommentAsAnswerInput!
   ): UnmarkDiscussionCommentAsAnswerPayload
-  
+
   """
   Unmark a pull request file as viewed
   """
@@ -23015,7 +23015,7 @@ type Mutation {
     """
     input: UnmarkFileAsViewedInput!
   ): UnmarkFileAsViewedPayload
-  
+
   """
   Unmark an issue as a duplicate of another issue.
   """
@@ -23025,7 +23025,7 @@ type Mutation {
     """
     input: UnmarkIssueAsDuplicateInput!
   ): UnmarkIssueAsDuplicatePayload
-  
+
   """
   Unmark a project as a template.
   """
@@ -23035,7 +23035,7 @@ type Mutation {
     """
     input: UnmarkProjectV2AsTemplateInput!
   ): UnmarkProjectV2AsTemplatePayload
-  
+
   """
   Unminimizes a comment on an Issue, Commit, Pull Request, or Gist
   """
@@ -23045,7 +23045,7 @@ type Mutation {
     """
     input: UnminimizeCommentInput!
   ): UnminimizeCommentPayload
-  
+
   """
   Unpin a pinned issue from a repository
   """
@@ -23055,7 +23055,7 @@ type Mutation {
     """
     input: UnpinIssueInput!
   ): UnpinIssuePayload
-  
+
   """
   Marks a review thread as unresolved.
   """
@@ -23065,7 +23065,7 @@ type Mutation {
     """
     input: UnresolveReviewThreadInput!
   ): UnresolveReviewThreadPayload
-  
+
   """
   Update a branch protection rule
   """
@@ -23075,7 +23075,7 @@ type Mutation {
     """
     input: UpdateBranchProtectionRuleInput!
   ): UpdateBranchProtectionRulePayload
-  
+
   """
   Update a check run
   """
@@ -23085,7 +23085,7 @@ type Mutation {
     """
     input: UpdateCheckRunInput!
   ): UpdateCheckRunPayload
-  
+
   """
   Modifies the settings of an existing check suite
   """
@@ -23095,7 +23095,7 @@ type Mutation {
     """
     input: UpdateCheckSuitePreferencesInput!
   ): UpdateCheckSuitePreferencesPayload
-  
+
   """
   Update a discussion
   """
@@ -23105,7 +23105,7 @@ type Mutation {
     """
     input: UpdateDiscussionInput!
   ): UpdateDiscussionPayload
-  
+
   """
   Update the contents of a comment on a Discussion
   """
@@ -23115,7 +23115,7 @@ type Mutation {
     """
     input: UpdateDiscussionCommentInput!
   ): UpdateDiscussionCommentPayload
-  
+
   """
   Updates the role of an enterprise administrator.
   """
@@ -23125,7 +23125,7 @@ type Mutation {
     """
     input: UpdateEnterpriseAdministratorRoleInput!
   ): UpdateEnterpriseAdministratorRolePayload
-  
+
   """
   Sets whether private repository forks are enabled for an enterprise.
   """
@@ -23135,7 +23135,7 @@ type Mutation {
     """
     input: UpdateEnterpriseAllowPrivateRepositoryForkingSettingInput!
   ): UpdateEnterpriseAllowPrivateRepositoryForkingSettingPayload
-  
+
   """
   Sets the base repository permission for organizations in an enterprise.
   """
@@ -23145,7 +23145,7 @@ type Mutation {
     """
     input: UpdateEnterpriseDefaultRepositoryPermissionSettingInput!
   ): UpdateEnterpriseDefaultRepositoryPermissionSettingPayload
-  
+
   """
   Sets whether organization members with admin permissions on a repository can change repository visibility.
   """
@@ -23155,7 +23155,7 @@ type Mutation {
     """
     input: UpdateEnterpriseMembersCanChangeRepositoryVisibilitySettingInput!
   ): UpdateEnterpriseMembersCanChangeRepositoryVisibilitySettingPayload
-  
+
   """
   Sets the members can create repositories setting for an enterprise.
   """
@@ -23165,7 +23165,7 @@ type Mutation {
     """
     input: UpdateEnterpriseMembersCanCreateRepositoriesSettingInput!
   ): UpdateEnterpriseMembersCanCreateRepositoriesSettingPayload
-  
+
   """
   Sets the members can delete issues setting for an enterprise.
   """
@@ -23175,7 +23175,7 @@ type Mutation {
     """
     input: UpdateEnterpriseMembersCanDeleteIssuesSettingInput!
   ): UpdateEnterpriseMembersCanDeleteIssuesSettingPayload
-  
+
   """
   Sets the members can delete repositories setting for an enterprise.
   """
@@ -23185,7 +23185,7 @@ type Mutation {
     """
     input: UpdateEnterpriseMembersCanDeleteRepositoriesSettingInput!
   ): UpdateEnterpriseMembersCanDeleteRepositoriesSettingPayload
-  
+
   """
   Sets whether members can invite collaborators are enabled for an enterprise.
   """
@@ -23195,7 +23195,7 @@ type Mutation {
     """
     input: UpdateEnterpriseMembersCanInviteCollaboratorsSettingInput!
   ): UpdateEnterpriseMembersCanInviteCollaboratorsSettingPayload
-  
+
   """
   Sets whether or not an organization admin can make purchases.
   """
@@ -23205,7 +23205,7 @@ type Mutation {
     """
     input: UpdateEnterpriseMembersCanMakePurchasesSettingInput!
   ): UpdateEnterpriseMembersCanMakePurchasesSettingPayload
-  
+
   """
   Sets the members can update protected branches setting for an enterprise.
   """
@@ -23215,7 +23215,7 @@ type Mutation {
     """
     input: UpdateEnterpriseMembersCanUpdateProtectedBranchesSettingInput!
   ): UpdateEnterpriseMembersCanUpdateProtectedBranchesSettingPayload
-  
+
   """
   Sets the members can view dependency insights for an enterprise.
   """
@@ -23225,7 +23225,7 @@ type Mutation {
     """
     input: UpdateEnterpriseMembersCanViewDependencyInsightsSettingInput!
   ): UpdateEnterpriseMembersCanViewDependencyInsightsSettingPayload
-  
+
   """
   Sets whether organization projects are enabled for an enterprise.
   """
@@ -23235,7 +23235,7 @@ type Mutation {
     """
     input: UpdateEnterpriseOrganizationProjectsSettingInput!
   ): UpdateEnterpriseOrganizationProjectsSettingPayload
-  
+
   """
   Updates the role of an enterprise owner with an organization.
   """
@@ -23245,7 +23245,7 @@ type Mutation {
     """
     input: UpdateEnterpriseOwnerOrganizationRoleInput!
   ): UpdateEnterpriseOwnerOrganizationRolePayload
-  
+
   """
   Updates an enterprise's profile.
   """
@@ -23255,7 +23255,7 @@ type Mutation {
     """
     input: UpdateEnterpriseProfileInput!
   ): UpdateEnterpriseProfilePayload
-  
+
   """
   Sets whether repository projects are enabled for a enterprise.
   """
@@ -23265,7 +23265,7 @@ type Mutation {
     """
     input: UpdateEnterpriseRepositoryProjectsSettingInput!
   ): UpdateEnterpriseRepositoryProjectsSettingPayload
-  
+
   """
   Sets whether team discussions are enabled for an enterprise.
   """
@@ -23275,7 +23275,7 @@ type Mutation {
     """
     input: UpdateEnterpriseTeamDiscussionsSettingInput!
   ): UpdateEnterpriseTeamDiscussionsSettingPayload
-  
+
   """
   Sets whether two factor authentication is required for all users in an enterprise.
   """
@@ -23285,7 +23285,7 @@ type Mutation {
     """
     input: UpdateEnterpriseTwoFactorAuthenticationRequiredSettingInput!
   ): UpdateEnterpriseTwoFactorAuthenticationRequiredSettingPayload
-  
+
   """
   Updates an environment.
   """
@@ -23295,7 +23295,7 @@ type Mutation {
     """
     input: UpdateEnvironmentInput!
   ): UpdateEnvironmentPayload
-  
+
   """
   Sets whether an IP allow list is enabled on an owner.
   """
@@ -23305,7 +23305,7 @@ type Mutation {
     """
     input: UpdateIpAllowListEnabledSettingInput!
   ): UpdateIpAllowListEnabledSettingPayload
-  
+
   """
   Updates an IP allow list entry.
   """
@@ -23315,7 +23315,7 @@ type Mutation {
     """
     input: UpdateIpAllowListEntryInput!
   ): UpdateIpAllowListEntryPayload
-  
+
   """
   Sets whether IP allow list configuration for installed GitHub Apps is enabled on an owner.
   """
@@ -23325,7 +23325,7 @@ type Mutation {
     """
     input: UpdateIpAllowListForInstalledAppsEnabledSettingInput!
   ): UpdateIpAllowListForInstalledAppsEnabledSettingPayload
-  
+
   """
   Updates an Issue.
   """
@@ -23335,7 +23335,7 @@ type Mutation {
     """
     input: UpdateIssueInput!
   ): UpdateIssuePayload
-  
+
   """
   Updates an IssueComment object.
   """
@@ -23345,7 +23345,7 @@ type Mutation {
     """
     input: UpdateIssueCommentInput!
   ): UpdateIssueCommentPayload
-  
+
   """
   Updates an existing label.
   """
@@ -23355,7 +23355,7 @@ type Mutation {
     """
     input: UpdateLabelInput!
   ): UpdateLabelPayload @preview(toggledBy: "bane-preview")
-  
+
   """
   Update the setting to restrict notifications to only verified or approved domains available to an owner.
   """
@@ -23365,7 +23365,7 @@ type Mutation {
     """
     input: UpdateNotificationRestrictionSettingInput!
   ): UpdateNotificationRestrictionSettingPayload
-  
+
   """
   Sets whether private repository forks are enabled for an organization.
   """
@@ -23375,7 +23375,7 @@ type Mutation {
     """
     input: UpdateOrganizationAllowPrivateRepositoryForkingSettingInput!
   ): UpdateOrganizationAllowPrivateRepositoryForkingSettingPayload
-  
+
   """
   Sets whether contributors are required to sign off on web-based commits for repositories in an organization.
   """
@@ -23385,7 +23385,7 @@ type Mutation {
     """
     input: UpdateOrganizationWebCommitSignoffSettingInput!
   ): UpdateOrganizationWebCommitSignoffSettingPayload
-  
+
   """
   Updates an existing project.
   """
@@ -23395,7 +23395,7 @@ type Mutation {
     """
     input: UpdateProjectInput!
   ): UpdateProjectPayload
-  
+
   """
   Updates an existing project card.
   """
@@ -23405,7 +23405,7 @@ type Mutation {
     """
     input: UpdateProjectCardInput!
   ): UpdateProjectCardPayload
-  
+
   """
   Updates an existing project column.
   """
@@ -23415,7 +23415,7 @@ type Mutation {
     """
     input: UpdateProjectColumnInput!
   ): UpdateProjectColumnPayload
-  
+
   """
   Updates an existing project (beta).
   """
@@ -23425,7 +23425,7 @@ type Mutation {
     """
     input: UpdateProjectV2Input!
   ): UpdateProjectV2Payload
-  
+
   """
   Update the collaborators on a team or a project
   """
@@ -23435,7 +23435,7 @@ type Mutation {
     """
     input: UpdateProjectV2CollaboratorsInput!
   ): UpdateProjectV2CollaboratorsPayload
-  
+
   """
   Updates a draft issue within a Project.
   """
@@ -23445,7 +23445,7 @@ type Mutation {
     """
     input: UpdateProjectV2DraftIssueInput!
   ): UpdateProjectV2DraftIssuePayload
-  
+
   """
   This mutation updates the value of a field for an item in a Project. Currently
   only single-select, text, number, date, and iteration fields are supported.
@@ -23456,7 +23456,7 @@ type Mutation {
     """
     input: UpdateProjectV2ItemFieldValueInput!
   ): UpdateProjectV2ItemFieldValuePayload
-  
+
   """
   This mutation updates the position of the item in the project, where the position represents the priority of an item.
   """
@@ -23466,7 +23466,7 @@ type Mutation {
     """
     input: UpdateProjectV2ItemPositionInput!
   ): UpdateProjectV2ItemPositionPayload
-  
+
   """
   Update a pull request
   """
@@ -23476,7 +23476,7 @@ type Mutation {
     """
     input: UpdatePullRequestInput!
   ): UpdatePullRequestPayload
-  
+
   """
   Merge or Rebase HEAD from upstream branch into pull request branch
   """
@@ -23486,7 +23486,7 @@ type Mutation {
     """
     input: UpdatePullRequestBranchInput!
   ): UpdatePullRequestBranchPayload
-  
+
   """
   Updates the body of a pull request review.
   """
@@ -23496,7 +23496,7 @@ type Mutation {
     """
     input: UpdatePullRequestReviewInput!
   ): UpdatePullRequestReviewPayload
-  
+
   """
   Updates a pull request review comment.
   """
@@ -23506,7 +23506,7 @@ type Mutation {
     """
     input: UpdatePullRequestReviewCommentInput!
   ): UpdatePullRequestReviewCommentPayload
-  
+
   """
   Update a Git Ref.
   """
@@ -23516,7 +23516,7 @@ type Mutation {
     """
     input: UpdateRefInput!
   ): UpdateRefPayload
-  
+
   """
   Creates, updates and/or deletes multiple refs in a repository.
 
@@ -23543,7 +23543,7 @@ type Mutation {
     """
     input: UpdateRefsInput!
   ): UpdateRefsPayload @preview(toggledBy: "update-refs-preview")
-  
+
   """
   Update information about a repository.
   """
@@ -23553,7 +23553,7 @@ type Mutation {
     """
     input: UpdateRepositoryInput!
   ): UpdateRepositoryPayload
-  
+
   """
   Update a repository ruleset
   """
@@ -23563,7 +23563,7 @@ type Mutation {
     """
     input: UpdateRepositoryRulesetInput!
   ): UpdateRepositoryRulesetPayload
-  
+
   """
   Sets whether contributors are required to sign off on web-based commits for a repository.
   """
@@ -23573,7 +23573,7 @@ type Mutation {
     """
     input: UpdateRepositoryWebCommitSignoffSettingInput!
   ): UpdateRepositoryWebCommitSignoffSettingPayload
-  
+
   """
   Change visibility of your sponsorship and opt in or out of email updates from the maintainer.
   """
@@ -23583,7 +23583,7 @@ type Mutation {
     """
     input: UpdateSponsorshipPreferencesInput!
   ): UpdateSponsorshipPreferencesPayload
-  
+
   """
   Updates the state for subscribable subjects.
   """
@@ -23593,7 +23593,7 @@ type Mutation {
     """
     input: UpdateSubscriptionInput!
   ): UpdateSubscriptionPayload
-  
+
   """
   Updates a team discussion.
   """
@@ -23603,7 +23603,7 @@ type Mutation {
     """
     input: UpdateTeamDiscussionInput!
   ): UpdateTeamDiscussionPayload
-  
+
   """
   Updates a discussion comment.
   """
@@ -23613,7 +23613,7 @@ type Mutation {
     """
     input: UpdateTeamDiscussionCommentInput!
   ): UpdateTeamDiscussionCommentPayload
-  
+
   """
   Updates team review assignment.
   """
@@ -23622,8 +23622,9 @@ type Mutation {
     Parameters for UpdateTeamReviewAssignment
     """
     input: UpdateTeamReviewAssignmentInput!
-  ): UpdateTeamReviewAssignmentPayload @preview(toggledBy: "stone-crop-preview")
-  
+  ): UpdateTeamReviewAssignmentPayload
+    @preview(toggledBy: "stone-crop-preview")
+
   """
   Update team repository.
   """
@@ -23633,7 +23634,7 @@ type Mutation {
     """
     input: UpdateTeamsRepositoryInput!
   ): UpdateTeamsRepositoryPayload
-  
+
   """
   Replaces the repository's topics with the given topics.
   """
@@ -23643,7 +23644,7 @@ type Mutation {
     """
     input: UpdateTopicsInput!
   ): UpdateTopicsPayload
-  
+
   """
   Verify that a verifiable domain has the expected DNS record.
   """
@@ -23689,7 +23690,7 @@ type OIDCProvider implements Node {
   The enterprise this identity provider belongs to.
   """
   enterprise: Enterprise
-  
+
   """
   ExternalIdentities provisioned by this identity provider.
   """
@@ -23698,44 +23699,44 @@ type OIDCProvider implements Node {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Filter to external identities with the users login
     """
     login: String
-    
+
     """
     Filter to external identities with valid org membership only
     """
     membersOnly: Boolean
-    
+
     """
     Filter to external identities with the users userName/NameID attribute
     """
     userName: String
   ): ExternalIdentityConnection!
   id: ID!
-  
+
   """
   The OIDC identity provider type
   """
   providerType: OIDCProviderType!
-  
+
   """
   The id of the tenant this provider is attached to
   """
@@ -23760,12 +23761,12 @@ interface OauthApplicationAuditEntryData {
   The name of the OAuth application.
   """
   oauthApplicationName: String
-  
+
   """
   The HTTP path for the OAuth application
   """
   oauthApplicationResourcePath: URI
-  
+
   """
   The HTTP URL for the OAuth application
   """
@@ -23780,118 +23781,118 @@ type OauthApplicationCreateAuditEntry implements AuditEntry & Node & OauthApplic
   The action name
   """
   action: String!
-  
+
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
-  
+
   """
   The IP address of the actor
   """
   actorIp: String
-  
+
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
-  
+
   """
   The username of the user who initiated the action
   """
   actorLogin: String
-  
+
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
-  
+
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
-  
+
   """
   The application URL of the OAuth application.
   """
   applicationUrl: URI
-  
+
   """
   The callback URL of the OAuth application.
   """
   callbackUrl: URI
-  
+
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
   id: ID!
-  
+
   """
   The name of the OAuth application.
   """
   oauthApplicationName: String
-  
+
   """
   The HTTP path for the OAuth application
   """
   oauthApplicationResourcePath: URI
-  
+
   """
   The HTTP URL for the OAuth application
   """
   oauthApplicationUrl: URI
-  
+
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
-  
+
   """
   The Organization associated with the Audit Entry.
   """
   organization: Organization
-  
+
   """
   The name of the Organization.
   """
   organizationName: String
-  
+
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
-  
+
   """
   The HTTP URL for the organization
   """
   organizationUrl: URI
-  
+
   """
   The rate limit of the OAuth application.
   """
   rateLimit: Int
-  
+
   """
   The state of the OAuth application.
   """
   state: OauthApplicationCreateAuditEntryState
-  
+
   """
   The user affected by the action
   """
   user: User
-  
+
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
-  
+
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
-  
+
   """
   The HTTP URL for the user.
   """
@@ -23972,88 +23973,88 @@ type OrgAddBillingManagerAuditEntry implements AuditEntry & Node & OrganizationA
   The action name
   """
   action: String!
-  
+
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
-  
+
   """
   The IP address of the actor
   """
   actorIp: String
-  
+
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
-  
+
   """
   The username of the user who initiated the action
   """
   actorLogin: String
-  
+
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
-  
+
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
-  
+
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
   id: ID!
-  
+
   """
   The email address used to invite a billing manager for the organization.
   """
   invitationEmail: String
-  
+
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
-  
+
   """
   The Organization associated with the Audit Entry.
   """
   organization: Organization
-  
+
   """
   The name of the Organization.
   """
   organizationName: String
-  
+
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
-  
+
   """
   The HTTP URL for the organization
   """
   organizationUrl: URI
-  
+
   """
   The user affected by the action
   """
   user: User
-  
+
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
-  
+
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
-  
+
   """
   The HTTP URL for the user.
   """
@@ -24068,88 +24069,88 @@ type OrgAddMemberAuditEntry implements AuditEntry & Node & OrganizationAuditEntr
   The action name
   """
   action: String!
-  
+
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
-  
+
   """
   The IP address of the actor
   """
   actorIp: String
-  
+
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
-  
+
   """
   The username of the user who initiated the action
   """
   actorLogin: String
-  
+
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
-  
+
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
-  
+
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
   id: ID!
-  
+
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
-  
+
   """
   The Organization associated with the Audit Entry.
   """
   organization: Organization
-  
+
   """
   The name of the Organization.
   """
   organizationName: String
-  
+
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
-  
+
   """
   The HTTP URL for the organization
   """
   organizationUrl: URI
-  
+
   """
   The permission level of the member added to the organization.
   """
   permission: OrgAddMemberAuditEntryPermission
-  
+
   """
   The user affected by the action
   """
   user: User
-  
+
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
-  
+
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
-  
+
   """
   The HTTP URL for the user.
   """
@@ -24178,103 +24179,103 @@ type OrgBlockUserAuditEntry implements AuditEntry & Node & OrganizationAuditEntr
   The action name
   """
   action: String!
-  
+
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
-  
+
   """
   The IP address of the actor
   """
   actorIp: String
-  
+
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
-  
+
   """
   The username of the user who initiated the action
   """
   actorLogin: String
-  
+
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
-  
+
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
-  
+
   """
   The blocked user.
   """
   blockedUser: User
-  
+
   """
   The username of the blocked user.
   """
   blockedUserName: String
-  
+
   """
   The HTTP path for the blocked user.
   """
   blockedUserResourcePath: URI
-  
+
   """
   The HTTP URL for the blocked user.
   """
   blockedUserUrl: URI
-  
+
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
   id: ID!
-  
+
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
-  
+
   """
   The Organization associated with the Audit Entry.
   """
   organization: Organization
-  
+
   """
   The name of the Organization.
   """
   organizationName: String
-  
+
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
-  
+
   """
   The HTTP URL for the organization
   """
   organizationUrl: URI
-  
+
   """
   The user affected by the action
   """
   user: User
-  
+
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
-  
+
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
-  
+
   """
   The HTTP URL for the user.
   """
@@ -24289,83 +24290,83 @@ type OrgConfigDisableCollaboratorsOnlyAuditEntry implements AuditEntry & Node & 
   The action name
   """
   action: String!
-  
+
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
-  
+
   """
   The IP address of the actor
   """
   actorIp: String
-  
+
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
-  
+
   """
   The username of the user who initiated the action
   """
   actorLogin: String
-  
+
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
-  
+
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
-  
+
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
   id: ID!
-  
+
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
-  
+
   """
   The Organization associated with the Audit Entry.
   """
   organization: Organization
-  
+
   """
   The name of the Organization.
   """
   organizationName: String
-  
+
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
-  
+
   """
   The HTTP URL for the organization
   """
   organizationUrl: URI
-  
+
   """
   The user affected by the action
   """
   user: User
-  
+
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
-  
+
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
-  
+
   """
   The HTTP URL for the user.
   """
@@ -24380,83 +24381,83 @@ type OrgConfigEnableCollaboratorsOnlyAuditEntry implements AuditEntry & Node & O
   The action name
   """
   action: String!
-  
+
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
-  
+
   """
   The IP address of the actor
   """
   actorIp: String
-  
+
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
-  
+
   """
   The username of the user who initiated the action
   """
   actorLogin: String
-  
+
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
-  
+
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
-  
+
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
   id: ID!
-  
+
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
-  
+
   """
   The Organization associated with the Audit Entry.
   """
   organization: Organization
-  
+
   """
   The name of the Organization.
   """
   organizationName: String
-  
+
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
-  
+
   """
   The HTTP URL for the organization
   """
   organizationUrl: URI
-  
+
   """
   The user affected by the action
   """
   user: User
-  
+
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
-  
+
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
-  
+
   """
   The HTTP URL for the user.
   """
@@ -24471,88 +24472,88 @@ type OrgCreateAuditEntry implements AuditEntry & Node & OrganizationAuditEntryDa
   The action name
   """
   action: String!
-  
+
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
-  
+
   """
   The IP address of the actor
   """
   actorIp: String
-  
+
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
-  
+
   """
   The username of the user who initiated the action
   """
   actorLogin: String
-  
+
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
-  
+
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
-  
+
   """
   The billing plan for the Organization.
   """
   billingPlan: OrgCreateAuditEntryBillingPlan
-  
+
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
   id: ID!
-  
+
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
-  
+
   """
   The Organization associated with the Audit Entry.
   """
   organization: Organization
-  
+
   """
   The name of the Organization.
   """
   organizationName: String
-  
+
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
-  
+
   """
   The HTTP URL for the organization
   """
   organizationUrl: URI
-  
+
   """
   The user affected by the action
   """
   user: User
-  
+
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
-  
+
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
-  
+
   """
   The HTTP URL for the user.
   """
@@ -24593,83 +24594,83 @@ type OrgDisableOauthAppRestrictionsAuditEntry implements AuditEntry & Node & Org
   The action name
   """
   action: String!
-  
+
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
-  
+
   """
   The IP address of the actor
   """
   actorIp: String
-  
+
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
-  
+
   """
   The username of the user who initiated the action
   """
   actorLogin: String
-  
+
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
-  
+
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
-  
+
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
   id: ID!
-  
+
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
-  
+
   """
   The Organization associated with the Audit Entry.
   """
   organization: Organization
-  
+
   """
   The name of the Organization.
   """
   organizationName: String
-  
+
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
-  
+
   """
   The HTTP URL for the organization
   """
   organizationUrl: URI
-  
+
   """
   The user affected by the action
   """
   user: User
-  
+
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
-  
+
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
-  
+
   """
   The HTTP URL for the user.
   """
@@ -24684,103 +24685,103 @@ type OrgDisableSamlAuditEntry implements AuditEntry & Node & OrganizationAuditEn
   The action name
   """
   action: String!
-  
+
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
-  
+
   """
   The IP address of the actor
   """
   actorIp: String
-  
+
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
-  
+
   """
   The username of the user who initiated the action
   """
   actorLogin: String
-  
+
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
-  
+
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
-  
+
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
-  
+
   """
   The SAML provider's digest algorithm URL.
   """
   digestMethodUrl: URI
   id: ID!
-  
+
   """
   The SAML provider's issuer URL.
   """
   issuerUrl: URI
-  
+
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
-  
+
   """
   The Organization associated with the Audit Entry.
   """
   organization: Organization
-  
+
   """
   The name of the Organization.
   """
   organizationName: String
-  
+
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
-  
+
   """
   The HTTP URL for the organization
   """
   organizationUrl: URI
-  
+
   """
   The SAML provider's signature algorithm URL.
   """
   signatureMethodUrl: URI
-  
+
   """
   The SAML provider's single sign-on URL.
   """
   singleSignOnUrl: URI
-  
+
   """
   The user affected by the action
   """
   user: User
-  
+
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
-  
+
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
-  
+
   """
   The HTTP URL for the user.
   """
@@ -24795,83 +24796,83 @@ type OrgDisableTwoFactorRequirementAuditEntry implements AuditEntry & Node & Org
   The action name
   """
   action: String!
-  
+
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
-  
+
   """
   The IP address of the actor
   """
   actorIp: String
-  
+
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
-  
+
   """
   The username of the user who initiated the action
   """
   actorLogin: String
-  
+
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
-  
+
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
-  
+
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
   id: ID!
-  
+
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
-  
+
   """
   The Organization associated with the Audit Entry.
   """
   organization: Organization
-  
+
   """
   The name of the Organization.
   """
   organizationName: String
-  
+
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
-  
+
   """
   The HTTP URL for the organization
   """
   organizationUrl: URI
-  
+
   """
   The user affected by the action
   """
   user: User
-  
+
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
-  
+
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
-  
+
   """
   The HTTP URL for the user.
   """
@@ -24886,83 +24887,83 @@ type OrgEnableOauthAppRestrictionsAuditEntry implements AuditEntry & Node & Orga
   The action name
   """
   action: String!
-  
+
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
-  
+
   """
   The IP address of the actor
   """
   actorIp: String
-  
+
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
-  
+
   """
   The username of the user who initiated the action
   """
   actorLogin: String
-  
+
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
-  
+
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
-  
+
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
   id: ID!
-  
+
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
-  
+
   """
   The Organization associated with the Audit Entry.
   """
   organization: Organization
-  
+
   """
   The name of the Organization.
   """
   organizationName: String
-  
+
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
-  
+
   """
   The HTTP URL for the organization
   """
   organizationUrl: URI
-  
+
   """
   The user affected by the action
   """
   user: User
-  
+
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
-  
+
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
-  
+
   """
   The HTTP URL for the user.
   """
@@ -24977,103 +24978,103 @@ type OrgEnableSamlAuditEntry implements AuditEntry & Node & OrganizationAuditEnt
   The action name
   """
   action: String!
-  
+
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
-  
+
   """
   The IP address of the actor
   """
   actorIp: String
-  
+
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
-  
+
   """
   The username of the user who initiated the action
   """
   actorLogin: String
-  
+
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
-  
+
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
-  
+
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
-  
+
   """
   The SAML provider's digest algorithm URL.
   """
   digestMethodUrl: URI
   id: ID!
-  
+
   """
   The SAML provider's issuer URL.
   """
   issuerUrl: URI
-  
+
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
-  
+
   """
   The Organization associated with the Audit Entry.
   """
   organization: Organization
-  
+
   """
   The name of the Organization.
   """
   organizationName: String
-  
+
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
-  
+
   """
   The HTTP URL for the organization
   """
   organizationUrl: URI
-  
+
   """
   The SAML provider's signature algorithm URL.
   """
   signatureMethodUrl: URI
-  
+
   """
   The SAML provider's single sign-on URL.
   """
   singleSignOnUrl: URI
-  
+
   """
   The user affected by the action
   """
   user: User
-  
+
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
-  
+
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
-  
+
   """
   The HTTP URL for the user.
   """
@@ -25088,83 +25089,83 @@ type OrgEnableTwoFactorRequirementAuditEntry implements AuditEntry & Node & Orga
   The action name
   """
   action: String!
-  
+
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
-  
+
   """
   The IP address of the actor
   """
   actorIp: String
-  
+
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
-  
+
   """
   The username of the user who initiated the action
   """
   actorLogin: String
-  
+
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
-  
+
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
-  
+
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
   id: ID!
-  
+
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
-  
+
   """
   The Organization associated with the Audit Entry.
   """
   organization: Organization
-  
+
   """
   The name of the Organization.
   """
   organizationName: String
-  
+
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
-  
+
   """
   The HTTP URL for the organization
   """
   organizationUrl: URI
-  
+
   """
   The user affected by the action
   """
   user: User
-  
+
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
-  
+
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
-  
+
   """
   The HTTP URL for the user.
   """
@@ -25179,7 +25180,7 @@ input OrgEnterpriseOwnerOrder {
   The ordering direction.
   """
   direction: OrderDirection!
-  
+
   """
   The field to order enterprise owners by.
   """
@@ -25204,93 +25205,93 @@ type OrgInviteMemberAuditEntry implements AuditEntry & Node & OrganizationAuditE
   The action name
   """
   action: String!
-  
+
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
-  
+
   """
   The IP address of the actor
   """
   actorIp: String
-  
+
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
-  
+
   """
   The username of the user who initiated the action
   """
   actorLogin: String
-  
+
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
-  
+
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
-  
+
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
-  
+
   """
   The email address of the organization invitation.
   """
   email: String
   id: ID!
-  
+
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
-  
+
   """
   The Organization associated with the Audit Entry.
   """
   organization: Organization
-  
+
   """
   The organization invitation.
   """
   organizationInvitation: OrganizationInvitation
-  
+
   """
   The name of the Organization.
   """
   organizationName: String
-  
+
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
-  
+
   """
   The HTTP URL for the organization
   """
   organizationUrl: URI
-  
+
   """
   The user affected by the action
   """
   user: User
-  
+
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
-  
+
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
-  
+
   """
   The HTTP URL for the user.
   """
@@ -25305,98 +25306,98 @@ type OrgInviteToBusinessAuditEntry implements AuditEntry & EnterpriseAuditEntryD
   The action name
   """
   action: String!
-  
+
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
-  
+
   """
   The IP address of the actor
   """
   actorIp: String
-  
+
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
-  
+
   """
   The username of the user who initiated the action
   """
   actorLogin: String
-  
+
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
-  
+
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
-  
+
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
-  
+
   """
   The HTTP path for this enterprise.
   """
   enterpriseResourcePath: URI
-  
+
   """
   The slug of the enterprise.
   """
   enterpriseSlug: String
-  
+
   """
   The HTTP URL for this enterprise.
   """
   enterpriseUrl: URI
   id: ID!
-  
+
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
-  
+
   """
   The Organization associated with the Audit Entry.
   """
   organization: Organization
-  
+
   """
   The name of the Organization.
   """
   organizationName: String
-  
+
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
-  
+
   """
   The HTTP URL for the organization
   """
   organizationUrl: URI
-  
+
   """
   The user affected by the action
   """
   user: User
-  
+
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
-  
+
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
-  
+
   """
   The HTTP URL for the user.
   """
@@ -25411,98 +25412,98 @@ type OrgOauthAppAccessApprovedAuditEntry implements AuditEntry & Node & OauthApp
   The action name
   """
   action: String!
-  
+
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
-  
+
   """
   The IP address of the actor
   """
   actorIp: String
-  
+
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
-  
+
   """
   The username of the user who initiated the action
   """
   actorLogin: String
-  
+
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
-  
+
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
-  
+
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
   id: ID!
-  
+
   """
   The name of the OAuth application.
   """
   oauthApplicationName: String
-  
+
   """
   The HTTP path for the OAuth application
   """
   oauthApplicationResourcePath: URI
-  
+
   """
   The HTTP URL for the OAuth application
   """
   oauthApplicationUrl: URI
-  
+
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
-  
+
   """
   The Organization associated with the Audit Entry.
   """
   organization: Organization
-  
+
   """
   The name of the Organization.
   """
   organizationName: String
-  
+
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
-  
+
   """
   The HTTP URL for the organization
   """
   organizationUrl: URI
-  
+
   """
   The user affected by the action
   """
   user: User
-  
+
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
-  
+
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
-  
+
   """
   The HTTP URL for the user.
   """
@@ -25517,98 +25518,98 @@ type OrgOauthAppAccessBlockedAuditEntry implements AuditEntry & Node & OauthAppl
   The action name
   """
   action: String!
-  
+
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
-  
+
   """
   The IP address of the actor
   """
   actorIp: String
-  
+
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
-  
+
   """
   The username of the user who initiated the action
   """
   actorLogin: String
-  
+
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
-  
+
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
-  
+
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
   id: ID!
-  
+
   """
   The name of the OAuth application.
   """
   oauthApplicationName: String
-  
+
   """
   The HTTP path for the OAuth application
   """
   oauthApplicationResourcePath: URI
-  
+
   """
   The HTTP URL for the OAuth application
   """
   oauthApplicationUrl: URI
-  
+
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
-  
+
   """
   The Organization associated with the Audit Entry.
   """
   organization: Organization
-  
+
   """
   The name of the Organization.
   """
   organizationName: String
-  
+
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
-  
+
   """
   The HTTP URL for the organization
   """
   organizationUrl: URI
-  
+
   """
   The user affected by the action
   """
   user: User
-  
+
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
-  
+
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
-  
+
   """
   The HTTP URL for the user.
   """
@@ -25623,98 +25624,98 @@ type OrgOauthAppAccessDeniedAuditEntry implements AuditEntry & Node & OauthAppli
   The action name
   """
   action: String!
-  
+
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
-  
+
   """
   The IP address of the actor
   """
   actorIp: String
-  
+
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
-  
+
   """
   The username of the user who initiated the action
   """
   actorLogin: String
-  
+
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
-  
+
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
-  
+
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
   id: ID!
-  
+
   """
   The name of the OAuth application.
   """
   oauthApplicationName: String
-  
+
   """
   The HTTP path for the OAuth application
   """
   oauthApplicationResourcePath: URI
-  
+
   """
   The HTTP URL for the OAuth application
   """
   oauthApplicationUrl: URI
-  
+
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
-  
+
   """
   The Organization associated with the Audit Entry.
   """
   organization: Organization
-  
+
   """
   The name of the Organization.
   """
   organizationName: String
-  
+
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
-  
+
   """
   The HTTP URL for the organization
   """
   organizationUrl: URI
-  
+
   """
   The user affected by the action
   """
   user: User
-  
+
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
-  
+
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
-  
+
   """
   The HTTP URL for the user.
   """
@@ -25729,98 +25730,98 @@ type OrgOauthAppAccessRequestedAuditEntry implements AuditEntry & Node & OauthAp
   The action name
   """
   action: String!
-  
+
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
-  
+
   """
   The IP address of the actor
   """
   actorIp: String
-  
+
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
-  
+
   """
   The username of the user who initiated the action
   """
   actorLogin: String
-  
+
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
-  
+
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
-  
+
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
   id: ID!
-  
+
   """
   The name of the OAuth application.
   """
   oauthApplicationName: String
-  
+
   """
   The HTTP path for the OAuth application
   """
   oauthApplicationResourcePath: URI
-  
+
   """
   The HTTP URL for the OAuth application
   """
   oauthApplicationUrl: URI
-  
+
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
-  
+
   """
   The Organization associated with the Audit Entry.
   """
   organization: Organization
-  
+
   """
   The name of the Organization.
   """
   organizationName: String
-  
+
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
-  
+
   """
   The HTTP URL for the organization
   """
   organizationUrl: URI
-  
+
   """
   The user affected by the action
   """
   user: User
-  
+
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
-  
+
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
-  
+
   """
   The HTTP URL for the user.
   """
@@ -25835,98 +25836,98 @@ type OrgOauthAppAccessUnblockedAuditEntry implements AuditEntry & Node & OauthAp
   The action name
   """
   action: String!
-  
+
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
-  
+
   """
   The IP address of the actor
   """
   actorIp: String
-  
+
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
-  
+
   """
   The username of the user who initiated the action
   """
   actorLogin: String
-  
+
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
-  
+
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
-  
+
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
   id: ID!
-  
+
   """
   The name of the OAuth application.
   """
   oauthApplicationName: String
-  
+
   """
   The HTTP path for the OAuth application
   """
   oauthApplicationResourcePath: URI
-  
+
   """
   The HTTP URL for the OAuth application
   """
   oauthApplicationUrl: URI
-  
+
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
-  
+
   """
   The Organization associated with the Audit Entry.
   """
   organization: Organization
-  
+
   """
   The name of the Organization.
   """
   organizationName: String
-  
+
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
-  
+
   """
   The HTTP URL for the organization
   """
   organizationUrl: URI
-  
+
   """
   The user affected by the action
   """
   user: User
-  
+
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
-  
+
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
-  
+
   """
   The HTTP URL for the user.
   """
@@ -25941,88 +25942,88 @@ type OrgRemoveBillingManagerAuditEntry implements AuditEntry & Node & Organizati
   The action name
   """
   action: String!
-  
+
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
-  
+
   """
   The IP address of the actor
   """
   actorIp: String
-  
+
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
-  
+
   """
   The username of the user who initiated the action
   """
   actorLogin: String
-  
+
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
-  
+
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
-  
+
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
   id: ID!
-  
+
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
-  
+
   """
   The Organization associated with the Audit Entry.
   """
   organization: Organization
-  
+
   """
   The name of the Organization.
   """
   organizationName: String
-  
+
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
-  
+
   """
   The HTTP URL for the organization
   """
   organizationUrl: URI
-  
+
   """
   The reason for the billing manager being removed.
   """
   reason: OrgRemoveBillingManagerAuditEntryReason
-  
+
   """
   The user affected by the action
   """
   user: User
-  
+
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
-  
+
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
-  
+
   """
   The HTTP URL for the user.
   """
@@ -26055,93 +26056,93 @@ type OrgRemoveMemberAuditEntry implements AuditEntry & Node & OrganizationAuditE
   The action name
   """
   action: String!
-  
+
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
-  
+
   """
   The IP address of the actor
   """
   actorIp: String
-  
+
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
-  
+
   """
   The username of the user who initiated the action
   """
   actorLogin: String
-  
+
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
-  
+
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
-  
+
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
   id: ID!
-  
+
   """
   The types of membership the member has with the organization.
   """
   membershipTypes: [OrgRemoveMemberAuditEntryMembershipType!]
-  
+
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
-  
+
   """
   The Organization associated with the Audit Entry.
   """
   organization: Organization
-  
+
   """
   The name of the Organization.
   """
   organizationName: String
-  
+
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
-  
+
   """
   The HTTP URL for the organization
   """
   organizationUrl: URI
-  
+
   """
   The reason for the member being removed.
   """
   reason: OrgRemoveMemberAuditEntryReason
-  
+
   """
   The user affected by the action
   """
   user: User
-  
+
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
-  
+
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
-  
+
   """
   The HTTP URL for the user.
   """
@@ -26218,93 +26219,93 @@ type OrgRemoveOutsideCollaboratorAuditEntry implements AuditEntry & Node & Organ
   The action name
   """
   action: String!
-  
+
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
-  
+
   """
   The IP address of the actor
   """
   actorIp: String
-  
+
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
-  
+
   """
   The username of the user who initiated the action
   """
   actorLogin: String
-  
+
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
-  
+
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
-  
+
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
   id: ID!
-  
+
   """
   The types of membership the outside collaborator has with the organization.
   """
   membershipTypes: [OrgRemoveOutsideCollaboratorAuditEntryMembershipType!]
-  
+
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
-  
+
   """
   The Organization associated with the Audit Entry.
   """
   organization: Organization
-  
+
   """
   The name of the Organization.
   """
   organizationName: String
-  
+
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
-  
+
   """
   The HTTP URL for the organization
   """
   organizationUrl: URI
-  
+
   """
   The reason for the outside collaborator being removed from the Organization.
   """
   reason: OrgRemoveOutsideCollaboratorAuditEntryReason
-  
+
   """
   The user affected by the action
   """
   user: User
-  
+
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
-  
+
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
-  
+
   """
   The HTTP URL for the user.
   """
@@ -26354,118 +26355,118 @@ type OrgRestoreMemberAuditEntry implements AuditEntry & Node & OrganizationAudit
   The action name
   """
   action: String!
-  
+
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
-  
+
   """
   The IP address of the actor
   """
   actorIp: String
-  
+
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
-  
+
   """
   The username of the user who initiated the action
   """
   actorLogin: String
-  
+
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
-  
+
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
-  
+
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
   id: ID!
-  
+
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
-  
+
   """
   The Organization associated with the Audit Entry.
   """
   organization: Organization
-  
+
   """
   The name of the Organization.
   """
   organizationName: String
-  
+
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
-  
+
   """
   The HTTP URL for the organization
   """
   organizationUrl: URI
-  
+
   """
   The number of custom email routings for the restored member.
   """
   restoredCustomEmailRoutingsCount: Int
-  
+
   """
   The number of issue assignments for the restored member.
   """
   restoredIssueAssignmentsCount: Int
-  
+
   """
   Restored organization membership objects.
   """
   restoredMemberships: [OrgRestoreMemberAuditEntryMembership!]
-  
+
   """
   The number of restored memberships.
   """
   restoredMembershipsCount: Int
-  
+
   """
   The number of repositories of the restored member.
   """
   restoredRepositoriesCount: Int
-  
+
   """
   The number of starred repositories for the restored member.
   """
   restoredRepositoryStarsCount: Int
-  
+
   """
   The number of watched repositories for the restored member.
   """
   restoredRepositoryWatchesCount: Int
-  
+
   """
   The user affected by the action
   """
   user: User
-  
+
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
-  
+
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
-  
+
   """
   The HTTP URL for the user.
   """
@@ -26487,17 +26488,17 @@ type OrgRestoreMemberMembershipOrganizationAuditEntryData implements Organizatio
   The Organization associated with the Audit Entry.
   """
   organization: Organization
-  
+
   """
   The name of the Organization.
   """
   organizationName: String
-  
+
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
-  
+
   """
   The HTTP URL for the organization
   """
@@ -26512,17 +26513,17 @@ type OrgRestoreMemberMembershipRepositoryAuditEntryData implements RepositoryAud
   The repository associated with the action
   """
   repository: Repository
-  
+
   """
   The name of the repository
   """
   repositoryName: String
-  
+
   """
   The HTTP path for the repository
   """
   repositoryResourcePath: URI
-  
+
   """
   The HTTP URL for the repository
   """
@@ -26537,17 +26538,17 @@ type OrgRestoreMemberMembershipTeamAuditEntryData implements TeamAuditEntryData 
   The team associated with the action
   """
   team: Team
-  
+
   """
   The name of the team
   """
   teamName: String
-  
+
   """
   The HTTP path for this team
   """
   teamResourcePath: URI
-  
+
   """
   The HTTP URL for this team
   """
@@ -26562,103 +26563,103 @@ type OrgUnblockUserAuditEntry implements AuditEntry & Node & OrganizationAuditEn
   The action name
   """
   action: String!
-  
+
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
-  
+
   """
   The IP address of the actor
   """
   actorIp: String
-  
+
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
-  
+
   """
   The username of the user who initiated the action
   """
   actorLogin: String
-  
+
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
-  
+
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
-  
+
   """
   The user being unblocked by the organization.
   """
   blockedUser: User
-  
+
   """
   The username of the blocked user.
   """
   blockedUserName: String
-  
+
   """
   The HTTP path for the blocked user.
   """
   blockedUserResourcePath: URI
-  
+
   """
   The HTTP URL for the blocked user.
   """
   blockedUserUrl: URI
-  
+
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
   id: ID!
-  
+
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
-  
+
   """
   The Organization associated with the Audit Entry.
   """
   organization: Organization
-  
+
   """
   The name of the Organization.
   """
   organizationName: String
-  
+
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
-  
+
   """
   The HTTP URL for the organization
   """
   organizationUrl: URI
-  
+
   """
   The user affected by the action
   """
   user: User
-  
+
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
-  
+
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
-  
+
   """
   The HTTP URL for the user.
   """
@@ -26673,93 +26674,93 @@ type OrgUpdateDefaultRepositoryPermissionAuditEntry implements AuditEntry & Node
   The action name
   """
   action: String!
-  
+
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
-  
+
   """
   The IP address of the actor
   """
   actorIp: String
-  
+
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
-  
+
   """
   The username of the user who initiated the action
   """
   actorLogin: String
-  
+
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
-  
+
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
-  
+
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
   id: ID!
-  
+
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
-  
+
   """
   The Organization associated with the Audit Entry.
   """
   organization: Organization
-  
+
   """
   The name of the Organization.
   """
   organizationName: String
-  
+
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
-  
+
   """
   The HTTP URL for the organization
   """
   organizationUrl: URI
-  
+
   """
   The new base repository permission level for the organization.
   """
   permission: OrgUpdateDefaultRepositoryPermissionAuditEntryPermission
-  
+
   """
   The former base repository permission level for the organization.
   """
   permissionWas: OrgUpdateDefaultRepositoryPermissionAuditEntryPermission
-  
+
   """
   The user affected by the action
   """
   user: User
-  
+
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
-  
+
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
-  
+
   """
   The HTTP URL for the user.
   """
@@ -26796,93 +26797,93 @@ type OrgUpdateMemberAuditEntry implements AuditEntry & Node & OrganizationAuditE
   The action name
   """
   action: String!
-  
+
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
-  
+
   """
   The IP address of the actor
   """
   actorIp: String
-  
+
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
-  
+
   """
   The username of the user who initiated the action
   """
   actorLogin: String
-  
+
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
-  
+
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
-  
+
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
   id: ID!
-  
+
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
-  
+
   """
   The Organization associated with the Audit Entry.
   """
   organization: Organization
-  
+
   """
   The name of the Organization.
   """
   organizationName: String
-  
+
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
-  
+
   """
   The HTTP URL for the organization
   """
   organizationUrl: URI
-  
+
   """
   The new member permission level for the organization.
   """
   permission: OrgUpdateMemberAuditEntryPermission
-  
+
   """
   The former member permission level for the organization.
   """
   permissionWas: OrgUpdateMemberAuditEntryPermission
-  
+
   """
   The user affected by the action
   """
   user: User
-  
+
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
-  
+
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
-  
+
   """
   The HTTP URL for the user.
   """
@@ -26911,93 +26912,93 @@ type OrgUpdateMemberRepositoryCreationPermissionAuditEntry implements AuditEntry
   The action name
   """
   action: String!
-  
+
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
-  
+
   """
   The IP address of the actor
   """
   actorIp: String
-  
+
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
-  
+
   """
   The username of the user who initiated the action
   """
   actorLogin: String
-  
+
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
-  
+
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
-  
+
   """
   Can members create repositories in the organization.
   """
   canCreateRepositories: Boolean
-  
+
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
   id: ID!
-  
+
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
-  
+
   """
   The Organization associated with the Audit Entry.
   """
   organization: Organization
-  
+
   """
   The name of the Organization.
   """
   organizationName: String
-  
+
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
-  
+
   """
   The HTTP URL for the organization
   """
   organizationUrl: URI
-  
+
   """
   The user affected by the action
   """
   user: User
-  
+
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
-  
+
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
-  
+
   """
   The HTTP URL for the user.
   """
   userUrl: URI
-  
+
   """
   The permission for visibility level of repositories for this organization.
   """
@@ -27050,88 +27051,88 @@ type OrgUpdateMemberRepositoryInvitationPermissionAuditEntry implements AuditEnt
   The action name
   """
   action: String!
-  
+
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
-  
+
   """
   The IP address of the actor
   """
   actorIp: String
-  
+
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
-  
+
   """
   The username of the user who initiated the action
   """
   actorLogin: String
-  
+
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
-  
+
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
-  
+
   """
   Can outside collaborators be invited to repositories in the organization.
   """
   canInviteOutsideCollaboratorsToRepositories: Boolean
-  
+
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
   id: ID!
-  
+
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
-  
+
   """
   The Organization associated with the Audit Entry.
   """
   organization: Organization
-  
+
   """
   The name of the Organization.
   """
   organizationName: String
-  
+
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
-  
+
   """
   The HTTP URL for the organization
   """
   organizationUrl: URI
-  
+
   """
   The user affected by the action
   """
   user: User
-  
+
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
-  
+
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
-  
+
   """
   The HTTP URL for the user.
   """
@@ -27146,17 +27147,17 @@ type Organization implements Actor & AnnouncementBanner & MemberStatusable & Nod
   The text of the announcement
   """
   announcement: String
-  
+
   """
   The expiration date of the announcement, if any
   """
   announcementExpiresAt: DateTime
-  
+
   """
   Whether the announcement can be dismissed by the user
   """
   announcementUserDismissible: Boolean
-  
+
   """
   Determine if this repository owner has any items that can be pinned to their profile.
   """
@@ -27166,12 +27167,12 @@ type Organization implements Actor & AnnouncementBanner & MemberStatusable & Nod
     """
     type: PinnableItemType
   ): Boolean!
-  
+
   """
   Identifies the date and time when the organization was archived.
   """
   archivedAt: DateTime
-  
+
   """
   Audit log entries of the organization
   """
@@ -27180,33 +27181,33 @@ type Organization implements Actor & AnnouncementBanner & MemberStatusable & Nod
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for the returned audit log entries.
     """
     orderBy: AuditLogOrder = { field: CREATED_AT, direction: DESC }
-    
+
     """
     The query string to filter audit entries
     """
     query: String
   ): OrganizationAuditEntryConnection!
-  
+
   """
   A URL pointing to the organization's public avatar.
   """
@@ -27216,27 +27217,27 @@ type Organization implements Actor & AnnouncementBanner & MemberStatusable & Nod
     """
     size: Int
   ): URI!
-  
+
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
-  
+
   """
   Identifies the primary key from the database.
   """
   databaseId: Int
-  
+
   """
   The organization's public profile description.
   """
   description: String
-  
+
   """
   The organization's public profile description rendered to HTML.
   """
   descriptionHTML: String
-  
+
   """
   A list of domains owned by the organization.
   """
@@ -27245,43 +27246,43 @@ type Organization implements Actor & AnnouncementBanner & MemberStatusable & Nod
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Filter by if the domain is approved.
     """
     isApproved: Boolean = null
-    
+
     """
     Filter by if the domain is verified.
     """
     isVerified: Boolean = null
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for verifiable domains returned.
     """
     orderBy: VerifiableDomainOrder = { field: DOMAIN, direction: ASC }
   ): VerifiableDomainConnection
-  
+
   """
   The organization's public email.
   """
   email: String
-  
+
   """
   A list of owners of the organization's enterprise account.
   """
@@ -27290,59 +27291,59 @@ type Organization implements Actor & AnnouncementBanner & MemberStatusable & Nod
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for enterprise owners returned from the connection.
     """
     orderBy: OrgEnterpriseOwnerOrder = { field: LOGIN, direction: ASC }
-    
+
     """
     The organization role to filter by.
     """
     organizationRole: RoleInOrganization
-    
+
     """
     The search string to look for.
     """
     query: String
   ): OrganizationEnterpriseOwnerConnection!
-  
+
   """
   The estimated next GitHub Sponsors payout for this user/organization in cents (USD).
   """
   estimatedNextSponsorsPayoutInCents: Int!
-  
+
   """
   True if this user/organization has a GitHub Sponsors listing.
   """
   hasSponsorsListing: Boolean!
   id: ID!
-  
+
   """
   The interaction ability settings for this organization.
   """
   interactionAbility: RepositoryInteractionAbility
-  
+
   """
   The setting value for whether the organization has an IP allow list enabled.
   """
   ipAllowListEnabledSetting: IpAllowListEnabledSettingValue!
-  
+
   """
   The IP addresses that are allowed to access resources owned by the organization.
   """
@@ -27351,33 +27352,33 @@ type Organization implements Actor & AnnouncementBanner & MemberStatusable & Nod
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for IP allow list entries returned.
     """
     orderBy: IpAllowListEntryOrder = { field: ALLOW_LIST_VALUE, direction: ASC }
   ): IpAllowListEntryConnection!
-  
+
   """
   The setting value for whether the organization has IP allow list configuration for installed GitHub Apps enabled.
   """
   ipAllowListForInstalledAppsEnabledSetting: IpAllowListForInstalledAppsEnabledSettingValue!
-  
+
   """
   Whether the given account is sponsoring this user/organization.
   """
@@ -27387,33 +27388,33 @@ type Organization implements Actor & AnnouncementBanner & MemberStatusable & Nod
     """
     accountLogin: String!
   ): Boolean!
-  
+
   """
   True if the viewer is sponsored by this user/organization.
   """
   isSponsoringViewer: Boolean!
-  
+
   """
   Whether the organization has verified its profile email and website.
   """
   isVerified: Boolean!
-  
+
   """
   Showcases a selection of repositories and gists that the profile owner has
   either curated or that have been selected automatically based on popularity.
   """
   itemShowcase: ProfileItemShowcase!
-  
+
   """
   The organization's public profile location.
   """
   location: String
-  
+
   """
   The organization's login name.
   """
   login: String!
-  
+
   """
   A list of all mannequins for this organization.
   """
@@ -27422,33 +27423,33 @@ type Organization implements Actor & AnnouncementBanner & MemberStatusable & Nod
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Filter mannequins by login.
     """
     login: String
-    
+
     """
     Ordering options for mannequins returned from the connection.
     """
     orderBy: MannequinOrder = { field: CREATED_AT, direction: ASC }
   ): MannequinConnection!
-  
+
   """
   Get the status messages members of this entity have set that are either public or visible only to the organization.
   """
@@ -27457,33 +27458,33 @@ type Organization implements Actor & AnnouncementBanner & MemberStatusable & Nod
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for user statuses returned from the connection.
     """
     orderBy: UserStatusOrder = { field: UPDATED_AT, direction: DESC }
   ): UserStatusConnection!
-  
+
   """
   Members can fork private repositories in this organization
   """
   membersCanForkPrivateRepositories: Boolean!
-  
+
   """
   A list of users who are members of this organization.
   """
@@ -27492,53 +27493,53 @@ type Organization implements Actor & AnnouncementBanner & MemberStatusable & Nod
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): OrganizationMemberConnection!
-  
+
   """
   The estimated monthly GitHub Sponsors income for this user/organization in cents (USD).
   """
   monthlyEstimatedSponsorsIncomeInCents: Int!
-  
+
   """
   The organization's public profile name.
   """
   name: String
-  
+
   """
   The HTTP path creating a new team
   """
   newTeamResourcePath: URI!
-  
+
   """
   The HTTP URL creating a new team
   """
   newTeamUrl: URI!
-  
+
   """
   Indicates if email notification delivery for this organization is restricted to verified or approved domains.
   """
   notificationDeliveryRestrictionEnabledSetting: NotificationRestrictionSettingValue!
-  
+
   """
   The billing email for the organization.
   """
   organizationBillingEmail: String
-  
+
   """
   A list of packages under the owner.
   """
@@ -27547,43 +27548,43 @@ type Organization implements Actor & AnnouncementBanner & MemberStatusable & Nod
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Find packages by their names.
     """
     names: [String]
-    
+
     """
     Ordering of the returned packages.
     """
     orderBy: PackageOrder = { field: CREATED_AT, direction: DESC }
-    
+
     """
     Filter registry package by type.
     """
     packageType: PackageType
-    
+
     """
     Find packages in a repository by ID.
     """
     repositoryId: ID
   ): PackageConnection!
-  
+
   """
   A list of users who have been invited to join this organization.
   """
@@ -27592,23 +27593,23 @@ type Organization implements Actor & AnnouncementBanner & MemberStatusable & Nod
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): UserConnection!
-  
+
   """
   A list of repositories and gists this profile owner can pin to their profile.
   """
@@ -27617,28 +27618,28 @@ type Organization implements Actor & AnnouncementBanner & MemberStatusable & Nod
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Filter the types of pinnable items that are returned.
     """
     types: [PinnableItemType!]
   ): PinnableItemConnection!
-  
+
   """
   A list of repositories and gists this profile owner has pinned to their profile
   """
@@ -27647,33 +27648,33 @@ type Organization implements Actor & AnnouncementBanner & MemberStatusable & Nod
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Filter the types of pinned items that are returned.
     """
     types: [PinnableItemType!]
   ): PinnableItemConnection!
-  
+
   """
   Returns how many more items this profile owner can pin to their profile.
   """
   pinnedItemsRemaining: Int!
-  
+
   """
   Find project by number.
   """
@@ -27683,7 +27684,7 @@ type Organization implements Actor & AnnouncementBanner & MemberStatusable & Nod
     """
     number: Int!
   ): Project
-  
+
   """
   Find a project by number.
   """
@@ -27693,7 +27694,7 @@ type Organization implements Actor & AnnouncementBanner & MemberStatusable & Nod
     """
     number: Int!
   ): ProjectV2
-  
+
   """
   A list of projects under the owner.
   """
@@ -27702,48 +27703,48 @@ type Organization implements Actor & AnnouncementBanner & MemberStatusable & Nod
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for projects returned from the connection
     """
     orderBy: ProjectOrder
-    
+
     """
     Query to search projects by, currently only searching by name.
     """
     search: String
-    
+
     """
     A list of states to filter the projects by.
     """
     states: [ProjectState!]
   ): ProjectConnection!
-  
+
   """
   The HTTP path listing organization's projects
   """
   projectsResourcePath: URI!
-  
+
   """
   The HTTP URL listing organization's projects
   """
   projectsUrl: URI!
-  
+
   """
   A list of projects under the owner.
   """
@@ -27752,33 +27753,33 @@ type Organization implements Actor & AnnouncementBanner & MemberStatusable & Nod
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     How to order the returned projects.
     """
     orderBy: ProjectV2Order = { field: NUMBER, direction: DESC }
-    
+
     """
     A project to search for under the the owner.
     """
     query: String
   ): ProjectV2Connection!
-  
+
   """
   Recent projects that this user has modified in the context of the owner.
   """
@@ -27787,23 +27788,23 @@ type Organization implements Actor & AnnouncementBanner & MemberStatusable & Nod
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): ProjectV2Connection!
-  
+
   """
   A list of repositories that the user owns.
   """
@@ -27814,65 +27815,65 @@ type Organization implements Actor & AnnouncementBanner & MemberStatusable & Nod
     current viewer owns.
     """
     affiliations: [RepositoryAffiliation]
-    
+
     """
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     If non-null, filters repositories according to whether they have issues enabled
     """
     hasIssuesEnabled: Boolean
-    
+
     """
     If non-null, filters repositories according to whether they are archived and not maintained
     """
     isArchived: Boolean
-    
+
     """
     If non-null, filters repositories according to whether they are forks of another repository
     """
     isFork: Boolean
-    
+
     """
     If non-null, filters repositories according to whether they have been locked
     """
     isLocked: Boolean
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for repositories returned from the connection
     """
     orderBy: RepositoryOrder
-    
+
     """
     Array of owner's affiliation options for repositories returned from the
     connection. For example, OWNER will include only repositories that the
     organization or user being viewed owns.
     """
     ownerAffiliations: [RepositoryAffiliation] = [OWNER, COLLABORATOR]
-    
+
     """
     If non-null, filters repositories according to privacy
     """
     privacy: RepositoryPrivacy
   ): RepositoryConnection!
-  
+
   """
   Find Repository.
   """
@@ -27881,13 +27882,13 @@ type Organization implements Actor & AnnouncementBanner & MemberStatusable & Nod
     Follow repository renames. If disabled, a repository referenced by its old name will return an error.
     """
     followRenames: Boolean = true
-    
+
     """
     Name of Repository to find.
     """
     name: String!
   ): Repository
-  
+
   """
   Discussion comments this user has authored.
   """
@@ -27896,33 +27897,33 @@ type Organization implements Actor & AnnouncementBanner & MemberStatusable & Nod
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Filter discussion comments to only those that were marked as the answer
     """
     onlyAnswers: Boolean = false
-    
+
     """
     Filter discussion comments to only those in a specific repository.
     """
     repositoryId: ID
   ): DiscussionCommentConnection!
-  
+
   """
   Discussions this user has started.
   """
@@ -27931,44 +27932,44 @@ type Organization implements Actor & AnnouncementBanner & MemberStatusable & Nod
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Filter discussions to only those that have been answered or not. Defaults to
     including both answered and unanswered discussions.
     """
     answered: Boolean = null
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for discussions returned from the connection.
     """
     orderBy: DiscussionOrder = { field: CREATED_AT, direction: DESC }
-    
+
     """
     Filter discussions to only those in a specific repository.
     """
     repositoryId: ID
-    
+
     """
     A list of states to filter the discussions by.
     """
     states: [DiscussionState!] = []
   ): DiscussionConnection!
-  
+
   """
   A list of all repository migrations for this organization.
   """
@@ -27977,49 +27978,49 @@ type Organization implements Actor & AnnouncementBanner & MemberStatusable & Nod
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for repository migrations returned.
     """
     orderBy: RepositoryMigrationOrder = { field: CREATED_AT, direction: ASC }
-    
+
     """
     Filter repository migrations by repository name.
     """
     repositoryName: String
-    
+
     """
     Filter repository migrations by state.
     """
     state: MigrationState
   ): RepositoryMigrationConnection!
-  
+
   """
   When true the organization requires all members, billing managers, and outside
   collaborators to enable two-factor authentication.
   """
   requiresTwoFactorAuthentication: Boolean
-  
+
   """
   The HTTP path for this organization.
   """
   resourcePath: URI!
-  
+
   """
   Returns a single ruleset from the current organization by ID.
   """
@@ -28029,7 +28030,7 @@ type Organization implements Actor & AnnouncementBanner & MemberStatusable & Nod
     """
     databaseId: Int!
   ): RepositoryRuleset
-  
+
   """
   A list of rulesets for this organization.
   """
@@ -28038,28 +28039,28 @@ type Organization implements Actor & AnnouncementBanner & MemberStatusable & Nod
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Return rulesets configured at higher levels that apply to this organization
     """
     includeParents: Boolean = true
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): RepositoryRulesetConnection
-  
+
   """
   The Organization's SAML identity provider. Visible to (1) organization owners,
   (2) organization owners' personal access tokens (classic) with read:org or
@@ -28067,7 +28068,7 @@ type Organization implements Actor & AnnouncementBanner & MemberStatusable & Nod
   access to members.
   """
   samlIdentityProvider: OrganizationIdentityProvider
-  
+
   """
   List of users and organizations this entity is sponsoring.
   """
@@ -28076,28 +28077,28 @@ type Organization implements Actor & AnnouncementBanner & MemberStatusable & Nod
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for the users and organizations returned from the connection.
     """
     orderBy: SponsorOrder = { field: RELEVANCE, direction: DESC }
   ): SponsorConnection!
-  
+
   """
   List of sponsors for this user or organization.
   """
@@ -28106,34 +28107,34 @@ type Organization implements Actor & AnnouncementBanner & MemberStatusable & Nod
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for sponsors returned from the connection.
     """
     orderBy: SponsorOrder = { field: RELEVANCE, direction: DESC }
-    
+
     """
     If given, will filter for sponsors at the given tier. Will only return
     sponsors whose tier the viewer is permitted to see.
     """
     tierId: ID
   ): SponsorConnection!
-  
+
   """
   Events involving this sponsorable, such as new sponsorships.
   """
@@ -28142,67 +28143,67 @@ type Organization implements Actor & AnnouncementBanner & MemberStatusable & Nod
     Filter activities to only the specified actions.
     """
     actions: [SponsorsActivityAction!] = []
-    
+
     """
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Whether to include those events where this sponsorable acted as the sponsor.
     Defaults to only including events where this sponsorable was the recipient
     of a sponsorship.
     """
     includeAsSponsor: Boolean = false
-    
+
     """
     Whether or not to include private activities in the result set. Defaults to including public and private activities.
     """
     includePrivate: Boolean = true
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for activity returned from the connection.
     """
     orderBy: SponsorsActivityOrder = { field: TIMESTAMP, direction: DESC }
-    
+
     """
     Filter activities returned to only those that occurred in the most recent
     specified time period. Set to ALL to avoid filtering by when the activity
     occurred. Will be ignored if `since` or `until` is given.
     """
     period: SponsorsActivityPeriod = MONTH
-    
+
     """
     Filter activities to those that occurred on or after this time.
     """
     since: DateTime
-    
+
     """
     Filter activities to those that occurred before this time.
     """
     until: DateTime
   ): SponsorsActivityConnection!
-  
+
   """
   The GitHub Sponsors listing for this user or organization.
   """
   sponsorsListing: SponsorsListing
-  
+
   """
   The sponsorship from the viewer to this user/organization; that is, the sponsorship where you're the sponsor.
   """
@@ -28213,7 +28214,7 @@ type Organization implements Actor & AnnouncementBanner & MemberStatusable & Nod
     """
     activeOnly: Boolean = true
   ): Sponsorship
-  
+
   """
   The sponsorship from this user/organization to the viewer; that is, the sponsorship you're receiving.
   """
@@ -28224,7 +28225,7 @@ type Organization implements Actor & AnnouncementBanner & MemberStatusable & Nod
     """
     activeOnly: Boolean = true
   ): Sponsorship
-  
+
   """
   List of sponsorship updates sent from this sponsorable to sponsors.
   """
@@ -28233,28 +28234,28 @@ type Organization implements Actor & AnnouncementBanner & MemberStatusable & Nod
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for sponsorship updates returned from the connection.
     """
     orderBy: SponsorshipNewsletterOrder = { field: CREATED_AT, direction: DESC }
   ): SponsorshipNewsletterConnection!
-  
+
   """
   The sponsorships where this user or organization is the maintainer receiving the funds.
   """
@@ -28264,39 +28265,39 @@ type Organization implements Actor & AnnouncementBanner & MemberStatusable & Nod
     sponsorships this maintainer has ever received.
     """
     activeOnly: Boolean = true
-    
+
     """
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Whether or not to include private sponsorships in the result set
     """
     includePrivate: Boolean = false
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for sponsorships returned from this connection. If left
     blank, the sponsorships will be ordered based on relevancy to the viewer.
     """
     orderBy: SponsorshipOrder
   ): SponsorshipConnection!
-  
+
   """
   The sponsorships where this user or organization is the funder.
   """
@@ -28305,41 +28306,41 @@ type Organization implements Actor & AnnouncementBanner & MemberStatusable & Nod
     Whether to include only sponsorships that are active right now, versus all sponsorships this sponsor has ever made.
     """
     activeOnly: Boolean = true
-    
+
     """
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Filter sponsorships returned to those for the specified maintainers. That
     is, the recipient of the sponsorship is a user or organization with one of
     the given logins.
     """
     maintainerLogins: [String!]
-    
+
     """
     Ordering options for sponsorships returned from this connection. If left
     blank, the sponsorships will be ordered based on relevancy to the viewer.
     """
     orderBy: SponsorshipOrder
   ): SponsorshipConnection!
-  
+
   """
   Find an organization's team by its slug.
   """
@@ -28349,7 +28350,7 @@ type Organization implements Actor & AnnouncementBanner & MemberStatusable & Nod
     """
     slug: String!
   ): Team
-  
+
   """
   A list of teams in this organization.
   """
@@ -28358,73 +28359,73 @@ type Organization implements Actor & AnnouncementBanner & MemberStatusable & Nod
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     If true, filters teams that are mapped to an LDAP Group (Enterprise only)
     """
     ldapMapped: Boolean
-    
+
     """
     If non-null, filters teams according to notification setting
     """
     notificationSetting: TeamNotificationSetting
-    
+
     """
     Ordering options for teams returned from the connection
     """
     orderBy: TeamOrder
-    
+
     """
     If non-null, filters teams according to privacy
     """
     privacy: TeamPrivacy
-    
+
     """
     If non-null, filters teams with query on team name and team slug
     """
     query: String
-    
+
     """
     If non-null, filters teams according to whether the viewer is an admin or member on team
     """
     role: TeamRole
-    
+
     """
     If true, restrict to only root teams
     """
     rootTeamsOnly: Boolean = false
-    
+
     """
     User logins to filter by
     """
     userLogins: [String!]
   ): TeamConnection!
-  
+
   """
   The HTTP path listing organization's teams
   """
   teamsResourcePath: URI!
-  
+
   """
   The HTTP URL listing organization's teams
   """
   teamsUrl: URI!
-  
+
   """
   The amount in United States cents (e.g., 500 = $5.00 USD) that this entity has
   spent on GitHub to fund sponsorships. Only returns a value when viewed by the
@@ -28435,83 +28436,83 @@ type Organization implements Actor & AnnouncementBanner & MemberStatusable & Nod
     Filter payments to those that occurred on or after this time.
     """
     since: DateTime
-    
+
     """
     Filter payments to those made to the users or organizations with the specified usernames.
     """
     sponsorableLogins: [String!] = []
-    
+
     """
     Filter payments to those that occurred before this time.
     """
     until: DateTime
   ): Int
-  
+
   """
   The organization's Twitter username.
   """
   twitterUsername: String
-  
+
   """
   Identifies the date and time when the object was last updated.
   """
   updatedAt: DateTime!
-  
+
   """
   The HTTP URL for this organization.
   """
   url: URI!
-  
+
   """
   Organization is adminable by the viewer.
   """
   viewerCanAdminister: Boolean!
-  
+
   """
   Can the viewer pin repositories and gists to the profile?
   """
   viewerCanChangePinnedItems: Boolean!
-  
+
   """
   Can the current viewer create new projects on this owner.
   """
   viewerCanCreateProjects: Boolean!
-  
+
   """
   Viewer can create repositories on this organization
   """
   viewerCanCreateRepositories: Boolean!
-  
+
   """
   Viewer can create teams on this organization.
   """
   viewerCanCreateTeams: Boolean!
-  
+
   """
   Whether or not the viewer is able to sponsor this user/organization.
   """
   viewerCanSponsor: Boolean!
-  
+
   """
   Viewer is an active member of this organization.
   """
   viewerIsAMember: Boolean!
-  
+
   """
   Whether or not this Organization is followed by the viewer.
   """
   viewerIsFollowing: Boolean!
-  
+
   """
   True if the viewer is sponsoring this user/organization.
   """
   viewerIsSponsoring: Boolean!
-  
+
   """
   Whether contributors are required to sign off on web-based commits for repositories in this organization.
   """
   webCommitSignoffRequired: Boolean!
-  
+
   """
   The organization's public profile URL.
   """
@@ -28590,17 +28591,17 @@ type OrganizationAuditEntryConnection {
   A list of edges.
   """
   edges: [OrganizationAuditEntryEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [OrganizationAuditEntry]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -28615,17 +28616,17 @@ interface OrganizationAuditEntryData {
   The Organization associated with the Audit Entry.
   """
   organization: Organization
-  
+
   """
   The name of the Organization.
   """
   organizationName: String
-  
+
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
-  
+
   """
   The HTTP URL for the organization
   """
@@ -28640,7 +28641,7 @@ type OrganizationAuditEntryEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -28655,17 +28656,17 @@ type OrganizationConnection {
   A list of edges.
   """
   edges: [OrganizationEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [Organization]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -28680,7 +28681,7 @@ type OrganizationEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -28695,17 +28696,17 @@ type OrganizationEnterpriseOwnerConnection {
   A list of edges.
   """
   edges: [OrganizationEnterpriseOwnerEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [User]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -28720,12 +28721,12 @@ type OrganizationEnterpriseOwnerEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
   node: User
-  
+
   """
   The role of the owner with respect to the organization.
   """
@@ -28743,7 +28744,7 @@ type OrganizationIdentityProvider implements Node {
   The digest algorithm used to sign SAML requests for the Identity Provider.
   """
   digestMethod: URI
-  
+
   """
   External Identities provisioned by this Identity Provider
   """
@@ -28752,59 +28753,59 @@ type OrganizationIdentityProvider implements Node {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Filter to external identities with the users login
     """
     login: String
-    
+
     """
     Filter to external identities with valid org membership only
     """
     membersOnly: Boolean
-    
+
     """
     Filter to external identities with the users userName/NameID attribute
     """
     userName: String
   ): ExternalIdentityConnection!
   id: ID!
-  
+
   """
   The x509 certificate used by the Identity Provider to sign assertions and responses.
   """
   idpCertificate: X509Certificate
-  
+
   """
   The Issuer Entity ID for the SAML Identity Provider
   """
   issuer: String
-  
+
   """
   Organization this Identity Provider belongs to
   """
   organization: Organization
-  
+
   """
   The signature algorithm used to sign SAML requests for the Identity Provider.
   """
   signatureMethod: URI
-  
+
   """
   The URL endpoint for the Identity Provider's SAML SSO.
   """
@@ -28819,38 +28820,38 @@ type OrganizationInvitation implements Node {
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
-  
+
   """
   The email address of the user invited to the organization.
   """
   email: String
   id: ID!
-  
+
   """
   The source of the invitation.
   """
   invitationSource: OrganizationInvitationSource!
-  
+
   """
   The type of invitation that was sent (e.g. email, user).
   """
   invitationType: OrganizationInvitationType!
-  
+
   """
   The user who was invited to the organization.
   """
   invitee: User
-  
+
   """
   The user who created the invitation.
   """
   inviter: User!
-  
+
   """
   The organization the invite is for
   """
   organization: Organization!
-  
+
   """
   The user's pending role in the organization (e.g. member, owner).
   """
@@ -28865,17 +28866,17 @@ type OrganizationInvitationConnection {
   A list of edges.
   """
   edges: [OrganizationInvitationEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [OrganizationInvitation]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -28890,7 +28891,7 @@ type OrganizationInvitationEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -28959,17 +28960,17 @@ type OrganizationMemberConnection {
   A list of edges.
   """
   edges: [OrganizationMemberEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [User]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -28984,17 +28985,17 @@ type OrganizationMemberEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   Whether the organization member has two factor enabled or not. Returns null if information is not available to viewer.
   """
   hasTwoFactorEnabled: Boolean
-  
+
   """
   The item at the end of the edge.
   """
   node: User
-  
+
   """
   The role this user has in the organization.
   """
@@ -29045,43 +29046,43 @@ type OrganizationMigration implements Node {
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
-  
+
   """
   Identifies the primary key from the database.
   """
   databaseId: String
-  
+
   """
   The reason the organization migration failed.
   """
   failureReason: String
   id: ID!
-  
+
   """
   The remaining amount of repos to be migrated.
   """
   remainingRepositoriesCount: Int
-  
+
   """
   The name of the source organization to be migrated.
   """
   sourceOrgName: String!
-  
+
   """
   The URL of the source organization to migrate.
   """
   sourceOrgUrl: URI!
-  
+
   """
   The migration state.
   """
   state: OrganizationMigrationState!
-  
+
   """
   The name of the target organization.
   """
   targetOrgName: String!
-  
+
   """
   The total amount of repositories to be migrated.
   """
@@ -29147,7 +29148,7 @@ input OrganizationOrder {
   The ordering direction.
   """
   direction: OrderDirection!
-  
+
   """
   The field to order organizations by.
   """
@@ -29176,12 +29177,12 @@ type OrganizationTeamsHovercardContext implements HovercardContext {
   A string describing this context
   """
   message: String!
-  
+
   """
   An octicon to accompany this context
   """
   octicon: String!
-  
+
   """
   Teams in this organization the user is a member of that are relevant
   """
@@ -29190,33 +29191,33 @@ type OrganizationTeamsHovercardContext implements HovercardContext {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): TeamConnection!
-  
+
   """
   The path for the full team list for this user
   """
   teamsResourcePath: URI!
-  
+
   """
   The URL for the full team list for this user
   """
   teamsUrl: URI!
-  
+
   """
   The total number of teams the user is on in the organization
   """
@@ -29231,12 +29232,12 @@ type OrganizationsHovercardContext implements HovercardContext {
   A string describing this context
   """
   message: String!
-  
+
   """
   An octicon to accompany this context
   """
   octicon: String!
-  
+
   """
   Organizations this user is a member of that are relevant
   """
@@ -29245,28 +29246,28 @@ type OrganizationsHovercardContext implements HovercardContext {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for the User's organizations.
     """
     orderBy: OrganizationOrder = null
   ): OrganizationConnection!
-  
+
   """
   The total number of organizations this user is in
   """
@@ -29278,32 +29279,32 @@ Information for an uploaded package.
 """
 type Package implements Node {
   id: ID!
-  
+
   """
   Find the latest version for the package.
   """
   latestVersion: PackageVersion
-  
+
   """
   Identifies the name of the package.
   """
   name: String!
-  
+
   """
   Identifies the type of the package.
   """
   packageType: PackageType!
-  
+
   """
   The repository this package belongs to.
   """
   repository: Repository
-  
+
   """
   Statistics about package activity.
   """
   statistics: PackageStatistics
-  
+
   """
   Find package version by version string.
   """
@@ -29313,7 +29314,7 @@ type Package implements Node {
     """
     version: String!
   ): PackageVersion
-  
+
   """
   list of versions for this package
   """
@@ -29322,22 +29323,22 @@ type Package implements Node {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering of the returned packages.
     """
@@ -29353,17 +29354,17 @@ type PackageConnection {
   A list of edges.
   """
   edges: [PackageEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [Package]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -29378,7 +29379,7 @@ type PackageEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -29390,42 +29391,42 @@ A file in a package version.
 """
 type PackageFile implements Node {
   id: ID!
-  
+
   """
   MD5 hash of the file.
   """
   md5: String
-  
+
   """
   Name of the file.
   """
   name: String!
-  
+
   """
   The package version this file belongs to.
   """
   packageVersion: PackageVersion
-  
+
   """
   SHA1 hash of the file.
   """
   sha1: String
-  
+
   """
   SHA256 hash of the file.
   """
   sha256: String
-  
+
   """
   Size of the file in bytes.
   """
   size: Int
-  
+
   """
   Identifies the date and time when the object was last updated.
   """
   updatedAt: DateTime!
-  
+
   """
   URL to download the asset.
   """
@@ -29440,17 +29441,17 @@ type PackageFileConnection {
   A list of edges.
   """
   edges: [PackageFileEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [PackageFile]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -29465,7 +29466,7 @@ type PackageFileEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -29480,7 +29481,7 @@ input PackageFileOrder {
   The direction in which to order package files by the specified field.
   """
   direction: OrderDirection
-  
+
   """
   The field in which to order package files by.
   """
@@ -29505,7 +29506,7 @@ input PackageOrder {
   The direction in which to order packages by the specified field.
   """
   direction: OrderDirection
-  
+
   """
   The field in which to order packages by.
   """
@@ -29527,7 +29528,7 @@ Represents an owner of a package.
 """
 interface PackageOwner {
   id: ID!
-  
+
   """
   A list of packages under the owner.
   """
@@ -29536,37 +29537,37 @@ interface PackageOwner {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Find packages by their names.
     """
     names: [String]
-    
+
     """
     Ordering of the returned packages.
     """
     orderBy: PackageOrder = { field: CREATED_AT, direction: DESC }
-    
+
     """
     Filter registry package by type.
     """
     packageType: PackageType
-    
+
     """
     Find packages in a repository by ID.
     """
@@ -29589,12 +29590,12 @@ A version tag contains the mapping between a tag name and a version.
 """
 type PackageTag implements Node {
   id: ID!
-  
+
   """
   Identifies the tag name of the version.
   """
   name: String!
-  
+
   """
   Version that the tag is associated with.
   """
@@ -29657,64 +29658,64 @@ type PackageVersion implements Node {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering of the returned package files.
     """
     orderBy: PackageFileOrder = { field: CREATED_AT, direction: ASC }
   ): PackageFileConnection!
   id: ID!
-  
+
   """
   The package associated with this version.
   """
   package: Package
-  
+
   """
   The platform this version was built for.
   """
   platform: String
-  
+
   """
   Whether or not this version is a pre-release.
   """
   preRelease: Boolean!
-  
+
   """
   The README of this package version.
   """
   readme: String
-  
+
   """
   The release associated with this package version.
   """
   release: Release
-  
+
   """
   Statistics about package activity.
   """
   statistics: PackageVersionStatistics
-  
+
   """
   The package version summary.
   """
   summary: String
-  
+
   """
   The version string.
   """
@@ -29729,17 +29730,17 @@ type PackageVersionConnection {
   A list of edges.
   """
   edges: [PackageVersionEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [PackageVersion]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -29754,7 +29755,7 @@ type PackageVersionEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -29769,7 +29770,7 @@ input PackageVersionOrder {
   The direction in which to order package versions by the specified field.
   """
   direction: OrderDirection
-  
+
   """
   The field in which to order package versions by.
   """
@@ -29804,17 +29805,17 @@ type PageInfo {
   When paginating forwards, the cursor to continue.
   """
   endCursor: String
-  
+
   """
   When paginating forwards, are there more items?
   """
   hasNextPage: Boolean!
-  
+
   """
   When paginating backwards, are there more items?
   """
   hasPreviousPage: Boolean!
-  
+
   """
   When paginating backwards, the cursor to continue.
   """
@@ -29864,12 +29865,12 @@ type PermissionSource {
   The organization the repository belongs to.
   """
   organization: Organization!
-  
+
   """
   The level of access this source has granted to the user.
   """
   permission: DefaultRepositoryPermissionField!
-  
+
   """
   The source of this permission.
   """
@@ -29884,7 +29885,7 @@ input PinIssueInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The ID of the issue to be pinned
   """
@@ -29899,7 +29900,7 @@ type PinIssuePayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The issue that was pinned
   """
@@ -29919,17 +29920,17 @@ type PinnableItemConnection {
   A list of edges.
   """
   edges: [PinnableItemEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [PinnableItem]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -29944,7 +29945,7 @@ type PinnableItemEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -29997,43 +29998,43 @@ type PinnedDiscussion implements Node & RepositoryNode {
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
-  
+
   """
   Identifies the primary key from the database.
   """
   databaseId: Int
-  
+
   """
   The discussion that was pinned.
   """
   discussion: Discussion!
-  
+
   """
   Color stops of the chosen gradient
   """
   gradientStopColors: [String!]!
   id: ID!
-  
+
   """
   Background texture pattern
   """
   pattern: PinnedDiscussionPattern!
-  
+
   """
   The actor that pinned this discussion.
   """
   pinnedBy: Actor!
-  
+
   """
   Preconfigured background gradient option
   """
   preconfiguredGradient: PinnedDiscussionGradient
-  
+
   """
   The repository associated with this node.
   """
   repository: Repository!
-  
+
   """
   Identifies the date and time when the object was last updated.
   """
@@ -30048,17 +30049,17 @@ type PinnedDiscussionConnection {
   A list of edges.
   """
   edges: [PinnedDiscussionEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [PinnedDiscussion]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -30073,7 +30074,7 @@ type PinnedDiscussionEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -30144,13 +30145,13 @@ type PinnedEvent implements Node {
   Identifies the actor who performed the event.
   """
   actor: Actor
-  
+
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
   id: ID!
-  
+
   """
   Identifies the issue associated with the event.
   """
@@ -30165,23 +30166,23 @@ type PinnedIssue implements Node {
   Identifies the primary key from the database.
   """
   databaseId: Int
-  
+
   """
   Identifies the primary key from the database as a BigInt.
   """
   fullDatabaseId: BigInt
   id: ID!
-  
+
   """
   The issue that was pinned.
   """
   issue: Issue!
-  
+
   """
   The actor that pinned this issue.
   """
   pinnedBy: Actor!
-  
+
   """
   The repository that this issue was pinned to.
   """
@@ -30196,17 +30197,17 @@ type PinnedIssueConnection {
   A list of edges.
   """
   edges: [PinnedIssueEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [PinnedIssue]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -30221,7 +30222,7 @@ type PinnedIssueEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -30241,118 +30242,118 @@ type PrivateRepositoryForkingDisableAuditEntry implements AuditEntry & Enterpris
   The action name
   """
   action: String!
-  
+
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
-  
+
   """
   The IP address of the actor
   """
   actorIp: String
-  
+
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
-  
+
   """
   The username of the user who initiated the action
   """
   actorLogin: String
-  
+
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
-  
+
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
-  
+
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
-  
+
   """
   The HTTP path for this enterprise.
   """
   enterpriseResourcePath: URI
-  
+
   """
   The slug of the enterprise.
   """
   enterpriseSlug: String
-  
+
   """
   The HTTP URL for this enterprise.
   """
   enterpriseUrl: URI
   id: ID!
-  
+
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
-  
+
   """
   The Organization associated with the Audit Entry.
   """
   organization: Organization
-  
+
   """
   The name of the Organization.
   """
   organizationName: String
-  
+
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
-  
+
   """
   The HTTP URL for the organization
   """
   organizationUrl: URI
-  
+
   """
   The repository associated with the action
   """
   repository: Repository
-  
+
   """
   The name of the repository
   """
   repositoryName: String
-  
+
   """
   The HTTP path for the repository
   """
   repositoryResourcePath: URI
-  
+
   """
   The HTTP URL for the repository
   """
   repositoryUrl: URI
-  
+
   """
   The user affected by the action
   """
   user: User
-  
+
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
-  
+
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
-  
+
   """
   The HTTP URL for the user.
   """
@@ -30367,118 +30368,118 @@ type PrivateRepositoryForkingEnableAuditEntry implements AuditEntry & Enterprise
   The action name
   """
   action: String!
-  
+
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
-  
+
   """
   The IP address of the actor
   """
   actorIp: String
-  
+
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
-  
+
   """
   The username of the user who initiated the action
   """
   actorLogin: String
-  
+
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
-  
+
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
-  
+
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
-  
+
   """
   The HTTP path for this enterprise.
   """
   enterpriseResourcePath: URI
-  
+
   """
   The slug of the enterprise.
   """
   enterpriseSlug: String
-  
+
   """
   The HTTP URL for this enterprise.
   """
   enterpriseUrl: URI
   id: ID!
-  
+
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
-  
+
   """
   The Organization associated with the Audit Entry.
   """
   organization: Organization
-  
+
   """
   The name of the Organization.
   """
   organizationName: String
-  
+
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
-  
+
   """
   The HTTP URL for the organization
   """
   organizationUrl: URI
-  
+
   """
   The repository associated with the action
   """
   repository: Repository
-  
+
   """
   The name of the repository
   """
   repositoryName: String
-  
+
   """
   The HTTP path for the repository
   """
   repositoryResourcePath: URI
-  
+
   """
   The HTTP URL for the repository
   """
   repositoryUrl: URI
-  
+
   """
   The user affected by the action
   """
   user: User
-  
+
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
-  
+
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
-  
+
   """
   The HTTP URL for the user.
   """
@@ -30494,7 +30495,7 @@ type ProfileItemShowcase {
   Whether or not the owner has pinned any repositories or gists.
   """
   hasPinnedItems: Boolean!
-  
+
   """
   The repositories and gists in the showcase. If the profile owner has any
   pinned items, those will be returned. Otherwise, the profile owner's popular
@@ -30505,17 +30506,17 @@ type ProfileItemShowcase {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
@@ -30536,34 +30537,34 @@ interface ProfileOwner {
     """
     type: PinnableItemType
   ): Boolean!
-  
+
   """
   The public profile email.
   """
   email: String
   id: ID!
-  
+
   """
   Showcases a selection of repositories and gists that the profile owner has
   either curated or that have been selected automatically based on popularity.
   """
   itemShowcase: ProfileItemShowcase!
-  
+
   """
   The public profile location.
   """
   location: String
-  
+
   """
   The username used to login.
   """
   login: String!
-  
+
   """
   The public profile name.
   """
   name: String
-  
+
   """
   A list of repositories and gists this profile owner can pin to their profile.
   """
@@ -30572,28 +30573,28 @@ interface ProfileOwner {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Filter the types of pinnable items that are returned.
     """
     types: [PinnableItemType!]
   ): PinnableItemConnection!
-  
+
   """
   A list of repositories and gists this profile owner has pinned to their profile
   """
@@ -30602,38 +30603,38 @@ interface ProfileOwner {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Filter the types of pinned items that are returned.
     """
     types: [PinnableItemType!]
   ): PinnableItemConnection!
-  
+
   """
   Returns how many more items this profile owner can pin to their profile.
   """
   pinnedItemsRemaining: Int!
-  
+
   """
   Can the viewer pin repositories and gists to the profile?
   """
   viewerCanChangePinnedItems: Boolean!
-  
+
   """
   The public profile website URL.
   """
@@ -30648,22 +30649,22 @@ type Project implements Closable & Node & Updatable {
   The project's description body.
   """
   body: String
-  
+
   """
   The projects description body rendered to HTML.
   """
   bodyHTML: HTML!
-  
+
   """
   Indicates if the object is closed (definition of closed may depend on type)
   """
   closed: Boolean!
-  
+
   """
   Identifies the date and time when the object was closed.
   """
   closedAt: DateTime
-  
+
   """
   List of columns in the project
   """
@@ -30672,54 +30673,54 @@ type Project implements Closable & Node & Updatable {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): ProjectColumnConnection!
-  
+
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
-  
+
   """
   The actor who originally created the project.
   """
   creator: Actor
-  
+
   """
   Identifies the primary key from the database.
   """
   databaseId: Int
   id: ID!
-  
+
   """
   The project's name.
   """
   name: String!
-  
+
   """
   The project's number.
   """
   number: Int!
-  
+
   """
   The project's owner. Currently limited to repositories, organizations, and users.
   """
   owner: ProjectOwner!
-  
+
   """
   List of pending cards in this project
   """
@@ -30728,63 +30729,63 @@ type Project implements Closable & Node & Updatable {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     A list of archived states to filter the cards by
     """
     archivedStates: [ProjectCardArchivedState] = [ARCHIVED, NOT_ARCHIVED]
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): ProjectCardConnection!
-  
+
   """
   Project progress details.
   """
   progress: ProjectProgress!
-  
+
   """
   The HTTP path for this project
   """
   resourcePath: URI!
-  
+
   """
   Whether the project is open or closed.
   """
   state: ProjectState!
-  
+
   """
   Identifies the date and time when the object was last updated.
   """
   updatedAt: DateTime!
-  
+
   """
   The HTTP URL for this project
   """
   url: URI!
-  
+
   """
   Indicates if the object can be closed by the viewer.
   """
   viewerCanClose: Boolean!
-  
+
   """
   Indicates if the object can be reopened by the viewer.
   """
   viewerCanReopen: Boolean!
-  
+
   """
   Check if the current viewer can update this object.
   """
@@ -30802,58 +30803,58 @@ type ProjectCard implements Node {
   associated with a column, they will not become pending in the future.
   """
   column: ProjectColumn
-  
+
   """
   The card content item
   """
   content: ProjectCardItem
-  
+
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
-  
+
   """
   The actor who created this card
   """
   creator: Actor
-  
+
   """
   Identifies the primary key from the database.
   """
   databaseId: Int
   id: ID!
-  
+
   """
   Whether the card is archived
   """
   isArchived: Boolean!
-  
+
   """
   The card note
   """
   note: String
-  
+
   """
   The project that contains this card.
   """
   project: Project!
-  
+
   """
   The HTTP path for this card
   """
   resourcePath: URI!
-  
+
   """
   The state of ProjectCard
   """
   state: ProjectCardState
-  
+
   """
   Identifies the date and time when the object was last updated.
   """
   updatedAt: DateTime!
-  
+
   """
   The HTTP URL for this card
   """
@@ -30882,17 +30883,17 @@ type ProjectCardConnection {
   A list of edges.
   """
   edges: [ProjectCardEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [ProjectCard]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -30907,7 +30908,7 @@ type ProjectCardEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -30922,7 +30923,7 @@ input ProjectCardImport {
   The issue or pull request number.
   """
   number: Int!
-  
+
   """
   Repository name with owner (owner/repository).
   """
@@ -30964,64 +30965,64 @@ type ProjectColumn implements Node {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     A list of archived states to filter the cards by
     """
     archivedStates: [ProjectCardArchivedState] = [ARCHIVED, NOT_ARCHIVED]
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): ProjectCardConnection!
-  
+
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
-  
+
   """
   Identifies the primary key from the database.
   """
   databaseId: Int
   id: ID!
-  
+
   """
   The project column's name.
   """
   name: String!
-  
+
   """
   The project that contains this column.
   """
   project: Project!
-  
+
   """
   The semantic purpose of the column
   """
   purpose: ProjectColumnPurpose
-  
+
   """
   The HTTP path for this project column
   """
   resourcePath: URI!
-  
+
   """
   Identifies the date and time when the object was last updated.
   """
   updatedAt: DateTime!
-  
+
   """
   The HTTP URL for this project column
   """
@@ -31036,17 +31037,17 @@ type ProjectColumnConnection {
   A list of edges.
   """
   edges: [ProjectColumnEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [ProjectColumn]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -31061,7 +31062,7 @@ type ProjectColumnEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -31076,12 +31077,12 @@ input ProjectColumnImport {
   The name of the column.
   """
   columnName: String!
-  
+
   """
   A list of issues and pull requests in the column.
   """
   issues: [ProjectCardImport!]
-  
+
   """
   The position of the column, starting from 0.
   """
@@ -31114,17 +31115,17 @@ type ProjectConnection {
   A list of edges.
   """
   edges: [ProjectEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [Project]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -31139,7 +31140,7 @@ type ProjectEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -31154,7 +31155,7 @@ input ProjectOrder {
   The direction in which to order projects by the specified field.
   """
   direction: OrderDirection!
-  
+
   """
   The field in which to order projects by.
   """
@@ -31184,7 +31185,7 @@ Represents an owner of a Project.
 """
 interface ProjectOwner {
   id: ID!
-  
+
   """
   Find project by number.
   """
@@ -31194,7 +31195,7 @@ interface ProjectOwner {
     """
     number: Int!
   ): Project
-  
+
   """
   A list of projects under the owner.
   """
@@ -31203,48 +31204,48 @@ interface ProjectOwner {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for projects returned from the connection
     """
     orderBy: ProjectOrder
-    
+
     """
     Query to search projects by, currently only searching by name.
     """
     search: String
-    
+
     """
     A list of states to filter the projects by.
     """
     states: [ProjectState!]
   ): ProjectConnection!
-  
+
   """
   The HTTP path listing owners projects
   """
   projectsResourcePath: URI!
-  
+
   """
   The HTTP URL listing owners projects
   """
   projectsUrl: URI!
-  
+
   """
   Can the current viewer create new projects on this owner.
   """
@@ -31259,32 +31260,32 @@ type ProjectProgress {
   The number of done cards.
   """
   doneCount: Int!
-  
+
   """
   The percentage of done cards.
   """
   donePercentage: Float!
-  
+
   """
   Whether progress tracking is enabled and cards with purpose exist for this project
   """
   enabled: Boolean!
-  
+
   """
   The number of in-progress cards.
   """
   inProgressCount: Int!
-  
+
   """
   The percentage of in-progress cards.
   """
   inProgressPercentage: Float!
-  
+
   """
   The number of to do cards.
   """
   todoCount: Int!
-  
+
   """
   The percentage of to do cards.
   """
@@ -31335,27 +31336,27 @@ type ProjectV2 implements Closable & Node & Updatable {
   Returns true if the project is closed.
   """
   closed: Boolean!
-  
+
   """
   Identifies the date and time when the object was closed.
   """
   closedAt: DateTime
-  
+
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
-  
+
   """
   The actor who originally created the project.
   """
   creator: Actor
-  
+
   """
   Identifies the primary key from the database.
   """
   databaseId: Int
-  
+
   """
   A field of the project
   """
@@ -31365,7 +31366,7 @@ type ProjectV2 implements Closable & Node & Updatable {
     """
     name: String!
   ): ProjectV2FieldConfiguration
-  
+
   """
   List of fields and their constraints in the project
   """
@@ -31374,29 +31375,29 @@ type ProjectV2 implements Closable & Node & Updatable {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for project v2 fields returned from the connection
     """
     orderBy: ProjectV2FieldOrder = { field: POSITION, direction: ASC }
   ): ProjectV2FieldConfigurationConnection!
   id: ID!
-  
+
   """
   List of items in the project
   """
@@ -31405,48 +31406,48 @@ type ProjectV2 implements Closable & Node & Updatable {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for project v2 items returned from the connection
     """
     orderBy: ProjectV2ItemOrder = { field: POSITION, direction: ASC }
   ): ProjectV2ItemConnection!
-  
+
   """
   The project's number.
   """
   number: Int!
-  
+
   """
   The project's owner. Currently limited to organizations and users.
   """
   owner: ProjectV2Owner!
-  
+
   """
   Returns true if the project is public.
   """
   public: Boolean!
-  
+
   """
   The project's readme.
   """
   readme: String
-  
+
   """
   The repositories the project is linked to.
   """
@@ -31455,38 +31456,38 @@ type ProjectV2 implements Closable & Node & Updatable {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for repositories returned from the connection
     """
     orderBy: RepositoryOrder = { field: CREATED_AT, direction: DESC }
   ): RepositoryConnection!
-  
+
   """
   The HTTP path for this project
   """
   resourcePath: URI!
-  
+
   """
   The project's short description.
   """
   shortDescription: String
-  
+
   """
   The teams the project is linked to.
   """
@@ -31495,48 +31496,48 @@ type ProjectV2 implements Closable & Node & Updatable {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for teams returned from this connection.
     """
     orderBy: TeamOrder = { field: NAME, direction: ASC }
   ): TeamConnection!
-  
+
   """
   Returns true if this project is a template.
   """
   template: Boolean!
-  
+
   """
   The project's name.
   """
   title: String!
-  
+
   """
   Identifies the date and time when the object was last updated.
   """
   updatedAt: DateTime!
-  
+
   """
   The HTTP URL for this project
   """
   url: URI!
-  
+
   """
   A view of the project
   """
@@ -31546,22 +31547,22 @@ type ProjectV2 implements Closable & Node & Updatable {
     """
     number: Int!
   ): ProjectV2View
-  
+
   """
   Indicates if the object can be closed by the viewer.
   """
   viewerCanClose: Boolean!
-  
+
   """
   Indicates if the object can be reopened by the viewer.
   """
   viewerCanReopen: Boolean!
-  
+
   """
   Check if the current viewer can update this object.
   """
   viewerCanUpdate: Boolean!
-  
+
   """
   List of views in the project
   """
@@ -31570,28 +31571,28 @@ type ProjectV2 implements Closable & Node & Updatable {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for project v2 views returned from the connection
     """
     orderBy: ProjectV2ViewOrder = { field: POSITION, direction: ASC }
   ): ProjectV2ViewConnection!
-  
+
   """
   A workflow of the project
   """
@@ -31601,7 +31602,7 @@ type ProjectV2 implements Closable & Node & Updatable {
     """
     number: Int!
   ): ProjectV2Workflow
-  
+
   """
   List of the workflows in the project
   """
@@ -31610,22 +31611,22 @@ type ProjectV2 implements Closable & Node & Updatable {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for project v2 workflows returned from the connection
     """
@@ -31646,17 +31647,17 @@ type ProjectV2ActorConnection {
   A list of edges.
   """
   edges: [ProjectV2ActorEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [ProjectV2Actor]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -31671,7 +31672,7 @@ type ProjectV2ActorEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -31686,12 +31687,12 @@ input ProjectV2Collaborator {
   The role to grant the collaborator
   """
   role: ProjectV2Roles!
-  
+
   """
   The ID of the team as a collaborator.
   """
   teamId: ID @possibleTypes(concreteTypes: ["Team"])
-  
+
   """
   The ID of the user as a collaborator.
   """
@@ -31706,17 +31707,17 @@ type ProjectV2Connection {
   A list of edges.
   """
   edges: [ProjectV2Edge]
-  
+
   """
   A list of nodes.
   """
   nodes: [ProjectV2]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -31753,7 +31754,7 @@ type ProjectV2Edge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -31768,28 +31769,28 @@ type ProjectV2Field implements Node & ProjectV2FieldCommon {
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
-  
+
   """
   The field's type.
   """
   dataType: ProjectV2FieldType!
-  
+
   """
   Identifies the primary key from the database.
   """
   databaseId: Int
   id: ID!
-  
+
   """
   The project field's name.
   """
   name: String!
-  
+
   """
   The project that contains this field.
   """
   project: ProjectV2!
-  
+
   """
   Identifies the date and time when the object was last updated.
   """
@@ -31804,28 +31805,28 @@ interface ProjectV2FieldCommon {
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
-  
+
   """
   The field's type.
   """
   dataType: ProjectV2FieldType!
-  
+
   """
   Identifies the primary key from the database.
   """
   databaseId: Int
   id: ID!
-  
+
   """
   The project field's name.
   """
   name: String!
-  
+
   """
   The project that contains this field.
   """
   project: ProjectV2!
-  
+
   """
   Identifies the date and time when the object was last updated.
   """
@@ -31847,17 +31848,17 @@ type ProjectV2FieldConfigurationConnection {
   A list of edges.
   """
   edges: [ProjectV2FieldConfigurationEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [ProjectV2FieldConfiguration]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -31872,7 +31873,7 @@ type ProjectV2FieldConfigurationEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -31887,17 +31888,17 @@ type ProjectV2FieldConnection {
   A list of edges.
   """
   edges: [ProjectV2FieldEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [ProjectV2Field]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -31912,7 +31913,7 @@ type ProjectV2FieldEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -31927,7 +31928,7 @@ input ProjectV2FieldOrder {
   The ordering direction.
   """
   direction: OrderDirection!
-  
+
   """
   The field to order the project v2 fields by.
   """
@@ -32022,22 +32023,22 @@ input ProjectV2FieldValue {
   The ISO 8601 date to set on the field.
   """
   date: Date
-  
+
   """
   The id of the iteration to set on the field.
   """
   iterationId: String
-  
+
   """
   The number to set on the field.
   """
   number: Float
-  
+
   """
   The id of the single select option to set on the field.
   """
   singleSelectOptionId: String
-  
+
   """
   The text to set on the field.
   """
@@ -32062,22 +32063,22 @@ type ProjectV2Item implements Node {
   The content of the referenced draft issue, issue, or pull request
   """
   content: ProjectV2ItemContent
-  
+
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
-  
+
   """
   The actor who created the item.
   """
   creator: Actor
-  
+
   """
   Identifies the primary key from the database.
   """
   databaseId: Int
-  
+
   """
   The field value of the first project field which matches the 'name' argument that is set on the item.
   """
@@ -32087,7 +32088,7 @@ type ProjectV2Item implements Node {
     """
     name: String!
   ): ProjectV2ItemFieldValue
-  
+
   """
   The field values that are set on the item.
   """
@@ -32096,44 +32097,44 @@ type ProjectV2Item implements Node {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for project v2 item field values returned from the connection
     """
     orderBy: ProjectV2ItemFieldValueOrder = { field: POSITION, direction: ASC }
   ): ProjectV2ItemFieldValueConnection!
   id: ID!
-  
+
   """
   Whether the item is archived.
   """
   isArchived: Boolean!
-  
+
   """
   The project that contains this item.
   """
   project: ProjectV2!
-  
+
   """
   The type of the item.
   """
   type: ProjectV2ItemType!
-  
+
   """
   Identifies the date and time when the object was last updated.
   """
@@ -32148,17 +32149,17 @@ type ProjectV2ItemConnection {
   A list of edges.
   """
   edges: [ProjectV2ItemEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [ProjectV2Item]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -32178,7 +32179,7 @@ type ProjectV2ItemEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -32193,33 +32194,33 @@ type ProjectV2ItemFieldDateValue implements Node & ProjectV2ItemFieldValueCommon
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
-  
+
   """
   The actor who created the item.
   """
   creator: Actor
-  
+
   """
   Identifies the primary key from the database.
   """
   databaseId: Int
-  
+
   """
   Date value for the field
   """
   date: Date
-  
+
   """
   The project field that contains this value.
   """
   field: ProjectV2FieldConfiguration!
   id: ID!
-  
+
   """
   The project item that contains this value.
   """
   item: ProjectV2Item!
-  
+
   """
   Identifies the date and time when the object was last updated.
   """
@@ -32234,53 +32235,53 @@ type ProjectV2ItemFieldIterationValue implements Node & ProjectV2ItemFieldValueC
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
-  
+
   """
   The actor who created the item.
   """
   creator: Actor
-  
+
   """
   Identifies the primary key from the database.
   """
   databaseId: Int
-  
+
   """
   The duration of the iteration in days.
   """
   duration: Int!
-  
+
   """
   The project field that contains this value.
   """
   field: ProjectV2FieldConfiguration!
   id: ID!
-  
+
   """
   The project item that contains this value.
   """
   item: ProjectV2Item!
-  
+
   """
   The ID of the iteration.
   """
   iterationId: String!
-  
+
   """
   The start date of the iteration.
   """
   startDate: Date!
-  
+
   """
   The title of the iteration.
   """
   title: String!
-  
+
   """
   The title of the iteration, with HTML.
   """
   titleHTML: String!
-  
+
   """
   Identifies the date and time when the object was last updated.
   """
@@ -32295,7 +32296,7 @@ type ProjectV2ItemFieldLabelValue {
   The field that contains this value.
   """
   field: ProjectV2FieldConfiguration!
-  
+
   """
   Labels value of a field
   """
@@ -32304,17 +32305,17 @@ type ProjectV2ItemFieldLabelValue {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
@@ -32330,7 +32331,7 @@ type ProjectV2ItemFieldMilestoneValue {
   The field that contains this value.
   """
   field: ProjectV2FieldConfiguration!
-  
+
   """
   Milestone value of a field
   """
@@ -32345,33 +32346,33 @@ type ProjectV2ItemFieldNumberValue implements Node & ProjectV2ItemFieldValueComm
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
-  
+
   """
   The actor who created the item.
   """
   creator: Actor
-  
+
   """
   Identifies the primary key from the database.
   """
   databaseId: Int
-  
+
   """
   The project field that contains this value.
   """
   field: ProjectV2FieldConfiguration!
   id: ID!
-  
+
   """
   The project item that contains this value.
   """
   item: ProjectV2Item!
-  
+
   """
   Number as a float(8)
   """
   number: Float
-  
+
   """
   Identifies the date and time when the object was last updated.
   """
@@ -32386,7 +32387,7 @@ type ProjectV2ItemFieldPullRequestValue {
   The field that contains this value.
   """
   field: ProjectV2FieldConfiguration!
-  
+
   """
   The pull requests for this field
   """
@@ -32395,22 +32396,22 @@ type ProjectV2ItemFieldPullRequestValue {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for pull requests.
     """
@@ -32426,7 +32427,7 @@ type ProjectV2ItemFieldRepositoryValue {
   The field that contains this value.
   """
   field: ProjectV2FieldConfiguration!
-  
+
   """
   The repository for this field.
   """
@@ -32441,7 +32442,7 @@ type ProjectV2ItemFieldReviewerValue {
   The field that contains this value.
   """
   field: ProjectV2FieldConfiguration!
-  
+
   """
   The reviewers for this field.
   """
@@ -32450,17 +32451,17 @@ type ProjectV2ItemFieldReviewerValue {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
@@ -32476,58 +32477,58 @@ type ProjectV2ItemFieldSingleSelectValue implements Node & ProjectV2ItemFieldVal
   The color applied to the selected single-select option.
   """
   color: ProjectV2SingleSelectFieldOptionColor!
-  
+
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
-  
+
   """
   The actor who created the item.
   """
   creator: Actor
-  
+
   """
   Identifies the primary key from the database.
   """
   databaseId: Int
-  
+
   """
   A plain-text description of the selected single-select option, such as what the option means.
   """
   description: String
-  
+
   """
   The description of the selected single-select option, including HTML tags.
   """
   descriptionHTML: String
-  
+
   """
   The project field that contains this value.
   """
   field: ProjectV2FieldConfiguration!
   id: ID!
-  
+
   """
   The project item that contains this value.
   """
   item: ProjectV2Item!
-  
+
   """
   The name of the selected single select option.
   """
   name: String
-  
+
   """
   The html name of the selected single select option.
   """
   nameHTML: String
-  
+
   """
   The id of the selected single select option.
   """
   optionId: String
-  
+
   """
   Identifies the date and time when the object was last updated.
   """
@@ -32542,33 +32543,33 @@ type ProjectV2ItemFieldTextValue implements Node & ProjectV2ItemFieldValueCommon
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
-  
+
   """
   The actor who created the item.
   """
   creator: Actor
-  
+
   """
   Identifies the primary key from the database.
   """
   databaseId: Int
-  
+
   """
   The project field that contains this value.
   """
   field: ProjectV2FieldConfiguration!
   id: ID!
-  
+
   """
   The project item that contains this value.
   """
   item: ProjectV2Item!
-  
+
   """
   Text value of a field
   """
   text: String
-  
+
   """
   Identifies the date and time when the object was last updated.
   """
@@ -32583,7 +32584,7 @@ type ProjectV2ItemFieldUserValue {
   The field that contains this value.
   """
   field: ProjectV2FieldConfiguration!
-  
+
   """
   The users for this field
   """
@@ -32592,17 +32593,17 @@ type ProjectV2ItemFieldUserValue {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
@@ -32633,28 +32634,28 @@ interface ProjectV2ItemFieldValueCommon {
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
-  
+
   """
   The actor who created the item.
   """
   creator: Actor
-  
+
   """
   Identifies the primary key from the database.
   """
   databaseId: Int
-  
+
   """
   The project field that contains this value.
   """
   field: ProjectV2FieldConfiguration!
   id: ID!
-  
+
   """
   The project item that contains this value.
   """
   item: ProjectV2Item!
-  
+
   """
   Identifies the date and time when the object was last updated.
   """
@@ -32669,17 +32670,17 @@ type ProjectV2ItemFieldValueConnection {
   A list of edges.
   """
   edges: [ProjectV2ItemFieldValueEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [ProjectV2ItemFieldValue]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -32694,7 +32695,7 @@ type ProjectV2ItemFieldValueEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -32709,7 +32710,7 @@ input ProjectV2ItemFieldValueOrder {
   The ordering direction.
   """
   direction: OrderDirection!
-  
+
   """
   The field to order the project v2 item field values by.
   """
@@ -32734,7 +32735,7 @@ input ProjectV2ItemOrder {
   The ordering direction.
   """
   direction: OrderDirection!
-  
+
   """
   The field to order the project v2 items by.
   """
@@ -32781,33 +32782,33 @@ type ProjectV2IterationField implements Node & ProjectV2FieldCommon {
   Iteration configuration settings
   """
   configuration: ProjectV2IterationFieldConfiguration!
-  
+
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
-  
+
   """
   The field's type.
   """
   dataType: ProjectV2FieldType!
-  
+
   """
   Identifies the primary key from the database.
   """
   databaseId: Int
   id: ID!
-  
+
   """
   The project field's name.
   """
   name: String!
-  
+
   """
   The project that contains this field.
   """
   project: ProjectV2!
-  
+
   """
   Identifies the date and time when the object was last updated.
   """
@@ -32822,17 +32823,17 @@ type ProjectV2IterationFieldConfiguration {
   The iteration's completed iterations
   """
   completedIterations: [ProjectV2IterationFieldIteration!]!
-  
+
   """
   The iteration's duration in days
   """
   duration: Int!
-  
+
   """
   The iteration's iterations
   """
   iterations: [ProjectV2IterationFieldIteration!]!
-  
+
   """
   The iteration's start day of the week
   """
@@ -32847,22 +32848,22 @@ type ProjectV2IterationFieldIteration {
   The iteration's duration in days
   """
   duration: Int!
-  
+
   """
   The iteration's ID.
   """
   id: String!
-  
+
   """
   The iteration's start date
   """
   startDate: Date!
-  
+
   """
   The iteration's title.
   """
   title: String!
-  
+
   """
   The iteration's html title.
   """
@@ -32877,7 +32878,7 @@ input ProjectV2Order {
   The direction in which to order projects by the specified field.
   """
   direction: OrderDirection!
-  
+
   """
   The field in which to order projects by.
   """
@@ -32911,7 +32912,7 @@ Represents an owner of a project (beta).
 """
 interface ProjectV2Owner {
   id: ID!
-  
+
   """
   Find a project by number.
   """
@@ -32921,7 +32922,7 @@ interface ProjectV2Owner {
     """
     number: Int!
   ): ProjectV2
-  
+
   """
   A list of projects under the owner.
   """
@@ -32930,27 +32931,27 @@ interface ProjectV2Owner {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     How to order the returned projects.
     """
     orderBy: ProjectV2Order = { field: NUMBER, direction: DESC }
-    
+
     """
     A project to search for under the the owner.
     """
@@ -32970,17 +32971,17 @@ interface ProjectV2Recent {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
@@ -33018,23 +33019,23 @@ type ProjectV2SingleSelectField implements Node & ProjectV2FieldCommon {
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
-  
+
   """
   The field's type.
   """
   dataType: ProjectV2FieldType!
-  
+
   """
   Identifies the primary key from the database.
   """
   databaseId: Int
   id: ID!
-  
+
   """
   The project field's name.
   """
   name: String!
-  
+
   """
   Options for the single select field
   """
@@ -33044,12 +33045,12 @@ type ProjectV2SingleSelectField implements Node & ProjectV2FieldCommon {
     """
     names: [String!]
   ): [ProjectV2SingleSelectFieldOption!]!
-  
+
   """
   The project that contains this field.
   """
   project: ProjectV2!
-  
+
   """
   Identifies the date and time when the object was last updated.
   """
@@ -33064,27 +33065,27 @@ type ProjectV2SingleSelectFieldOption {
   The option's display color.
   """
   color: ProjectV2SingleSelectFieldOptionColor!
-  
+
   """
   The option's plain-text description.
   """
   description: String!
-  
+
   """
   The option's description, possibly containing HTML.
   """
   descriptionHTML: String!
-  
+
   """
   The option's ID.
   """
   id: String!
-  
+
   """
   The option's name.
   """
   name: String!
-  
+
   """
   The option's html name.
   """
@@ -33137,12 +33138,12 @@ input ProjectV2SingleSelectFieldOptionInput {
   The display color of the option
   """
   color: ProjectV2SingleSelectFieldOptionColor!
-  
+
   """
   The description text of the option
   """
   description: String!
-  
+
   """
   The name of the option
   """
@@ -33157,7 +33158,7 @@ type ProjectV2SortBy {
   The direction of the sorting. Possible values are ASC and DESC.
   """
   direction: OrderDirection!
-  
+
   """
   The field by which items are sorted.
   """
@@ -33172,17 +33173,17 @@ type ProjectV2SortByConnection {
   A list of edges.
   """
   edges: [ProjectV2SortByEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [ProjectV2SortBy]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -33197,7 +33198,7 @@ type ProjectV2SortByEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -33212,7 +33213,7 @@ type ProjectV2SortByField {
   The direction of the sorting. Possible values are ASC and DESC.
   """
   direction: OrderDirection!
-  
+
   """
   The field by which items are sorted.
   """
@@ -33227,17 +33228,17 @@ type ProjectV2SortByFieldConnection {
   A list of edges.
   """
   edges: [ProjectV2SortByFieldEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [ProjectV2SortByField]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -33252,7 +33253,7 @@ type ProjectV2SortByFieldEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -33281,12 +33282,12 @@ type ProjectV2View implements Node {
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
-  
+
   """
   Identifies the primary key from the database.
   """
   databaseId: Int
-  
+
   """
   The view's visible fields.
   """
@@ -33295,33 +33296,33 @@ type ProjectV2View implements Node {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for the project v2 fields returned from the connection.
     """
     orderBy: ProjectV2FieldOrder = { field: POSITION, direction: ASC }
   ): ProjectV2FieldConfigurationConnection
-  
+
   """
   The project view's filter.
   """
   filter: String
-  
+
   """
   The view's group-by field.
   """
@@ -33330,22 +33331,22 @@ type ProjectV2View implements Node {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for the project v2 fields returned from the connection.
     """
@@ -33354,7 +33355,7 @@ type ProjectV2View implements Node {
     @deprecated(
       reason: "The `ProjectV2View#order_by` API is deprecated in favour of the more capable `ProjectV2View#group_by_field` API. Check out the `ProjectV2View#group_by_fields` API as an example for the more capable alternative. Removal on 2023-04-01 UTC."
     )
-  
+
   """
   The view's group-by field.
   """
@@ -33363,49 +33364,49 @@ type ProjectV2View implements Node {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for the project v2 fields returned from the connection.
     """
     orderBy: ProjectV2FieldOrder = { field: POSITION, direction: ASC }
   ): ProjectV2FieldConfigurationConnection
   id: ID!
-  
+
   """
   The project view's layout.
   """
   layout: ProjectV2ViewLayout!
-  
+
   """
   The project view's name.
   """
   name: String!
-  
+
   """
   The project view's number.
   """
   number: Int!
-  
+
   """
   The project that contains this view.
   """
   project: ProjectV2!
-  
+
   """
   The view's sort-by config.
   """
@@ -33414,17 +33415,17 @@ type ProjectV2View implements Node {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
@@ -33433,7 +33434,7 @@ type ProjectV2View implements Node {
     @deprecated(
       reason: "The `ProjectV2View#sort_by` API is deprecated in favour of the more capable `ProjectV2View#sort_by_fields` API. Check out the `ProjectV2View#sort_by_fields` API as an example for the more capable alternative. Removal on 2023-04-01 UTC."
     )
-  
+
   """
   The view's sort-by config.
   """
@@ -33442,28 +33443,28 @@ type ProjectV2View implements Node {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): ProjectV2SortByFieldConnection
-  
+
   """
   Identifies the date and time when the object was last updated.
   """
   updatedAt: DateTime!
-  
+
   """
   The view's vertical-group-by field.
   """
@@ -33472,22 +33473,22 @@ type ProjectV2View implements Node {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for the project v2 fields returned from the connection.
     """
@@ -33496,7 +33497,7 @@ type ProjectV2View implements Node {
     @deprecated(
       reason: "The `ProjectV2View#vertical_group_by` API is deprecated in favour of the more capable `ProjectV2View#vertical_group_by_fields` API. Check out the `ProjectV2View#vertical_group_by_fields` API as an example for the more capable alternative. Removal on 2023-04-01 UTC."
     )
-  
+
   """
   The view's vertical-group-by field.
   """
@@ -33505,28 +33506,28 @@ type ProjectV2View implements Node {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for the project v2 fields returned from the connection.
     """
     orderBy: ProjectV2FieldOrder = { field: POSITION, direction: ASC }
   ): ProjectV2FieldConfigurationConnection
-  
+
   """
   The view's visible fields.
   """
@@ -33535,22 +33536,22 @@ type ProjectV2View implements Node {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for the project v2 fields returned from the connection.
     """
@@ -33569,17 +33570,17 @@ type ProjectV2ViewConnection {
   A list of edges.
   """
   edges: [ProjectV2ViewEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [ProjectV2View]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -33594,7 +33595,7 @@ type ProjectV2ViewEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -33627,7 +33628,7 @@ input ProjectV2ViewOrder {
   The ordering direction.
   """
   direction: OrderDirection!
-  
+
   """
   The field to order the project v2 views by.
   """
@@ -33660,33 +33661,33 @@ type ProjectV2Workflow implements Node {
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
-  
+
   """
   Identifies the primary key from the database.
   """
   databaseId: Int
-  
+
   """
   The workflows' enabled state.
   """
   enabled: Boolean!
   id: ID!
-  
+
   """
   The workflows' name.
   """
   name: String!
-  
+
   """
   The workflows' number.
   """
   number: Int!
-  
+
   """
   The project that contains this workflow.
   """
   project: ProjectV2!
-  
+
   """
   Identifies the date and time when the object was last updated.
   """
@@ -33701,17 +33702,17 @@ type ProjectV2WorkflowConnection {
   A list of edges.
   """
   edges: [ProjectV2WorkflowEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [ProjectV2Workflow]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -33726,7 +33727,7 @@ type ProjectV2WorkflowEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -33741,7 +33742,7 @@ input ProjectV2WorkflowOrder {
   The ordering direction.
   """
   direction: OrderDirection!
-  
+
   """
   The field to order the project v2 workflows by.
   """
@@ -33778,29 +33779,29 @@ type PublicKey implements Node {
   The last time this authorization was used to perform an action. Values will be null for keys not owned by the user.
   """
   accessedAt: DateTime
-  
+
   """
   Identifies the date and time when the key was created. Keys created before
   March 5th, 2014 have inaccurate values. Values will be null for keys not owned by the user.
   """
   createdAt: DateTime
-  
+
   """
   The fingerprint for this PublicKey.
   """
   fingerprint: String!
   id: ID!
-  
+
   """
   Whether this PublicKey is read-only or not. Values will be null for keys not owned by the user.
   """
   isReadOnly: Boolean
-  
+
   """
   The public key string.
   """
   key: String!
-  
+
   """
   Identifies the date and time when the key was updated. Keys created before
   March 5th, 2014 may have inaccurate values. Values will be null for keys not
@@ -33817,17 +33818,17 @@ type PublicKeyConnection {
   A list of edges.
   """
   edges: [PublicKeyEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [PublicKey]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -33842,7 +33843,7 @@ type PublicKeyEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -33857,7 +33858,7 @@ input PublishSponsorsTierInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The ID of the draft tier to publish.
   """
@@ -33872,7 +33873,7 @@ type PublishSponsorsTierPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The tier that was published.
   """
@@ -33887,12 +33888,12 @@ type PullRequest implements Assignable & Closable & Comment & Labelable & Lockab
   Reason that the conversation was locked.
   """
   activeLockReason: LockReason
-  
+
   """
   The number of additions in this pull request.
   """
   additions: Int!
-  
+
   """
   A list of Users assigned to this object.
   """
@@ -33901,103 +33902,103 @@ type PullRequest implements Assignable & Closable & Comment & Labelable & Lockab
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): UserConnection!
-  
+
   """
   The actor who authored the comment.
   """
   author: Actor
-  
+
   """
   Author's association with the subject of the comment.
   """
   authorAssociation: CommentAuthorAssociation!
-  
+
   """
   Returns the auto-merge request object if one exists for this pull request.
   """
   autoMergeRequest: AutoMergeRequest
-  
+
   """
   Identifies the base Ref associated with the pull request.
   """
   baseRef: Ref
-  
+
   """
   Identifies the name of the base Ref associated with the pull request, even if the ref has been deleted.
   """
   baseRefName: String!
-  
+
   """
   Identifies the oid of the base ref associated with the pull request, even if the ref has been deleted.
   """
   baseRefOid: GitObjectID!
-  
+
   """
   The repository associated with this pull request's base Ref.
   """
   baseRepository: Repository
-  
+
   """
   The body as Markdown.
   """
   body: String!
-  
+
   """
   The body rendered to HTML.
   """
   bodyHTML: HTML!
-  
+
   """
   The body rendered to text.
   """
   bodyText: String!
-  
+
   """
   Whether or not the pull request is rebaseable.
   """
   canBeRebased: Boolean! @preview(toggledBy: "merge-info-preview")
-  
+
   """
   The number of changed files in this pull request.
   """
   changedFiles: Int!
-  
+
   """
   The HTTP path for the checks of this pull request.
   """
   checksResourcePath: URI!
-  
+
   """
   The HTTP URL for the checks of this pull request.
   """
   checksUrl: URI!
-  
+
   """
   `true` if the pull request is closed
   """
   closed: Boolean!
-  
+
   """
   Identifies the date and time when the object was closed.
   """
   closedAt: DateTime
-  
+
   """
   List of issues that were may be closed by this pull request
   """
@@ -34006,33 +34007,33 @@ type PullRequest implements Assignable & Closable & Comment & Labelable & Lockab
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for issues returned from the connection
     """
     orderBy: IssueOrder
-    
+
     """
     Return only manually linked Issues
     """
     userLinkedOnly: Boolean = false
   ): IssueConnection
-  
+
   """
   A list of comments associated with the pull request.
   """
@@ -34041,28 +34042,28 @@ type PullRequest implements Assignable & Closable & Comment & Labelable & Lockab
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for issue comments returned from the connection.
     """
     orderBy: IssueCommentOrder
   ): IssueCommentConnection!
-  
+
   """
   A list of commits present in this pull request's head branch not present in the base branch.
   """
@@ -34071,48 +34072,48 @@ type PullRequest implements Assignable & Closable & Comment & Labelable & Lockab
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): PullRequestCommitConnection!
-  
+
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
-  
+
   """
   Check if this comment was created via an email reply.
   """
   createdViaEmail: Boolean!
-  
+
   """
   Identifies the primary key from the database.
   """
   databaseId: Int
-  
+
   """
   The number of deletions in this pull request.
   """
   deletions: Int!
-  
+
   """
   The actor who edited this pull request's body.
   """
   editor: Actor
-  
+
   """
   Lists the files changed within this pull request.
   """
@@ -34121,48 +34122,48 @@ type PullRequest implements Assignable & Closable & Comment & Labelable & Lockab
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): PullRequestChangedFileConnection
-  
+
   """
   Identifies the head Ref associated with the pull request.
   """
   headRef: Ref
-  
+
   """
   Identifies the name of the head Ref associated with the pull request, even if the ref has been deleted.
   """
   headRefName: String!
-  
+
   """
   Identifies the oid of the head ref associated with the pull request, even if the ref has been deleted.
   """
   headRefOid: GitObjectID!
-  
+
   """
   The repository associated with this pull request's head Ref.
   """
   headRepository: Repository
-  
+
   """
   The owner of the repository associated with this pull request's head Ref.
   """
   headRepositoryOwner: RepositoryOwner
-  
+
   """
   The hovercard information for this issue
   """
@@ -34173,27 +34174,27 @@ type PullRequest implements Assignable & Closable & Comment & Labelable & Lockab
     includeNotificationContexts: Boolean = true
   ): Hovercard!
   id: ID!
-  
+
   """
   Check if this comment was edited and includes an edit with the creation data
   """
   includesCreatedEdit: Boolean!
-  
+
   """
   The head and base repositories are different.
   """
   isCrossRepository: Boolean!
-  
+
   """
   Identifies if the pull request is a draft.
   """
   isDraft: Boolean!
-  
+
   """
   Is this pull request read by the viewer
   """
   isReadByViewer: Boolean
-  
+
   """
   A list of labels associated with the object.
   """
@@ -34202,33 +34203,33 @@ type PullRequest implements Assignable & Closable & Comment & Labelable & Lockab
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for labels returned from the connection.
     """
     orderBy: LabelOrder = { field: CREATED_AT, direction: ASC }
   ): LabelConnection
-  
+
   """
   The moment the editor made the last edit
   """
   lastEditedAt: DateTime
-  
+
   """
   A list of latest reviews per user associated with the pull request.
   """
@@ -34237,28 +34238,28 @@ type PullRequest implements Assignable & Closable & Comment & Labelable & Lockab
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Only return reviews from user who have write access to the repository
     """
     writersOnly: Boolean = false
   ): PullRequestReviewConnection
-  
+
   """
   A list of latest reviews per user associated with the pull request that are not also pending review.
   """
@@ -34267,78 +34268,78 @@ type PullRequest implements Assignable & Closable & Comment & Labelable & Lockab
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): PullRequestReviewConnection
-  
+
   """
   `true` if the pull request is locked
   """
   locked: Boolean!
-  
+
   """
   Indicates whether maintainers can modify the pull request.
   """
   maintainerCanModify: Boolean!
-  
+
   """
   The commit that was created when this pull request was merged.
   """
   mergeCommit: Commit
-  
+
   """
   The merge queue entry of the pull request in the base branch's merge queue
   """
   mergeQueueEntry: MergeQueueEntry
-  
+
   """
   Detailed information about the current pull request merge state status.
   """
   mergeStateStatus: MergeStateStatus! @preview(toggledBy: "merge-info-preview")
-  
+
   """
   Whether or not the pull request can be merged based on the existence of merge conflicts.
   """
   mergeable: MergeableState!
-  
+
   """
   Whether or not the pull request was merged.
   """
   merged: Boolean!
-  
+
   """
   The date and time that the pull request was merged.
   """
   mergedAt: DateTime
-  
+
   """
   The actor who merged the pull request.
   """
   mergedBy: Actor
-  
+
   """
   Identifies the milestone associated with the pull request.
   """
   milestone: Milestone
-  
+
   """
   Identifies the pull request number.
   """
   number: Int!
-  
+
   """
   A list of Users that are participating in the Pull Request conversation.
   """
@@ -34347,28 +34348,28 @@ type PullRequest implements Assignable & Closable & Comment & Labelable & Lockab
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): UserConnection!
-  
+
   """
   The permalink to the pull request.
   """
   permalink: URI!
-  
+
   """
   The commit that GitHub automatically generated to test if this pull request
   could be merged. This field will not return a value if the pull request is
@@ -34376,7 +34377,7 @@ type PullRequest implements Assignable & Closable & Comment & Labelable & Lockab
   `mergeable` field for more details on the mergeability of the pull request.
   """
   potentialMergeCommit: Commit
-  
+
   """
   List of project cards associated with this pull request.
   """
@@ -34385,28 +34386,28 @@ type PullRequest implements Assignable & Closable & Comment & Labelable & Lockab
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     A list of archived states to filter the cards by
     """
     archivedStates: [ProjectCardArchivedState] = [ARCHIVED, NOT_ARCHIVED]
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): ProjectCardConnection!
-  
+
   """
   List of project items associated with this pull request.
   """
@@ -34415,28 +34416,28 @@ type PullRequest implements Assignable & Closable & Comment & Labelable & Lockab
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Include archived items.
     """
     includeArchived: Boolean = true
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): ProjectV2ItemConnection!
-  
+
   """
   Find a project by number.
   """
@@ -34446,7 +34447,7 @@ type PullRequest implements Assignable & Closable & Comment & Labelable & Lockab
     """
     number: Int!
   ): ProjectV2
-  
+
   """
   A list of projects under the owner.
   """
@@ -34455,43 +34456,43 @@ type PullRequest implements Assignable & Closable & Comment & Labelable & Lockab
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     How to order the returned projects.
     """
     orderBy: ProjectV2Order = { field: NUMBER, direction: DESC }
-    
+
     """
     A project to search for under the the owner.
     """
     query: String
   ): ProjectV2Connection!
-  
+
   """
   Identifies when the comment was published at.
   """
   publishedAt: DateTime
-  
+
   """
   A list of reactions grouped by content left on the subject.
   """
   reactionGroups: [ReactionGroup!]
-  
+
   """
   A list of Reactions left on the Issue.
   """
@@ -34500,58 +34501,58 @@ type PullRequest implements Assignable & Closable & Comment & Labelable & Lockab
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Allows filtering Reactions by emoji.
     """
     content: ReactionContent
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Allows specifying the order in which reactions are returned.
     """
     orderBy: ReactionOrder
   ): ReactionConnection!
-  
+
   """
   The repository associated with this node.
   """
   repository: Repository!
-  
+
   """
   The HTTP path for this pull request.
   """
   resourcePath: URI!
-  
+
   """
   The HTTP path for reverting this pull request.
   """
   revertResourcePath: URI!
-  
+
   """
   The HTTP URL for reverting this pull request.
   """
   revertUrl: URI!
-  
+
   """
   The current status of this pull request with respect to code review.
   """
   reviewDecision: PullRequestReviewDecision
-  
+
   """
   A list of review requests associated with the pull request.
   """
@@ -34560,23 +34561,23 @@ type PullRequest implements Assignable & Closable & Comment & Labelable & Lockab
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): ReviewRequestConnection
-  
+
   """
   The list of all review threads for this pull request.
   """
@@ -34585,23 +34586,23 @@ type PullRequest implements Assignable & Closable & Comment & Labelable & Lockab
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): PullRequestReviewThreadConnection!
-  
+
   """
   A list of reviews associated with the pull request.
   """
@@ -34610,43 +34611,43 @@ type PullRequest implements Assignable & Closable & Comment & Labelable & Lockab
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Filter by author of the review.
     """
     author: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     A list of states to filter the reviews.
     """
     states: [PullRequestReviewState!]
   ): PullRequestReviewConnection
-  
+
   """
   Identifies the state of the pull request.
   """
   state: PullRequestState!
-  
+
   """
   A list of reviewer suggestions based on commit history and past review comments.
   """
   suggestedReviewers: [SuggestedReviewer]!
-  
+
   """
   A list of events, comments, commits, etc. associated with the pull request.
   """
@@ -34655,22 +34656,22 @@ type PullRequest implements Assignable & Closable & Comment & Labelable & Lockab
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Allows filtering timeline events by a `since` timestamp.
     """
@@ -34679,7 +34680,7 @@ type PullRequest implements Assignable & Closable & Comment & Labelable & Lockab
     @deprecated(
       reason: "`timeline` will be removed Use PullRequest.timelineItems instead. Removal on 2020-10-01 UTC."
     )
-  
+
   """
   A list of events, comments, commits, etc. associated with the pull request.
   """
@@ -34688,63 +34689,63 @@ type PullRequest implements Assignable & Closable & Comment & Labelable & Lockab
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Filter timeline items by type.
     """
     itemTypes: [PullRequestTimelineItemsItemType!]
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Filter timeline items by a `since` timestamp.
     """
     since: DateTime
-    
+
     """
     Skips the first _n_ elements in the list.
     """
     skip: Int
   ): PullRequestTimelineItemsConnection!
-  
+
   """
   Identifies the pull request title.
   """
   title: String!
-  
+
   """
   Identifies the pull request title rendered to HTML.
   """
   titleHTML: HTML!
-  
+
   """
   Returns a count of how many comments this pull request has received.
   """
   totalCommentsCount: Int
-  
+
   """
   Identifies the date and time when the object was last updated.
   """
   updatedAt: DateTime!
-  
+
   """
   The HTTP URL for this pull request.
   """
   url: URI!
-  
+
   """
   A list of edits to this content.
   """
@@ -34753,104 +34754,104 @@ type PullRequest implements Assignable & Closable & Comment & Labelable & Lockab
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): UserContentEditConnection
-  
+
   """
   Whether or not the viewer can apply suggestion.
   """
   viewerCanApplySuggestion: Boolean!
-  
+
   """
   Indicates if the object can be closed by the viewer.
   """
   viewerCanClose: Boolean!
-  
+
   """
   Check if the viewer can restore the deleted head ref.
   """
   viewerCanDeleteHeadRef: Boolean!
-  
+
   """
   Whether or not the viewer can disable auto-merge
   """
   viewerCanDisableAutoMerge: Boolean!
-  
+
   """
   Can the viewer edit files within this pull request.
   """
   viewerCanEditFiles: Boolean!
-  
+
   """
   Whether or not the viewer can enable auto-merge
   """
   viewerCanEnableAutoMerge: Boolean!
-  
+
   """
   Indicates whether the viewer can bypass branch protections and merge the pull request immediately
   """
   viewerCanMergeAsAdmin: Boolean!
-  
+
   """
   Can user react to this subject
   """
   viewerCanReact: Boolean!
-  
+
   """
   Indicates if the object can be reopened by the viewer.
   """
   viewerCanReopen: Boolean!
-  
+
   """
   Check if the viewer is able to change their subscription status for the repository.
   """
   viewerCanSubscribe: Boolean!
-  
+
   """
   Check if the current viewer can update this object.
   """
   viewerCanUpdate: Boolean!
-  
+
   """
   Whether or not the viewer can update the head ref of this PR, by merging or rebasing the base ref.
   If the head ref is up to date or unable to be updated by this user, this will return false.
   """
   viewerCanUpdateBranch: Boolean!
-  
+
   """
   Reasons why the current viewer can not update this comment.
   """
   viewerCannotUpdateReasons: [CommentCannotUpdateReason!]!
-  
+
   """
   Did the viewer author this comment.
   """
   viewerDidAuthor: Boolean!
-  
+
   """
   The latest review given from the viewer.
   """
   viewerLatestReview: PullRequestReview
-  
+
   """
   The person who has requested the viewer for review on this pull request.
   """
   viewerLatestReviewRequest: ReviewRequest
-  
+
   """
   The merge body text for the viewer and method.
   """
@@ -34860,7 +34861,7 @@ type PullRequest implements Assignable & Closable & Comment & Labelable & Lockab
     """
     mergeType: PullRequestMergeMethod
   ): String!
-  
+
   """
   The merge headline text for the viewer and method.
   """
@@ -34870,7 +34871,7 @@ type PullRequest implements Assignable & Closable & Comment & Labelable & Lockab
     """
     mergeType: PullRequestMergeMethod
   ): String!
-  
+
   """
   Identifies if the viewer is watching, not watching, or ignoring the subscribable entity.
   """
@@ -34899,22 +34900,22 @@ type PullRequestChangedFile {
   The number of additions to the file.
   """
   additions: Int!
-  
+
   """
   How the file was changed in this PullRequest
   """
   changeType: PatchStatus!
-  
+
   """
   The number of deletions to the file.
   """
   deletions: Int!
-  
+
   """
   The path of the file.
   """
   path: String!
-  
+
   """
   The state of the file for the viewer.
   """
@@ -34929,17 +34930,17 @@ type PullRequestChangedFileConnection {
   A list of edges.
   """
   edges: [PullRequestChangedFileEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [PullRequestChangedFile]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -34954,7 +34955,7 @@ type PullRequestChangedFileEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -34970,17 +34971,17 @@ type PullRequestCommit implements Node & UniformResourceLocatable {
   """
   commit: Commit!
   id: ID!
-  
+
   """
   The pull request this commit belongs to
   """
   pullRequest: PullRequest!
-  
+
   """
   The HTTP path for this pull request commit
   """
   resourcePath: URI!
-  
+
   """
   The HTTP URL for this pull request commit
   """
@@ -34999,44 +35000,44 @@ type PullRequestCommitCommentThread implements Node & RepositoryNode {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): CommitCommentConnection!
-  
+
   """
   The commit the comments were made on.
   """
   commit: Commit!
   id: ID!
-  
+
   """
   The file the comments were made on.
   """
   path: String
-  
+
   """
   The position in the diff for the commit that the comment was made on.
   """
   position: Int
-  
+
   """
   The pull request this commit comment thread belongs to
   """
   pullRequest: PullRequest!
-  
+
   """
   The repository associated with this node.
   """
@@ -35051,17 +35052,17 @@ type PullRequestCommitConnection {
   A list of edges.
   """
   edges: [PullRequestCommitEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [PullRequestCommit]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -35076,7 +35077,7 @@ type PullRequestCommitEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -35091,17 +35092,17 @@ type PullRequestConnection {
   A list of edges.
   """
   edges: [PullRequestEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [PullRequest]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -35120,28 +35121,28 @@ type PullRequestContributionsByRepository {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for contributions returned from the connection.
     """
     orderBy: ContributionOrder = { direction: DESC }
   ): CreatedPullRequestContributionConnection!
-  
+
   """
   The repository in which the pull requests were opened.
   """
@@ -35156,7 +35157,7 @@ type PullRequestEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -35189,7 +35190,7 @@ input PullRequestOrder {
   The direction in which to order pull requests by the specified field.
   """
   direction: OrderDirection!
-  
+
   """
   The field in which to order pull requests by.
   """
@@ -35218,22 +35219,22 @@ type PullRequestParameters {
   New, reviewable commits pushed will dismiss previous pull request review approvals.
   """
   dismissStaleReviewsOnPush: Boolean!
-  
+
   """
   Require an approving review in pull requests that modify files that have a designated code owner.
   """
   requireCodeOwnerReview: Boolean!
-  
+
   """
   Whether the most recent reviewable push must be approved by someone other than the person who pushed it.
   """
   requireLastPushApproval: Boolean!
-  
+
   """
   The number of approving reviews that are required before a pull request can be merged.
   """
   requiredApprovingReviewCount: Int!
-  
+
   """
   All conversations on code must be resolved before a pull request can be merged.
   """
@@ -35248,22 +35249,22 @@ input PullRequestParametersInput {
   New, reviewable commits pushed will dismiss previous pull request review approvals.
   """
   dismissStaleReviewsOnPush: Boolean!
-  
+
   """
   Require an approving review in pull requests that modify files that have a designated code owner.
   """
   requireCodeOwnerReview: Boolean!
-  
+
   """
   Whether the most recent reviewable push must be approved by someone other than the person who pushed it.
   """
   requireLastPushApproval: Boolean!
-  
+
   """
   The number of approving reviews that are required before a pull request can be merged.
   """
   requiredApprovingReviewCount: Int!
-  
+
   """
   All conversations on code must be resolved before a pull request can be merged.
   """
@@ -35278,32 +35279,32 @@ type PullRequestReview implements Comment & Deletable & Node & Reactable & Repos
   The actor who authored the comment.
   """
   author: Actor
-  
+
   """
   Author's association with the subject of the comment.
   """
   authorAssociation: CommentAuthorAssociation!
-  
+
   """
   Indicates whether the author of this review has push access to the repository.
   """
   authorCanPushToRepository: Boolean!
-  
+
   """
   Identifies the pull request review body.
   """
   body: String!
-  
+
   """
   The body rendered to HTML.
   """
   bodyHTML: HTML!
-  
+
   """
   The body of this review rendered as plain text.
   """
   bodyText: String!
-  
+
   """
   A list of review comments for the current pull request review.
   """
@@ -35312,59 +35313,59 @@ type PullRequestReview implements Comment & Deletable & Node & Reactable & Repos
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): PullRequestReviewCommentConnection!
-  
+
   """
   Identifies the commit associated with this pull request review.
   """
   commit: Commit
-  
+
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
-  
+
   """
   Check if this comment was created via an email reply.
   """
   createdViaEmail: Boolean!
-  
+
   """
   Identifies the primary key from the database.
   """
   databaseId: Int
-  
+
   """
   The actor who edited the comment.
   """
   editor: Actor
   id: ID!
-  
+
   """
   Check if this comment was edited and includes an edit with the creation data
   """
   includesCreatedEdit: Boolean!
-  
+
   """
   The moment the editor made the last edit
   """
   lastEditedAt: DateTime
-  
+
   """
   A list of teams that this review was made on behalf of.
   """
@@ -35373,38 +35374,38 @@ type PullRequestReview implements Comment & Deletable & Node & Reactable & Repos
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): TeamConnection!
-  
+
   """
   Identifies when the comment was published at.
   """
   publishedAt: DateTime
-  
+
   """
   Identifies the pull request associated with this pull request review.
   """
   pullRequest: PullRequest!
-  
+
   """
   A list of reactions grouped by content left on the subject.
   """
   reactionGroups: [ReactionGroup!]
-  
+
   """
   A list of Reactions left on the Issue.
   """
@@ -35413,63 +35414,63 @@ type PullRequestReview implements Comment & Deletable & Node & Reactable & Repos
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Allows filtering Reactions by emoji.
     """
     content: ReactionContent
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Allows specifying the order in which reactions are returned.
     """
     orderBy: ReactionOrder
   ): ReactionConnection!
-  
+
   """
   The repository associated with this node.
   """
   repository: Repository!
-  
+
   """
   The HTTP path permalink for this PullRequestReview.
   """
   resourcePath: URI!
-  
+
   """
   Identifies the current state of the pull request review.
   """
   state: PullRequestReviewState!
-  
+
   """
   Identifies when the Pull Request Review was submitted
   """
   submittedAt: DateTime
-  
+
   """
   Identifies the date and time when the object was last updated.
   """
   updatedAt: DateTime!
-  
+
   """
   The HTTP URL permalink for this PullRequestReview.
   """
   url: URI!
-  
+
   """
   A list of edits to this content.
   """
@@ -35478,43 +35479,43 @@ type PullRequestReview implements Comment & Deletable & Node & Reactable & Repos
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): UserContentEditConnection
-  
+
   """
   Check if the current viewer can delete this object.
   """
   viewerCanDelete: Boolean!
-  
+
   """
   Can user react to this subject
   """
   viewerCanReact: Boolean!
-  
+
   """
   Check if the current viewer can update this object.
   """
   viewerCanUpdate: Boolean!
-  
+
   """
   Reasons why the current viewer can not update this comment.
   """
   viewerCannotUpdateReasons: [CommentCannotUpdateReason!]!
-  
+
   """
   Did the viewer author this comment.
   """
@@ -35529,100 +35530,100 @@ type PullRequestReviewComment implements Comment & Deletable & Minimizable & Nod
   The actor who authored the comment.
   """
   author: Actor
-  
+
   """
   Author's association with the subject of the comment.
   """
   authorAssociation: CommentAuthorAssociation!
-  
+
   """
   The comment body of this review comment.
   """
   body: String!
-  
+
   """
   The body rendered to HTML.
   """
   bodyHTML: HTML!
-  
+
   """
   The comment body of this review comment rendered as plain text.
   """
   bodyText: String!
-  
+
   """
   Identifies the commit associated with the comment.
   """
   commit: Commit
-  
+
   """
   Identifies when the comment was created.
   """
   createdAt: DateTime!
-  
+
   """
   Check if this comment was created via an email reply.
   """
   createdViaEmail: Boolean!
-  
+
   """
   Identifies the primary key from the database.
   """
   databaseId: Int
-  
+
   """
   The diff hunk to which the comment applies.
   """
   diffHunk: String!
-  
+
   """
   Identifies when the comment was created in a draft state.
   """
   draftedAt: DateTime!
-  
+
   """
   The actor who edited the comment.
   """
   editor: Actor
   id: ID!
-  
+
   """
   Check if this comment was edited and includes an edit with the creation data
   """
   includesCreatedEdit: Boolean!
-  
+
   """
   Returns whether or not a comment has been minimized.
   """
   isMinimized: Boolean!
-  
+
   """
   The moment the editor made the last edit
   """
   lastEditedAt: DateTime
-  
+
   """
   The end line number on the file to which the comment applies
   """
   line: Int
-  
+
   """
   Returns why the comment was minimized. One of `abuse`, `off-topic`,
   `outdated`, `resolved`, `duplicate` and `spam`. Note that the case and
   formatting of these values differs from the inputs to the `MinimizeComment` mutation.
   """
   minimizedReason: String
-  
+
   """
   Identifies the original commit associated with the comment.
   """
   originalCommit: Commit
-  
+
   """
   The end line number on the file to which the comment applied when it was first created
   """
   originalLine: Int
-  
+
   """
   The original line index in the diff to which the comment applies.
   """
@@ -35630,22 +35631,22 @@ type PullRequestReviewComment implements Comment & Deletable & Minimizable & Nod
     @deprecated(
       reason: "We are phasing out diff-relative positioning for PR comments Removal on 2023-10-01 UTC."
     )
-  
+
   """
   The start line number on the file to which the comment applied when it was first created
   """
   originalStartLine: Int
-  
+
   """
   Identifies when the comment body is outdated
   """
   outdated: Boolean!
-  
+
   """
   The path to which the comment applies.
   """
   path: String!
-  
+
   """
   The line index in the diff to which the comment applies.
   """
@@ -35653,27 +35654,27 @@ type PullRequestReviewComment implements Comment & Deletable & Minimizable & Nod
     @deprecated(
       reason: "We are phasing out diff-relative positioning for PR comments Use the `line` and `startLine` fields instead, which are file line numbers instead of diff line numbers Removal on 2023-10-01 UTC."
     )
-  
+
   """
   Identifies when the comment was published at.
   """
   publishedAt: DateTime
-  
+
   """
   The pull request associated with this review comment.
   """
   pullRequest: PullRequest!
-  
+
   """
   The pull request review associated with this review comment.
   """
   pullRequestReview: PullRequestReview
-  
+
   """
   A list of reactions grouped by content left on the subject.
   """
   reactionGroups: [ReactionGroup!]
-  
+
   """
   A list of Reactions left on the Issue.
   """
@@ -35682,73 +35683,73 @@ type PullRequestReviewComment implements Comment & Deletable & Minimizable & Nod
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Allows filtering Reactions by emoji.
     """
     content: ReactionContent
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Allows specifying the order in which reactions are returned.
     """
     orderBy: ReactionOrder
   ): ReactionConnection!
-  
+
   """
   The comment this is a reply to.
   """
   replyTo: PullRequestReviewComment
-  
+
   """
   The repository associated with this node.
   """
   repository: Repository!
-  
+
   """
   The HTTP path permalink for this review comment.
   """
   resourcePath: URI!
-  
+
   """
   The start line number on the file to which the comment applies
   """
   startLine: Int
-  
+
   """
   Identifies the state of the comment.
   """
   state: PullRequestReviewCommentState!
-  
+
   """
   The level at which the comments in the corresponding thread are targeted, can be a diff line or a file
   """
   subjectType: PullRequestReviewThreadSubjectType!
-  
+
   """
   Identifies when the comment was last updated.
   """
   updatedAt: DateTime!
-  
+
   """
   The HTTP URL permalink for this review comment.
   """
   url: URI!
-  
+
   """
   A list of edits to this content.
   """
@@ -35757,48 +35758,48 @@ type PullRequestReviewComment implements Comment & Deletable & Minimizable & Nod
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): UserContentEditConnection
-  
+
   """
   Check if the current viewer can delete this object.
   """
   viewerCanDelete: Boolean!
-  
+
   """
   Check if the current viewer can minimize this object.
   """
   viewerCanMinimize: Boolean!
-  
+
   """
   Can user react to this subject
   """
   viewerCanReact: Boolean!
-  
+
   """
   Check if the current viewer can update this object.
   """
   viewerCanUpdate: Boolean!
-  
+
   """
   Reasons why the current viewer can not update this comment.
   """
   viewerCannotUpdateReasons: [CommentCannotUpdateReason!]!
-  
+
   """
   Did the viewer author this comment.
   """
@@ -35813,17 +35814,17 @@ type PullRequestReviewCommentConnection {
   A list of edges.
   """
   edges: [PullRequestReviewCommentEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [PullRequestReviewComment]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -35838,7 +35839,7 @@ type PullRequestReviewCommentEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -35867,17 +35868,17 @@ type PullRequestReviewConnection {
   A list of edges.
   """
   edges: [PullRequestReviewEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [PullRequestReview]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -35896,28 +35897,28 @@ type PullRequestReviewContributionsByRepository {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for contributions returned from the connection.
     """
     orderBy: ContributionOrder = { direction: DESC }
   ): CreatedPullRequestReviewContributionConnection!
-  
+
   """
   The repository in which the pull request reviews were made.
   """
@@ -35950,7 +35951,7 @@ type PullRequestReviewEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -36017,109 +36018,109 @@ type PullRequestReviewThread implements Node {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Skips the first _n_ elements in the list.
     """
     skip: Int
   ): PullRequestReviewCommentConnection!
-  
+
   """
   The side of the diff on which this thread was placed.
   """
   diffSide: DiffSide!
   id: ID!
-  
+
   """
   Whether or not the thread has been collapsed (resolved)
   """
   isCollapsed: Boolean!
-  
+
   """
   Indicates whether this thread was outdated by newer changes.
   """
   isOutdated: Boolean!
-  
+
   """
   Whether this thread has been resolved
   """
   isResolved: Boolean!
-  
+
   """
   The line in the file to which this thread refers
   """
   line: Int
-  
+
   """
   The original line in the file to which this thread refers.
   """
   originalLine: Int
-  
+
   """
   The original start line in the file to which this thread refers (multi-line only).
   """
   originalStartLine: Int
-  
+
   """
   Identifies the file path of this thread.
   """
   path: String!
-  
+
   """
   Identifies the pull request associated with this thread.
   """
   pullRequest: PullRequest!
-  
+
   """
   Identifies the repository associated with this thread.
   """
   repository: Repository!
-  
+
   """
   The user who resolved this thread
   """
   resolvedBy: User
-  
+
   """
   The side of the diff that the first line of the thread starts on (multi-line only)
   """
   startDiffSide: DiffSide
-  
+
   """
   The start line in the file to which this thread refers (multi-line only)
   """
   startLine: Int
-  
+
   """
   The level at which the comments in the corresponding thread are targeted, can be a diff line or a file
   """
   subjectType: PullRequestReviewThreadSubjectType!
-  
+
   """
   Indicates whether the current viewer can reply to this thread.
   """
   viewerCanReply: Boolean!
-  
+
   """
   Whether or not the viewer can resolve this thread
   """
   viewerCanResolve: Boolean!
-  
+
   """
   Whether or not the viewer can unresolve this thread
   """
@@ -36134,17 +36135,17 @@ type PullRequestReviewThreadConnection {
   A list of edges.
   """
   edges: [PullRequestReviewThreadEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [PullRequestReviewThread]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -36159,7 +36160,7 @@ type PullRequestReviewThreadEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -36188,12 +36189,12 @@ type PullRequestRevisionMarker {
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
-  
+
   """
   The last commit the viewer has seen.
   """
   lastSeenCommit: Commit!
-  
+
   """
   The pull request to which the marker belongs.
   """
@@ -36226,12 +36227,12 @@ type PullRequestTemplate {
   The body of the template
   """
   body: String
-  
+
   """
   The filename of the template
   """
   filename: String
-  
+
   """
   The repository the template belongs to
   """
@@ -36250,99 +36251,99 @@ type PullRequestThread implements Node {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Skips the first _n_ elements in the list.
     """
     skip: Int
   ): PullRequestReviewCommentConnection!
-  
+
   """
   The side of the diff on which this thread was placed.
   """
   diffSide: DiffSide!
   id: ID!
-  
+
   """
   Whether or not the thread has been collapsed (resolved)
   """
   isCollapsed: Boolean!
-  
+
   """
   Indicates whether this thread was outdated by newer changes.
   """
   isOutdated: Boolean!
-  
+
   """
   Whether this thread has been resolved
   """
   isResolved: Boolean!
-  
+
   """
   The line in the file to which this thread refers
   """
   line: Int
-  
+
   """
   Identifies the file path of this thread.
   """
   path: String!
-  
+
   """
   Identifies the pull request associated with this thread.
   """
   pullRequest: PullRequest!
-  
+
   """
   Identifies the repository associated with this thread.
   """
   repository: Repository!
-  
+
   """
   The user who resolved this thread
   """
   resolvedBy: User
-  
+
   """
   The side of the diff that the first line of the thread starts on (multi-line only)
   """
   startDiffSide: DiffSide
-  
+
   """
   The line of the first file diff in the thread.
   """
   startLine: Int
-  
+
   """
   The level at which the comments in the corresponding thread are targeted, can be a diff line or a file
   """
   subjectType: PullRequestReviewThreadSubjectType!
-  
+
   """
   Indicates whether the current viewer can reply to this thread.
   """
   viewerCanReply: Boolean!
-  
+
   """
   Whether or not the viewer can resolve this thread
   """
   viewerCanResolve: Boolean!
-  
+
   """
   Whether or not the viewer can unresolve this thread
   """
@@ -36357,17 +36358,17 @@ type PullRequestTimelineConnection {
   A list of edges.
   """
   edges: [PullRequestTimelineItemEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [PullRequestTimelineItem]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -36419,7 +36420,7 @@ type PullRequestTimelineItemEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -36496,32 +36497,32 @@ type PullRequestTimelineItemsConnection {
   A list of edges.
   """
   edges: [PullRequestTimelineItemsEdge]
-  
+
   """
   Identifies the count of items after applying `before` and `after` filters.
   """
   filteredCount: Int!
-  
+
   """
   A list of nodes.
   """
   nodes: [PullRequestTimelineItems]
-  
+
   """
   Identifies the count of items after applying `before`/`after` filters and `first`/`last`/`skip` slicing.
   """
   pageCount: Int!
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
   totalCount: Int!
-  
+
   """
   Identifies the date and time when the timeline was last updated.
   """
@@ -36536,7 +36537,7 @@ type PullRequestTimelineItemsEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -36800,27 +36801,27 @@ A Git push.
 """
 type Push implements Node {
   id: ID!
-  
+
   """
   The SHA after the push
   """
   nextSha: GitObjectID
-  
+
   """
   The permalink for this push.
   """
   permalink: URI!
-  
+
   """
   The SHA before the push
   """
   previousSha: GitObjectID
-  
+
   """
   The actor who pushed
   """
   pusher: Actor!
-  
+
   """
   The repository that was pushed to
   """
@@ -36835,7 +36836,7 @@ type PushAllowance implements Node {
   The actor that can push.
   """
   actor: PushAllowanceActor
-  
+
   """
   Identifies the branch protection rule associated with the allowed user, team, or app.
   """
@@ -36856,17 +36857,17 @@ type PushAllowanceConnection {
   A list of edges.
   """
   edges: [PushAllowanceEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [PushAllowance]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -36881,7 +36882,7 @@ type PushAllowanceEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -36901,12 +36902,12 @@ type Query {
     """
     key: String!
   ): CodeOfConduct
-  
+
   """
   Look up a code of conduct by its key
   """
   codesOfConduct: [CodeOfConduct]
-  
+
   """
   Look up an enterprise by URL slug.
   """
@@ -36915,13 +36916,13 @@ type Query {
     The enterprise invitation token.
     """
     invitationToken: String
-    
+
     """
     The enterprise URL slug.
     """
     slug: String!
   ): Enterprise
-  
+
   """
   Look up a pending enterprise administrator invitation by invitee, enterprise and role.
   """
@@ -36930,18 +36931,18 @@ type Query {
     The slug of the enterprise the user was invited to join.
     """
     enterpriseSlug: String!
-    
+
     """
     The role for the business member invitation.
     """
     role: EnterpriseAdministratorRole!
-    
+
     """
     The login of the user invited to join the business.
     """
     userLogin: String!
   ): EnterpriseAdministratorInvitation
-  
+
   """
   Look up a pending enterprise administrator invitation by invitation token.
   """
@@ -36951,7 +36952,7 @@ type Query {
     """
     invitationToken: String!
   ): EnterpriseAdministratorInvitation
-  
+
   """
   Look up an open source license by its key
   """
@@ -36961,12 +36962,12 @@ type Query {
     """
     key: String!
   ): License
-  
+
   """
   Return a list of known open source licenses
   """
   licenses: [License]!
-  
+
   """
   Get alphabetically sorted list of Marketplace categories
   """
@@ -36975,18 +36976,18 @@ type Query {
     Exclude categories with no listings.
     """
     excludeEmpty: Boolean
-    
+
     """
     Returns top level categories only, excluding any subcategories.
     """
     excludeSubcategories: Boolean
-    
+
     """
     Return only the specified categories.
     """
     includeCategories: [String!]
   ): [MarketplaceCategory!]!
-  
+
   """
   Look up a Marketplace category by its slug.
   """
@@ -36995,13 +36996,13 @@ type Query {
     The URL slug of the category.
     """
     slug: String!
-    
+
     """
     Also check topic aliases for the category slug
     """
     useTopicAliases: Boolean
   ): MarketplaceCategory
-  
+
   """
   Look up a single Marketplace listing
   """
@@ -37011,7 +37012,7 @@ type Query {
     """
     slug: String!
   ): MarketplaceListing
-  
+
   """
   Look up Marketplace listings
   """
@@ -37020,75 +37021,75 @@ type Query {
     Select listings that can be administered by the specified user.
     """
     adminId: ID
-    
+
     """
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Select listings visible to the viewer even if they are not approved. If omitted or
     false, only approved listings will be returned.
     """
     allStates: Boolean
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Select only listings with the given category.
     """
     categorySlug: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Select listings for products owned by the specified organization.
     """
     organizationId: ID
-    
+
     """
     Select only listings where the primary category matches the given category slug.
     """
     primaryCategoryOnly: Boolean = false
-    
+
     """
     Select the listings with these slugs, if they are visible to the viewer.
     """
     slugs: [String]
-    
+
     """
     Also check topic aliases for the category slug
     """
     useTopicAliases: Boolean
-    
+
     """
     Select listings to which user has admin access. If omitted, listings visible to the
     viewer are returned.
     """
     viewerCanAdmin: Boolean
-    
+
     """
     Select only listings that offer a free trial.
     """
     withFreeTrialsOnly: Boolean = false
   ): MarketplaceListingConnection!
-  
+
   """
   Return information about the GitHub instance
   """
   meta: GitHubMetadata!
-  
+
   """
   Fetches an object given its ID.
   """
@@ -37098,7 +37099,7 @@ type Query {
     """
     id: ID!
   ): Node
-  
+
   """
   Lookup nodes by a list of IDs.
   """
@@ -37108,7 +37109,7 @@ type Query {
     """
     ids: [ID!]!
   ): [Node]!
-  
+
   """
   Lookup a organization by login.
   """
@@ -37118,7 +37119,7 @@ type Query {
     """
     login: String!
   ): Organization
-  
+
   """
   The client's rate limit information.
   """
@@ -37128,13 +37129,13 @@ type Query {
     """
     dryRun: Boolean = false
   ): RateLimit
-  
+
   """
   Workaround for re-exposing the root query object. (Refer to
   https://github.com/facebook/relay/issues/112 for more information.)
   """
   relay: Query!
-  
+
   """
   Lookup a given repository by the owner and repository name.
   """
@@ -37143,18 +37144,18 @@ type Query {
     Follow repository renames. If disabled, a repository referenced by its old name will return an error.
     """
     followRenames: Boolean = true
-    
+
     """
     The name of the repository
     """
     name: String!
-    
+
     """
     The login field of a user or organization
     """
     owner: String!
   ): Repository
-  
+
   """
   Lookup a repository owner (ie. either a User or an Organization) by login.
   """
@@ -37164,7 +37165,7 @@ type Query {
     """
     login: String!
   ): RepositoryOwner
-  
+
   """
   Lookup resource by a URL.
   """
@@ -37174,7 +37175,7 @@ type Query {
     """
     url: URI!
   ): UniformResourceLocatable
-  
+
   """
   Perform a search across resources, returning a maximum of 1,000 results.
   """
@@ -37183,33 +37184,33 @@ type Query {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     The search string to look for.
     """
     query: String!
-    
+
     """
     The types of search items to search within.
     """
     type: SearchType!
   ): SearchResultItemConnection!
-  
+
   """
   GitHub Security Advisories
   """
@@ -37218,48 +37219,48 @@ type Query {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     A list of classifications to filter advisories by.
     """
     classifications: [SecurityAdvisoryClassification!]
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Filter advisories by identifier, e.g. GHSA or CVE.
     """
     identifier: SecurityAdvisoryIdentifierFilter
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for the returned topics.
     """
     orderBy: SecurityAdvisoryOrder = { field: UPDATED_AT, direction: DESC }
-    
+
     """
     Filter advisories to those published since a time in the past.
     """
     publishedSince: DateTime
-    
+
     """
     Filter advisories to those updated since a time in the past.
     """
     updatedSince: DateTime
   ): SecurityAdvisoryConnection!
-  
+
   """
   Fetch a Security Advisory by its GHSA ID
   """
@@ -37269,7 +37270,7 @@ type Query {
     """
     ghsaId: String!
   ): SecurityAdvisory
-  
+
   """
   Software Vulnerabilities documented by GitHub Security Advisories
   """
@@ -37278,48 +37279,49 @@ type Query {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     A list of advisory classifications to filter vulnerabilities by.
     """
     classifications: [SecurityAdvisoryClassification!]
-    
+
     """
     An ecosystem to filter vulnerabilities by.
     """
     ecosystem: SecurityAdvisoryEcosystem
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for the returned topics.
     """
-    orderBy: SecurityVulnerabilityOrder = { field: UPDATED_AT, direction: DESC }
-    
+    orderBy: SecurityVulnerabilityOrder = { field: UPDATED_AT, direction: DESC
+    }
+
     """
     A package name to filter vulnerabilities by.
     """
     package: String
-    
+
     """
     A list of severities to filter vulnerabilities by.
     """
     severities: [SecurityAdvisorySeverity!]
   ): SecurityVulnerabilityConnection!
-  
+
   """
   Users and organizations who can be sponsored via GitHub Sponsors.
   """
@@ -37328,12 +37330,12 @@ type Query {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Optional filter for which dependencies should be checked for sponsorable
     owners. Only sponsorable owners of dependencies in this ecosystem will be
@@ -37344,24 +37346,24 @@ type Query {
     **Reason:** The type is switching from SecurityAdvisoryEcosystem to DependencyGraphEcosystem.
     """
     dependencyEcosystem: SecurityAdvisoryEcosystem
-    
+
     """
     Optional filter for which dependencies should be checked for sponsorable
     owners. Only sponsorable owners of dependencies in this ecosystem will be
     included. Used when onlyDependencies = true.
     """
     ecosystem: DependencyGraphEcosystem
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Whether only sponsorables who own the viewer's dependencies will be
     returned. Must be authenticated to use. Can check an organization instead
@@ -37369,12 +37371,12 @@ type Query {
     orgLoginForDependencies.
     """
     onlyDependencies: Boolean = false
-    
+
     """
     Ordering options for users and organizations returned from the connection.
     """
     orderBy: SponsorableOrder = { field: LOGIN, direction: ASC }
-    
+
     """
     Optional organization username for whose dependencies should be checked.
     Used when onlyDependencies = true. Omit to check your own dependencies. If
@@ -37383,7 +37385,7 @@ type Query {
     """
     orgLoginForDependencies: String
   ): SponsorableItemConnection!
-  
+
   """
   Look up a topic by name.
   """
@@ -37393,7 +37395,7 @@ type Query {
     """
     name: String!
   ): Topic
-  
+
   """
   Lookup a user by login.
   """
@@ -37403,7 +37405,7 @@ type Query {
     """
     login: String!
   ): User
-  
+
   """
   The currently authenticated user.
   """
@@ -37418,27 +37420,27 @@ type RateLimit {
   The point cost for the current query counting against the rate limit.
   """
   cost: Int!
-  
+
   """
   The maximum number of points the client is permitted to consume in a 60 minute window.
   """
   limit: Int!
-  
+
   """
   The maximum number of nodes this query may return
   """
   nodeCount: Int!
-  
+
   """
   The number of points remaining in the current rate limit window.
   """
   remaining: Int!
-  
+
   """
   The time at which the current rate limit window resets in UTC epoch seconds.
   """
   resetAt: DateTime!
-  
+
   """
   The number of points used in the current rate limit window.
   """
@@ -37454,12 +37456,12 @@ interface Reactable {
   """
   databaseId: Int
   id: ID!
-  
+
   """
   A list of reactions grouped by content left on the subject.
   """
   reactionGroups: [ReactionGroup!]
-  
+
   """
   A list of Reactions left on the Issue.
   """
@@ -37468,33 +37470,33 @@ interface Reactable {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Allows filtering Reactions by emoji.
     """
     content: ReactionContent
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Allows specifying the order in which reactions are returned.
     """
     orderBy: ReactionOrder
   ): ReactionConnection!
-  
+
   """
   Can user react to this subject
   """
@@ -37509,17 +37511,17 @@ type ReactingUserConnection {
   A list of edges.
   """
   edges: [ReactingUserEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [User]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -37535,7 +37537,7 @@ type ReactingUserEdge {
   """
   cursor: String!
   node: User!
-  
+
   """
   The moment when the user made the reaction.
   """
@@ -37550,23 +37552,23 @@ type Reaction implements Node {
   Identifies the emoji reaction.
   """
   content: ReactionContent!
-  
+
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
-  
+
   """
   Identifies the primary key from the database.
   """
   databaseId: Int
   id: ID!
-  
+
   """
   The reactable piece of content
   """
   reactable: Reactable!
-  
+
   """
   Identifies the user who created this reaction.
   """
@@ -37581,22 +37583,22 @@ type ReactionConnection {
   A list of edges.
   """
   edges: [ReactionEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [Reaction]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
   totalCount: Int!
-  
+
   """
   Whether or not the authenticated user has left a reaction on the subject.
   """
@@ -37649,7 +37651,7 @@ type ReactionEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -37664,12 +37666,12 @@ type ReactionGroup {
   Identifies the emoji reaction.
   """
   content: ReactionContent!
-  
+
   """
   Identifies when the reaction was created.
   """
   createdAt: DateTime
-  
+
   """
   Reactors to the reaction subject with the emotion represented by this reaction group.
   """
@@ -37678,28 +37680,28 @@ type ReactionGroup {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): ReactorConnection!
-  
+
   """
   The subject that was reacted to.
   """
   subject: Reactable!
-  
+
   """
   Users who have reacted to the reaction subject with the emotion represented by this reaction group
   """
@@ -37708,17 +37710,17 @@ type ReactionGroup {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
@@ -37727,7 +37729,7 @@ type ReactionGroup {
     @deprecated(
       reason: "Reactors can now be mannequins, bots, and organizations. Use the `reactors` field instead. Removal on 2021-10-01 UTC."
     )
-  
+
   """
   Whether or not the authenticated user has left a reaction on the subject.
   """
@@ -37742,7 +37744,7 @@ input ReactionOrder {
   The direction in which to order reactions by the specified field.
   """
   direction: OrderDirection!
-  
+
   """
   The field in which to order reactions by.
   """
@@ -37772,17 +37774,17 @@ type ReactorConnection {
   A list of edges.
   """
   edges: [ReactorEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [Reactor]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -37797,12 +37799,12 @@ type ReactorEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The author of the reaction.
   """
   node: Reactor!
-  
+
   """
   The moment when the user made the reaction.
   """
@@ -37817,23 +37819,23 @@ type ReadyForReviewEvent implements Node & UniformResourceLocatable {
   Identifies the actor who performed the event.
   """
   actor: Actor
-  
+
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
   id: ID!
-  
+
   """
   PullRequest referenced by event.
   """
   pullRequest: PullRequest!
-  
+
   """
   The HTTP path for this ready for review event.
   """
   resourcePath: URI!
-  
+
   """
   The HTTP URL for this ready for review event.
   """
@@ -37852,53 +37854,53 @@ type Ref implements Node {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     The base ref name to filter the pull requests by.
     """
     baseRefName: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     The head ref name to filter the pull requests by.
     """
     headRefName: String
-    
+
     """
     A list of label names to filter the pull requests by.
     """
     labels: [String!]
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for pull requests returned from the connection.
     """
     orderBy: IssueOrder
-    
+
     """
     A list of states to filter the pull requests by.
     """
     states: [PullRequestState!]
   ): PullRequestConnection!
-  
+
   """
   Branch protection rules for this ref
   """
   branchProtectionRule: BranchProtectionRule
-  
+
   """
   Compares the current ref as a base ref to another head ref, if the comparison can be made.
   """
@@ -37909,27 +37911,27 @@ type Ref implements Node {
     headRef: String!
   ): Comparison
   id: ID!
-  
+
   """
   The ref name.
   """
   name: String!
-  
+
   """
   The ref's prefix, such as `refs/heads/` or `refs/tags/`.
   """
   prefix: String!
-  
+
   """
   Branch protection rules that are viewable by non-admins
   """
   refUpdateRule: RefUpdateRule
-  
+
   """
   The repository the ref belongs to.
   """
   repository: Repository!
-  
+
   """
   The object the ref points to. Returns null when object does not exist.
   """
@@ -37944,17 +37946,17 @@ type RefConnection {
   A list of edges.
   """
   edges: [RefEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [Ref]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -37969,7 +37971,7 @@ type RefEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -37984,7 +37986,7 @@ type RefNameConditionTarget {
   Array of ref names or patterns to exclude. The condition will not pass if any of these patterns match.
   """
   exclude: [String!]!
-  
+
   """
   Array of ref names or patterns to include. One of these patterns must match
   for the condition to pass. Also accepts `~DEFAULT_BRANCH` to include the
@@ -38001,7 +38003,7 @@ input RefNameConditionTargetInput {
   Array of ref names or patterns to exclude. The condition will not pass if any of these patterns match.
   """
   exclude: [String!]!
-  
+
   """
   Array of ref names or patterns to include. One of these patterns must match
   for the condition to pass. Also accepts `~DEFAULT_BRANCH` to include the
@@ -38018,7 +38020,7 @@ input RefOrder {
   The direction in which to order refs by the specified field.
   """
   direction: OrderDirection!
-  
+
   """
   The field in which to order refs by.
   """
@@ -38047,17 +38049,17 @@ input RefUpdate @preview(toggledBy: "update-refs-preview") {
   The value this ref should be updated to.
   """
   afterOid: GitObjectID!
-  
+
   """
   The value this ref needs to point to before the update.
   """
   beforeOid: GitObjectID
-  
+
   """
   Force a non fast-forward update.
   """
   force: Boolean = false
-  
+
   """
   The fully qualified name of the ref to be update. For example `refs/heads/branch-name`
   """
@@ -38072,57 +38074,57 @@ type RefUpdateRule {
   Can this branch be deleted.
   """
   allowsDeletions: Boolean!
-  
+
   """
   Are force pushes allowed on this branch.
   """
   allowsForcePushes: Boolean!
-  
+
   """
   Can matching branches be created.
   """
   blocksCreations: Boolean!
-  
+
   """
   Identifies the protection rule pattern.
   """
   pattern: String!
-  
+
   """
   Number of approving reviews required to update matching branches.
   """
   requiredApprovingReviewCount: Int
-  
+
   """
   List of required status check contexts that must pass for commits to be accepted to matching branches.
   """
   requiredStatusCheckContexts: [String]
-  
+
   """
   Are reviews from code owners required to update matching branches.
   """
   requiresCodeOwnerReviews: Boolean!
-  
+
   """
   Are conversations required to be resolved before merging.
   """
   requiresConversationResolution: Boolean!
-  
+
   """
   Are merge commits prohibited from being pushed to this branch.
   """
   requiresLinearHistory: Boolean!
-  
+
   """
   Are commits required to be signed.
   """
   requiresSignatures: Boolean!
-  
+
   """
   Is the viewer allowed to dismiss reviews.
   """
   viewerAllowedToDismissReviews: Boolean!
-  
+
   """
   Can the viewer push to the branch
   """
@@ -38137,33 +38139,33 @@ type ReferencedEvent implements Node {
   Identifies the actor who performed the event.
   """
   actor: Actor
-  
+
   """
   Identifies the commit associated with the 'referenced' event.
   """
   commit: Commit
-  
+
   """
   Identifies the repository associated with the 'referenced' event.
   """
   commitRepository: Repository!
-  
+
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
   id: ID!
-  
+
   """
   Reference originated in a different repository.
   """
   isCrossRepository: Boolean!
-  
+
   """
   Checks if the commit message itself references the subject. Can be false in the case of a commit comment reference.
   """
   isDirectReference: Boolean!
-  
+
   """
   Object referenced by event.
   """
@@ -38183,7 +38185,7 @@ input RegenerateEnterpriseIdentityProviderRecoveryCodesInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The ID of the enterprise on which to set an identity provider.
   """
@@ -38198,7 +38200,7 @@ type RegenerateEnterpriseIdentityProviderRecoveryCodesPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The identity provider for the enterprise.
   """
@@ -38213,7 +38215,7 @@ input RegenerateVerifiableDomainTokenInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The ID of the verifiable domain to regenerate the verification token of.
   """
@@ -38228,7 +38230,7 @@ type RegenerateVerifiableDomainTokenPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The verification token that was generated.
   """
@@ -38243,17 +38245,17 @@ input RejectDeploymentsInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   Optional comment for rejecting deployments
   """
   comment: String = ""
-  
+
   """
   The ids of environments to reject deployments
   """
   environmentIds: [ID!]!
-  
+
   """
   The node ID of the workflow run containing the pending deployments.
   """
@@ -38268,7 +38270,7 @@ type RejectDeploymentsPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The affected deployments.
   """
@@ -38283,43 +38285,43 @@ type Release implements Node & Reactable & UniformResourceLocatable {
   The author of the release
   """
   author: User
-  
+
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
-  
+
   """
   Identifies the primary key from the database.
   """
   databaseId: Int
-  
+
   """
   The description of the release.
   """
   description: String
-  
+
   """
   The description of this release rendered to HTML.
   """
   descriptionHTML: HTML
   id: ID!
-  
+
   """
   Whether or not the release is a draft
   """
   isDraft: Boolean!
-  
+
   """
   Whether or not the release is the latest releast
   """
   isLatest: Boolean!
-  
+
   """
   Whether or not the release is a prerelease
   """
   isPrerelease: Boolean!
-  
+
   """
   A list of users mentioned in the release description
   """
@@ -38328,38 +38330,38 @@ type Release implements Node & Reactable & UniformResourceLocatable {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): UserConnection
-  
+
   """
   The title of the release.
   """
   name: String
-  
+
   """
   Identifies the date and time when the release was created.
   """
   publishedAt: DateTime
-  
+
   """
   A list of reactions grouped by content left on the subject.
   """
   reactionGroups: [ReactionGroup!]
-  
+
   """
   A list of Reactions left on the Issue.
   """
@@ -38368,33 +38370,33 @@ type Release implements Node & Reactable & UniformResourceLocatable {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Allows filtering Reactions by emoji.
     """
     content: ReactionContent
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Allows specifying the order in which reactions are returned.
     """
     orderBy: ReactionOrder
   ): ReactionConnection!
-  
+
   """
   List of releases assets which are dependent on this release.
   """
@@ -38403,38 +38405,38 @@ type Release implements Node & Reactable & UniformResourceLocatable {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     A list of names to filter the assets by.
     """
     name: String
   ): ReleaseAssetConnection!
-  
+
   """
   The repository that the release belongs to.
   """
   repository: Repository!
-  
+
   """
   The HTTP path for this issue
   """
   resourcePath: URI!
-  
+
   """
   A description of the release, rendered to HTML without any links in it.
   """
@@ -38444,32 +38446,32 @@ type Release implements Node & Reactable & UniformResourceLocatable {
     """
     limit: Int = 200
   ): HTML
-  
+
   """
   The Git tag the release points to
   """
   tag: Ref
-  
+
   """
   The tag commit for this release.
   """
   tagCommit: Commit
-  
+
   """
   The name of the release's Git tag
   """
   tagName: String!
-  
+
   """
   Identifies the date and time when the object was last updated.
   """
   updatedAt: DateTime!
-  
+
   """
   The HTTP URL for this issue
   """
   url: URI!
-  
+
   """
   Can user react to this subject
   """
@@ -38484,48 +38486,48 @@ type ReleaseAsset implements Node {
   The asset's content-type
   """
   contentType: String!
-  
+
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
-  
+
   """
   The number of times this asset was downloaded
   """
   downloadCount: Int!
-  
+
   """
   Identifies the URL where you can download the release asset via the browser.
   """
   downloadUrl: URI!
   id: ID!
-  
+
   """
   Identifies the title of the release asset.
   """
   name: String!
-  
+
   """
   Release that the asset is associated with
   """
   release: Release
-  
+
   """
   The size (in bytes) of the asset
   """
   size: Int!
-  
+
   """
   Identifies the date and time when the object was last updated.
   """
   updatedAt: DateTime!
-  
+
   """
   The user that performed the upload
   """
   uploadedBy: User!
-  
+
   """
   Identifies the URL of the release asset.
   """
@@ -38540,17 +38542,17 @@ type ReleaseAssetConnection {
   A list of edges.
   """
   edges: [ReleaseAssetEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [ReleaseAsset]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -38565,7 +38567,7 @@ type ReleaseAssetEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -38580,17 +38582,17 @@ type ReleaseConnection {
   A list of edges.
   """
   edges: [ReleaseEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [Release]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -38605,7 +38607,7 @@ type ReleaseEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -38620,7 +38622,7 @@ input ReleaseOrder {
   The direction in which to order releases by the specified field.
   """
   direction: OrderDirection!
-  
+
   """
   The field in which to order releases by.
   """
@@ -38653,12 +38655,12 @@ input RemoveAssigneesFromAssignableInput {
       concreteTypes: ["Issue", "PullRequest"]
       abstractType: "Assignable"
     )
-  
+
   """
   The id of users to remove as assignees.
   """
   assigneeIds: [ID!]! @possibleTypes(concreteTypes: ["User"])
-  
+
   """
   A unique identifier for the client performing the mutation.
   """
@@ -38673,7 +38675,7 @@ type RemoveAssigneesFromAssignablePayload {
   The item that was unassigned.
   """
   assignable: Assignable
-  
+
   """
   A unique identifier for the client performing the mutation.
   """
@@ -38688,12 +38690,12 @@ input RemoveEnterpriseAdminInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The Enterprise ID from which to remove the administrator.
   """
   enterpriseId: ID! @possibleTypes(concreteTypes: ["Enterprise"])
-  
+
   """
   The login of the user to remove as an administrator.
   """
@@ -38708,22 +38710,22 @@ type RemoveEnterpriseAdminPayload {
   The user who was removed as an administrator.
   """
   admin: User
-  
+
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The updated enterprise.
   """
   enterprise: Enterprise
-  
+
   """
   A message confirming the result of removing an administrator.
   """
   message: String
-  
+
   """
   The viewer performing the mutation.
   """
@@ -38738,7 +38740,7 @@ input RemoveEnterpriseIdentityProviderInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The ID of the enterprise from which to remove the identity provider.
   """
@@ -38753,7 +38755,7 @@ type RemoveEnterpriseIdentityProviderPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The identity provider that was removed from the enterprise.
   """
@@ -38768,12 +38770,12 @@ input RemoveEnterpriseMemberInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The ID of the enterprise from which the user should be removed.
   """
   enterpriseId: ID! @possibleTypes(concreteTypes: ["Enterprise"])
-  
+
   """
   The ID of the user to remove from the enterprise.
   """
@@ -38788,17 +38790,17 @@ type RemoveEnterpriseMemberPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The updated enterprise.
   """
   enterprise: Enterprise
-  
+
   """
   The user that was removed from the enterprise.
   """
   user: User
-  
+
   """
   The viewer performing the mutation.
   """
@@ -38813,12 +38815,12 @@ input RemoveEnterpriseOrganizationInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The ID of the enterprise from which the organization should be removed.
   """
   enterpriseId: ID! @possibleTypes(concreteTypes: ["Enterprise"])
-  
+
   """
   The ID of the organization to remove from the enterprise.
   """
@@ -38833,17 +38835,17 @@ type RemoveEnterpriseOrganizationPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The updated enterprise.
   """
   enterprise: Enterprise
-  
+
   """
   The organization that was removed from the enterprise.
   """
   organization: Organization
-  
+
   """
   The viewer performing the mutation.
   """
@@ -38858,12 +38860,12 @@ input RemoveEnterpriseSupportEntitlementInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The ID of the Enterprise which the admin belongs to.
   """
   enterpriseId: ID! @possibleTypes(concreteTypes: ["Enterprise"])
-  
+
   """
   The login of a member who will lose the support entitlement.
   """
@@ -38878,7 +38880,7 @@ type RemoveEnterpriseSupportEntitlementPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   A message confirming the result of removing the support entitlement.
   """
@@ -38893,12 +38895,12 @@ input RemoveLabelsFromLabelableInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The ids of labels to remove.
   """
   labelIds: [ID!]! @possibleTypes(concreteTypes: ["Label"])
-  
+
   """
   The id of the Labelable to remove labels from.
   """
@@ -38917,7 +38919,7 @@ type RemoveLabelsFromLabelablePayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The Labelable the labels were removed from.
   """
@@ -38932,12 +38934,12 @@ input RemoveOutsideCollaboratorInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The ID of the organization to remove the outside collaborator from.
   """
   organizationId: ID! @possibleTypes(concreteTypes: ["Organization"])
-  
+
   """
   The ID of the outside collaborator to remove.
   """
@@ -38952,7 +38954,7 @@ type RemoveOutsideCollaboratorPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The user that was removed as an outside collaborator.
   """
@@ -38967,12 +38969,12 @@ input RemoveReactionInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The name of the emoji reaction to remove.
   """
   content: ReactionContent!
-  
+
   """
   The Node ID of the subject to modify.
   """
@@ -39003,17 +39005,17 @@ type RemoveReactionPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The reaction object.
   """
   reaction: Reaction
-  
+
   """
   The reaction groups for the subject.
   """
   reactionGroups: [ReactionGroup!]
-  
+
   """
   The reactable subject.
   """
@@ -39028,7 +39030,7 @@ input RemoveStarInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The Starrable ID to unstar.
   """
@@ -39047,7 +39049,7 @@ type RemoveStarPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The starrable.
   """
@@ -39062,7 +39064,7 @@ input RemoveUpvoteInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The Node ID of the discussion or comment to remove upvote.
   """
@@ -39081,7 +39083,7 @@ type RemoveUpvotePayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The votable subject.
   """
@@ -39096,33 +39098,33 @@ type RemovedFromMergeQueueEvent implements Node {
   Identifies the actor who performed the event.
   """
   actor: Actor
-  
+
   """
   Identifies the before commit SHA for the 'removed_from_merge_queue' event.
   """
   beforeCommit: Commit
-  
+
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
-  
+
   """
   The user who removed this Pull Request from the merge queue
   """
   enqueuer: User
   id: ID!
-  
+
   """
   The merge queue where this pull request was removed from.
   """
   mergeQueue: MergeQueue
-  
+
   """
   PullRequest referenced by event.
   """
   pullRequest: PullRequest
-  
+
   """
   The reason this pull request was removed from the queue.
   """
@@ -39137,23 +39139,23 @@ type RemovedFromProjectEvent implements Node {
   Identifies the actor who performed the event.
   """
   actor: Actor
-  
+
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
-  
+
   """
   Identifies the primary key from the database.
   """
   databaseId: Int
   id: ID!
-  
+
   """
   Project referenced by event.
   """
   project: Project @preview(toggledBy: "starfox-preview")
-  
+
   """
   Column name referenced by this project event.
   """
@@ -39168,23 +39170,23 @@ type RenamedTitleEvent implements Node {
   Identifies the actor who performed the event.
   """
   actor: Actor
-  
+
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
-  
+
   """
   Identifies the current title of the issue or pull request.
   """
   currentTitle: String!
   id: ID!
-  
+
   """
   Identifies the previous title of the issue or pull request.
   """
   previousTitle: String!
-  
+
   """
   Subject that was renamed.
   """
@@ -39204,7 +39206,7 @@ input ReopenDiscussionInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   ID of the discussion to be reopened.
   """
@@ -39219,7 +39221,7 @@ type ReopenDiscussionPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The discussion that was reopened.
   """
@@ -39234,7 +39236,7 @@ input ReopenIssueInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   ID of the issue to be opened.
   """
@@ -39249,7 +39251,7 @@ type ReopenIssuePayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The issue that was opened.
   """
@@ -39264,7 +39266,7 @@ input ReopenPullRequestInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   ID of the pull request to be reopened.
   """
@@ -39279,7 +39281,7 @@ type ReopenPullRequestPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The pull request that was reopened.
   """
@@ -39294,18 +39296,18 @@ type ReopenedEvent implements Node {
   Identifies the actor who performed the event.
   """
   actor: Actor
-  
+
   """
   Object that was reopened.
   """
   closable: Closable!
-  
+
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
   id: ID!
-  
+
   """
   The reason the issue state was changed to open.
   """
@@ -39320,108 +39322,108 @@ type RepoAccessAuditEntry implements AuditEntry & Node & OrganizationAuditEntryD
   The action name
   """
   action: String!
-  
+
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
-  
+
   """
   The IP address of the actor
   """
   actorIp: String
-  
+
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
-  
+
   """
   The username of the user who initiated the action
   """
   actorLogin: String
-  
+
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
-  
+
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
-  
+
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
   id: ID!
-  
+
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
-  
+
   """
   The Organization associated with the Audit Entry.
   """
   organization: Organization
-  
+
   """
   The name of the Organization.
   """
   organizationName: String
-  
+
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
-  
+
   """
   The HTTP URL for the organization
   """
   organizationUrl: URI
-  
+
   """
   The repository associated with the action
   """
   repository: Repository
-  
+
   """
   The name of the repository
   """
   repositoryName: String
-  
+
   """
   The HTTP path for the repository
   """
   repositoryResourcePath: URI
-  
+
   """
   The HTTP URL for the repository
   """
   repositoryUrl: URI
-  
+
   """
   The user affected by the action
   """
   user: User
-  
+
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
-  
+
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
-  
+
   """
   The HTTP URL for the user.
   """
   userUrl: URI
-  
+
   """
   The visibility of the repository
   """
@@ -39454,108 +39456,108 @@ type RepoAddMemberAuditEntry implements AuditEntry & Node & OrganizationAuditEnt
   The action name
   """
   action: String!
-  
+
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
-  
+
   """
   The IP address of the actor
   """
   actorIp: String
-  
+
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
-  
+
   """
   The username of the user who initiated the action
   """
   actorLogin: String
-  
+
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
-  
+
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
-  
+
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
   id: ID!
-  
+
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
-  
+
   """
   The Organization associated with the Audit Entry.
   """
   organization: Organization
-  
+
   """
   The name of the Organization.
   """
   organizationName: String
-  
+
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
-  
+
   """
   The HTTP URL for the organization
   """
   organizationUrl: URI
-  
+
   """
   The repository associated with the action
   """
   repository: Repository
-  
+
   """
   The name of the repository
   """
   repositoryName: String
-  
+
   """
   The HTTP path for the repository
   """
   repositoryResourcePath: URI
-  
+
   """
   The HTTP URL for the repository
   """
   repositoryUrl: URI
-  
+
   """
   The user affected by the action
   """
   user: User
-  
+
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
-  
+
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
-  
+
   """
   The HTTP URL for the user.
   """
   userUrl: URI
-  
+
   """
   The visibility of the repository
   """
@@ -39588,113 +39590,113 @@ type RepoAddTopicAuditEntry implements AuditEntry & Node & OrganizationAuditEntr
   The action name
   """
   action: String!
-  
+
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
-  
+
   """
   The IP address of the actor
   """
   actorIp: String
-  
+
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
-  
+
   """
   The username of the user who initiated the action
   """
   actorLogin: String
-  
+
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
-  
+
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
-  
+
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
   id: ID!
-  
+
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
-  
+
   """
   The Organization associated with the Audit Entry.
   """
   organization: Organization
-  
+
   """
   The name of the Organization.
   """
   organizationName: String
-  
+
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
-  
+
   """
   The HTTP URL for the organization
   """
   organizationUrl: URI
-  
+
   """
   The repository associated with the action
   """
   repository: Repository
-  
+
   """
   The name of the repository
   """
   repositoryName: String
-  
+
   """
   The HTTP path for the repository
   """
   repositoryResourcePath: URI
-  
+
   """
   The HTTP URL for the repository
   """
   repositoryUrl: URI
-  
+
   """
   The name of the topic added to the repository
   """
   topic: Topic
-  
+
   """
   The name of the topic added to the repository
   """
   topicName: String
-  
+
   """
   The user affected by the action
   """
   user: User
-  
+
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
-  
+
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
-  
+
   """
   The HTTP URL for the user.
   """
@@ -39709,108 +39711,108 @@ type RepoArchivedAuditEntry implements AuditEntry & Node & OrganizationAuditEntr
   The action name
   """
   action: String!
-  
+
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
-  
+
   """
   The IP address of the actor
   """
   actorIp: String
-  
+
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
-  
+
   """
   The username of the user who initiated the action
   """
   actorLogin: String
-  
+
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
-  
+
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
-  
+
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
   id: ID!
-  
+
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
-  
+
   """
   The Organization associated with the Audit Entry.
   """
   organization: Organization
-  
+
   """
   The name of the Organization.
   """
   organizationName: String
-  
+
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
-  
+
   """
   The HTTP URL for the organization
   """
   organizationUrl: URI
-  
+
   """
   The repository associated with the action
   """
   repository: Repository
-  
+
   """
   The name of the repository
   """
   repositoryName: String
-  
+
   """
   The HTTP path for the repository
   """
   repositoryResourcePath: URI
-  
+
   """
   The HTTP URL for the repository
   """
   repositoryUrl: URI
-  
+
   """
   The user affected by the action
   """
   user: User
-  
+
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
-  
+
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
-  
+
   """
   The HTTP URL for the user.
   """
   userUrl: URI
-  
+
   """
   The visibility of the repository
   """
@@ -39843,113 +39845,113 @@ type RepoChangeMergeSettingAuditEntry implements AuditEntry & Node & Organizatio
   The action name
   """
   action: String!
-  
+
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
-  
+
   """
   The IP address of the actor
   """
   actorIp: String
-  
+
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
-  
+
   """
   The username of the user who initiated the action
   """
   actorLogin: String
-  
+
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
-  
+
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
-  
+
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
   id: ID!
-  
+
   """
   Whether the change was to enable (true) or disable (false) the merge type
   """
   isEnabled: Boolean
-  
+
   """
   The merge method affected by the change
   """
   mergeType: RepoChangeMergeSettingAuditEntryMergeType
-  
+
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
-  
+
   """
   The Organization associated with the Audit Entry.
   """
   organization: Organization
-  
+
   """
   The name of the Organization.
   """
   organizationName: String
-  
+
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
-  
+
   """
   The HTTP URL for the organization
   """
   organizationUrl: URI
-  
+
   """
   The repository associated with the action
   """
   repository: Repository
-  
+
   """
   The name of the repository
   """
   repositoryName: String
-  
+
   """
   The HTTP path for the repository
   """
   repositoryResourcePath: URI
-  
+
   """
   The HTTP URL for the repository
   """
   repositoryUrl: URI
-  
+
   """
   The user affected by the action
   """
   user: User
-  
+
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
-  
+
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
-  
+
   """
   The HTTP URL for the user.
   """
@@ -39982,103 +39984,103 @@ type RepoConfigDisableAnonymousGitAccessAuditEntry implements AuditEntry & Node 
   The action name
   """
   action: String!
-  
+
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
-  
+
   """
   The IP address of the actor
   """
   actorIp: String
-  
+
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
-  
+
   """
   The username of the user who initiated the action
   """
   actorLogin: String
-  
+
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
-  
+
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
-  
+
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
   id: ID!
-  
+
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
-  
+
   """
   The Organization associated with the Audit Entry.
   """
   organization: Organization
-  
+
   """
   The name of the Organization.
   """
   organizationName: String
-  
+
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
-  
+
   """
   The HTTP URL for the organization
   """
   organizationUrl: URI
-  
+
   """
   The repository associated with the action
   """
   repository: Repository
-  
+
   """
   The name of the repository
   """
   repositoryName: String
-  
+
   """
   The HTTP path for the repository
   """
   repositoryResourcePath: URI
-  
+
   """
   The HTTP URL for the repository
   """
   repositoryUrl: URI
-  
+
   """
   The user affected by the action
   """
   user: User
-  
+
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
-  
+
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
-  
+
   """
   The HTTP URL for the user.
   """
@@ -40093,103 +40095,103 @@ type RepoConfigDisableCollaboratorsOnlyAuditEntry implements AuditEntry & Node &
   The action name
   """
   action: String!
-  
+
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
-  
+
   """
   The IP address of the actor
   """
   actorIp: String
-  
+
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
-  
+
   """
   The username of the user who initiated the action
   """
   actorLogin: String
-  
+
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
-  
+
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
-  
+
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
   id: ID!
-  
+
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
-  
+
   """
   The Organization associated with the Audit Entry.
   """
   organization: Organization
-  
+
   """
   The name of the Organization.
   """
   organizationName: String
-  
+
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
-  
+
   """
   The HTTP URL for the organization
   """
   organizationUrl: URI
-  
+
   """
   The repository associated with the action
   """
   repository: Repository
-  
+
   """
   The name of the repository
   """
   repositoryName: String
-  
+
   """
   The HTTP path for the repository
   """
   repositoryResourcePath: URI
-  
+
   """
   The HTTP URL for the repository
   """
   repositoryUrl: URI
-  
+
   """
   The user affected by the action
   """
   user: User
-  
+
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
-  
+
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
-  
+
   """
   The HTTP URL for the user.
   """
@@ -40204,103 +40206,103 @@ type RepoConfigDisableContributorsOnlyAuditEntry implements AuditEntry & Node & 
   The action name
   """
   action: String!
-  
+
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
-  
+
   """
   The IP address of the actor
   """
   actorIp: String
-  
+
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
-  
+
   """
   The username of the user who initiated the action
   """
   actorLogin: String
-  
+
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
-  
+
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
-  
+
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
   id: ID!
-  
+
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
-  
+
   """
   The Organization associated with the Audit Entry.
   """
   organization: Organization
-  
+
   """
   The name of the Organization.
   """
   organizationName: String
-  
+
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
-  
+
   """
   The HTTP URL for the organization
   """
   organizationUrl: URI
-  
+
   """
   The repository associated with the action
   """
   repository: Repository
-  
+
   """
   The name of the repository
   """
   repositoryName: String
-  
+
   """
   The HTTP path for the repository
   """
   repositoryResourcePath: URI
-  
+
   """
   The HTTP URL for the repository
   """
   repositoryUrl: URI
-  
+
   """
   The user affected by the action
   """
   user: User
-  
+
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
-  
+
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
-  
+
   """
   The HTTP URL for the user.
   """
@@ -40315,103 +40317,103 @@ type RepoConfigDisableSockpuppetDisallowedAuditEntry implements AuditEntry & Nod
   The action name
   """
   action: String!
-  
+
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
-  
+
   """
   The IP address of the actor
   """
   actorIp: String
-  
+
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
-  
+
   """
   The username of the user who initiated the action
   """
   actorLogin: String
-  
+
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
-  
+
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
-  
+
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
   id: ID!
-  
+
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
-  
+
   """
   The Organization associated with the Audit Entry.
   """
   organization: Organization
-  
+
   """
   The name of the Organization.
   """
   organizationName: String
-  
+
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
-  
+
   """
   The HTTP URL for the organization
   """
   organizationUrl: URI
-  
+
   """
   The repository associated with the action
   """
   repository: Repository
-  
+
   """
   The name of the repository
   """
   repositoryName: String
-  
+
   """
   The HTTP path for the repository
   """
   repositoryResourcePath: URI
-  
+
   """
   The HTTP URL for the repository
   """
   repositoryUrl: URI
-  
+
   """
   The user affected by the action
   """
   user: User
-  
+
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
-  
+
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
-  
+
   """
   The HTTP URL for the user.
   """
@@ -40426,103 +40428,103 @@ type RepoConfigEnableAnonymousGitAccessAuditEntry implements AuditEntry & Node &
   The action name
   """
   action: String!
-  
+
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
-  
+
   """
   The IP address of the actor
   """
   actorIp: String
-  
+
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
-  
+
   """
   The username of the user who initiated the action
   """
   actorLogin: String
-  
+
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
-  
+
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
-  
+
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
   id: ID!
-  
+
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
-  
+
   """
   The Organization associated with the Audit Entry.
   """
   organization: Organization
-  
+
   """
   The name of the Organization.
   """
   organizationName: String
-  
+
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
-  
+
   """
   The HTTP URL for the organization
   """
   organizationUrl: URI
-  
+
   """
   The repository associated with the action
   """
   repository: Repository
-  
+
   """
   The name of the repository
   """
   repositoryName: String
-  
+
   """
   The HTTP path for the repository
   """
   repositoryResourcePath: URI
-  
+
   """
   The HTTP URL for the repository
   """
   repositoryUrl: URI
-  
+
   """
   The user affected by the action
   """
   user: User
-  
+
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
-  
+
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
-  
+
   """
   The HTTP URL for the user.
   """
@@ -40537,103 +40539,103 @@ type RepoConfigEnableCollaboratorsOnlyAuditEntry implements AuditEntry & Node & 
   The action name
   """
   action: String!
-  
+
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
-  
+
   """
   The IP address of the actor
   """
   actorIp: String
-  
+
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
-  
+
   """
   The username of the user who initiated the action
   """
   actorLogin: String
-  
+
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
-  
+
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
-  
+
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
   id: ID!
-  
+
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
-  
+
   """
   The Organization associated with the Audit Entry.
   """
   organization: Organization
-  
+
   """
   The name of the Organization.
   """
   organizationName: String
-  
+
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
-  
+
   """
   The HTTP URL for the organization
   """
   organizationUrl: URI
-  
+
   """
   The repository associated with the action
   """
   repository: Repository
-  
+
   """
   The name of the repository
   """
   repositoryName: String
-  
+
   """
   The HTTP path for the repository
   """
   repositoryResourcePath: URI
-  
+
   """
   The HTTP URL for the repository
   """
   repositoryUrl: URI
-  
+
   """
   The user affected by the action
   """
   user: User
-  
+
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
-  
+
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
-  
+
   """
   The HTTP URL for the user.
   """
@@ -40648,103 +40650,103 @@ type RepoConfigEnableContributorsOnlyAuditEntry implements AuditEntry & Node & O
   The action name
   """
   action: String!
-  
+
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
-  
+
   """
   The IP address of the actor
   """
   actorIp: String
-  
+
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
-  
+
   """
   The username of the user who initiated the action
   """
   actorLogin: String
-  
+
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
-  
+
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
-  
+
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
   id: ID!
-  
+
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
-  
+
   """
   The Organization associated with the Audit Entry.
   """
   organization: Organization
-  
+
   """
   The name of the Organization.
   """
   organizationName: String
-  
+
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
-  
+
   """
   The HTTP URL for the organization
   """
   organizationUrl: URI
-  
+
   """
   The repository associated with the action
   """
   repository: Repository
-  
+
   """
   The name of the repository
   """
   repositoryName: String
-  
+
   """
   The HTTP path for the repository
   """
   repositoryResourcePath: URI
-  
+
   """
   The HTTP URL for the repository
   """
   repositoryUrl: URI
-  
+
   """
   The user affected by the action
   """
   user: User
-  
+
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
-  
+
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
-  
+
   """
   The HTTP URL for the user.
   """
@@ -40759,103 +40761,103 @@ type RepoConfigEnableSockpuppetDisallowedAuditEntry implements AuditEntry & Node
   The action name
   """
   action: String!
-  
+
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
-  
+
   """
   The IP address of the actor
   """
   actorIp: String
-  
+
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
-  
+
   """
   The username of the user who initiated the action
   """
   actorLogin: String
-  
+
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
-  
+
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
-  
+
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
   id: ID!
-  
+
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
-  
+
   """
   The Organization associated with the Audit Entry.
   """
   organization: Organization
-  
+
   """
   The name of the Organization.
   """
   organizationName: String
-  
+
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
-  
+
   """
   The HTTP URL for the organization
   """
   organizationUrl: URI
-  
+
   """
   The repository associated with the action
   """
   repository: Repository
-  
+
   """
   The name of the repository
   """
   repositoryName: String
-  
+
   """
   The HTTP path for the repository
   """
   repositoryResourcePath: URI
-  
+
   """
   The HTTP URL for the repository
   """
   repositoryUrl: URI
-  
+
   """
   The user affected by the action
   """
   user: User
-  
+
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
-  
+
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
-  
+
   """
   The HTTP URL for the user.
   """
@@ -40870,103 +40872,103 @@ type RepoConfigLockAnonymousGitAccessAuditEntry implements AuditEntry & Node & O
   The action name
   """
   action: String!
-  
+
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
-  
+
   """
   The IP address of the actor
   """
   actorIp: String
-  
+
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
-  
+
   """
   The username of the user who initiated the action
   """
   actorLogin: String
-  
+
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
-  
+
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
-  
+
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
   id: ID!
-  
+
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
-  
+
   """
   The Organization associated with the Audit Entry.
   """
   organization: Organization
-  
+
   """
   The name of the Organization.
   """
   organizationName: String
-  
+
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
-  
+
   """
   The HTTP URL for the organization
   """
   organizationUrl: URI
-  
+
   """
   The repository associated with the action
   """
   repository: Repository
-  
+
   """
   The name of the repository
   """
   repositoryName: String
-  
+
   """
   The HTTP path for the repository
   """
   repositoryResourcePath: URI
-  
+
   """
   The HTTP URL for the repository
   """
   repositoryUrl: URI
-  
+
   """
   The user affected by the action
   """
   user: User
-  
+
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
-  
+
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
-  
+
   """
   The HTTP URL for the user.
   """
@@ -40981,103 +40983,103 @@ type RepoConfigUnlockAnonymousGitAccessAuditEntry implements AuditEntry & Node &
   The action name
   """
   action: String!
-  
+
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
-  
+
   """
   The IP address of the actor
   """
   actorIp: String
-  
+
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
-  
+
   """
   The username of the user who initiated the action
   """
   actorLogin: String
-  
+
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
-  
+
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
-  
+
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
   id: ID!
-  
+
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
-  
+
   """
   The Organization associated with the Audit Entry.
   """
   organization: Organization
-  
+
   """
   The name of the Organization.
   """
   organizationName: String
-  
+
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
-  
+
   """
   The HTTP URL for the organization
   """
   organizationUrl: URI
-  
+
   """
   The repository associated with the action
   """
   repository: Repository
-  
+
   """
   The name of the repository
   """
   repositoryName: String
-  
+
   """
   The HTTP path for the repository
   """
   repositoryResourcePath: URI
-  
+
   """
   The HTTP URL for the repository
   """
   repositoryUrl: URI
-  
+
   """
   The user affected by the action
   """
   user: User
-  
+
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
-  
+
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
-  
+
   """
   The HTTP URL for the user.
   """
@@ -41092,118 +41094,118 @@ type RepoCreateAuditEntry implements AuditEntry & Node & OrganizationAuditEntryD
   The action name
   """
   action: String!
-  
+
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
-  
+
   """
   The IP address of the actor
   """
   actorIp: String
-  
+
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
-  
+
   """
   The username of the user who initiated the action
   """
   actorLogin: String
-  
+
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
-  
+
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
-  
+
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
-  
+
   """
   The name of the parent repository for this forked repository.
   """
   forkParentName: String
-  
+
   """
   The name of the root repository for this network.
   """
   forkSourceName: String
   id: ID!
-  
+
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
-  
+
   """
   The Organization associated with the Audit Entry.
   """
   organization: Organization
-  
+
   """
   The name of the Organization.
   """
   organizationName: String
-  
+
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
-  
+
   """
   The HTTP URL for the organization
   """
   organizationUrl: URI
-  
+
   """
   The repository associated with the action
   """
   repository: Repository
-  
+
   """
   The name of the repository
   """
   repositoryName: String
-  
+
   """
   The HTTP path for the repository
   """
   repositoryResourcePath: URI
-  
+
   """
   The HTTP URL for the repository
   """
   repositoryUrl: URI
-  
+
   """
   The user affected by the action
   """
   user: User
-  
+
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
-  
+
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
-  
+
   """
   The HTTP URL for the user.
   """
   userUrl: URI
-  
+
   """
   The visibility of the repository
   """
@@ -41236,108 +41238,108 @@ type RepoDestroyAuditEntry implements AuditEntry & Node & OrganizationAuditEntry
   The action name
   """
   action: String!
-  
+
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
-  
+
   """
   The IP address of the actor
   """
   actorIp: String
-  
+
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
-  
+
   """
   The username of the user who initiated the action
   """
   actorLogin: String
-  
+
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
-  
+
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
-  
+
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
   id: ID!
-  
+
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
-  
+
   """
   The Organization associated with the Audit Entry.
   """
   organization: Organization
-  
+
   """
   The name of the Organization.
   """
   organizationName: String
-  
+
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
-  
+
   """
   The HTTP URL for the organization
   """
   organizationUrl: URI
-  
+
   """
   The repository associated with the action
   """
   repository: Repository
-  
+
   """
   The name of the repository
   """
   repositoryName: String
-  
+
   """
   The HTTP path for the repository
   """
   repositoryResourcePath: URI
-  
+
   """
   The HTTP URL for the repository
   """
   repositoryUrl: URI
-  
+
   """
   The user affected by the action
   """
   user: User
-  
+
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
-  
+
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
-  
+
   """
   The HTTP URL for the user.
   """
   userUrl: URI
-  
+
   """
   The visibility of the repository
   """
@@ -41370,108 +41372,108 @@ type RepoRemoveMemberAuditEntry implements AuditEntry & Node & OrganizationAudit
   The action name
   """
   action: String!
-  
+
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
-  
+
   """
   The IP address of the actor
   """
   actorIp: String
-  
+
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
-  
+
   """
   The username of the user who initiated the action
   """
   actorLogin: String
-  
+
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
-  
+
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
-  
+
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
   id: ID!
-  
+
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
-  
+
   """
   The Organization associated with the Audit Entry.
   """
   organization: Organization
-  
+
   """
   The name of the Organization.
   """
   organizationName: String
-  
+
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
-  
+
   """
   The HTTP URL for the organization
   """
   organizationUrl: URI
-  
+
   """
   The repository associated with the action
   """
   repository: Repository
-  
+
   """
   The name of the repository
   """
   repositoryName: String
-  
+
   """
   The HTTP path for the repository
   """
   repositoryResourcePath: URI
-  
+
   """
   The HTTP URL for the repository
   """
   repositoryUrl: URI
-  
+
   """
   The user affected by the action
   """
   user: User
-  
+
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
-  
+
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
-  
+
   """
   The HTTP URL for the user.
   """
   userUrl: URI
-  
+
   """
   The visibility of the repository
   """
@@ -41504,113 +41506,113 @@ type RepoRemoveTopicAuditEntry implements AuditEntry & Node & OrganizationAuditE
   The action name
   """
   action: String!
-  
+
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
-  
+
   """
   The IP address of the actor
   """
   actorIp: String
-  
+
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
-  
+
   """
   The username of the user who initiated the action
   """
   actorLogin: String
-  
+
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
-  
+
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
-  
+
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
   id: ID!
-  
+
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
-  
+
   """
   The Organization associated with the Audit Entry.
   """
   organization: Organization
-  
+
   """
   The name of the Organization.
   """
   organizationName: String
-  
+
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
-  
+
   """
   The HTTP URL for the organization
   """
   organizationUrl: URI
-  
+
   """
   The repository associated with the action
   """
   repository: Repository
-  
+
   """
   The name of the repository
   """
   repositoryName: String
-  
+
   """
   The HTTP path for the repository
   """
   repositoryResourcePath: URI
-  
+
   """
   The HTTP URL for the repository
   """
   repositoryUrl: URI
-  
+
   """
   The name of the topic added to the repository
   """
   topic: Topic
-  
+
   """
   The name of the topic added to the repository
   """
   topicName: String
-  
+
   """
   The user affected by the action
   """
   user: User
-  
+
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
-  
+
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
-  
+
   """
   The HTTP URL for the user.
   """
@@ -41656,12 +41658,12 @@ type Repository implements Node & PackageOwner & ProjectOwner & ProjectV2Recent 
   always be updated even if it is not required to be up to date before merging.
   """
   allowUpdateBranch: Boolean!
-  
+
   """
   Identifies the date and time when the repository was archived.
   """
   archivedAt: DateTime
-  
+
   """
   A list of users that can be assigned to issues in this repository.
   """
@@ -41670,33 +41672,33 @@ type Repository implements Node & PackageOwner & ProjectOwner & ProjectV2Recent 
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Filters users with query on user name and login.
     """
     query: String
   ): UserConnection!
-  
+
   """
   Whether or not Auto-merge can be enabled on pull requests in this repository.
   """
   autoMergeAllowed: Boolean!
-  
+
   """
   A list of branch protection rules for this repository.
   """
@@ -41705,28 +41707,28 @@ type Repository implements Node & PackageOwner & ProjectOwner & ProjectV2Recent 
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): BranchProtectionRuleConnection!
-  
+
   """
   Returns the code of conduct for this repository
   """
   codeOfConduct: CodeOfConduct
-  
+
   """
   Information extracted from the repository's `CODEOWNERS` file.
   """
@@ -41736,7 +41738,7 @@ type Repository implements Node & PackageOwner & ProjectOwner & ProjectV2Recent 
     """
     refName: String
   ): RepositoryCodeowners
-  
+
   """
   A list of collaborators associated with the repository.
   """
@@ -41745,38 +41747,38 @@ type Repository implements Node & PackageOwner & ProjectOwner & ProjectV2Recent 
     Collaborators affiliation level with a repository.
     """
     affiliation: CollaboratorAffiliation
-    
+
     """
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     The login of one specific collaborator.
     """
     login: String
-    
+
     """
     Filters users with query on user name and login
     """
     query: String
   ): RepositoryCollaboratorConnection
-  
+
   """
   A list of commit comments associated with the repository.
   """
@@ -41785,53 +41787,53 @@ type Repository implements Node & PackageOwner & ProjectOwner & ProjectV2Recent 
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): CommitCommentConnection!
-  
+
   """
   Returns a list of contact links associated to the repository
   """
   contactLinks: [RepositoryContactLink!]
-  
+
   """
   Returns the contributing guidelines for this repository.
   """
   contributingGuidelines: ContributingGuidelines
-  
+
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
-  
+
   """
   Identifies the primary key from the database.
   """
   databaseId: Int
-  
+
   """
   The Ref associated with the repository's default branch.
   """
   defaultBranchRef: Ref
-  
+
   """
   Whether or not branches are automatically deleted when merged in this repository.
   """
   deleteBranchOnMerge: Boolean!
-  
+
   """
   A list of dependency manifests contained in the repository
   """
@@ -41840,38 +41842,38 @@ type Repository implements Node & PackageOwner & ProjectOwner & ProjectV2Recent 
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Cursor to paginate dependencies
     """
     dependenciesAfter: String
-    
+
     """
     Number of dependencies to fetch
     """
     dependenciesFirst: Int
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Flag to scope to only manifests with dependencies
     """
     withDependencies: Boolean
   ): DependencyGraphManifestConnection @preview(toggledBy: "hawkgirl-preview")
-  
+
   """
   A list of deploy keys that are on this repository.
   """
@@ -41880,23 +41882,23 @@ type Repository implements Node & PackageOwner & ProjectOwner & ProjectV2Recent 
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): DeployKeyConnection!
-  
+
   """
   Deployments associated with the repository
   """
@@ -41905,43 +41907,43 @@ type Repository implements Node & PackageOwner & ProjectOwner & ProjectV2Recent 
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Environments to list deployments for
     """
     environments: [String!]
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for deployments returned from the connection.
     """
     orderBy: DeploymentOrder = { field: CREATED_AT, direction: ASC }
   ): DeploymentConnection!
-  
+
   """
   The description of the repository.
   """
   description: String
-  
+
   """
   The description of the repository rendered to HTML.
   """
   descriptionHTML: HTML!
-  
+
   """
   Returns a single discussion from the current repository by number.
   """
@@ -41951,7 +41953,7 @@ type Repository implements Node & PackageOwner & ProjectOwner & ProjectV2Recent 
     """
     number: Int!
   ): Discussion
-  
+
   """
   A list of discussion categories that are available in the repository.
   """
@@ -41960,28 +41962,28 @@ type Repository implements Node & PackageOwner & ProjectOwner & ProjectV2Recent 
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Filter by categories that are assignable by the viewer.
     """
     filterByAssignable: Boolean = false
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): DiscussionCategoryConnection!
-  
+
   """
   A discussion category by slug.
   """
@@ -41991,7 +41993,7 @@ type Repository implements Node & PackageOwner & ProjectOwner & ProjectV2Recent 
     """
     slug: String!
   ): DiscussionCategory
-  
+
   """
   A list of discussions that have been opened in the repository.
   """
@@ -42000,48 +42002,48 @@ type Repository implements Node & PackageOwner & ProjectOwner & ProjectV2Recent 
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Only show answered or unanswered discussions
     """
     answered: Boolean = null
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Only include discussions that belong to the category with this ID.
     """
     categoryId: ID = null
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for discussions returned from the connection.
     """
     orderBy: DiscussionOrder = { field: UPDATED_AT, direction: DESC }
-    
+
     """
     A list of states to filter the discussions by.
     """
     states: [DiscussionState!] = []
   ): DiscussionConnection!
-  
+
   """
   The number of kilobytes this repository occupies on disk.
   """
   diskUsage: Int
-  
+
   """
   Returns a single active environment from the current repository by name.
   """
@@ -42051,7 +42053,7 @@ type Repository implements Node & PackageOwner & ProjectOwner & ProjectV2Recent 
     """
     name: String!
   ): Environment
-  
+
   """
   A list of environments that are in this repository.
   """
@@ -42060,38 +42062,38 @@ type Repository implements Node & PackageOwner & ProjectOwner & ProjectV2Recent 
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for the environments
     """
     orderBy: Environments = { field: NAME, direction: ASC }
   ): EnvironmentConnection!
-  
+
   """
   Returns how many forks there are of this repository in the whole network.
   """
   forkCount: Int!
-  
+
   """
   Whether this repository allows forks.
   """
   forkingAllowed: Boolean!
-  
+
   """
   A list of direct forked repositories.
   """
@@ -42102,156 +42104,156 @@ type Repository implements Node & PackageOwner & ProjectOwner & ProjectV2Recent 
     current viewer owns.
     """
     affiliations: [RepositoryAffiliation]
-    
+
     """
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     If non-null, filters repositories according to whether they have issues enabled
     """
     hasIssuesEnabled: Boolean
-    
+
     """
     If non-null, filters repositories according to whether they have been locked
     """
     isLocked: Boolean
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for repositories returned from the connection
     """
     orderBy: RepositoryOrder
-    
+
     """
     Array of owner's affiliation options for repositories returned from the
     connection. For example, OWNER will include only repositories that the
     organization or user being viewed owns.
     """
     ownerAffiliations: [RepositoryAffiliation] = [OWNER, COLLABORATOR]
-    
+
     """
     If non-null, filters repositories according to privacy
     """
     privacy: RepositoryPrivacy
   ): RepositoryConnection!
-  
+
   """
   The funding links for this repository
   """
   fundingLinks: [FundingLink!]!
-  
+
   """
   Indicates if the repository has the Discussions feature enabled.
   """
   hasDiscussionsEnabled: Boolean!
-  
+
   """
   Indicates if the repository has issues feature enabled.
   """
   hasIssuesEnabled: Boolean!
-  
+
   """
   Indicates if the repository has the Projects feature enabled.
   """
   hasProjectsEnabled: Boolean!
-  
+
   """
   Whether vulnerability alerts are enabled for the repository.
   """
   hasVulnerabilityAlertsEnabled: Boolean!
-  
+
   """
   Indicates if the repository has wiki feature enabled.
   """
   hasWikiEnabled: Boolean!
-  
+
   """
   The repository's URL.
   """
   homepageUrl: URI
   id: ID!
-  
+
   """
   The interaction ability settings for this repository.
   """
   interactionAbility: RepositoryInteractionAbility
-  
+
   """
   Indicates if the repository is unmaintained.
   """
   isArchived: Boolean!
-  
+
   """
   Returns true if blank issue creation is allowed
   """
   isBlankIssuesEnabled: Boolean!
-  
+
   """
   Returns whether or not this repository disabled.
   """
   isDisabled: Boolean!
-  
+
   """
   Returns whether or not this repository is empty.
   """
   isEmpty: Boolean!
-  
+
   """
   Identifies if the repository is a fork.
   """
   isFork: Boolean!
-  
+
   """
   Indicates if a repository is either owned by an organization, or is a private fork of an organization repository.
   """
   isInOrganization: Boolean!
-  
+
   """
   Indicates if the repository has been locked or not.
   """
   isLocked: Boolean!
-  
+
   """
   Identifies if the repository is a mirror.
   """
   isMirror: Boolean!
-  
+
   """
   Identifies if the repository is private or internal.
   """
   isPrivate: Boolean!
-  
+
   """
   Returns true if this repository has a security policy
   """
   isSecurityPolicyEnabled: Boolean
-  
+
   """
   Identifies if the repository is a template that can be used to generate new repositories.
   """
   isTemplate: Boolean!
-  
+
   """
   Is this repository a user configuration repository?
   """
   isUserConfigurationRepository: Boolean!
-  
+
   """
   Returns a single issue from the current repository by number.
   """
@@ -42261,7 +42263,7 @@ type Repository implements Node & PackageOwner & ProjectOwner & ProjectV2Recent 
     """
     number: Int!
   ): Issue
-  
+
   """
   Returns a single issue-like object from the current repository by number.
   """
@@ -42271,12 +42273,12 @@ type Repository implements Node & PackageOwner & ProjectOwner & ProjectV2Recent 
     """
     number: Int!
   ): IssueOrPullRequest
-  
+
   """
   Returns a list of issue templates associated to the repository
   """
   issueTemplates: [IssueTemplate!]
-  
+
   """
   A list of issues that have been opened in the repository.
   """
@@ -42285,43 +42287,43 @@ type Repository implements Node & PackageOwner & ProjectOwner & ProjectV2Recent 
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Filtering options for issues returned from the connection.
     """
     filterBy: IssueFilters
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     A list of label names to filter the pull requests by.
     """
     labels: [String!]
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for issues returned from the connection.
     """
     orderBy: IssueOrder
-    
+
     """
     A list of states to filter the issues by.
     """
     states: [IssueState!]
   ): IssueConnection!
-  
+
   """
   Returns a single label by name
   """
@@ -42331,7 +42333,7 @@ type Repository implements Node & PackageOwner & ProjectOwner & ProjectV2Recent 
     """
     name: String!
   ): Label
-  
+
   """
   A list of labels associated with the repository.
   """
@@ -42340,33 +42342,33 @@ type Repository implements Node & PackageOwner & ProjectOwner & ProjectV2Recent 
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for labels returned from the connection.
     """
     orderBy: LabelOrder = { field: CREATED_AT, direction: ASC }
-    
+
     """
     If provided, searches labels by name and description.
     """
     query: String
   ): LabelConnection
-  
+
   """
   A list containing a breakdown of the language composition of the repository.
   """
@@ -42375,43 +42377,43 @@ type Repository implements Node & PackageOwner & ProjectOwner & ProjectV2Recent 
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Order for connection
     """
     orderBy: LanguageOrder
   ): LanguageConnection
-  
+
   """
   Get the latest release for the repository if one exists.
   """
   latestRelease: Release
-  
+
   """
   The license associated with the repository
   """
   licenseInfo: License
-  
+
   """
   The reason the repository has been locked.
   """
   lockReason: RepositoryLockReason
-  
+
   """
   A list of Users that can be mentioned in the context of the repository.
   """
@@ -42420,43 +42422,43 @@ type Repository implements Node & PackageOwner & ProjectOwner & ProjectV2Recent 
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Filters users with query on user name and login
     """
     query: String
   ): UserConnection!
-  
+
   """
   Whether or not PRs are merged with a merge commit on this repository.
   """
   mergeCommitAllowed: Boolean!
-  
+
   """
   How the default commit message will be generated when merging a pull request.
   """
   mergeCommitMessage: MergeCommitMessage!
-  
+
   """
   How the default commit title will be generated when merging a pull request.
   """
   mergeCommitTitle: MergeCommitTitle!
-  
+
   """
   The merge queue for a specified branch, otherwise the default branch if not provided.
   """
@@ -42466,7 +42468,7 @@ type Repository implements Node & PackageOwner & ProjectOwner & ProjectV2Recent 
     """
     branch: String
   ): MergeQueue
-  
+
   """
   Returns a single milestone from the current repository by number.
   """
@@ -42476,7 +42478,7 @@ type Repository implements Node & PackageOwner & ProjectOwner & ProjectV2Recent 
     """
     number: Int!
   ): Milestone
-  
+
   """
   A list of milestones associated with the repository.
   """
@@ -42485,53 +42487,53 @@ type Repository implements Node & PackageOwner & ProjectOwner & ProjectV2Recent 
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for milestones.
     """
     orderBy: MilestoneOrder
-    
+
     """
     Filters milestones with a query on the title
     """
     query: String
-    
+
     """
     Filter by the state of the milestones.
     """
     states: [MilestoneState!]
   ): MilestoneConnection
-  
+
   """
   The repository's original mirror URL.
   """
   mirrorUrl: URI
-  
+
   """
   The name of the repository.
   """
   name: String!
-  
+
   """
   The repository's name with owner.
   """
   nameWithOwner: String!
-  
+
   """
   A Git object in the repository
   """
@@ -42540,23 +42542,23 @@ type Repository implements Node & PackageOwner & ProjectOwner & ProjectV2Recent 
     A Git revision expression suitable for rev-parse
     """
     expression: String
-    
+
     """
     The Git object ID
     """
     oid: GitObjectID
   ): GitObject
-  
+
   """
   The image used to represent this repository in Open Graph data.
   """
   openGraphImageUrl: URI!
-  
+
   """
   The User owner of the repository.
   """
   owner: RepositoryOwner!
-  
+
   """
   A list of packages under the owner.
   """
@@ -42565,48 +42567,48 @@ type Repository implements Node & PackageOwner & ProjectOwner & ProjectV2Recent 
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Find packages by their names.
     """
     names: [String]
-    
+
     """
     Ordering of the returned packages.
     """
     orderBy: PackageOrder = { field: CREATED_AT, direction: DESC }
-    
+
     """
     Filter registry package by type.
     """
     packageType: PackageType
-    
+
     """
     Find packages in a repository by ID.
     """
     repositoryId: ID
   ): PackageConnection!
-  
+
   """
   The repository parent, if this is a fork.
   """
   parent: Repository
-  
+
   """
   A list of discussions that have been pinned in this repository.
   """
@@ -42615,23 +42617,23 @@ type Repository implements Node & PackageOwner & ProjectOwner & ProjectV2Recent 
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): PinnedDiscussionConnection!
-  
+
   """
   A list of pinned issues for this repository.
   """
@@ -42640,28 +42642,28 @@ type Repository implements Node & PackageOwner & ProjectOwner & ProjectV2Recent 
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): PinnedIssueConnection
-  
+
   """
   The primary language of the repository's code.
   """
   primaryLanguage: Language
-  
+
   """
   Find project by number.
   """
@@ -42671,7 +42673,7 @@ type Repository implements Node & PackageOwner & ProjectOwner & ProjectV2Recent 
     """
     number: Int!
   ): Project
-  
+
   """
   Finds and returns the Project according to the provided Project number.
   """
@@ -42681,7 +42683,7 @@ type Repository implements Node & PackageOwner & ProjectOwner & ProjectV2Recent 
     """
     number: Int!
   ): ProjectV2
-  
+
   """
   A list of projects under the owner.
   """
@@ -42690,48 +42692,48 @@ type Repository implements Node & PackageOwner & ProjectOwner & ProjectV2Recent 
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for projects returned from the connection
     """
     orderBy: ProjectOrder
-    
+
     """
     Query to search projects by, currently only searching by name.
     """
     search: String
-    
+
     """
     A list of states to filter the projects by.
     """
     states: [ProjectState!]
   ): ProjectConnection!
-  
+
   """
   The HTTP path listing the repository's projects
   """
   projectsResourcePath: URI!
-  
+
   """
   The HTTP URL listing the repository's projects
   """
   projectsUrl: URI!
-  
+
   """
   List of projects linked to this repository.
   """
@@ -42740,33 +42742,33 @@ type Repository implements Node & PackageOwner & ProjectOwner & ProjectV2Recent 
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     How to order the returned projects.
     """
     orderBy: ProjectV2Order = { field: NUMBER, direction: DESC }
-    
+
     """
     A project to search for linked to the repo.
     """
     query: String
   ): ProjectV2Connection!
-  
+
   """
   Returns a single pull request from the current repository by number.
   """
@@ -42776,12 +42778,12 @@ type Repository implements Node & PackageOwner & ProjectOwner & ProjectV2Recent 
     """
     number: Int!
   ): PullRequest
-  
+
   """
   Returns a list of pull request templates associated to the repository
   """
   pullRequestTemplates: [PullRequestTemplate!]
-  
+
   """
   A list of pull requests that have been opened in the repository.
   """
@@ -42790,58 +42792,58 @@ type Repository implements Node & PackageOwner & ProjectOwner & ProjectV2Recent 
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     The base ref name to filter the pull requests by.
     """
     baseRefName: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     The head ref name to filter the pull requests by.
     """
     headRefName: String
-    
+
     """
     A list of label names to filter the pull requests by.
     """
     labels: [String!]
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for pull requests returned from the connection.
     """
     orderBy: IssueOrder
-    
+
     """
     A list of states to filter the pull requests by.
     """
     states: [PullRequestState!]
   ): PullRequestConnection!
-  
+
   """
   Identifies the date and time when the repository was last pushed to.
   """
   pushedAt: DateTime
-  
+
   """
   Whether or not rebase-merging is enabled on this repository.
   """
   rebaseMergeAllowed: Boolean!
-  
+
   """
   Recent projects that this user has modified in the context of the owner.
   """
@@ -42850,23 +42852,23 @@ type Repository implements Node & PackageOwner & ProjectOwner & ProjectV2Recent 
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): ProjectV2Connection!
-  
+
   """
   Fetch a given ref from the repository
   """
@@ -42877,7 +42879,7 @@ type Repository implements Node & PackageOwner & ProjectOwner & ProjectV2Recent 
     """
     qualifiedName: String!
   ): Ref
-  
+
   """
   Fetch a list of refs from the repository
   """
@@ -42886,43 +42888,43 @@ type Repository implements Node & PackageOwner & ProjectOwner & ProjectV2Recent 
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     DEPRECATED: use orderBy. The ordering direction.
     """
     direction: OrderDirection
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for refs returned from the connection.
     """
     orderBy: RefOrder
-    
+
     """
     Filters refs with query on name
     """
     query: String
-    
+
     """
     A ref name prefix like `refs/heads/`, `refs/tags/`, etc.
     """
     refPrefix: String!
   ): RefConnection
-  
+
   """
   Lookup a single release given various criteria.
   """
@@ -42932,7 +42934,7 @@ type Repository implements Node & PackageOwner & ProjectOwner & ProjectV2Recent 
     """
     tagName: String!
   ): Release
-  
+
   """
   List of releases which are dependent on this repository.
   """
@@ -42941,28 +42943,28 @@ type Repository implements Node & PackageOwner & ProjectOwner & ProjectV2Recent 
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Order for connection
     """
     orderBy: ReleaseOrder
   ): ReleaseConnection!
-  
+
   """
   A list of applied repository-topic associations for this repository.
   """
@@ -42971,28 +42973,28 @@ type Repository implements Node & PackageOwner & ProjectOwner & ProjectV2Recent 
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): RepositoryTopicConnection!
-  
+
   """
   The HTTP path for this repository
   """
   resourcePath: URI!
-  
+
   """
   Returns a single ruleset from the current repository by ID.
   """
@@ -43001,13 +43003,13 @@ type Repository implements Node & PackageOwner & ProjectOwner & ProjectV2Recent 
     The ID of the ruleset to be returned.
     """
     databaseId: Int!
-    
+
     """
     Include rulesets configured at higher levels that apply to this repository
     """
     includeParents: Boolean = true
   ): RepositoryRuleset
-  
+
   """
   A list of rulesets for this repository.
   """
@@ -43016,33 +43018,33 @@ type Repository implements Node & PackageOwner & ProjectOwner & ProjectV2Recent 
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Return rulesets configured at higher levels that apply to this repository
     """
     includeParents: Boolean = true
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): RepositoryRulesetConnection
-  
+
   """
   The security policy URL.
   """
   securityPolicyUrl: URI
-  
+
   """
   A description of the repository, rendered to HTML without any links in it.
   """
@@ -43052,22 +43054,22 @@ type Repository implements Node & PackageOwner & ProjectOwner & ProjectV2Recent 
     """
     limit: Int = 200
   ): HTML!
-  
+
   """
   Whether or not squash-merging is enabled on this repository.
   """
   squashMergeAllowed: Boolean!
-  
+
   """
   How the default commit message will be generated when squash merging a pull request.
   """
   squashMergeCommitMessage: SquashMergeCommitMessage!
-  
+
   """
   How the default commit title will be generated when squash merging a pull request.
   """
   squashMergeCommitTitle: SquashMergeCommitTitle!
-  
+
   """
   Whether a squash merge commit can use the pull request title as default.
   """
@@ -43075,17 +43077,17 @@ type Repository implements Node & PackageOwner & ProjectOwner & ProjectV2Recent 
     @deprecated(
       reason: "`squashPrTitleUsedAsDefault` will be removed. Use `Repository.squashMergeCommitTitle` instead. Removal on 2023-04-01 UTC."
     )
-  
+
   """
   The SSH URL to clone this repository
   """
   sshUrl: GitSSHRemote!
-  
+
   """
   Returns a count of how many stargazers there are on this object
   """
   stargazerCount: Int!
-  
+
   """
   A list of users who have starred this starrable.
   """
@@ -43094,28 +43096,28 @@ type Repository implements Node & PackageOwner & ProjectOwner & ProjectV2Recent 
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Order for connection
     """
     orderBy: StarOrder
   ): StargazerConnection!
-  
+
   """
   Returns a list of all submodules in this repository parsed from the
   .gitmodules file as of the default branch's HEAD commit.
@@ -43125,103 +43127,103 @@ type Repository implements Node & PackageOwner & ProjectOwner & ProjectV2Recent 
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): SubmoduleConnection!
-  
+
   """
   Temporary authentication token for cloning this repository.
   """
   tempCloneToken: String
-  
+
   """
   The repository from which this repository was generated, if any.
   """
   templateRepository: Repository
-  
+
   """
   Identifies the date and time when the object was last updated.
   """
   updatedAt: DateTime!
-  
+
   """
   The HTTP URL for this repository
   """
   url: URI!
-  
+
   """
   Whether this repository has a custom image to use with Open Graph as opposed to being represented by the owner's avatar.
   """
   usesCustomOpenGraphImage: Boolean!
-  
+
   """
   Indicates whether the viewer has admin permissions on this repository.
   """
   viewerCanAdminister: Boolean!
-  
+
   """
   Can the current viewer create new projects on this owner.
   """
   viewerCanCreateProjects: Boolean!
-  
+
   """
   Check if the viewer is able to change their subscription status for the repository.
   """
   viewerCanSubscribe: Boolean!
-  
+
   """
   Indicates whether the viewer can update the topics of this repository.
   """
   viewerCanUpdateTopics: Boolean!
-  
+
   """
   The last commit email for the viewer.
   """
   viewerDefaultCommitEmail: String
-  
+
   """
   The last used merge method by the viewer or the default for the repository.
   """
   viewerDefaultMergeMethod: PullRequestMergeMethod!
-  
+
   """
   Returns a boolean indicating whether the viewing user has starred this starrable.
   """
   viewerHasStarred: Boolean!
-  
+
   """
   The users permission level on the repository. Will return null if authenticated as an GitHub App.
   """
   viewerPermission: RepositoryPermission
-  
+
   """
   A list of emails this viewer can commit with.
   """
   viewerPossibleCommitEmails: [String!]
-  
+
   """
   Identifies if the viewer is watching, not watching, or ignoring the subscribable entity.
   """
   viewerSubscription: SubscriptionState
-  
+
   """
   Indicates the repository's visibility level.
   """
   visibility: RepositoryVisibility!
-  
+
   """
   Returns a single vulnerability alert from the current repository by number.
   """
@@ -43231,7 +43233,7 @@ type Repository implements Node & PackageOwner & ProjectOwner & ProjectV2Recent 
     """
     number: Int!
   ): RepositoryVulnerabilityAlert
-  
+
   """
   A list of vulnerability alerts that are on this repository.
   """
@@ -43240,33 +43242,33 @@ type Repository implements Node & PackageOwner & ProjectOwner & ProjectV2Recent 
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Filter by the scope of the alert's dependency
     """
     dependencyScopes: [RepositoryVulnerabilityAlertDependencyScope!]
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Filter by the state of the alert
     """
     states: [RepositoryVulnerabilityAlertState!]
   ): RepositoryVulnerabilityAlertConnection
-  
+
   """
   A list of users watching the repository.
   """
@@ -43275,23 +43277,23 @@ type Repository implements Node & PackageOwner & ProjectOwner & ProjectV2Recent 
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): UserConnection!
-  
+
   """
   Whether contributors are required to sign off on web-based commits in this repository.
   """
@@ -43325,17 +43327,17 @@ interface RepositoryAuditEntryData {
   The repository associated with the action
   """
   repository: Repository
-  
+
   """
   The name of the repository
   """
   repositoryName: String
-  
+
   """
   The HTTP path for the repository
   """
   repositoryResourcePath: URI
-  
+
   """
   The HTTP URL for the repository
   """
@@ -43360,32 +43362,32 @@ type RepositoryCodeownersError {
   The column number where the error occurs.
   """
   column: Int!
-  
+
   """
   A short string describing the type of error.
   """
   kind: String!
-  
+
   """
   The line number where the error occurs.
   """
   line: Int!
-  
+
   """
   A complete description of the error, combining information from other fields.
   """
   message: String!
-  
+
   """
   The path to the file when the error occurs.
   """
   path: String!
-  
+
   """
   The content of the line where the error occurs.
   """
   source: String!
-  
+
   """
   A suggestion of how to fix the error.
   """
@@ -43400,17 +43402,17 @@ type RepositoryCollaboratorConnection {
   A list of edges.
   """
   edges: [RepositoryCollaboratorEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [User]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -43426,12 +43428,12 @@ type RepositoryCollaboratorEdge {
   """
   cursor: String!
   node: User!
-  
+
   """
   The permission the user has on the repository.
   """
   permission: RepositoryPermission!
-  
+
   """
   A list of sources for the user's access to the repository.
   """
@@ -43446,22 +43448,22 @@ type RepositoryConnection {
   A list of edges.
   """
   edges: [RepositoryEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [Repository]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
   totalCount: Int!
-  
+
   """
   The total size in kilobytes of all repositories in the connection.
   """
@@ -43476,12 +43478,12 @@ type RepositoryContactLink {
   The contact link purpose.
   """
   about: String!
-  
+
   """
   The contact link name.
   """
   name: String!
-  
+
   """
   The contact link URL.
   """
@@ -43526,38 +43528,38 @@ interface RepositoryDiscussionAuthor {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Filter discussions to only those that have been answered or not. Defaults to
     including both answered and unanswered discussions.
     """
     answered: Boolean = null
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for discussions returned from the connection.
     """
     orderBy: DiscussionOrder = { field: CREATED_AT, direction: DESC }
-    
+
     """
     Filter discussions to only those in a specific repository.
     """
     repositoryId: ID
-    
+
     """
     A list of states to filter the discussions by.
     """
@@ -43577,27 +43579,27 @@ interface RepositoryDiscussionCommentAuthor {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Filter discussion comments to only those that were marked as the answer
     """
     onlyAnswers: Boolean = false
-    
+
     """
     Filter discussion comments to only those in a specific repository.
     """
@@ -43613,7 +43615,7 @@ type RepositoryEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -43648,132 +43650,132 @@ interface RepositoryInfo {
   Identifies the date and time when the repository was archived.
   """
   archivedAt: DateTime
-  
+
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
-  
+
   """
   The description of the repository.
   """
   description: String
-  
+
   """
   The description of the repository rendered to HTML.
   """
   descriptionHTML: HTML!
-  
+
   """
   Returns how many forks there are of this repository in the whole network.
   """
   forkCount: Int!
-  
+
   """
   Indicates if the repository has the Discussions feature enabled.
   """
   hasDiscussionsEnabled: Boolean!
-  
+
   """
   Indicates if the repository has issues feature enabled.
   """
   hasIssuesEnabled: Boolean!
-  
+
   """
   Indicates if the repository has the Projects feature enabled.
   """
   hasProjectsEnabled: Boolean!
-  
+
   """
   Indicates if the repository has wiki feature enabled.
   """
   hasWikiEnabled: Boolean!
-  
+
   """
   The repository's URL.
   """
   homepageUrl: URI
-  
+
   """
   Indicates if the repository is unmaintained.
   """
   isArchived: Boolean!
-  
+
   """
   Identifies if the repository is a fork.
   """
   isFork: Boolean!
-  
+
   """
   Indicates if a repository is either owned by an organization, or is a private fork of an organization repository.
   """
   isInOrganization: Boolean!
-  
+
   """
   Indicates if the repository has been locked or not.
   """
   isLocked: Boolean!
-  
+
   """
   Identifies if the repository is a mirror.
   """
   isMirror: Boolean!
-  
+
   """
   Identifies if the repository is private or internal.
   """
   isPrivate: Boolean!
-  
+
   """
   Identifies if the repository is a template that can be used to generate new repositories.
   """
   isTemplate: Boolean!
-  
+
   """
   The license associated with the repository
   """
   licenseInfo: License
-  
+
   """
   The reason the repository has been locked.
   """
   lockReason: RepositoryLockReason
-  
+
   """
   The repository's original mirror URL.
   """
   mirrorUrl: URI
-  
+
   """
   The name of the repository.
   """
   name: String!
-  
+
   """
   The repository's name with owner.
   """
   nameWithOwner: String!
-  
+
   """
   The image used to represent this repository in Open Graph data.
   """
   openGraphImageUrl: URI!
-  
+
   """
   The User owner of the repository.
   """
   owner: RepositoryOwner!
-  
+
   """
   Identifies the date and time when the repository was last pushed to.
   """
   pushedAt: DateTime
-  
+
   """
   The HTTP path for this repository
   """
   resourcePath: URI!
-  
+
   """
   A description of the repository, rendered to HTML without any links in it.
   """
@@ -43783,22 +43785,22 @@ interface RepositoryInfo {
     """
     limit: Int = 200
   ): HTML!
-  
+
   """
   Identifies the date and time when the object was last updated.
   """
   updatedAt: DateTime!
-  
+
   """
   The HTTP URL for this repository
   """
   url: URI!
-  
+
   """
   Whether this repository has a custom image to use with Open Graph as opposed to being represented by the owner's avatar.
   """
   usesCustomOpenGraphImage: Boolean!
-  
+
   """
   Indicates the repository's visibility level.
   """
@@ -43813,12 +43815,12 @@ type RepositoryInteractionAbility {
   The time the currently active limit expires.
   """
   expiresAt: DateTime
-  
+
   """
   The current limit that is enabled on this object.
   """
   limit: RepositoryInteractionLimit!
-  
+
   """
   The origin of the currently active interaction limit.
   """
@@ -43900,27 +43902,27 @@ type RepositoryInvitation implements Node {
   """
   email: String
   id: ID!
-  
+
   """
   The user who received the invitation.
   """
   invitee: User
-  
+
   """
   The user who created the invitation.
   """
   inviter: User!
-  
+
   """
   The permalink for this repository invitation.
   """
   permalink: URI!
-  
+
   """
   The permission granted on this repository by this invitation.
   """
   permission: RepositoryPermission!
-  
+
   """
   The Repository the user is invited to.
   """
@@ -43935,17 +43937,17 @@ type RepositoryInvitationConnection {
   A list of edges.
   """
   edges: [RepositoryInvitationEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [RepositoryInvitation]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -43960,7 +43962,7 @@ type RepositoryInvitationEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -43975,7 +43977,7 @@ input RepositoryInvitationOrder {
   The ordering direction.
   """
   direction: OrderDirection!
-  
+
   """
   The field to order repository invitations by.
   """
@@ -44026,48 +44028,48 @@ type RepositoryMigration implements Migration & Node {
   The migration flag to continue on error.
   """
   continueOnError: Boolean!
-  
+
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
-  
+
   """
   Identifies the primary key from the database.
   """
   databaseId: String
-  
+
   """
   The reason the migration failed.
   """
   failureReason: String
   id: ID!
-  
+
   """
   The URL for the migration log (expires 1 day after migration completes).
   """
   migrationLogUrl: URI
-  
+
   """
   The migration source.
   """
   migrationSource: MigrationSource!
-  
+
   """
   The target repository name.
   """
   repositoryName: String!
-  
+
   """
   The migration source URL, for example `https://github.com` or `https://monalisa.ghe.com`.
   """
   sourceUrl: URI!
-  
+
   """
   The migration state.
   """
   state: MigrationState!
-  
+
   """
   The number of warnings encountered for this migration. To review the warnings,
   check the [Migration Log](https://docs.github.com/en/migrations/using-github-enterprise-importer/completing-your-migration-with-github-enterprise-importer/accessing-your-migration-logs-for-github-enterprise-importer).
@@ -44083,17 +44085,17 @@ type RepositoryMigrationConnection {
   A list of edges.
   """
   edges: [RepositoryMigrationEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [RepositoryMigration]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -44108,7 +44110,7 @@ type RepositoryMigrationEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -44123,7 +44125,7 @@ input RepositoryMigrationOrder {
   The ordering direction.
   """
   direction: RepositoryMigrationOrderDirection!
-  
+
   """
   The field to order repository migrations by.
   """
@@ -44162,13 +44164,13 @@ type RepositoryNameConditionTarget {
   Array of repository names or patterns to exclude. The condition will not pass if any of these patterns match.
   """
   exclude: [String!]!
-  
+
   """
   Array of repository names or patterns to include. One of these patterns must
   match for the condition to pass. Also accepts `~ALL` to include all repositories.
   """
   include: [String!]!
-  
+
   """
   Target changes that match these patterns will be prevented except by those with bypass permissions.
   """
@@ -44183,13 +44185,13 @@ input RepositoryNameConditionTargetInput {
   Array of repository names or patterns to exclude. The condition will not pass if any of these patterns match.
   """
   exclude: [String!]!
-  
+
   """
   Array of repository names or patterns to include. One of these patterns must
   match for the condition to pass. Also accepts `~ALL` to include all repositories.
   """
   include: [String!]!
-  
+
   """
   Target changes that match these patterns will be prevented except by those with bypass permissions.
   """
@@ -44214,7 +44216,7 @@ input RepositoryOrder {
   The ordering direction.
   """
   direction: OrderDirection!
-  
+
   """
   The field to order repositories by.
   """
@@ -44261,12 +44263,12 @@ interface RepositoryOwner {
     size: Int
   ): URI!
   id: ID!
-  
+
   """
   The username used to login.
   """
   login: String!
-  
+
   """
   A list of repositories that the user owns.
   """
@@ -44277,65 +44279,65 @@ interface RepositoryOwner {
     current viewer owns.
     """
     affiliations: [RepositoryAffiliation]
-    
+
     """
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     If non-null, filters repositories according to whether they have issues enabled
     """
     hasIssuesEnabled: Boolean
-    
+
     """
     If non-null, filters repositories according to whether they are archived and not maintained
     """
     isArchived: Boolean
-    
+
     """
     If non-null, filters repositories according to whether they are forks of another repository
     """
     isFork: Boolean
-    
+
     """
     If non-null, filters repositories according to whether they have been locked
     """
     isLocked: Boolean
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for repositories returned from the connection
     """
     orderBy: RepositoryOrder
-    
+
     """
     Array of owner's affiliation options for repositories returned from the
     connection. For example, OWNER will include only repositories that the
     organization or user being viewed owns.
     """
     ownerAffiliations: [RepositoryAffiliation] = [OWNER, COLLABORATOR]
-    
+
     """
     If non-null, filters repositories according to privacy
     """
     privacy: RepositoryPrivacy
   ): RepositoryConnection!
-  
+
   """
   Find Repository.
   """
@@ -44344,18 +44346,18 @@ interface RepositoryOwner {
     Follow repository renames. If disabled, a repository referenced by its old name will return an error.
     """
     followRenames: Boolean = true
-    
+
     """
     Name of Repository to find.
     """
     name: String!
   ): Repository
-  
+
   """
   The HTTP URL for the owner.
   """
   resourcePath: URI!
-  
+
   """
   The HTTP URL for the owner.
   """
@@ -44408,17 +44410,17 @@ A repository rule.
 """
 type RepositoryRule implements Node {
   id: ID!
-  
+
   """
   The parameters for this rule.
   """
   parameters: RuleParameters
-  
+
   """
   The repository ruleset associated with this rule configuration
   """
   repositoryRuleset: RepositoryRuleset
-  
+
   """
   The type of rule.
   """
@@ -44433,12 +44435,12 @@ type RepositoryRuleConditions {
   Configuration for the ref_name condition
   """
   refName: RefNameConditionTarget
-  
+
   """
   Configuration for the repository_id condition
   """
   repositoryId: RepositoryIdConditionTarget
-  
+
   """
   Configuration for the repository_name condition
   """
@@ -44453,12 +44455,12 @@ input RepositoryRuleConditionsInput {
   Configuration for the ref_name condition
   """
   refName: RefNameConditionTargetInput
-  
+
   """
   Configuration for the repository_id condition
   """
   repositoryId: RepositoryIdConditionTargetInput
-  
+
   """
   Configuration for the repository_name condition
   """
@@ -44473,17 +44475,17 @@ type RepositoryRuleConnection {
   A list of edges.
   """
   edges: [RepositoryRuleEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [RepositoryRule]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -44498,7 +44500,7 @@ type RepositoryRuleEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -44513,12 +44515,12 @@ input RepositoryRuleInput {
   Optional ID of this rule when updating
   """
   id: ID @possibleTypes(concreteTypes: ["RepositoryRule"])
-  
+
   """
   The parameters for the rule.
   """
   parameters: RuleParametersInput
-  
+
   """
   The type of rule to create.
   """
@@ -44602,49 +44604,49 @@ type RepositoryRuleset implements Node {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): RepositoryRulesetBypassActorConnection
-  
+
   """
   The set of conditions that must evaluate to true for this ruleset to apply
   """
   conditions: RepositoryRuleConditions!
-  
+
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
-  
+
   """
   Identifies the primary key from the database.
   """
   databaseId: Int
-  
+
   """
   The enforcement level of this ruleset
   """
   enforcement: RuleEnforcement!
   id: ID!
-  
+
   """
   Name of the ruleset.
   """
   name: String!
-  
+
   """
   List of rules.
   """
@@ -44653,38 +44655,38 @@ type RepositoryRuleset implements Node {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     The type of rule.
     """
     type: RepositoryRuleType
   ): RepositoryRuleConnection
-  
+
   """
   Source of ruleset.
   """
   source: RuleSource!
-  
+
   """
   Target of the ruleset.
   """
   target: RepositoryRulesetTarget
-  
+
   """
   Identifies the date and time when the object was last updated.
   """
@@ -44699,28 +44701,28 @@ type RepositoryRulesetBypassActor implements Node {
   The actor that can bypass rules.
   """
   actor: BypassActor
-  
+
   """
   The mode for the bypass actor
   """
   bypassMode: RepositoryRulesetBypassActorBypassMode
   id: ID!
-  
+
   """
   This actor represents the ability for an organization admin to bypass
   """
   organizationAdmin: Boolean!
-  
+
   """
   If the actor is a repository role, the repository role's ID that can bypass
   """
   repositoryRoleDatabaseId: Int
-  
+
   """
   If the actor is a repository role, the repository role's name that can bypass
   """
   repositoryRoleName: String
-  
+
   """
   Identifies the ruleset associated with the allowed actor
   """
@@ -44749,17 +44751,17 @@ type RepositoryRulesetBypassActorConnection {
   A list of edges.
   """
   edges: [RepositoryRulesetBypassActorEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [RepositoryRulesetBypassActor]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -44774,7 +44776,7 @@ type RepositoryRulesetBypassActorEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -44790,17 +44792,17 @@ input RepositoryRulesetBypassActorInput {
   For Team and Integration bypasses, the Team or Integration ID
   """
   actorId: ID
-  
+
   """
   The bypass mode for this actor.
   """
   bypassMode: RepositoryRulesetBypassActorBypassMode!
-  
+
   """
   For org admin bupasses, true
   """
   organizationAdmin: Boolean
-  
+
   """
   For role bypasses, the role database ID
   """
@@ -44815,17 +44817,17 @@ type RepositoryRulesetConnection {
   A list of edges.
   """
   edges: [RepositoryRulesetEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [RepositoryRuleset]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -44840,7 +44842,7 @@ type RepositoryRulesetEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -44866,17 +44868,17 @@ A repository-topic connects a repository to a topic.
 """
 type RepositoryTopic implements Node & UniformResourceLocatable {
   id: ID!
-  
+
   """
   The HTTP path for this repository-topic.
   """
   resourcePath: URI!
-  
+
   """
   The topic.
   """
   topic: Topic!
-  
+
   """
   The HTTP URL for this repository-topic.
   """
@@ -44891,17 +44893,17 @@ type RepositoryTopicConnection {
   A list of edges.
   """
   edges: [RepositoryTopicEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [RepositoryTopic]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -44916,7 +44918,7 @@ type RepositoryTopicEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -44949,98 +44951,98 @@ type RepositoryVisibilityChangeDisableAuditEntry implements AuditEntry & Enterpr
   The action name
   """
   action: String!
-  
+
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
-  
+
   """
   The IP address of the actor
   """
   actorIp: String
-  
+
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
-  
+
   """
   The username of the user who initiated the action
   """
   actorLogin: String
-  
+
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
-  
+
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
-  
+
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
-  
+
   """
   The HTTP path for this enterprise.
   """
   enterpriseResourcePath: URI
-  
+
   """
   The slug of the enterprise.
   """
   enterpriseSlug: String
-  
+
   """
   The HTTP URL for this enterprise.
   """
   enterpriseUrl: URI
   id: ID!
-  
+
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
-  
+
   """
   The Organization associated with the Audit Entry.
   """
   organization: Organization
-  
+
   """
   The name of the Organization.
   """
   organizationName: String
-  
+
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
-  
+
   """
   The HTTP URL for the organization
   """
   organizationUrl: URI
-  
+
   """
   The user affected by the action
   """
   user: User
-  
+
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
-  
+
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
-  
+
   """
   The HTTP URL for the user.
   """
@@ -45055,98 +45057,98 @@ type RepositoryVisibilityChangeEnableAuditEntry implements AuditEntry & Enterpri
   The action name
   """
   action: String!
-  
+
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
-  
+
   """
   The IP address of the actor
   """
   actorIp: String
-  
+
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
-  
+
   """
   The username of the user who initiated the action
   """
   actorLogin: String
-  
+
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
-  
+
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
-  
+
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
-  
+
   """
   The HTTP path for this enterprise.
   """
   enterpriseResourcePath: URI
-  
+
   """
   The slug of the enterprise.
   """
   enterpriseSlug: String
-  
+
   """
   The HTTP URL for this enterprise.
   """
   enterpriseUrl: URI
   id: ID!
-  
+
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
-  
+
   """
   The Organization associated with the Audit Entry.
   """
   organization: Organization
-  
+
   """
   The name of the Organization.
   """
   organizationName: String
-  
+
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
-  
+
   """
   The HTTP URL for the organization
   """
   organizationUrl: URI
-  
+
   """
   The user affected by the action
   """
   user: User
-  
+
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
-  
+
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
-  
+
   """
   The HTTP URL for the user.
   """
@@ -45161,83 +45163,83 @@ type RepositoryVulnerabilityAlert implements Node & RepositoryNode {
   When was the alert auto-dismissed?
   """
   autoDismissedAt: DateTime
-  
+
   """
   When was the alert created?
   """
   createdAt: DateTime!
-  
+
   """
   The associated Dependabot update
   """
   dependabotUpdate: DependabotUpdate
-  
+
   """
   The scope of an alert's dependency
   """
   dependencyScope: RepositoryVulnerabilityAlertDependencyScope
-  
+
   """
   Comment explaining the reason the alert was dismissed
   """
   dismissComment: String
-  
+
   """
   The reason the alert was dismissed
   """
   dismissReason: String
-  
+
   """
   When was the alert dismissed?
   """
   dismissedAt: DateTime
-  
+
   """
   The user who dismissed the alert
   """
   dismisser: User
-  
+
   """
   When was the alert fixed?
   """
   fixedAt: DateTime
   id: ID!
-  
+
   """
   Identifies the alert number.
   """
   number: Int!
-  
+
   """
   The associated repository
   """
   repository: Repository!
-  
+
   """
   The associated security advisory
   """
   securityAdvisory: SecurityAdvisory
-  
+
   """
   The associated security vulnerability
   """
   securityVulnerability: SecurityVulnerability
-  
+
   """
   Identifies the state of the alert.
   """
   state: RepositoryVulnerabilityAlertState!
-  
+
   """
   The vulnerable manifest filename
   """
   vulnerableManifestFilename: String!
-  
+
   """
   The vulnerable manifest path
   """
   vulnerableManifestPath: String!
-  
+
   """
   The vulnerable requirements
   """
@@ -45252,17 +45254,17 @@ type RepositoryVulnerabilityAlertConnection {
   A list of edges.
   """
   edges: [RepositoryVulnerabilityAlertEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [RepositoryVulnerabilityAlert]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -45291,7 +45293,7 @@ type RepositoryVulnerabilityAlertEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -45328,22 +45330,22 @@ input RequestReviewsInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The Node ID of the pull request to modify.
   """
   pullRequestId: ID! @possibleTypes(concreteTypes: ["PullRequest"])
-  
+
   """
   The Node IDs of the team to request.
   """
   teamIds: [ID!] @possibleTypes(concreteTypes: ["Team"])
-  
+
   """
   Add users to the set rather than replace.
   """
   union: Boolean = false
-  
+
   """
   The Node IDs of the user to request.
   """
@@ -45358,17 +45360,17 @@ type RequestReviewsPayload {
   Identifies the actor who performed the event.
   """
   actor: Actor
-  
+
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The pull request that is getting requests.
   """
   pullRequest: PullRequest
-  
+
   """
   The edge from the pull request to the requested reviewers.
   """
@@ -45414,17 +45416,17 @@ type RequestedReviewerConnection {
   A list of edges.
   """
   edges: [RequestedReviewerEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [RequestedReviewer]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -45439,7 +45441,7 @@ type RequestedReviewerEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -45458,7 +45460,7 @@ interface RequirableByPullRequest {
     The id of the pull request this is required for
     """
     pullRequestId: ID
-    
+
     """
     The number of the pull request this is required for
     """
@@ -45494,7 +45496,7 @@ type RequiredStatusCheckDescription {
   The App that must provide this status in order for it to be accepted.
   """
   app: App
-  
+
   """
   The name of this status.
   """
@@ -45511,7 +45513,7 @@ input RequiredStatusCheckInput {
   use "any" to allow any app to set the status.
   """
   appId: ID
-  
+
   """
   Status check context that must pass for commits to be accepted to the matching branch.
   """
@@ -45529,7 +45531,7 @@ type RequiredStatusChecksParameters {
   Status checks that are required.
   """
   requiredStatusChecks: [StatusCheckConfiguration!]!
-  
+
   """
   Whether pull requests targeting a matching branch must be tested with the
   latest code. This setting will not take effect unless at least one status
@@ -45549,7 +45551,7 @@ input RequiredStatusChecksParametersInput {
   Status checks that are required.
   """
   requiredStatusChecks: [StatusCheckConfigurationInput!]!
-  
+
   """
   Whether pull requests targeting a matching branch must be tested with the
   latest code. This setting will not take effect unless at least one status
@@ -45566,12 +45568,12 @@ input RerequestCheckSuiteInput {
   The Node ID of the check suite.
   """
   checkSuiteId: ID! @possibleTypes(concreteTypes: ["CheckSuite"])
-  
+
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The Node ID of the repository.
   """
@@ -45586,7 +45588,7 @@ type RerequestCheckSuitePayload {
   The requested check suite.
   """
   checkSuite: CheckSuite
-  
+
   """
   A unique identifier for the client performing the mutation.
   """
@@ -45601,7 +45603,7 @@ input ResolveReviewThreadInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The ID of the thread to resolve
   """
@@ -45616,7 +45618,7 @@ type ResolveReviewThreadPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The thread to resolve.
   """
@@ -45633,22 +45635,22 @@ type RestrictedContribution implements Contribution {
   longer access.
   """
   isRestricted: Boolean!
-  
+
   """
   When this contribution was made.
   """
   occurredAt: DateTime!
-  
+
   """
   The HTTP path for this contribution.
   """
   resourcePath: URI!
-  
+
   """
   The HTTP URL for this contribution.
   """
   url: URI!
-  
+
   """
   The user who made this contribution.
   """
@@ -45663,7 +45665,7 @@ input RetireSponsorsTierInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The ID of the published tier to retire.
   """
@@ -45678,7 +45680,7 @@ type RetireSponsorsTierPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The tier that was retired.
   """
@@ -45693,22 +45695,22 @@ input RevertPullRequestInput {
   The description of the revert pull request.
   """
   body: String
-  
+
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   Indicates whether the revert pull request should be a draft.
   """
   draft: Boolean = false
-  
+
   """
   The ID of the pull request to revert.
   """
   pullRequestId: ID! @possibleTypes(concreteTypes: ["PullRequest"])
-  
+
   """
   The title of the revert pull request.
   """
@@ -45723,12 +45725,12 @@ type RevertPullRequestPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The pull request that was reverted.
   """
   pullRequest: PullRequest
-  
+
   """
   The new pull request that reverts the input pull request.
   """
@@ -45743,7 +45745,7 @@ type ReviewDismissalAllowance implements Node {
   The actor that can dismiss.
   """
   actor: ReviewDismissalAllowanceActor
-  
+
   """
   Identifies the branch protection rule associated with the allowed user, team, or app.
   """
@@ -45764,17 +45766,17 @@ type ReviewDismissalAllowanceConnection {
   A list of edges.
   """
   edges: [ReviewDismissalAllowanceEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [ReviewDismissalAllowance]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -45789,7 +45791,7 @@ type ReviewDismissalAllowanceEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -45804,53 +45806,53 @@ type ReviewDismissedEvent implements Node & UniformResourceLocatable {
   Identifies the actor who performed the event.
   """
   actor: Actor
-  
+
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
-  
+
   """
   Identifies the primary key from the database.
   """
   databaseId: Int
-  
+
   """
   Identifies the optional message associated with the 'review_dismissed' event.
   """
   dismissalMessage: String
-  
+
   """
   Identifies the optional message associated with the event, rendered to HTML.
   """
   dismissalMessageHTML: String
   id: ID!
-  
+
   """
   Identifies the previous state of the review with the 'review_dismissed' event.
   """
   previousReviewState: PullRequestReviewState!
-  
+
   """
   PullRequest referenced by event.
   """
   pullRequest: PullRequest!
-  
+
   """
   Identifies the commit which caused the review to become stale.
   """
   pullRequestCommit: PullRequestCommit
-  
+
   """
   The HTTP path for this review dismissed event.
   """
   resourcePath: URI!
-  
+
   """
   Identifies the review associated with the 'review_dismissed' event.
   """
   review: PullRequestReview
-  
+
   """
   The HTTP URL for this review dismissed event.
   """
@@ -45865,18 +45867,18 @@ type ReviewRequest implements Node {
   Whether this request was created for a code owner
   """
   asCodeOwner: Boolean!
-  
+
   """
   Identifies the primary key from the database.
   """
   databaseId: Int
   id: ID!
-  
+
   """
   Identifies the pull request associated with this review request.
   """
   pullRequest: PullRequest!
-  
+
   """
   The reviewer that is requested.
   """
@@ -45891,17 +45893,17 @@ type ReviewRequestConnection {
   A list of edges.
   """
   edges: [ReviewRequestEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [ReviewRequest]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -45916,7 +45918,7 @@ type ReviewRequestEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -45931,18 +45933,18 @@ type ReviewRequestRemovedEvent implements Node {
   Identifies the actor who performed the event.
   """
   actor: Actor
-  
+
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
   id: ID!
-  
+
   """
   PullRequest referenced by event.
   """
   pullRequest: PullRequest!
-  
+
   """
   Identifies the reviewer whose review request was removed.
   """
@@ -45957,18 +45959,18 @@ type ReviewRequestedEvent implements Node {
   Identifies the actor who performed the event.
   """
   actor: Actor
-  
+
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
   id: ID!
-  
+
   """
   PullRequest referenced by event.
   """
   pullRequest: PullRequest!
-  
+
   """
   Identifies the reviewer whose review was requested.
   """
@@ -45984,12 +45986,12 @@ type ReviewStatusHovercardContext implements HovercardContext {
   A string describing this context
   """
   message: String!
-  
+
   """
   An octicon to accompany this context
   """
   octicon: String!
-  
+
   """
   The current status of the pull request with respect to code review.
   """
@@ -46004,12 +46006,12 @@ input RevokeEnterpriseOrganizationsMigratorRoleInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The ID of the enterprise to which all organizations managed by it will be granted the migrator role.
   """
   enterpriseId: ID! @possibleTypes(concreteTypes: ["Enterprise"])
-  
+
   """
   The login of the user to revoke the migrator role
   """
@@ -46024,7 +46026,7 @@ type RevokeEnterpriseOrganizationsMigratorRolePayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The organizations that had the migrator role revoked for the given user.
   """
@@ -46033,17 +46035,17 @@ type RevokeEnterpriseOrganizationsMigratorRolePayload {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
@@ -46059,17 +46061,17 @@ input RevokeMigratorRoleInput {
   The user login or Team slug to revoke the migrator role from.
   """
   actor: String!
-  
+
   """
   Specifies the type of the actor, can be either USER or TEAM.
   """
   actorType: ActorType!
-  
+
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The ID of the organization that the user/team belongs to.
   """
@@ -46084,7 +46086,7 @@ type RevokeMigratorRolePayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   Did the operation succeed?
   """
@@ -46149,42 +46151,42 @@ input RuleParametersInput {
   Parameters used for the `branch_name_pattern` rule type
   """
   branchNamePattern: BranchNamePatternParametersInput
-  
+
   """
   Parameters used for the `commit_author_email_pattern` rule type
   """
   commitAuthorEmailPattern: CommitAuthorEmailPatternParametersInput
-  
+
   """
   Parameters used for the `commit_message_pattern` rule type
   """
   commitMessagePattern: CommitMessagePatternParametersInput
-  
+
   """
   Parameters used for the `committer_email_pattern` rule type
   """
   committerEmailPattern: CommitterEmailPatternParametersInput
-  
+
   """
   Parameters used for the `pull_request` rule type
   """
   pullRequest: PullRequestParametersInput
-  
+
   """
   Parameters used for the `required_deployments` rule type
   """
   requiredDeployments: RequiredDeploymentsParametersInput
-  
+
   """
   Parameters used for the `required_status_checks` rule type
   """
   requiredStatusChecks: RequiredStatusChecksParametersInput
-  
+
   """
   Parameters used for the `tag_name_pattern` rule type
   """
   tagNamePattern: TagNamePatternParametersInput
-  
+
   """
   Parameters used for the `update` rule type
   """
@@ -46248,23 +46250,23 @@ type SavedReply implements Node {
   The body of the saved reply.
   """
   body: String!
-  
+
   """
   The saved reply body rendered to HTML.
   """
   bodyHTML: HTML!
-  
+
   """
   Identifies the primary key from the database.
   """
   databaseId: Int
   id: ID!
-  
+
   """
   The title of the saved reply.
   """
   title: String!
-  
+
   """
   The user that saved this reply.
   """
@@ -46279,17 +46281,17 @@ type SavedReplyConnection {
   A list of edges.
   """
   edges: [SavedReplyEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [SavedReply]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -46304,7 +46306,7 @@ type SavedReplyEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -46319,7 +46321,7 @@ input SavedReplyOrder {
   The ordering direction.
   """
   direction: OrderDirection!
-  
+
   """
   The field to order saved replies by.
   """
@@ -46360,48 +46362,48 @@ type SearchResultItemConnection {
   across all types.
   """
   codeCount: Int!
-  
+
   """
   The total number of discussions that matched the search query. Regardless of
   the total number of matches, a maximum of 1,000 results will be available
   across all types.
   """
   discussionCount: Int!
-  
+
   """
   A list of edges.
   """
   edges: [SearchResultItemEdge]
-  
+
   """
   The total number of issues that matched the search query. Regardless of the
   total number of matches, a maximum of 1,000 results will be available across all types.
   """
   issueCount: Int!
-  
+
   """
   A list of nodes.
   """
   nodes: [SearchResultItem]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   The total number of repositories that matched the search query. Regardless of
   the total number of matches, a maximum of 1,000 results will be available
   across all types.
   """
   repositoryCount: Int!
-  
+
   """
   The total number of users that matched the search query. Regardless of the
   total number of matches, a maximum of 1,000 results will be available across all types.
   """
   userCount: Int!
-  
+
   """
   The total number of wiki pages that matched the search query. Regardless of
   the total number of matches, a maximum of 1,000 results will be available
@@ -46418,12 +46420,12 @@ type SearchResultItemEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
   node: SearchResultItem
-  
+
   """
   Text matches on the result found.
   """
@@ -46460,12 +46462,12 @@ type SecurityAdvisory implements Node {
   The classification of the advisory
   """
   classification: SecurityAdvisoryClassification!
-  
+
   """
   The CVSS associated with this advisory
   """
   cvss: CVSS!
-  
+
   """
   CWEs associated with this Advisory
   """
@@ -46474,84 +46476,84 @@ type SecurityAdvisory implements Node {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): CWEConnection!
-  
+
   """
   Identifies the primary key from the database.
   """
   databaseId: Int
-  
+
   """
   This is a long plaintext description of the advisory
   """
   description: String!
-  
+
   """
   The GitHub Security Advisory ID
   """
   ghsaId: String!
   id: ID!
-  
+
   """
   A list of identifiers for this advisory
   """
   identifiers: [SecurityAdvisoryIdentifier!]!
-  
+
   """
   The permalink for the advisory's dependabot alerts page
   """
   notificationsPermalink: URI
-  
+
   """
   The organization that originated the advisory
   """
   origin: String!
-  
+
   """
   The permalink for the advisory
   """
   permalink: URI
-  
+
   """
   When the advisory was published
   """
   publishedAt: DateTime!
-  
+
   """
   A list of references for this advisory
   """
   references: [SecurityAdvisoryReference!]!
-  
+
   """
   The severity of the advisory
   """
   severity: SecurityAdvisorySeverity!
-  
+
   """
   A short plaintext summary of the advisory
   """
   summary: String!
-  
+
   """
   When the advisory was last updated
   """
   updatedAt: DateTime!
-  
+
   """
   Vulnerabilities associated with this Advisory
   """
@@ -46560,48 +46562,49 @@ type SecurityAdvisory implements Node {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     A list of advisory classifications to filter vulnerabilities by.
     """
     classifications: [SecurityAdvisoryClassification!]
-    
+
     """
     An ecosystem to filter vulnerabilities by.
     """
     ecosystem: SecurityAdvisoryEcosystem
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for the returned topics.
     """
-    orderBy: SecurityVulnerabilityOrder = { field: UPDATED_AT, direction: DESC }
-    
+    orderBy: SecurityVulnerabilityOrder = { field: UPDATED_AT, direction: DESC
+    }
+
     """
     A package name to filter vulnerabilities by.
     """
     package: String
-    
+
     """
     A list of severities to filter vulnerabilities by.
     """
     severities: [SecurityAdvisorySeverity!]
   ): SecurityVulnerabilityConnection!
-  
+
   """
   When the advisory was withdrawn, if it has been withdrawn
   """
@@ -46630,17 +46633,17 @@ type SecurityAdvisoryConnection {
   A list of edges.
   """
   edges: [SecurityAdvisoryEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [SecurityAdvisory]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -46709,7 +46712,7 @@ type SecurityAdvisoryEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -46724,7 +46727,7 @@ type SecurityAdvisoryIdentifier {
   The identifier type, e.g. GHSA, CVE
   """
   type: String!
-  
+
   """
   The identifier
   """
@@ -46739,7 +46742,7 @@ input SecurityAdvisoryIdentifierFilter {
   The identifier type.
   """
   type: SecurityAdvisoryIdentifierType!
-  
+
   """
   The identifier string. Supports exact or partial matching.
   """
@@ -46768,7 +46771,7 @@ input SecurityAdvisoryOrder {
   The ordering direction.
   """
   direction: OrderDirection!
-  
+
   """
   The field to order security advisories by.
   """
@@ -46797,7 +46800,7 @@ type SecurityAdvisoryPackage {
   The ecosystem the package belongs to, e.g. RUBYGEMS, NPM
   """
   ecosystem: SecurityAdvisoryEcosystem!
-  
+
   """
   The package name
   """
@@ -46854,27 +46857,27 @@ type SecurityVulnerability {
   The Advisory associated with this Vulnerability
   """
   advisory: SecurityAdvisory!
-  
+
   """
   The first version containing a fix for the vulnerability
   """
   firstPatchedVersion: SecurityAdvisoryPackageVersion
-  
+
   """
   A description of the vulnerable package
   """
   package: SecurityAdvisoryPackage!
-  
+
   """
   The severity of the vulnerability within this package
   """
   severity: SecurityAdvisorySeverity!
-  
+
   """
   When the vulnerability was last updated
   """
   updatedAt: DateTime!
-  
+
   """
   A string that describes the vulnerable package versions.
   This string follows a basic syntax with a few forms.
@@ -46895,17 +46898,17 @@ type SecurityVulnerabilityConnection {
   A list of edges.
   """
   edges: [SecurityVulnerabilityEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [SecurityVulnerability]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -46920,7 +46923,7 @@ type SecurityVulnerabilityEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -46935,7 +46938,7 @@ input SecurityVulnerabilityOrder {
   The ordering direction.
   """
   direction: OrderDirection!
-  
+
   """
   The field to order security vulnerabilities by.
   """
@@ -46960,32 +46963,32 @@ input SetEnterpriseIdentityProviderInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The digest algorithm used to sign SAML requests for the identity provider.
   """
   digestMethod: SamlDigestAlgorithm!
-  
+
   """
   The ID of the enterprise on which to set an identity provider.
   """
   enterpriseId: ID! @possibleTypes(concreteTypes: ["Enterprise"])
-  
+
   """
   The x509 certificate used by the identity provider to sign assertions and responses.
   """
   idpCertificate: String!
-  
+
   """
   The Issuer Entity ID for the SAML identity provider
   """
   issuer: String
-  
+
   """
   The signature algorithm used to sign SAML requests for the identity provider.
   """
   signatureMethod: SamlSignatureAlgorithm!
-  
+
   """
   The URL endpoint for the identity provider's SAML SSO.
   """
@@ -47000,7 +47003,7 @@ type SetEnterpriseIdentityProviderPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The identity provider for the enterprise.
   """
@@ -47015,17 +47018,17 @@ input SetOrganizationInteractionLimitInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   When this limit should expire.
   """
   expiry: RepositoryInteractionLimitExpiry
-  
+
   """
   The limit to set.
   """
   limit: RepositoryInteractionLimit!
-  
+
   """
   The ID of the organization to set a limit for.
   """
@@ -47040,7 +47043,7 @@ type SetOrganizationInteractionLimitPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The organization that the interaction limit was set for.
   """
@@ -47055,17 +47058,17 @@ input SetRepositoryInteractionLimitInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   When this limit should expire.
   """
   expiry: RepositoryInteractionLimitExpiry
-  
+
   """
   The limit to set.
   """
   limit: RepositoryInteractionLimit!
-  
+
   """
   The ID of the repository to set a limit for.
   """
@@ -47080,7 +47083,7 @@ type SetRepositoryInteractionLimitPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The repository that the interaction limit was set for.
   """
@@ -47095,17 +47098,17 @@ input SetUserInteractionLimitInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   When this limit should expire.
   """
   expiry: RepositoryInteractionLimitExpiry
-  
+
   """
   The limit to set.
   """
   limit: RepositoryInteractionLimit!
-  
+
   """
   The ID of the user to set a limit for.
   """
@@ -47120,7 +47123,7 @@ type SetUserInteractionLimitPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The user that the interaction limit was set for.
   """
@@ -47135,33 +47138,33 @@ type SmimeSignature implements GitSignature {
   Email used to sign this object.
   """
   email: String!
-  
+
   """
   True if the signature is valid and verified by GitHub.
   """
   isValid: Boolean!
-  
+
   """
   Payload for GPG signing object. Raw ODB object without the signature header.
   """
   payload: String!
-  
+
   """
   ASCII-armored signature header from object.
   """
   signature: String!
-  
+
   """
   GitHub user corresponding to the email signing this commit.
   """
   signer: User
-  
+
   """
   The state of this signature. `VALID` if signature is valid and verified by
   GitHub, otherwise represents reason why signature is considered invalid.
   """
   state: GitSignatureState!
-  
+
   """
   True if the signature was made with GitHub's signing key.
   """
@@ -47176,12 +47179,12 @@ type SocialAccount {
   Name of the social media account as it appears on the profile.
   """
   displayName: String!
-  
+
   """
   Software or company that hosts the social media account.
   """
   provider: SocialAccountProvider!
-  
+
   """
   URL of the social media account.
   """
@@ -47196,17 +47199,17 @@ type SocialAccountConnection {
   A list of edges.
   """
   edges: [SocialAccountEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [SocialAccount]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -47221,7 +47224,7 @@ type SocialAccountEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -47287,17 +47290,17 @@ type SponsorConnection {
   A list of edges.
   """
   edges: [SponsorEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [Sponsor]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -47312,7 +47315,7 @@ type SponsorEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -47327,7 +47330,7 @@ input SponsorOrder {
   The ordering direction.
   """
   direction: OrderDirection!
-  
+
   """
   The field to order sponsor entities by.
   """
@@ -47356,12 +47359,12 @@ interface Sponsorable {
   The estimated next GitHub Sponsors payout for this user/organization in cents (USD).
   """
   estimatedNextSponsorsPayoutInCents: Int!
-  
+
   """
   True if this user/organization has a GitHub Sponsors listing.
   """
   hasSponsorsListing: Boolean!
-  
+
   """
   Whether the given account is sponsoring this user/organization.
   """
@@ -47371,17 +47374,17 @@ interface Sponsorable {
     """
     accountLogin: String!
   ): Boolean!
-  
+
   """
   True if the viewer is sponsored by this user/organization.
   """
   isSponsoringViewer: Boolean!
-  
+
   """
   The estimated monthly GitHub Sponsors income for this user/organization in cents (USD).
   """
   monthlyEstimatedSponsorsIncomeInCents: Int!
-  
+
   """
   List of users and organizations this entity is sponsoring.
   """
@@ -47390,28 +47393,28 @@ interface Sponsorable {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for the users and organizations returned from the connection.
     """
     orderBy: SponsorOrder = { field: RELEVANCE, direction: DESC }
   ): SponsorConnection!
-  
+
   """
   List of sponsors for this user or organization.
   """
@@ -47420,34 +47423,34 @@ interface Sponsorable {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for sponsors returned from the connection.
     """
     orderBy: SponsorOrder = { field: RELEVANCE, direction: DESC }
-    
+
     """
     If given, will filter for sponsors at the given tier. Will only return
     sponsors whose tier the viewer is permitted to see.
     """
     tierId: ID
   ): SponsorConnection!
-  
+
   """
   Events involving this sponsorable, such as new sponsorships.
   """
@@ -47456,67 +47459,67 @@ interface Sponsorable {
     Filter activities to only the specified actions.
     """
     actions: [SponsorsActivityAction!] = []
-    
+
     """
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Whether to include those events where this sponsorable acted as the sponsor.
     Defaults to only including events where this sponsorable was the recipient
     of a sponsorship.
     """
     includeAsSponsor: Boolean = false
-    
+
     """
     Whether or not to include private activities in the result set. Defaults to including public and private activities.
     """
     includePrivate: Boolean = true
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for activity returned from the connection.
     """
     orderBy: SponsorsActivityOrder = { field: TIMESTAMP, direction: DESC }
-    
+
     """
     Filter activities returned to only those that occurred in the most recent
     specified time period. Set to ALL to avoid filtering by when the activity
     occurred. Will be ignored if `since` or `until` is given.
     """
     period: SponsorsActivityPeriod = MONTH
-    
+
     """
     Filter activities to those that occurred on or after this time.
     """
     since: DateTime
-    
+
     """
     Filter activities to those that occurred before this time.
     """
     until: DateTime
   ): SponsorsActivityConnection!
-  
+
   """
   The GitHub Sponsors listing for this user or organization.
   """
   sponsorsListing: SponsorsListing
-  
+
   """
   The sponsorship from the viewer to this user/organization; that is, the sponsorship where you're the sponsor.
   """
@@ -47527,7 +47530,7 @@ interface Sponsorable {
     """
     activeOnly: Boolean = true
   ): Sponsorship
-  
+
   """
   The sponsorship from this user/organization to the viewer; that is, the sponsorship you're receiving.
   """
@@ -47538,7 +47541,7 @@ interface Sponsorable {
     """
     activeOnly: Boolean = true
   ): Sponsorship
-  
+
   """
   List of sponsorship updates sent from this sponsorable to sponsors.
   """
@@ -47547,28 +47550,28 @@ interface Sponsorable {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for sponsorship updates returned from the connection.
     """
     orderBy: SponsorshipNewsletterOrder = { field: CREATED_AT, direction: DESC }
   ): SponsorshipNewsletterConnection!
-  
+
   """
   The sponsorships where this user or organization is the maintainer receiving the funds.
   """
@@ -47578,39 +47581,39 @@ interface Sponsorable {
     sponsorships this maintainer has ever received.
     """
     activeOnly: Boolean = true
-    
+
     """
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Whether or not to include private sponsorships in the result set
     """
     includePrivate: Boolean = false
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for sponsorships returned from this connection. If left
     blank, the sponsorships will be ordered based on relevancy to the viewer.
     """
     orderBy: SponsorshipOrder
   ): SponsorshipConnection!
-  
+
   """
   The sponsorships where this user or organization is the funder.
   """
@@ -47619,41 +47622,41 @@ interface Sponsorable {
     Whether to include only sponsorships that are active right now, versus all sponsorships this sponsor has ever made.
     """
     activeOnly: Boolean = true
-    
+
     """
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Filter sponsorships returned to those for the specified maintainers. That
     is, the recipient of the sponsorship is a user or organization with one of
     the given logins.
     """
     maintainerLogins: [String!]
-    
+
     """
     Ordering options for sponsorships returned from this connection. If left
     blank, the sponsorships will be ordered based on relevancy to the viewer.
     """
     orderBy: SponsorshipOrder
   ): SponsorshipConnection!
-  
+
   """
   The amount in United States cents (e.g., 500 = $5.00 USD) that this entity has
   spent on GitHub to fund sponsorships. Only returns a value when viewed by the
@@ -47664,23 +47667,23 @@ interface Sponsorable {
     Filter payments to those that occurred on or after this time.
     """
     since: DateTime
-    
+
     """
     Filter payments to those made to the users or organizations with the specified usernames.
     """
     sponsorableLogins: [String!] = []
-    
+
     """
     Filter payments to those that occurred before this time.
     """
     until: DateTime
   ): Int
-  
+
   """
   Whether or not the viewer is able to sponsor this user/organization.
   """
   viewerCanSponsor: Boolean!
-  
+
   """
   True if the viewer is sponsoring this user/organization.
   """
@@ -47700,17 +47703,17 @@ type SponsorableItemConnection {
   A list of edges.
   """
   edges: [SponsorableItemEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [SponsorableItem]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -47725,7 +47728,7 @@ type SponsorableItemEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -47740,7 +47743,7 @@ input SponsorableOrder {
   The ordering direction.
   """
   direction: OrderDirection!
-  
+
   """
   The field to order sponsorable entities by.
   """
@@ -47765,38 +47768,38 @@ type SponsorsActivity implements Node {
   What action this activity indicates took place.
   """
   action: SponsorsActivityAction!
-  
+
   """
   The sponsor's current privacy level.
   """
   currentPrivacyLevel: SponsorshipPrivacy
   id: ID!
-  
+
   """
   The tier that the sponsorship used to use, for tier change events.
   """
   previousSponsorsTier: SponsorsTier
-  
+
   """
   The user or organization who triggered this activity and was/is sponsoring the sponsorable.
   """
   sponsor: Sponsor
-  
+
   """
   The user or organization that is being sponsored, the maintainer.
   """
   sponsorable: Sponsorable!
-  
+
   """
   The associated sponsorship tier.
   """
   sponsorsTier: SponsorsTier
-  
+
   """
   The timestamp of this event.
   """
   timestamp: DateTime
-  
+
   """
   Was this sponsorship made alongside other sponsorships at the same time from the same sponsor?
   """
@@ -47841,17 +47844,17 @@ type SponsorsActivityConnection {
   A list of edges.
   """
   edges: [SponsorsActivityEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [SponsorsActivity]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -47866,7 +47869,7 @@ type SponsorsActivityEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -47881,7 +47884,7 @@ input SponsorsActivityOrder {
   The ordering direction.
   """
   direction: OrderDirection!
-  
+
   """
   The field to order activity by.
   """
@@ -48918,23 +48921,23 @@ type SponsorsGoal {
   A description of the goal from the maintainer.
   """
   description: String
-  
+
   """
   What the objective of this goal is.
   """
   kind: SponsorsGoalKind!
-  
+
   """
   The percentage representing how complete this goal is, between 0-100.
   """
   percentComplete: Int!
-  
+
   """
   What the goal amount is. Represents an amount in USD for monthly sponsorship
   amount goals. Represents a count of unique sponsors for total sponsors count goals.
   """
   targetValue: Int!
-  
+
   """
   A brief summary of the kind and target value of this goal.
   """
@@ -48963,43 +48966,43 @@ type SponsorsListing implements Node {
   The current goal the maintainer is trying to reach with GitHub Sponsors, if any.
   """
   activeGoal: SponsorsGoal
-  
+
   """
   The Stripe Connect account currently in use for payouts for this Sponsors
   listing, if any. Will only return a value when queried by the maintainer
   themselves, or by an admin of the sponsorable organization.
   """
   activeStripeConnectAccount: StripeConnectAccount
-  
+
   """
   The name of the country or region with the maintainer's bank account or fiscal
   host. Will only return a value when queried by the maintainer themselves, or
   by an admin of the sponsorable organization.
   """
   billingCountryOrRegion: String
-  
+
   """
   The email address used by GitHub to contact the sponsorable about their GitHub
   Sponsors profile. Will only return a value when queried by the maintainer
   themselves, or by an admin of the sponsorable organization.
   """
   contactEmailAddress: String
-  
+
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
-  
+
   """
   The HTTP path for the Sponsors dashboard for this Sponsors listing.
   """
   dashboardResourcePath: URI!
-  
+
   """
   The HTTP URL for the Sponsors dashboard for this Sponsors listing.
   """
   dashboardUrl: URI!
-  
+
   """
   The records featured on the GitHub Sponsors profile.
   """
@@ -49012,66 +49015,66 @@ type SponsorsListing implements Node {
       USER
     ]
   ): [SponsorsListingFeaturedItem!]!
-  
+
   """
   The fiscal host used for payments, if any. Will only return a value when
   queried by the maintainer themselves, or by an admin of the sponsorable organization.
   """
   fiscalHost: Organization
-  
+
   """
   The full description of the listing.
   """
   fullDescription: String!
-  
+
   """
   The full description of the listing rendered to HTML.
   """
   fullDescriptionHTML: HTML!
   id: ID!
-  
+
   """
   Whether this listing is publicly visible.
   """
   isPublic: Boolean!
-  
+
   """
   The listing's full name.
   """
   name: String!
-  
+
   """
   A future date on which this listing is eligible to receive a payout.
   """
   nextPayoutDate: Date
-  
+
   """
   The name of the country or region where the maintainer resides. Will only
   return a value when queried by the maintainer themselves, or by an admin of
   the sponsorable organization.
   """
   residenceCountryOrRegion: String
-  
+
   """
   The HTTP path for this Sponsors listing.
   """
   resourcePath: URI!
-  
+
   """
   The short description of the listing.
   """
   shortDescription: String!
-  
+
   """
   The short name of the listing.
   """
   slug: String!
-  
+
   """
   The entity this listing represents who can be sponsored on GitHub Sponsors.
   """
   sponsorable: Sponsorable!
-  
+
   """
   The tiers for this GitHub Sponsors profile.
   """
@@ -49080,17 +49083,17 @@ type SponsorsListing implements Node {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Whether to include tiers that aren't published. Only admins of the Sponsors
     listing can see draft tiers. Only admins of the Sponsors listing and viewers
@@ -49099,19 +49102,19 @@ type SponsorsListing implements Node {
     can see the GitHub Sponsors profile.
     """
     includeUnpublished: Boolean = false
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for Sponsors tiers returned from the connection.
     """
     orderBy: SponsorsTierOrder = { field: MONTHLY_PRICE_IN_CENTS, direction: ASC
     }
   ): SponsorsTierConnection
-  
+
   """
   The HTTP URL for this Sponsors listing.
   """
@@ -49131,31 +49134,31 @@ type SponsorsListingFeaturedItem implements Node {
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
-  
+
   """
   Will either be a description from the sponsorable maintainer about why they
   featured this item, or the item's description itself, such as a user's bio
   from their GitHub profile page.
   """
   description: String
-  
+
   """
   The record that is featured on the GitHub Sponsors profile.
   """
   featureable: SponsorsListingFeatureableItem!
   id: ID!
-  
+
   """
   The position of this featured item on the GitHub Sponsors profile with a lower
   position indicating higher precedence. Starts at 1.
   """
   position: Int!
-  
+
   """
   The GitHub Sponsors profile that features this record.
   """
   sponsorsListing: SponsorsListing!
-  
+
   """
   Identifies the date and time when the object was last updated.
   """
@@ -49184,61 +49187,61 @@ type SponsorsTier implements Node {
   SponsorsTier information only visible to users that can administer the associated Sponsors listing.
   """
   adminInfo: SponsorsTierAdminInfo
-  
+
   """
   Get a different tier for this tier's maintainer that is at the same frequency
   as this tier but with an equal or lesser cost. Returns the published tier with
   the monthly price closest to this tier's without going over.
   """
   closestLesserValueTier: SponsorsTier
-  
+
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
-  
+
   """
   The description of the tier.
   """
   description: String!
-  
+
   """
   The tier description rendered to HTML
   """
   descriptionHTML: HTML!
   id: ID!
-  
+
   """
   Whether this tier was chosen at checkout time by the sponsor rather than
   defined ahead of time by the maintainer who manages the Sponsors listing.
   """
   isCustomAmount: Boolean!
-  
+
   """
   Whether this tier is only for use with one-time sponsorships.
   """
   isOneTime: Boolean!
-  
+
   """
   How much this tier costs per month in cents.
   """
   monthlyPriceInCents: Int!
-  
+
   """
   How much this tier costs per month in USD.
   """
   monthlyPriceInDollars: Int!
-  
+
   """
   The name of the tier.
   """
   name: String!
-  
+
   """
   The sponsors listing that this tier belongs to.
   """
   sponsorsListing: SponsorsListing!
-  
+
   """
   Identifies the date and time when the object was last updated.
   """
@@ -49257,7 +49260,7 @@ type SponsorsTierAdminInfo {
   GitHub Sponsors profile.
   """
   isDraft: Boolean!
-  
+
   """
   Indicates whether this tier is published to the associated GitHub Sponsors
   profile. Published tiers are visible to anyone who can see the GitHub Sponsors
@@ -49265,7 +49268,7 @@ type SponsorsTierAdminInfo {
   profile is publicly visible.
   """
   isPublished: Boolean!
-  
+
   """
   Indicates whether this tier has been retired from the associated GitHub
   Sponsors profile. Retired tiers are no longer shown on the GitHub Sponsors
@@ -49273,7 +49276,7 @@ type SponsorsTierAdminInfo {
   still use retired tiers if the sponsor selected the tier before it was retired.
   """
   isRetired: Boolean!
-  
+
   """
   The sponsorships using this tier.
   """
@@ -49282,28 +49285,28 @@ type SponsorsTierAdminInfo {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Whether or not to return private sponsorships using this tier. Defaults to
     only returning public sponsorships on this tier.
     """
     includePrivate: Boolean = false
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for sponsorships returned from this connection. If left
     blank, the sponsorships will be ordered based on relevancy to the viewer.
@@ -49320,17 +49323,17 @@ type SponsorsTierConnection {
   A list of edges.
   """
   edges: [SponsorsTierEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [SponsorsTier]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -49345,7 +49348,7 @@ type SponsorsTierEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -49360,7 +49363,7 @@ input SponsorsTierOrder {
   The ordering direction.
   """
   direction: OrderDirection!
-  
+
   """
   The field to order tiers by.
   """
@@ -49390,24 +49393,24 @@ type Sponsorship implements Node {
   """
   createdAt: DateTime!
   id: ID!
-  
+
   """
   Whether the sponsorship is active. False implies the sponsor is a past sponsor
   of the maintainer, while true implies they are a current sponsor.
   """
   isActive: Boolean!
-  
+
   """
   Whether this sponsorship represents a one-time payment versus a recurring sponsorship.
   """
   isOneTimePayment: Boolean!
-  
+
   """
   Whether the sponsor has chosen to receive sponsorship update emails sent from
   the sponsorable. Only returns a non-null value when the viewer has permission to know this.
   """
   isSponsorOptedIntoEmail: Boolean
-  
+
   """
   The entity that is being sponsored
   """
@@ -49415,12 +49418,12 @@ type Sponsorship implements Node {
     @deprecated(
       reason: "`Sponsorship.maintainer` will be removed. Use `Sponsorship.sponsorable` instead. Removal on 2020-04-01 UTC."
     )
-  
+
   """
   The privacy level for this sponsorship.
   """
   privacyLevel: SponsorshipPrivacy!
-  
+
   """
   The user that is sponsoring. Returns null if the sponsorship is private or if sponsor is not a user.
   """
@@ -49428,22 +49431,22 @@ type Sponsorship implements Node {
     @deprecated(
       reason: "`Sponsorship.sponsor` will be removed. Use `Sponsorship.sponsorEntity` instead. Removal on 2020-10-01 UTC."
     )
-  
+
   """
   The user or organization that is sponsoring, if you have permission to view them.
   """
   sponsorEntity: Sponsor
-  
+
   """
   The entity that is being sponsored
   """
   sponsorable: Sponsorable!
-  
+
   """
   The associated sponsorship tier
   """
   tier: SponsorsTier
-  
+
   """
   Identifies the date and time when the current tier was chosen for this sponsorship.
   """
@@ -49458,28 +49461,28 @@ type SponsorshipConnection {
   A list of edges.
   """
   edges: [SponsorshipEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [Sponsorship]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
   totalCount: Int!
-  
+
   """
   The total amount in cents of all recurring sponsorships in the connection
   whose amount you can view. Does not include one-time sponsorships.
   """
   totalRecurringMonthlyPriceInCents: Int!
-  
+
   """
   The total amount in USD of all recurring sponsorships in the connection whose
   amount you can view. Does not include one-time sponsorships.
@@ -49495,7 +49498,7 @@ type SponsorshipEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -49510,33 +49513,33 @@ type SponsorshipNewsletter implements Node {
   The author of the newsletter.
   """
   author: User
-  
+
   """
   The contents of the newsletter, the message the sponsorable wanted to give.
   """
   body: String!
-  
+
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
   id: ID!
-  
+
   """
   Indicates if the newsletter has been made available to sponsors.
   """
   isPublished: Boolean!
-  
+
   """
   The user or organization this newsletter is from.
   """
   sponsorable: Sponsorable!
-  
+
   """
   The subject of the newsletter, what it's about.
   """
   subject: String!
-  
+
   """
   Identifies the date and time when the object was last updated.
   """
@@ -49551,17 +49554,17 @@ type SponsorshipNewsletterConnection {
   A list of edges.
   """
   edges: [SponsorshipNewsletterEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [SponsorshipNewsletter]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -49576,7 +49579,7 @@ type SponsorshipNewsletterEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -49591,7 +49594,7 @@ input SponsorshipNewsletterOrder {
   The ordering direction.
   """
   direction: OrderDirection!
-  
+
   """
   The field to order sponsorship newsletters by.
   """
@@ -49616,7 +49619,7 @@ input SponsorshipOrder {
   The ordering direction.
   """
   direction: OrderDirection!
-  
+
   """
   The field to order sponsorship by.
   """
@@ -49687,38 +49690,38 @@ type SshSignature implements GitSignature {
   Email used to sign this object.
   """
   email: String!
-  
+
   """
   True if the signature is valid and verified by GitHub.
   """
   isValid: Boolean!
-  
+
   """
   Hex-encoded fingerprint of the key that signed this object.
   """
   keyFingerprint: String
-  
+
   """
   Payload for GPG signing object. Raw ODB object without the signature header.
   """
   payload: String!
-  
+
   """
   ASCII-armored signature header from object.
   """
   signature: String!
-  
+
   """
   GitHub user corresponding to the email signing this commit.
   """
   signer: User
-  
+
   """
   The state of this signature. `VALID` if signature is valid and verified by
   GitHub, otherwise represents reason why signature is considered invalid.
   """
   state: GitSignatureState!
-  
+
   """
   True if the signature was made with GitHub's signing key.
   """
@@ -49733,7 +49736,7 @@ input StarOrder {
   The direction in which to order nodes.
   """
   direction: OrderDirection!
-  
+
   """
   The field in which to order nodes by.
   """
@@ -49758,17 +49761,17 @@ type StargazerConnection {
   A list of edges.
   """
   edges: [StargazerEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [User]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -49784,7 +49787,7 @@ type StargazerEdge {
   """
   cursor: String!
   node: User!
-  
+
   """
   Identifies when the item was starred.
   """
@@ -49796,12 +49799,12 @@ Things that can be starred.
 """
 interface Starrable {
   id: ID!
-  
+
   """
   Returns a count of how many stargazers there are on this object
   """
   stargazerCount: Int!
-  
+
   """
   A list of users who have starred this starrable.
   """
@@ -49810,28 +49813,28 @@ interface Starrable {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Order for connection
     """
     orderBy: StarOrder
   ): StargazerConnection!
-  
+
   """
   Returns a boolean indicating whether the viewing user has starred this starrable.
   """
@@ -49846,22 +49849,22 @@ type StarredRepositoryConnection {
   A list of edges.
   """
   edges: [StarredRepositoryEdge]
-  
+
   """
   Is the list of stars for this user truncated? This is true for users that have many stars.
   """
   isOverLimit: Boolean!
-  
+
   """
   A list of nodes.
   """
   nodes: [Repository]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -49877,7 +49880,7 @@ type StarredRepositoryEdge {
   """
   cursor: String!
   node: Repository!
-  
+
   """
   Identifies when the item was starred.
   """
@@ -49892,22 +49895,22 @@ input StartOrganizationMigrationInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The migration source access token.
   """
   sourceAccessToken: String!
-  
+
   """
   The URL of the organization to migrate.
   """
   sourceOrgUrl: URI!
-  
+
   """
   The ID of the enterprise the target organization belongs to.
   """
   targetEnterpriseId: ID! @possibleTypes(concreteTypes: ["Enterprise"])
-  
+
   """
   The name of the target organization.
   """
@@ -49922,7 +49925,7 @@ type StartOrganizationMigrationPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The new organization migration.
   """
@@ -49937,62 +49940,62 @@ input StartRepositoryMigrationInput {
   The migration source access token.
   """
   accessToken: String
-  
+
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   Whether to continue the migration on error. Defaults to `true`.
   """
   continueOnError: Boolean
-  
+
   """
   The signed URL to access the user-uploaded git archive.
   """
   gitArchiveUrl: String
-  
+
   """
   The GitHub personal access token of the user importing to the target repository.
   """
   githubPat: String
-  
+
   """
   Whether to lock the source repository.
   """
   lockSource: Boolean
-  
+
   """
   The signed URL to access the user-uploaded metadata archive.
   """
   metadataArchiveUrl: String
-  
+
   """
   The ID of the organization that will own the imported repository.
   """
   ownerId: ID! @possibleTypes(concreteTypes: ["Organization"])
-  
+
   """
   The name of the imported repository.
   """
   repositoryName: String!
-  
+
   """
   Whether to skip migrating releases for the repository.
   """
   skipReleases: Boolean
-  
+
   """
   The ID of the migration source.
   """
   sourceId: ID! @possibleTypes(concreteTypes: ["MigrationSource"])
-  
+
   """
   The URL of the source repository.
   """
   sourceRepositoryUrl: URI
-  
+
   """
   The visibility of the imported repository.
   """
@@ -50007,7 +50010,7 @@ type StartRepositoryMigrationPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The new repository migration.
   """
@@ -50026,28 +50029,28 @@ type Status implements Node {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): StatusCheckRollupContextConnection!
-  
+
   """
   The commit this status is attached to.
   """
   commit: Commit
-  
+
   """
   Looks up an individual status context by context name.
   """
@@ -50057,13 +50060,13 @@ type Status implements Node {
     """
     name: String!
   ): StatusContext
-  
+
   """
   The individual status contexts for this commit.
   """
   contexts: [StatusContext!]!
   id: ID!
-  
+
   """
   The combined commit status.
   """
@@ -50078,7 +50081,7 @@ type StatusCheckConfiguration {
   The status check context name that must be present on the commit.
   """
   context: String!
-  
+
   """
   The optional integration ID that this status check must originate from.
   """
@@ -50093,7 +50096,7 @@ input StatusCheckConfigurationInput {
   The status check context name that must be present on the commit.
   """
   context: String!
-  
+
   """
   The optional integration ID that this status check must originate from.
   """
@@ -50108,7 +50111,7 @@ type StatusCheckRollup implements Node {
   The commit the status and check runs are attached to.
   """
   commit: Commit
-  
+
   """
   A list of status contexts and check runs for this commit.
   """
@@ -50117,24 +50120,24 @@ type StatusCheckRollup implements Node {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): StatusCheckRollupContextConnection!
   id: ID!
-  
+
   """
   The combined status for the commit.
   """
@@ -50154,37 +50157,37 @@ type StatusCheckRollupContextConnection {
   The number of check runs in this rollup.
   """
   checkRunCount: Int!
-  
+
   """
   Counts of check runs by state.
   """
   checkRunCountsByState: [CheckRunStateCount!]
-  
+
   """
   A list of edges.
   """
   edges: [StatusCheckRollupContextEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [StatusCheckRollupContext]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   The number of status contexts in this rollup.
   """
   statusContextCount: Int!
-  
+
   """
   Counts of status contexts by state.
   """
   statusContextCountsByState: [StatusContextStateCount!]
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -50199,7 +50202,7 @@ type StatusCheckRollupContextEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -50219,33 +50222,33 @@ type StatusContext implements Node & RequirableByPullRequest {
     """
     size: Int = 40
   ): URI
-  
+
   """
   This commit this status context is attached to.
   """
   commit: Commit
-  
+
   """
   The name of this status context.
   """
   context: String!
-  
+
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
-  
+
   """
   The actor who created this status context.
   """
   creator: Actor
-  
+
   """
   The description for this status context.
   """
   description: String
   id: ID!
-  
+
   """
   Whether this is required to pass before merging for a specific pull request.
   """
@@ -50254,18 +50257,18 @@ type StatusContext implements Node & RequirableByPullRequest {
     The id of the pull request this is required for
     """
     pullRequestId: ID
-    
+
     """
     The number of the pull request this is required for
     """
     pullRequestNumber: Int
   ): Boolean!
-  
+
   """
   The state of this status context.
   """
   state: StatusState!
-  
+
   """
   The URL for this status context.
   """
@@ -50280,7 +50283,7 @@ type StatusContextStateCount {
   The number of statuses with this state.
   """
   count: Int!
-  
+
   """
   The state of a status context.
   """
@@ -50321,7 +50324,7 @@ type StripeConnectAccount {
   The account number used to identify this Stripe Connect account.
   """
   accountId: String!
-  
+
   """
   The name of the country or region of an external account, such as a bank
   account, tied to the Stripe Connect account. Will only return a value when
@@ -50329,24 +50332,24 @@ type StripeConnectAccount {
   themselves, or by an admin of the sponsorable organization.
   """
   billingCountryOrRegion: String
-  
+
   """
   The name of the country or region of the Stripe Connect account. Will only
   return a value when queried by the maintainer of the associated GitHub
   Sponsors profile themselves, or by an admin of the sponsorable organization.
   """
   countryOrRegion: String
-  
+
   """
   Whether this Stripe Connect account is currently in use for the associated GitHub Sponsors profile.
   """
   isActive: Boolean!
-  
+
   """
   The GitHub Sponsors profile associated with this Stripe Connect account.
   """
   sponsorsListing: SponsorsListing!
-  
+
   """
   The URL to access this Stripe Connect account on Stripe's website.
   """
@@ -50361,22 +50364,22 @@ input SubmitPullRequestReviewInput {
   The text field to set on the Pull Request Review.
   """
   body: String
-  
+
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The event to send to the Pull Request Review.
   """
   event: PullRequestReviewEvent!
-  
+
   """
   The Pull Request ID to submit any pending reviews.
   """
   pullRequestId: ID @possibleTypes(concreteTypes: ["PullRequest"])
-  
+
   """
   The Pull Request Review ID to submit.
   """
@@ -50391,7 +50394,7 @@ type SubmitPullRequestReviewPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The submitted pull request review.
   """
@@ -50406,32 +50409,32 @@ type Submodule {
   The branch of the upstream submodule for tracking updates
   """
   branch: String
-  
+
   """
   The git URL of the submodule repository
   """
   gitUrl: URI!
-  
+
   """
   The name of the submodule in .gitmodules
   """
   name: String!
-  
+
   """
   The name of the submodule in .gitmodules (Base64-encoded)
   """
   nameRaw: Base64String!
-  
+
   """
   The path in the superproject that this submodule is located in
   """
   path: String!
-  
+
   """
   The path in the superproject that this submodule is located in (Base64-encoded)
   """
   pathRaw: Base64String!
-  
+
   """
   The commit revision of the subproject repository being tracked by the submodule
   """
@@ -50446,17 +50449,17 @@ type SubmoduleConnection {
   A list of edges.
   """
   edges: [SubmoduleEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [Submodule]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -50471,7 +50474,7 @@ type SubmoduleEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -50483,12 +50486,12 @@ Entities that can be subscribed to for web and email notifications.
 """
 interface Subscribable {
   id: ID!
-  
+
   """
   Check if the viewer is able to change their subscription status for the repository.
   """
   viewerCanSubscribe: Boolean!
-  
+
   """
   Identifies if the viewer is watching, not watching, or ignoring the subscribable entity.
   """
@@ -50500,12 +50503,12 @@ Entities that can be subscribed to for web and email notifications.
 """
 interface SubscribableThread {
   id: ID!
-  
+
   """
   Identifies the viewer's thread subscription form action.
   """
   viewerThreadSubscriptionFormAction: ThreadSubscriptionFormAction
-  
+
   """
   Identifies the viewer's thread subscription status.
   """
@@ -50520,13 +50523,13 @@ type SubscribedEvent implements Node {
   Identifies the actor who performed the event.
   """
   actor: Actor
-  
+
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
   id: ID!
-  
+
   """
   Object referenced by event.
   """
@@ -50559,12 +50562,12 @@ type SuggestedReviewer {
   Is this suggestion based on past commits?
   """
   isAuthor: Boolean!
-  
+
   """
   Is this suggestion based on past review comments?
   """
   isCommenter: Boolean!
-  
+
   """
   Identifies the user suggested to review the pull request.
   """
@@ -50579,43 +50582,43 @@ type Tag implements GitObject & Node {
   An abbreviated version of the Git object ID
   """
   abbreviatedOid: String!
-  
+
   """
   The HTTP path for this Git object
   """
   commitResourcePath: URI!
-  
+
   """
   The HTTP URL for this Git object
   """
   commitUrl: URI!
   id: ID!
-  
+
   """
   The Git tag message.
   """
   message: String
-  
+
   """
   The Git tag name.
   """
   name: String!
-  
+
   """
   The Git object ID
   """
   oid: GitObjectID!
-  
+
   """
   The Repository the Git object belongs to
   """
   repository: Repository!
-  
+
   """
   Details about the tag author.
   """
   tagger: GitActor
-  
+
   """
   The Git object the tag points to.
   """
@@ -50630,17 +50633,17 @@ type TagNamePatternParameters {
   How this rule will appear to users.
   """
   name: String
-  
+
   """
   If true, the rule will fail if the pattern matches.
   """
   negate: Boolean!
-  
+
   """
   The operator to use for matching.
   """
   operator: String!
-  
+
   """
   The pattern to match with.
   """
@@ -50655,17 +50658,17 @@ input TagNamePatternParametersInput {
   How this rule will appear to users.
   """
   name: String
-  
+
   """
   If true, the rule will fail if the pattern matches.
   """
   negate: Boolean
-  
+
   """
   The operator to use for matching.
   """
   operator: String!
-  
+
   """
   The pattern to match with.
   """
@@ -50684,23 +50687,23 @@ type Team implements MemberStatusable & Node & Subscribable {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): TeamConnection!
-  
+
   """
   A URL pointing to the team's avatar.
   """
@@ -50710,7 +50713,7 @@ type Team implements MemberStatusable & Node & Subscribable {
     """
     size: Int = 400
   ): URI
-  
+
   """
   List of child teams belonging to this team
   """
@@ -50719,58 +50722,58 @@ type Team implements MemberStatusable & Node & Subscribable {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Whether to list immediate child teams or all descendant child teams.
     """
     immediateOnly: Boolean = true
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Order for connection
     """
     orderBy: TeamOrder
-    
+
     """
     User logins to filter by
     """
     userLogins: [String!]
   ): TeamConnection!
-  
+
   """
   The slug corresponding to the organization and team.
   """
   combinedSlug: String!
-  
+
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
-  
+
   """
   Identifies the primary key from the database.
   """
   databaseId: Int
-  
+
   """
   The description of the team.
   """
   description: String
-  
+
   """
   Find a team discussion by its number.
   """
@@ -50780,7 +50783,7 @@ type Team implements MemberStatusable & Node & Subscribable {
     """
     number: Int!
   ): TeamDiscussion
-  
+
   """
   A list of team discussions.
   """
@@ -50789,54 +50792,54 @@ type Team implements MemberStatusable & Node & Subscribable {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     If provided, filters discussions according to whether or not they are pinned.
     """
     isPinned: Boolean
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Order for connection
     """
     orderBy: TeamDiscussionOrder
   ): TeamDiscussionConnection!
-  
+
   """
   The HTTP path for team discussions
   """
   discussionsResourcePath: URI!
-  
+
   """
   The HTTP URL for team discussions
   """
   discussionsUrl: URI!
-  
+
   """
   The HTTP path for editing this team
   """
   editTeamResourcePath: URI!
-  
+
   """
   The HTTP URL for editing this team
   """
   editTeamUrl: URI!
   id: ID!
-  
+
   """
   A list of pending invitations for users to this team
   """
@@ -50845,23 +50848,23 @@ type Team implements MemberStatusable & Node & Subscribable {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): OrganizationInvitationConnection
-  
+
   """
   Get the status messages members of this entity have set that are either public or visible only to the organization.
   """
@@ -50870,28 +50873,28 @@ type Team implements MemberStatusable & Node & Subscribable {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for user statuses returned from the connection.
     """
     orderBy: UserStatusOrder = { field: UPDATED_AT, direction: DESC }
   ): UserStatusConnection!
-  
+
   """
   A list of users who are members of this team.
   """
@@ -50900,88 +50903,88 @@ type Team implements MemberStatusable & Node & Subscribable {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Filter by membership type
     """
     membership: TeamMembershipType = ALL
-    
+
     """
     Order for the connection.
     """
     orderBy: TeamMemberOrder
-    
+
     """
     The search string to look for.
     """
     query: String
-    
+
     """
     Filter by team member role
     """
     role: TeamMemberRole
   ): TeamMemberConnection!
-  
+
   """
   The HTTP path for the team' members
   """
   membersResourcePath: URI!
-  
+
   """
   The HTTP URL for the team' members
   """
   membersUrl: URI!
-  
+
   """
   The name of the team.
   """
   name: String!
-  
+
   """
   The HTTP path creating a new team
   """
   newTeamResourcePath: URI!
-  
+
   """
   The HTTP URL creating a new team
   """
   newTeamUrl: URI!
-  
+
   """
   The notification setting that the team has set.
   """
   notificationSetting: TeamNotificationSetting!
-  
+
   """
   The organization that owns this team.
   """
   organization: Organization!
-  
+
   """
   The parent team of the team.
   """
   parentTeam: Team
-  
+
   """
   The level of privacy the team has.
   """
   privacy: TeamPrivacy!
-  
+
   """
   Finds and returns the project according to the provided project number.
   """
@@ -50991,7 +50994,7 @@ type Team implements MemberStatusable & Node & Subscribable {
     """
     number: Int!
   ): ProjectV2
-  
+
   """
   List of projects this team has collaborator access to.
   """
@@ -51000,38 +51003,38 @@ type Team implements MemberStatusable & Node & Subscribable {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Filtering options for projects returned from this connection
     """
     filterBy: ProjectV2Filters = {}
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     How to order the returned projects.
     """
     orderBy: ProjectV2Order = { field: NUMBER, direction: DESC }
-    
+
     """
     The query to search projects by.
     """
     query: String = ""
   ): ProjectV2Connection!
-  
+
   """
   A list of repositories this team has access to.
   """
@@ -51040,107 +51043,107 @@ type Team implements MemberStatusable & Node & Subscribable {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Order for the connection.
     """
     orderBy: TeamRepositoryOrder
-    
+
     """
     The search string to look for. Repositories will be returned where the name contains your search string.
     """
     query: String
   ): TeamRepositoryConnection!
-  
+
   """
   The HTTP path for this team's repositories
   """
   repositoriesResourcePath: URI!
-  
+
   """
   The HTTP URL for this team's repositories
   """
   repositoriesUrl: URI!
-  
+
   """
   The HTTP path for this team
   """
   resourcePath: URI!
-  
+
   """
   What algorithm is used for review assignment for this team
   """
   reviewRequestDelegationAlgorithm: TeamReviewAssignmentAlgorithm
     @preview(toggledBy: "stone-crop-preview")
-  
+
   """
   True if review assignment is enabled for this team
   """
   reviewRequestDelegationEnabled: Boolean!
     @preview(toggledBy: "stone-crop-preview")
-  
+
   """
   How many team members are required for review assignment for this team
   """
   reviewRequestDelegationMemberCount: Int
     @preview(toggledBy: "stone-crop-preview")
-  
+
   """
   When assigning team members via delegation, whether the entire team should be notified as well.
   """
   reviewRequestDelegationNotifyTeam: Boolean!
     @preview(toggledBy: "stone-crop-preview")
-  
+
   """
   The slug corresponding to the team.
   """
   slug: String!
-  
+
   """
   The HTTP path for this team's teams
   """
   teamsResourcePath: URI!
-  
+
   """
   The HTTP URL for this team's teams
   """
   teamsUrl: URI!
-  
+
   """
   Identifies the date and time when the object was last updated.
   """
   updatedAt: DateTime!
-  
+
   """
   The HTTP URL for this team
   """
   url: URI!
-  
+
   """
   Team is adminable by the viewer.
   """
   viewerCanAdminister: Boolean!
-  
+
   """
   Check if the viewer is able to change their subscription status for the repository.
   """
   viewerCanSubscribe: Boolean!
-  
+
   """
   Identifies if the viewer is watching, not watching, or ignoring the subscribable entity.
   """
@@ -51155,108 +51158,108 @@ type TeamAddMemberAuditEntry implements AuditEntry & Node & OrganizationAuditEnt
   The action name
   """
   action: String!
-  
+
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
-  
+
   """
   The IP address of the actor
   """
   actorIp: String
-  
+
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
-  
+
   """
   The username of the user who initiated the action
   """
   actorLogin: String
-  
+
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
-  
+
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
-  
+
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
   id: ID!
-  
+
   """
   Whether the team was mapped to an LDAP Group.
   """
   isLdapMapped: Boolean
-  
+
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
-  
+
   """
   The Organization associated with the Audit Entry.
   """
   organization: Organization
-  
+
   """
   The name of the Organization.
   """
   organizationName: String
-  
+
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
-  
+
   """
   The HTTP URL for the organization
   """
   organizationUrl: URI
-  
+
   """
   The team associated with the action
   """
   team: Team
-  
+
   """
   The name of the team
   """
   teamName: String
-  
+
   """
   The HTTP path for this team
   """
   teamResourcePath: URI
-  
+
   """
   The HTTP URL for this team
   """
   teamUrl: URI
-  
+
   """
   The user affected by the action
   """
   user: User
-  
+
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
-  
+
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
-  
+
   """
   The HTTP URL for the user.
   """
@@ -51271,128 +51274,128 @@ type TeamAddRepositoryAuditEntry implements AuditEntry & Node & OrganizationAudi
   The action name
   """
   action: String!
-  
+
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
-  
+
   """
   The IP address of the actor
   """
   actorIp: String
-  
+
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
-  
+
   """
   The username of the user who initiated the action
   """
   actorLogin: String
-  
+
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
-  
+
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
-  
+
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
   id: ID!
-  
+
   """
   Whether the team was mapped to an LDAP Group.
   """
   isLdapMapped: Boolean
-  
+
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
-  
+
   """
   The Organization associated with the Audit Entry.
   """
   organization: Organization
-  
+
   """
   The name of the Organization.
   """
   organizationName: String
-  
+
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
-  
+
   """
   The HTTP URL for the organization
   """
   organizationUrl: URI
-  
+
   """
   The repository associated with the action
   """
   repository: Repository
-  
+
   """
   The name of the repository
   """
   repositoryName: String
-  
+
   """
   The HTTP path for the repository
   """
   repositoryResourcePath: URI
-  
+
   """
   The HTTP URL for the repository
   """
   repositoryUrl: URI
-  
+
   """
   The team associated with the action
   """
   team: Team
-  
+
   """
   The name of the team
   """
   teamName: String
-  
+
   """
   The HTTP path for this team
   """
   teamResourcePath: URI
-  
+
   """
   The HTTP URL for this team
   """
   teamUrl: URI
-  
+
   """
   The user affected by the action
   """
   user: User
-  
+
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
-  
+
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
-  
+
   """
   The HTTP URL for the user.
   """
@@ -51407,17 +51410,17 @@ interface TeamAuditEntryData {
   The team associated with the action
   """
   team: Team
-  
+
   """
   The name of the team
   """
   teamName: String
-  
+
   """
   The HTTP path for this team
   """
   teamResourcePath: URI
-  
+
   """
   The HTTP URL for this team
   """
@@ -51432,148 +51435,148 @@ type TeamChangeParentTeamAuditEntry implements AuditEntry & Node & OrganizationA
   The action name
   """
   action: String!
-  
+
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
-  
+
   """
   The IP address of the actor
   """
   actorIp: String
-  
+
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
-  
+
   """
   The username of the user who initiated the action
   """
   actorLogin: String
-  
+
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
-  
+
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
-  
+
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
   id: ID!
-  
+
   """
   Whether the team was mapped to an LDAP Group.
   """
   isLdapMapped: Boolean
-  
+
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
-  
+
   """
   The Organization associated with the Audit Entry.
   """
   organization: Organization
-  
+
   """
   The name of the Organization.
   """
   organizationName: String
-  
+
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
-  
+
   """
   The HTTP URL for the organization
   """
   organizationUrl: URI
-  
+
   """
   The new parent team.
   """
   parentTeam: Team
-  
+
   """
   The name of the new parent team
   """
   parentTeamName: String
-  
+
   """
   The name of the former parent team
   """
   parentTeamNameWas: String
-  
+
   """
   The HTTP path for the parent team
   """
   parentTeamResourcePath: URI
-  
+
   """
   The HTTP URL for the parent team
   """
   parentTeamUrl: URI
-  
+
   """
   The former parent team.
   """
   parentTeamWas: Team
-  
+
   """
   The HTTP path for the previous parent team
   """
   parentTeamWasResourcePath: URI
-  
+
   """
   The HTTP URL for the previous parent team
   """
   parentTeamWasUrl: URI
-  
+
   """
   The team associated with the action
   """
   team: Team
-  
+
   """
   The name of the team
   """
   teamName: String
-  
+
   """
   The HTTP path for this team
   """
   teamResourcePath: URI
-  
+
   """
   The HTTP URL for this team
   """
   teamUrl: URI
-  
+
   """
   The user affected by the action
   """
   user: User
-  
+
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
-  
+
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
-  
+
   """
   The HTTP URL for the user.
   """
@@ -51588,17 +51591,17 @@ type TeamConnection {
   A list of edges.
   """
   edges: [TeamEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [Team]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -51613,7 +51616,7 @@ type TeamDiscussion implements Comment & Deletable & Node & Reactable & Subscrib
   The actor who authored the comment.
   """
   author: Actor
-  
+
   """
   Author's association with the discussion's team.
   """
@@ -51621,22 +51624,22 @@ type TeamDiscussion implements Comment & Deletable & Node & Reactable & Subscrib
     @deprecated(
       reason: "The Team Discussions feature is deprecated in favor of Organization Discussions. Follow the guide at https://github.blog/changelog/2023-02-08-sunset-notice-team-discussions/ to find a suitable replacement. Removal on 2024-07-01 UTC."
     )
-  
+
   """
   The body as Markdown.
   """
   body: String!
-  
+
   """
   The body rendered to HTML.
   """
   bodyHTML: HTML!
-  
+
   """
   The body rendered to text.
   """
   bodyText: String!
-  
+
   """
   Identifies the discussion body hash.
   """
@@ -51644,7 +51647,7 @@ type TeamDiscussion implements Comment & Deletable & Node & Reactable & Subscrib
     @deprecated(
       reason: "The Team Discussions feature is deprecated in favor of Organization Discussions. Follow the guide at https://github.blog/changelog/2023-02-08-sunset-notice-team-discussions/ to find a suitable replacement. Removal on 2024-07-01 UTC."
     )
-  
+
   """
   A list of comments on this discussion.
   """
@@ -51653,27 +51656,27 @@ type TeamDiscussion implements Comment & Deletable & Node & Reactable & Subscrib
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     When provided, filters the connection such that results begin with the comment with this number.
     """
     fromComment: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Order for connection
     """
@@ -51682,7 +51685,7 @@ type TeamDiscussion implements Comment & Deletable & Node & Reactable & Subscrib
     @deprecated(
       reason: "The Team Discussions feature is deprecated in favor of Organization Discussions. Follow the guide at https://github.blog/changelog/2023-02-08-sunset-notice-team-discussions/ to find a suitable replacement. Removal on 2024-07-01 UTC."
     )
-  
+
   """
   The HTTP path for discussion comments
   """
@@ -51690,7 +51693,7 @@ type TeamDiscussion implements Comment & Deletable & Node & Reactable & Subscrib
     @deprecated(
       reason: "The Team Discussions feature is deprecated in favor of Organization Discussions. Follow the guide at https://github.blog/changelog/2023-02-08-sunset-notice-team-discussions/ to find a suitable replacement. Removal on 2024-07-01 UTC."
     )
-  
+
   """
   The HTTP URL for discussion comments
   """
@@ -51698,33 +51701,33 @@ type TeamDiscussion implements Comment & Deletable & Node & Reactable & Subscrib
     @deprecated(
       reason: "The Team Discussions feature is deprecated in favor of Organization Discussions. Follow the guide at https://github.blog/changelog/2023-02-08-sunset-notice-team-discussions/ to find a suitable replacement. Removal on 2024-07-01 UTC."
     )
-  
+
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
-  
+
   """
   Check if this comment was created via an email reply.
   """
   createdViaEmail: Boolean!
-  
+
   """
   Identifies the primary key from the database.
   """
   databaseId: Int
-  
+
   """
   The actor who edited the comment.
   """
   editor: Actor
   id: ID!
-  
+
   """
   Check if this comment was edited and includes an edit with the creation data
   """
   includesCreatedEdit: Boolean!
-  
+
   """
   Whether or not the discussion is pinned.
   """
@@ -51732,7 +51735,7 @@ type TeamDiscussion implements Comment & Deletable & Node & Reactable & Subscrib
     @deprecated(
       reason: "The Team Discussions feature is deprecated in favor of Organization Discussions. Follow the guide at https://github.blog/changelog/2023-02-08-sunset-notice-team-discussions/ to find a suitable replacement. Removal on 2024-07-01 UTC."
     )
-  
+
   """
   Whether or not the discussion is only visible to team members and org admins.
   """
@@ -51740,12 +51743,12 @@ type TeamDiscussion implements Comment & Deletable & Node & Reactable & Subscrib
     @deprecated(
       reason: "The Team Discussions feature is deprecated in favor of Organization Discussions. Follow the guide at https://github.blog/changelog/2023-02-08-sunset-notice-team-discussions/ to find a suitable replacement. Removal on 2024-07-01 UTC."
     )
-  
+
   """
   The moment the editor made the last edit
   """
   lastEditedAt: DateTime
-  
+
   """
   Identifies the discussion within its team.
   """
@@ -51753,17 +51756,17 @@ type TeamDiscussion implements Comment & Deletable & Node & Reactable & Subscrib
     @deprecated(
       reason: "The Team Discussions feature is deprecated in favor of Organization Discussions. Follow the guide at https://github.blog/changelog/2023-02-08-sunset-notice-team-discussions/ to find a suitable replacement. Removal on 2024-07-01 UTC."
     )
-  
+
   """
   Identifies when the comment was published at.
   """
   publishedAt: DateTime
-  
+
   """
   A list of reactions grouped by content left on the subject.
   """
   reactionGroups: [ReactionGroup!]
-  
+
   """
   A list of Reactions left on the Issue.
   """
@@ -51772,33 +51775,33 @@ type TeamDiscussion implements Comment & Deletable & Node & Reactable & Subscrib
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Allows filtering Reactions by emoji.
     """
     content: ReactionContent
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Allows specifying the order in which reactions are returned.
     """
     orderBy: ReactionOrder
   ): ReactionConnection!
-  
+
   """
   The HTTP path for this discussion
   """
@@ -51806,7 +51809,7 @@ type TeamDiscussion implements Comment & Deletable & Node & Reactable & Subscrib
     @deprecated(
       reason: "The Team Discussions feature is deprecated in favor of Organization Discussions. Follow the guide at https://github.blog/changelog/2023-02-08-sunset-notice-team-discussions/ to find a suitable replacement. Removal on 2024-07-01 UTC."
     )
-  
+
   """
   The team that defines the context of this discussion.
   """
@@ -51814,7 +51817,7 @@ type TeamDiscussion implements Comment & Deletable & Node & Reactable & Subscrib
     @deprecated(
       reason: "The Team Discussions feature is deprecated in favor of Organization Discussions. Follow the guide at https://github.blog/changelog/2023-02-08-sunset-notice-team-discussions/ to find a suitable replacement. Removal on 2024-07-01 UTC."
     )
-  
+
   """
   The title of the discussion
   """
@@ -51822,12 +51825,12 @@ type TeamDiscussion implements Comment & Deletable & Node & Reactable & Subscrib
     @deprecated(
       reason: "The Team Discussions feature is deprecated in favor of Organization Discussions. Follow the guide at https://github.blog/changelog/2023-02-08-sunset-notice-team-discussions/ to find a suitable replacement. Removal on 2024-07-01 UTC."
     )
-  
+
   """
   Identifies the date and time when the object was last updated.
   """
   updatedAt: DateTime!
-  
+
   """
   The HTTP URL for this discussion
   """
@@ -51835,7 +51838,7 @@ type TeamDiscussion implements Comment & Deletable & Node & Reactable & Subscrib
     @deprecated(
       reason: "The Team Discussions feature is deprecated in favor of Organization Discussions. Follow the guide at https://github.blog/changelog/2023-02-08-sunset-notice-team-discussions/ to find a suitable replacement. Removal on 2024-07-01 UTC."
     )
-  
+
   """
   A list of edits to this content.
   """
@@ -51844,28 +51847,28 @@ type TeamDiscussion implements Comment & Deletable & Node & Reactable & Subscrib
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): UserContentEditConnection
-  
+
   """
   Check if the current viewer can delete this object.
   """
   viewerCanDelete: Boolean!
-  
+
   """
   Whether or not the current viewer can pin this discussion.
   """
@@ -51873,32 +51876,32 @@ type TeamDiscussion implements Comment & Deletable & Node & Reactable & Subscrib
     @deprecated(
       reason: "The Team Discussions feature is deprecated in favor of Organization Discussions. Follow the guide at https://github.blog/changelog/2023-02-08-sunset-notice-team-discussions/ to find a suitable replacement. Removal on 2024-07-01 UTC."
     )
-  
+
   """
   Can user react to this subject
   """
   viewerCanReact: Boolean!
-  
+
   """
   Check if the viewer is able to change their subscription status for the repository.
   """
   viewerCanSubscribe: Boolean!
-  
+
   """
   Check if the current viewer can update this object.
   """
   viewerCanUpdate: Boolean!
-  
+
   """
   Reasons why the current viewer can not update this comment.
   """
   viewerCannotUpdateReasons: [CommentCannotUpdateReason!]!
-  
+
   """
   Did the viewer author this comment.
   """
   viewerDidAuthor: Boolean!
-  
+
   """
   Identifies if the viewer is watching, not watching, or ignoring the subscribable entity.
   """
@@ -51913,7 +51916,7 @@ type TeamDiscussionComment implements Comment & Deletable & Node & Reactable & U
   The actor who authored the comment.
   """
   author: Actor
-  
+
   """
   Author's association with the comment's team.
   """
@@ -51921,22 +51924,22 @@ type TeamDiscussionComment implements Comment & Deletable & Node & Reactable & U
     @deprecated(
       reason: "The Team Discussions feature is deprecated in favor of Organization Discussions. Follow the guide at https://github.blog/changelog/2023-02-08-sunset-notice-team-discussions/ to find a suitable replacement. Removal on 2024-07-01 UTC."
     )
-  
+
   """
   The body as Markdown.
   """
   body: String!
-  
+
   """
   The body rendered to HTML.
   """
   bodyHTML: HTML!
-  
+
   """
   The body rendered to text.
   """
   bodyText: String!
-  
+
   """
   The current version of the body content.
   """
@@ -51944,22 +51947,22 @@ type TeamDiscussionComment implements Comment & Deletable & Node & Reactable & U
     @deprecated(
       reason: "The Team Discussions feature is deprecated in favor of Organization Discussions. Follow the guide at https://github.blog/changelog/2023-02-08-sunset-notice-team-discussions/ to find a suitable replacement. Removal on 2024-07-01 UTC."
     )
-  
+
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
-  
+
   """
   Check if this comment was created via an email reply.
   """
   createdViaEmail: Boolean!
-  
+
   """
   Identifies the primary key from the database.
   """
   databaseId: Int
-  
+
   """
   The discussion this comment is about.
   """
@@ -51967,23 +51970,23 @@ type TeamDiscussionComment implements Comment & Deletable & Node & Reactable & U
     @deprecated(
       reason: "The Team Discussions feature is deprecated in favor of Organization Discussions. Follow the guide at https://github.blog/changelog/2023-02-08-sunset-notice-team-discussions/ to find a suitable replacement. Removal on 2024-07-01 UTC."
     )
-  
+
   """
   The actor who edited the comment.
   """
   editor: Actor
   id: ID!
-  
+
   """
   Check if this comment was edited and includes an edit with the creation data
   """
   includesCreatedEdit: Boolean!
-  
+
   """
   The moment the editor made the last edit
   """
   lastEditedAt: DateTime
-  
+
   """
   Identifies the comment number.
   """
@@ -51991,17 +51994,17 @@ type TeamDiscussionComment implements Comment & Deletable & Node & Reactable & U
     @deprecated(
       reason: "The Team Discussions feature is deprecated in favor of Organization Discussions. Follow the guide at https://github.blog/changelog/2023-02-08-sunset-notice-team-discussions/ to find a suitable replacement. Removal on 2024-07-01 UTC."
     )
-  
+
   """
   Identifies when the comment was published at.
   """
   publishedAt: DateTime
-  
+
   """
   A list of reactions grouped by content left on the subject.
   """
   reactionGroups: [ReactionGroup!]
-  
+
   """
   A list of Reactions left on the Issue.
   """
@@ -52010,33 +52013,33 @@ type TeamDiscussionComment implements Comment & Deletable & Node & Reactable & U
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Allows filtering Reactions by emoji.
     """
     content: ReactionContent
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Allows specifying the order in which reactions are returned.
     """
     orderBy: ReactionOrder
   ): ReactionConnection!
-  
+
   """
   The HTTP path for this comment
   """
@@ -52044,12 +52047,12 @@ type TeamDiscussionComment implements Comment & Deletable & Node & Reactable & U
     @deprecated(
       reason: "The Team Discussions feature is deprecated in favor of Organization Discussions. Follow the guide at https://github.blog/changelog/2023-02-08-sunset-notice-team-discussions/ to find a suitable replacement. Removal on 2024-07-01 UTC."
     )
-  
+
   """
   Identifies the date and time when the object was last updated.
   """
   updatedAt: DateTime!
-  
+
   """
   The HTTP URL for this comment
   """
@@ -52057,7 +52060,7 @@ type TeamDiscussionComment implements Comment & Deletable & Node & Reactable & U
     @deprecated(
       reason: "The Team Discussions feature is deprecated in favor of Organization Discussions. Follow the guide at https://github.blog/changelog/2023-02-08-sunset-notice-team-discussions/ to find a suitable replacement. Removal on 2024-07-01 UTC."
     )
-  
+
   """
   A list of edits to this content.
   """
@@ -52066,43 +52069,43 @@ type TeamDiscussionComment implements Comment & Deletable & Node & Reactable & U
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): UserContentEditConnection
-  
+
   """
   Check if the current viewer can delete this object.
   """
   viewerCanDelete: Boolean!
-  
+
   """
   Can user react to this subject
   """
   viewerCanReact: Boolean!
-  
+
   """
   Check if the current viewer can update this object.
   """
   viewerCanUpdate: Boolean!
-  
+
   """
   Reasons why the current viewer can not update this comment.
   """
   viewerCannotUpdateReasons: [CommentCannotUpdateReason!]!
-  
+
   """
   Did the viewer author this comment.
   """
@@ -52117,17 +52120,17 @@ type TeamDiscussionCommentConnection {
   A list of edges.
   """
   edges: [TeamDiscussionCommentEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [TeamDiscussionComment]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -52142,7 +52145,7 @@ type TeamDiscussionCommentEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -52157,7 +52160,7 @@ input TeamDiscussionCommentOrder {
   The direction in which to order nodes.
   """
   direction: OrderDirection!
-  
+
   """
   The field by which to order nodes.
   """
@@ -52182,17 +52185,17 @@ type TeamDiscussionConnection {
   A list of edges.
   """
   edges: [TeamDiscussionEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [TeamDiscussion]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -52207,7 +52210,7 @@ type TeamDiscussionEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -52222,7 +52225,7 @@ input TeamDiscussionOrder {
   The direction in which to order nodes.
   """
   direction: OrderDirection!
-  
+
   """
   The field by which to order nodes.
   """
@@ -52247,7 +52250,7 @@ type TeamEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -52262,17 +52265,17 @@ type TeamMemberConnection {
   A list of edges.
   """
   edges: [TeamMemberEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [User]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -52287,18 +52290,18 @@ type TeamMemberEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The HTTP path to the organization's member access page.
   """
   memberAccessResourcePath: URI!
-  
+
   """
   The HTTP URL to the organization's member access page.
   """
   memberAccessUrl: URI!
   node: User!
-  
+
   """
   The role the member has on the team.
   """
@@ -52313,7 +52316,7 @@ input TeamMemberOrder {
   The ordering direction.
   """
   direction: OrderDirection!
-  
+
   """
   The field to order team members by.
   """
@@ -52388,7 +52391,7 @@ input TeamOrder {
   The direction in which to order nodes.
   """
   direction: OrderDirection!
-  
+
   """
   The field in which to order nodes by.
   """
@@ -52427,108 +52430,108 @@ type TeamRemoveMemberAuditEntry implements AuditEntry & Node & OrganizationAudit
   The action name
   """
   action: String!
-  
+
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
-  
+
   """
   The IP address of the actor
   """
   actorIp: String
-  
+
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
-  
+
   """
   The username of the user who initiated the action
   """
   actorLogin: String
-  
+
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
-  
+
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
-  
+
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
   id: ID!
-  
+
   """
   Whether the team was mapped to an LDAP Group.
   """
   isLdapMapped: Boolean
-  
+
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
-  
+
   """
   The Organization associated with the Audit Entry.
   """
   organization: Organization
-  
+
   """
   The name of the Organization.
   """
   organizationName: String
-  
+
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
-  
+
   """
   The HTTP URL for the organization
   """
   organizationUrl: URI
-  
+
   """
   The team associated with the action
   """
   team: Team
-  
+
   """
   The name of the team
   """
   teamName: String
-  
+
   """
   The HTTP path for this team
   """
   teamResourcePath: URI
-  
+
   """
   The HTTP URL for this team
   """
   teamUrl: URI
-  
+
   """
   The user affected by the action
   """
   user: User
-  
+
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
-  
+
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
-  
+
   """
   The HTTP URL for the user.
   """
@@ -52543,128 +52546,128 @@ type TeamRemoveRepositoryAuditEntry implements AuditEntry & Node & OrganizationA
   The action name
   """
   action: String!
-  
+
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
-  
+
   """
   The IP address of the actor
   """
   actorIp: String
-  
+
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
-  
+
   """
   The username of the user who initiated the action
   """
   actorLogin: String
-  
+
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
-  
+
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
-  
+
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
   id: ID!
-  
+
   """
   Whether the team was mapped to an LDAP Group.
   """
   isLdapMapped: Boolean
-  
+
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
-  
+
   """
   The Organization associated with the Audit Entry.
   """
   organization: Organization
-  
+
   """
   The name of the Organization.
   """
   organizationName: String
-  
+
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
-  
+
   """
   The HTTP URL for the organization
   """
   organizationUrl: URI
-  
+
   """
   The repository associated with the action
   """
   repository: Repository
-  
+
   """
   The name of the repository
   """
   repositoryName: String
-  
+
   """
   The HTTP path for the repository
   """
   repositoryResourcePath: URI
-  
+
   """
   The HTTP URL for the repository
   """
   repositoryUrl: URI
-  
+
   """
   The team associated with the action
   """
   team: Team
-  
+
   """
   The name of the team
   """
   teamName: String
-  
+
   """
   The HTTP path for this team
   """
   teamResourcePath: URI
-  
+
   """
   The HTTP URL for this team
   """
   teamUrl: URI
-  
+
   """
   The user affected by the action
   """
   user: User
-  
+
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
-  
+
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
-  
+
   """
   The HTTP URL for the user.
   """
@@ -52679,17 +52682,17 @@ type TeamRepositoryConnection {
   A list of edges.
   """
   edges: [TeamRepositoryEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [Repository]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -52705,7 +52708,7 @@ type TeamRepositoryEdge {
   """
   cursor: String!
   node: Repository!
-  
+
   """
   The permission level the team has on the repository
   """
@@ -52720,7 +52723,7 @@ input TeamRepositoryOrder {
   The ordering direction.
   """
   direction: OrderDirection!
-  
+
   """
   The field to order repositories by.
   """
@@ -52793,12 +52796,12 @@ type TextMatch {
   The specific text fragment within the property matched on.
   """
   fragment: String!
-  
+
   """
   Highlights within the matched fragment.
   """
   highlights: [TextMatchHighlight!]!
-  
+
   """
   The property matched on.
   """
@@ -52813,12 +52816,12 @@ type TextMatchHighlight {
   The indice in the fragment where the matched text begins.
   """
   beginIndice: Int!
-  
+
   """
   The indice in the fragment where the matched text ends.
   """
   endIndice: Int!
-  
+
   """
   The text matched.
   """
@@ -52890,12 +52893,12 @@ A topic aggregates entities that are related to a subject.
 """
 type Topic implements Node & Starrable {
   id: ID!
-  
+
   """
   The topic's name.
   """
   name: String!
-  
+
   """
   A list of related topics, including aliases of this topic, sorted with the most relevant
   first. Returns up to 10 Topics.
@@ -52906,7 +52909,7 @@ type Topic implements Node & Starrable {
     """
     first: Int = 3
   ): [Topic!]!
-  
+
   """
   A list of repositories.
   """
@@ -52917,65 +52920,65 @@ type Topic implements Node & Starrable {
     current viewer owns.
     """
     affiliations: [RepositoryAffiliation]
-    
+
     """
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     If non-null, filters repositories according to whether they have issues enabled
     """
     hasIssuesEnabled: Boolean
-    
+
     """
     If non-null, filters repositories according to whether they have been locked
     """
     isLocked: Boolean
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for repositories returned from the connection
     """
     orderBy: RepositoryOrder
-    
+
     """
     Array of owner's affiliation options for repositories returned from the
     connection. For example, OWNER will include only repositories that the
     organization or user being viewed owns.
     """
     ownerAffiliations: [RepositoryAffiliation] = [OWNER, COLLABORATOR]
-    
+
     """
     If non-null, filters repositories according to privacy
     """
     privacy: RepositoryPrivacy
-    
+
     """
     If true, only repositories whose owner can be sponsored via GitHub Sponsors will be returned.
     """
     sponsorableOnly: Boolean = false
   ): RepositoryConnection!
-  
+
   """
   Returns a count of how many stargazers there are on this object
   """
   stargazerCount: Int!
-  
+
   """
   A list of users who have starred this starrable.
   """
@@ -52984,28 +52987,28 @@ type Topic implements Node & Starrable {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Order for connection
     """
     orderBy: StarOrder
   ): StargazerConnection!
-  
+
   """
   Returns a boolean indicating whether the viewing user has starred this starrable.
   """
@@ -53020,7 +53023,7 @@ interface TopicAuditEntryData {
   The name of the topic added to the repository
   """
   topic: Topic
-  
+
   """
   The name of the topic added to the repository
   """
@@ -53071,12 +53074,12 @@ input TransferEnterpriseOrganizationInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The ID of the enterprise where the organization should be transferred.
   """
   destinationEnterpriseId: ID! @possibleTypes(concreteTypes: ["Enterprise"])
-  
+
   """
   The ID of the organization to transfer.
   """
@@ -53091,7 +53094,7 @@ type TransferEnterpriseOrganizationPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The organization for which a transfer was initiated.
   """
@@ -53106,17 +53109,17 @@ input TransferIssueInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   Whether to create labels if they don't exist in the target repository (matched by name)
   """
   createLabelsIfMissing: Boolean = false
-  
+
   """
   The Node ID of the issue to be transferred
   """
   issueId: ID! @possibleTypes(concreteTypes: ["Issue"])
-  
+
   """
   The Node ID of the repository the issue should be transferred to
   """
@@ -53131,7 +53134,7 @@ type TransferIssuePayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The issue that was transferred
   """
@@ -53146,18 +53149,18 @@ type TransferredEvent implements Node {
   Identifies the actor who performed the event.
   """
   actor: Actor
-  
+
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
-  
+
   """
   The repository this came from
   """
   fromRepository: Repository
   id: ID!
-  
+
   """
   Identifies the issue associated with the event.
   """
@@ -53172,28 +53175,28 @@ type Tree implements GitObject & Node {
   An abbreviated version of the Git object ID
   """
   abbreviatedOid: String!
-  
+
   """
   The HTTP path for this Git object
   """
   commitResourcePath: URI!
-  
+
   """
   The HTTP URL for this Git object
   """
   commitUrl: URI!
-  
+
   """
   A list of tree entries.
   """
   entries: [TreeEntry!]
   id: ID!
-  
+
   """
   The Git object ID
   """
   oid: GitObjectID!
-  
+
   """
   The Repository the Git object belongs to
   """
@@ -53208,72 +53211,72 @@ type TreeEntry {
   The extension of the file
   """
   extension: String
-  
+
   """
   Whether or not this tree entry is generated
   """
   isGenerated: Boolean!
-  
+
   """
   The programming language this file is written in.
   """
   language: Language
-  
+
   """
   Number of lines in the file.
   """
   lineCount: Int
-  
+
   """
   Entry file mode.
   """
   mode: Int!
-  
+
   """
   Entry file name.
   """
   name: String!
-  
+
   """
   Entry file name. (Base64-encoded)
   """
   nameRaw: Base64String!
-  
+
   """
   Entry file object.
   """
   object: GitObject
-  
+
   """
   Entry file Git object ID.
   """
   oid: GitObjectID!
-  
+
   """
   The full path of the file.
   """
   path: String
-  
+
   """
   The full path of the file. (Base64-encoded)
   """
   pathRaw: Base64String
-  
+
   """
   The Repository the tree entry belongs to
   """
   repository: Repository!
-  
+
   """
   Entry byte size
   """
   size: Int!
-  
+
   """
   If the TreeEntry is for a directory occupied by a submodule project, this returns the corresponding submodule
   """
   submodule: Submodule
-  
+
   """
   Entry file type.
   """
@@ -53293,12 +53296,12 @@ input UnarchiveProjectV2ItemInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The ID of the ProjectV2Item to unarchive.
   """
   itemId: ID! @possibleTypes(concreteTypes: ["ProjectV2Item"])
-  
+
   """
   The ID of the Project to archive the item from.
   """
@@ -53313,7 +53316,7 @@ type UnarchiveProjectV2ItemPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The item unarchived from the project.
   """
@@ -53328,7 +53331,7 @@ input UnarchiveRepositoryInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The ID of the repository to unarchive.
   """
@@ -53343,7 +53346,7 @@ type UnarchiveRepositoryPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The repository that was unarchived.
   """
@@ -53358,23 +53361,23 @@ type UnassignedEvent implements Node {
   Identifies the actor who performed the event.
   """
   actor: Actor
-  
+
   """
   Identifies the assignable associated with the event.
   """
   assignable: Assignable!
-  
+
   """
   Identifies the user or mannequin that was unassigned.
   """
   assignee: Assignee
-  
+
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
   id: ID!
-  
+
   """
   Identifies the subject (user) who was unassigned.
   """
@@ -53392,7 +53395,7 @@ input UnfollowOrganizationInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   ID of the organization to unfollow.
   """
@@ -53407,7 +53410,7 @@ type UnfollowOrganizationPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The organization that was unfollowed.
   """
@@ -53422,7 +53425,7 @@ input UnfollowUserInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   ID of the user to unfollow.
   """
@@ -53437,7 +53440,7 @@ type UnfollowUserPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The user that was unfollowed.
   """
@@ -53452,7 +53455,7 @@ interface UniformResourceLocatable {
   The HTML path to this resource.
   """
   resourcePath: URI!
-  
+
   """
   The URL to this resource.
   """
@@ -53467,33 +53470,33 @@ type UnknownSignature implements GitSignature {
   Email used to sign this object.
   """
   email: String!
-  
+
   """
   True if the signature is valid and verified by GitHub.
   """
   isValid: Boolean!
-  
+
   """
   Payload for GPG signing object. Raw ODB object without the signature header.
   """
   payload: String!
-  
+
   """
   ASCII-armored signature header from object.
   """
   signature: String!
-  
+
   """
   GitHub user corresponding to the email signing this commit.
   """
   signer: User
-  
+
   """
   The state of this signature. `VALID` if signature is valid and verified by
   GitHub, otherwise represents reason why signature is considered invalid.
   """
   state: GitSignatureState!
-  
+
   """
   True if the signature was made with GitHub's signing key.
   """
@@ -53508,18 +53511,18 @@ type UnlabeledEvent implements Node {
   Identifies the actor who performed the event.
   """
   actor: Actor
-  
+
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
   id: ID!
-  
+
   """
   Identifies the label associated with the 'unlabeled' event.
   """
   label: Label!
-  
+
   """
   Identifies the `Labelable` associated with the event.
   """
@@ -53534,12 +53537,12 @@ input UnlinkProjectV2FromRepositoryInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The ID of the project to unlink from the repository.
   """
   projectId: ID! @possibleTypes(concreteTypes: ["ProjectV2"])
-  
+
   """
   The ID of the repository to unlink from the project.
   """
@@ -53554,7 +53557,7 @@ type UnlinkProjectV2FromRepositoryPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The repository the project is no longer linked to.
   """
@@ -53569,12 +53572,12 @@ input UnlinkProjectV2FromTeamInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The ID of the project to unlink from the team.
   """
   projectId: ID! @possibleTypes(concreteTypes: ["ProjectV2"])
-  
+
   """
   The ID of the team to unlink from the project.
   """
@@ -53589,7 +53592,7 @@ type UnlinkProjectV2FromTeamPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The team the project is unlinked from
   """
@@ -53604,12 +53607,12 @@ input UnlinkRepositoryFromProjectInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The ID of the Project linked to the Repository.
   """
   projectId: ID! @possibleTypes(concreteTypes: ["Project"])
-  
+
   """
   The ID of the Repository linked to the Project.
   """
@@ -53624,12 +53627,12 @@ type UnlinkRepositoryFromProjectPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The linked Project.
   """
   project: Project
-  
+
   """
   The linked Repository.
   """
@@ -53644,7 +53647,7 @@ input UnlockLockableInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   ID of the item to be unlocked.
   """
@@ -53663,12 +53666,12 @@ type UnlockLockablePayload {
   Identifies the actor who performed the event.
   """
   actor: Actor
-  
+
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The item that was unlocked.
   """
@@ -53683,13 +53686,13 @@ type UnlockedEvent implements Node {
   Identifies the actor who performed the event.
   """
   actor: Actor
-  
+
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
   id: ID!
-  
+
   """
   Object that was unlocked.
   """
@@ -53704,7 +53707,7 @@ input UnmarkDiscussionCommentAsAnswerInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The Node ID of the discussion comment to unmark as an answer.
   """
@@ -53719,7 +53722,7 @@ type UnmarkDiscussionCommentAsAnswerPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The discussion that includes the comment.
   """
@@ -53734,12 +53737,12 @@ input UnmarkFileAsViewedInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The path of the file to mark as unviewed
   """
   path: String!
-  
+
   """
   The Node ID of the pull request.
   """
@@ -53754,7 +53757,7 @@ type UnmarkFileAsViewedPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The updated pull request.
   """
@@ -53773,12 +53776,12 @@ input UnmarkIssueAsDuplicateInput {
       concreteTypes: ["Issue", "PullRequest"]
       abstractType: "IssueOrPullRequest"
     )
-  
+
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   ID of the issue or pull request currently marked as a duplicate.
   """
@@ -53797,7 +53800,7 @@ type UnmarkIssueAsDuplicatePayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The issue or pull request that was marked as a duplicate.
   """
@@ -53812,7 +53815,7 @@ input UnmarkProjectV2AsTemplateInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The ID of the Project to unmark as a template.
   """
@@ -53827,7 +53830,7 @@ type UnmarkProjectV2AsTemplatePayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The project.
   """
@@ -53842,23 +53845,23 @@ type UnmarkedAsDuplicateEvent implements Node {
   Identifies the actor who performed the event.
   """
   actor: Actor
-  
+
   """
   The authoritative issue or pull request which has been duplicated by another.
   """
   canonical: IssueOrPullRequest
-  
+
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
-  
+
   """
   The issue or pull request which has been marked as a duplicate of another.
   """
   duplicate: IssueOrPullRequest
   id: ID!
-  
+
   """
   Canonical and duplicate belong to different repositories.
   """
@@ -53873,7 +53876,7 @@ input UnminimizeCommentInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The Node ID of the subject to modify.
   """
@@ -53898,7 +53901,7 @@ type UnminimizeCommentPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The comment that was unminimized.
   """
@@ -53913,7 +53916,7 @@ input UnpinIssueInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The ID of the issue to be unpinned
   """
@@ -53928,7 +53931,7 @@ type UnpinIssuePayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The issue that was unpinned
   """
@@ -53943,13 +53946,13 @@ type UnpinnedEvent implements Node {
   Identifies the actor who performed the event.
   """
   actor: Actor
-  
+
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
   id: ID!
-  
+
   """
   Identifies the issue associated with the event.
   """
@@ -53964,7 +53967,7 @@ input UnresolveReviewThreadInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The ID of the thread to unresolve
   """
@@ -53979,7 +53982,7 @@ type UnresolveReviewThreadPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The thread to resolve.
   """
@@ -53994,13 +53997,13 @@ type UnsubscribedEvent implements Node {
   Identifies the actor who performed the event.
   """
   actor: Actor
-  
+
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
   id: ID!
-  
+
   """
   Object referenced by event.
   """
@@ -54035,144 +54038,144 @@ input UpdateBranchProtectionRuleInput {
   Can this branch be deleted.
   """
   allowsDeletions: Boolean
-  
+
   """
   Are force pushes allowed on this branch.
   """
   allowsForcePushes: Boolean
-  
+
   """
   Is branch creation a protected operation.
   """
   blocksCreations: Boolean
-  
+
   """
   The global relay id of the branch protection rule to be updated.
   """
   branchProtectionRuleId: ID!
     @possibleTypes(concreteTypes: ["BranchProtectionRule"])
-  
+
   """
   A list of User, Team, or App IDs allowed to bypass force push targeting matching branches.
   """
   bypassForcePushActorIds: [ID!]
-  
+
   """
   A list of User, Team, or App IDs allowed to bypass pull requests targeting matching branches.
   """
   bypassPullRequestActorIds: [ID!]
-  
+
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   Will new commits pushed to matching branches dismiss pull request review approvals.
   """
   dismissesStaleReviews: Boolean
-  
+
   """
   Can admins overwrite branch protection.
   """
   isAdminEnforced: Boolean
-  
+
   """
   Whether users can pull changes from upstream when the branch is locked. Set to
   `true` to allow fork syncing. Set to `false` to prevent fork syncing.
   """
   lockAllowsFetchAndMerge: Boolean
-  
+
   """
   Whether to set the branch as read-only. If this is true, users will not be able to push to the branch.
   """
   lockBranch: Boolean
-  
+
   """
   The glob-like pattern used to determine matching branches.
   """
   pattern: String
-  
+
   """
   A list of User, Team, or App IDs allowed to push to matching branches.
   """
   pushActorIds: [ID!]
-  
+
   """
   Whether the most recent push must be approved by someone other than the person who pushed it
   """
   requireLastPushApproval: Boolean
-  
+
   """
   Number of approving reviews required to update matching branches.
   """
   requiredApprovingReviewCount: Int
-  
+
   """
   The list of required deployment environments
   """
   requiredDeploymentEnvironments: [String!]
-  
+
   """
   List of required status check contexts that must pass for commits to be accepted to matching branches.
   """
   requiredStatusCheckContexts: [String!]
-  
+
   """
   The list of required status checks
   """
   requiredStatusChecks: [RequiredStatusCheckInput!]
-  
+
   """
   Are approving reviews required to update matching branches.
   """
   requiresApprovingReviews: Boolean
-  
+
   """
   Are reviews from code owners required to update matching branches.
   """
   requiresCodeOwnerReviews: Boolean
-  
+
   """
   Are commits required to be signed.
   """
   requiresCommitSignatures: Boolean
-  
+
   """
   Are conversations required to be resolved before merging.
   """
   requiresConversationResolution: Boolean
-  
+
   """
   Are successful deployments required before merging.
   """
   requiresDeployments: Boolean
-  
+
   """
   Are merge commits prohibited from being pushed to this branch.
   """
   requiresLinearHistory: Boolean
-  
+
   """
   Are status checks required to update matching branches.
   """
   requiresStatusChecks: Boolean
-  
+
   """
   Are branches required to be up to date before merging.
   """
   requiresStrictStatusChecks: Boolean
-  
+
   """
   Is pushing to matching branches restricted.
   """
   restrictsPushes: Boolean
-  
+
   """
   Is dismissal of pull request reviews restricted.
   """
   restrictsReviewDismissals: Boolean
-  
+
   """
   A list of User, Team, or App IDs allowed to dismiss reviews on pull requests targeting matching branches.
   """
@@ -54187,7 +54190,7 @@ type UpdateBranchProtectionRulePayload {
   The newly created BranchProtectionRule.
   """
   branchProtectionRule: BranchProtectionRule
-  
+
   """
   A unique identifier for the client performing the mutation.
   """
@@ -54202,57 +54205,57 @@ input UpdateCheckRunInput {
   Possible further actions the integrator can perform, which a user may trigger.
   """
   actions: [CheckRunAction!]
-  
+
   """
   The node of the check.
   """
   checkRunId: ID! @possibleTypes(concreteTypes: ["CheckRun"])
-  
+
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The time that the check run finished.
   """
   completedAt: DateTime
-  
+
   """
   The final conclusion of the check.
   """
   conclusion: CheckConclusionState
-  
+
   """
   The URL of the integrator's site that has the full details of the check.
   """
   detailsUrl: URI
-  
+
   """
   A reference for the run on the integrator's system.
   """
   externalId: String
-  
+
   """
   The name of the check.
   """
   name: String
-  
+
   """
   Descriptive details about the run.
   """
   output: CheckRunOutput
-  
+
   """
   The node ID of the repository.
   """
   repositoryId: ID! @possibleTypes(concreteTypes: ["Repository"])
-  
+
   """
   The time that the check run began.
   """
   startedAt: DateTime
-  
+
   """
   The current status.
   """
@@ -54267,7 +54270,7 @@ type UpdateCheckRunPayload {
   The updated check run.
   """
   checkRun: CheckRun
-  
+
   """
   A unique identifier for the client performing the mutation.
   """
@@ -54282,12 +54285,12 @@ input UpdateCheckSuitePreferencesInput {
   The check suite preferences to modify.
   """
   autoTriggerPreferences: [CheckSuiteAutoTriggerPreference!]!
-  
+
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The Node ID of the repository.
   """
@@ -54302,7 +54305,7 @@ type UpdateCheckSuitePreferencesPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The updated repository.
   """
@@ -54317,12 +54320,12 @@ input UpdateDiscussionCommentInput {
   The new contents of the comment body.
   """
   body: String!
-  
+
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The Node ID of the discussion comment to update.
   """
@@ -54337,7 +54340,7 @@ type UpdateDiscussionCommentPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The modified discussion comment.
   """
@@ -54352,22 +54355,22 @@ input UpdateDiscussionInput {
   The new contents of the discussion body.
   """
   body: String
-  
+
   """
   The Node ID of a discussion category within the same repository to change this discussion to.
   """
   categoryId: ID @possibleTypes(concreteTypes: ["DiscussionCategory"])
-  
+
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The Node ID of the discussion to update.
   """
   discussionId: ID! @possibleTypes(concreteTypes: ["Discussion"])
-  
+
   """
   The new discussion title.
   """
@@ -54382,7 +54385,7 @@ type UpdateDiscussionPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The modified discussion.
   """
@@ -54397,17 +54400,17 @@ input UpdateEnterpriseAdministratorRoleInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The ID of the Enterprise which the admin belongs to.
   """
   enterpriseId: ID! @possibleTypes(concreteTypes: ["Enterprise"])
-  
+
   """
   The login of a administrator whose role is being changed.
   """
   login: String!
-  
+
   """
   The new role for the Enterprise administrator.
   """
@@ -54422,7 +54425,7 @@ type UpdateEnterpriseAdministratorRolePayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   A message confirming the result of changing the administrator's role.
   """
@@ -54437,17 +54440,17 @@ input UpdateEnterpriseAllowPrivateRepositoryForkingSettingInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The ID of the enterprise on which to set the allow private repository forking setting.
   """
   enterpriseId: ID! @possibleTypes(concreteTypes: ["Enterprise"])
-  
+
   """
   The value for the allow private repository forking policy on the enterprise.
   """
   policyValue: EnterpriseAllowPrivateRepositoryForkingPolicyValue
-  
+
   """
   The value for the allow private repository forking setting on the enterprise.
   """
@@ -54462,12 +54465,12 @@ type UpdateEnterpriseAllowPrivateRepositoryForkingSettingPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The enterprise with the updated allow private repository forking setting.
   """
   enterprise: Enterprise
-  
+
   """
   A message confirming the result of updating the allow private repository forking setting.
   """
@@ -54482,12 +54485,12 @@ input UpdateEnterpriseDefaultRepositoryPermissionSettingInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The ID of the enterprise on which to set the base repository permission setting.
   """
   enterpriseId: ID! @possibleTypes(concreteTypes: ["Enterprise"])
-  
+
   """
   The value for the base repository permission setting on the enterprise.
   """
@@ -54502,12 +54505,12 @@ type UpdateEnterpriseDefaultRepositoryPermissionSettingPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The enterprise with the updated base repository permission setting.
   """
   enterprise: Enterprise
-  
+
   """
   A message confirming the result of updating the base repository permission setting.
   """
@@ -54522,12 +54525,12 @@ input UpdateEnterpriseMembersCanChangeRepositoryVisibilitySettingInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The ID of the enterprise on which to set the members can change repository visibility setting.
   """
   enterpriseId: ID! @possibleTypes(concreteTypes: ["Enterprise"])
-  
+
   """
   The value for the members can change repository visibility setting on the enterprise.
   """
@@ -54542,12 +54545,12 @@ type UpdateEnterpriseMembersCanChangeRepositoryVisibilitySettingPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The enterprise with the updated members can change repository visibility setting.
   """
   enterprise: Enterprise
-  
+
   """
   A message confirming the result of updating the members can change repository visibility setting.
   """
@@ -54562,32 +54565,32 @@ input UpdateEnterpriseMembersCanCreateRepositoriesSettingInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The ID of the enterprise on which to set the members can create repositories setting.
   """
   enterpriseId: ID! @possibleTypes(concreteTypes: ["Enterprise"])
-  
+
   """
   Allow members to create internal repositories. Defaults to current value.
   """
   membersCanCreateInternalRepositories: Boolean
-  
+
   """
   Allow members to create private repositories. Defaults to current value.
   """
   membersCanCreatePrivateRepositories: Boolean
-  
+
   """
   Allow members to create public repositories. Defaults to current value.
   """
   membersCanCreatePublicRepositories: Boolean
-  
+
   """
   When false, allow member organizations to set their own repository creation member privileges.
   """
   membersCanCreateRepositoriesPolicyEnabled: Boolean
-  
+
   """
   Value for the members can create repositories setting on the enterprise. This
   or the granular public/private/internal allowed fields (but not both) must be provided.
@@ -54603,12 +54606,12 @@ type UpdateEnterpriseMembersCanCreateRepositoriesSettingPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The enterprise with the updated members can create repositories setting.
   """
   enterprise: Enterprise
-  
+
   """
   A message confirming the result of updating the members can create repositories setting.
   """
@@ -54623,12 +54626,12 @@ input UpdateEnterpriseMembersCanDeleteIssuesSettingInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The ID of the enterprise on which to set the members can delete issues setting.
   """
   enterpriseId: ID! @possibleTypes(concreteTypes: ["Enterprise"])
-  
+
   """
   The value for the members can delete issues setting on the enterprise.
   """
@@ -54643,12 +54646,12 @@ type UpdateEnterpriseMembersCanDeleteIssuesSettingPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The enterprise with the updated members can delete issues setting.
   """
   enterprise: Enterprise
-  
+
   """
   A message confirming the result of updating the members can delete issues setting.
   """
@@ -54663,12 +54666,12 @@ input UpdateEnterpriseMembersCanDeleteRepositoriesSettingInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The ID of the enterprise on which to set the members can delete repositories setting.
   """
   enterpriseId: ID! @possibleTypes(concreteTypes: ["Enterprise"])
-  
+
   """
   The value for the members can delete repositories setting on the enterprise.
   """
@@ -54683,12 +54686,12 @@ type UpdateEnterpriseMembersCanDeleteRepositoriesSettingPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The enterprise with the updated members can delete repositories setting.
   """
   enterprise: Enterprise
-  
+
   """
   A message confirming the result of updating the members can delete repositories setting.
   """
@@ -54703,12 +54706,12 @@ input UpdateEnterpriseMembersCanInviteCollaboratorsSettingInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The ID of the enterprise on which to set the members can invite collaborators setting.
   """
   enterpriseId: ID! @possibleTypes(concreteTypes: ["Enterprise"])
-  
+
   """
   The value for the members can invite collaborators setting on the enterprise.
   """
@@ -54723,12 +54726,12 @@ type UpdateEnterpriseMembersCanInviteCollaboratorsSettingPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The enterprise with the updated members can invite collaborators setting.
   """
   enterprise: Enterprise
-  
+
   """
   A message confirming the result of updating the members can invite collaborators setting.
   """
@@ -54743,12 +54746,12 @@ input UpdateEnterpriseMembersCanMakePurchasesSettingInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The ID of the enterprise on which to set the members can make purchases setting.
   """
   enterpriseId: ID! @possibleTypes(concreteTypes: ["Enterprise"])
-  
+
   """
   The value for the members can make purchases setting on the enterprise.
   """
@@ -54763,12 +54766,12 @@ type UpdateEnterpriseMembersCanMakePurchasesSettingPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The enterprise with the updated members can make purchases setting.
   """
   enterprise: Enterprise
-  
+
   """
   A message confirming the result of updating the members can make purchases setting.
   """
@@ -54783,12 +54786,12 @@ input UpdateEnterpriseMembersCanUpdateProtectedBranchesSettingInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The ID of the enterprise on which to set the members can update protected branches setting.
   """
   enterpriseId: ID! @possibleTypes(concreteTypes: ["Enterprise"])
-  
+
   """
   The value for the members can update protected branches setting on the enterprise.
   """
@@ -54803,12 +54806,12 @@ type UpdateEnterpriseMembersCanUpdateProtectedBranchesSettingPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The enterprise with the updated members can update protected branches setting.
   """
   enterprise: Enterprise
-  
+
   """
   A message confirming the result of updating the members can update protected branches setting.
   """
@@ -54823,12 +54826,12 @@ input UpdateEnterpriseMembersCanViewDependencyInsightsSettingInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The ID of the enterprise on which to set the members can view dependency insights setting.
   """
   enterpriseId: ID! @possibleTypes(concreteTypes: ["Enterprise"])
-  
+
   """
   The value for the members can view dependency insights setting on the enterprise.
   """
@@ -54843,12 +54846,12 @@ type UpdateEnterpriseMembersCanViewDependencyInsightsSettingPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The enterprise with the updated members can view dependency insights setting.
   """
   enterprise: Enterprise
-  
+
   """
   A message confirming the result of updating the members can view dependency insights setting.
   """
@@ -54863,12 +54866,12 @@ input UpdateEnterpriseOrganizationProjectsSettingInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The ID of the enterprise on which to set the organization projects setting.
   """
   enterpriseId: ID! @possibleTypes(concreteTypes: ["Enterprise"])
-  
+
   """
   The value for the organization projects setting on the enterprise.
   """
@@ -54883,12 +54886,12 @@ type UpdateEnterpriseOrganizationProjectsSettingPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The enterprise with the updated organization projects setting.
   """
   enterprise: Enterprise
-  
+
   """
   A message confirming the result of updating the organization projects setting.
   """
@@ -54903,17 +54906,17 @@ input UpdateEnterpriseOwnerOrganizationRoleInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The ID of the Enterprise which the owner belongs to.
   """
   enterpriseId: ID! @possibleTypes(concreteTypes: ["Enterprise"])
-  
+
   """
   The ID of the organization for membership change.
   """
   organizationId: ID! @possibleTypes(concreteTypes: ["Organization"])
-  
+
   """
   The role to assume in the organization.
   """
@@ -54928,7 +54931,7 @@ type UpdateEnterpriseOwnerOrganizationRolePayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   A message confirming the result of changing the owner's organization role.
   """
@@ -54943,27 +54946,27 @@ input UpdateEnterpriseProfileInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The description of the enterprise.
   """
   description: String
-  
+
   """
   The Enterprise ID to update.
   """
   enterpriseId: ID! @possibleTypes(concreteTypes: ["Enterprise"])
-  
+
   """
   The location of the enterprise.
   """
   location: String
-  
+
   """
   The name of the enterprise.
   """
   name: String
-  
+
   """
   The URL of the enterprise's website.
   """
@@ -54978,7 +54981,7 @@ type UpdateEnterpriseProfilePayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The updated enterprise.
   """
@@ -54993,12 +54996,12 @@ input UpdateEnterpriseRepositoryProjectsSettingInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The ID of the enterprise on which to set the repository projects setting.
   """
   enterpriseId: ID! @possibleTypes(concreteTypes: ["Enterprise"])
-  
+
   """
   The value for the repository projects setting on the enterprise.
   """
@@ -55013,12 +55016,12 @@ type UpdateEnterpriseRepositoryProjectsSettingPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The enterprise with the updated repository projects setting.
   """
   enterprise: Enterprise
-  
+
   """
   A message confirming the result of updating the repository projects setting.
   """
@@ -55033,12 +55036,12 @@ input UpdateEnterpriseTeamDiscussionsSettingInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The ID of the enterprise on which to set the team discussions setting.
   """
   enterpriseId: ID! @possibleTypes(concreteTypes: ["Enterprise"])
-  
+
   """
   The value for the team discussions setting on the enterprise.
   """
@@ -55053,12 +55056,12 @@ type UpdateEnterpriseTeamDiscussionsSettingPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The enterprise with the updated team discussions setting.
   """
   enterprise: Enterprise
-  
+
   """
   A message confirming the result of updating the team discussions setting.
   """
@@ -55073,12 +55076,12 @@ input UpdateEnterpriseTwoFactorAuthenticationRequiredSettingInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The ID of the enterprise on which to set the two factor authentication required setting.
   """
   enterpriseId: ID! @possibleTypes(concreteTypes: ["Enterprise"])
-  
+
   """
   The value for the two factor authentication required setting on the enterprise.
   """
@@ -55093,12 +55096,12 @@ type UpdateEnterpriseTwoFactorAuthenticationRequiredSettingPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The enterprise with the updated two factor authentication required setting.
   """
   enterprise: Enterprise
-  
+
   """
   A message confirming the result of updating the two factor authentication required setting.
   """
@@ -55113,17 +55116,17 @@ input UpdateEnvironmentInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The node ID of the environment.
   """
   environmentId: ID! @possibleTypes(concreteTypes: ["Environment"])
-  
+
   """
   The ids of users or teams that can approve deployments to this environment
   """
   reviewers: [ID!]
-  
+
   """
   The wait timer in minutes.
   """
@@ -55138,7 +55141,7 @@ type UpdateEnvironmentPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The updated environment.
   """
@@ -55153,7 +55156,7 @@ input UpdateIpAllowListEnabledSettingInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The ID of the owner on which to set the IP allow list enabled setting.
   """
@@ -55162,7 +55165,7 @@ input UpdateIpAllowListEnabledSettingInput {
       concreteTypes: ["App", "Enterprise", "Organization"]
       abstractType: "IpAllowListOwner"
     )
-  
+
   """
   The value for the IP allow list enabled setting.
   """
@@ -55177,7 +55180,7 @@ type UpdateIpAllowListEnabledSettingPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The IP allow list owner on which the setting was updated.
   """
@@ -55192,22 +55195,22 @@ input UpdateIpAllowListEntryInput {
   An IP address or range of addresses in CIDR notation.
   """
   allowListValue: String!
-  
+
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The ID of the IP allow list entry to update.
   """
   ipAllowListEntryId: ID! @possibleTypes(concreteTypes: ["IpAllowListEntry"])
-  
+
   """
   Whether the IP allow list entry is active when an IP allow list is enabled.
   """
   isActive: Boolean!
-  
+
   """
   An optional name for the IP allow list entry.
   """
@@ -55222,7 +55225,7 @@ type UpdateIpAllowListEntryPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The IP allow list entry that was updated.
   """
@@ -55237,7 +55240,7 @@ input UpdateIpAllowListForInstalledAppsEnabledSettingInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The ID of the owner.
   """
@@ -55246,7 +55249,7 @@ input UpdateIpAllowListForInstalledAppsEnabledSettingInput {
       concreteTypes: ["App", "Enterprise", "Organization"]
       abstractType: "IpAllowListOwner"
     )
-  
+
   """
   The value for the IP allow list configuration for installed GitHub Apps setting.
   """
@@ -55261,7 +55264,7 @@ type UpdateIpAllowListForInstalledAppsEnabledSettingPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The IP allow list owner on which the setting was updated.
   """
@@ -55276,12 +55279,12 @@ input UpdateIssueCommentInput {
   The updated text of the comment.
   """
   body: String!
-  
+
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The ID of the IssueComment to modify.
   """
@@ -55296,7 +55299,7 @@ type UpdateIssueCommentPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The updated comment.
   """
@@ -55311,42 +55314,42 @@ input UpdateIssueInput {
   An array of Node IDs of users for this issue.
   """
   assigneeIds: [ID!] @possibleTypes(concreteTypes: ["User"])
-  
+
   """
   The body for the issue description.
   """
   body: String
-  
+
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The ID of the Issue to modify.
   """
   id: ID! @possibleTypes(concreteTypes: ["Issue"])
-  
+
   """
   An array of Node IDs of labels for this issue.
   """
   labelIds: [ID!] @possibleTypes(concreteTypes: ["Label"])
-  
+
   """
   The Node ID of the milestone for this issue.
   """
   milestoneId: ID @possibleTypes(concreteTypes: ["Milestone"])
-  
+
   """
   An array of Node IDs for projects associated with this issue.
   """
   projectIds: [ID!]
-  
+
   """
   The desired issue state.
   """
   state: IssueState
-  
+
   """
   The title for the issue.
   """
@@ -55361,12 +55364,12 @@ type UpdateIssuePayload {
   Identifies the actor who performed the event.
   """
   actor: Actor
-  
+
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The issue.
   """
@@ -55381,22 +55384,22 @@ input UpdateLabelInput @preview(toggledBy: "bane-preview") {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   A 6 character hex code, without the leading #, identifying the updated color of the label.
   """
   color: String
-  
+
   """
   A brief description of the label, such as its purpose.
   """
   description: String
-  
+
   """
   The Node ID of the label to be updated.
   """
   id: ID! @possibleTypes(concreteTypes: ["Label"])
-  
+
   """
   The updated name of the label.
   """
@@ -55411,7 +55414,7 @@ type UpdateLabelPayload @preview(toggledBy: "bane-preview") {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The updated label.
   """
@@ -55426,7 +55429,7 @@ input UpdateNotificationRestrictionSettingInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The ID of the owner on which to set the restrict notifications setting.
   """
@@ -55435,7 +55438,7 @@ input UpdateNotificationRestrictionSettingInput {
       concreteTypes: ["Enterprise", "Organization"]
       abstractType: "VerifiableDomainOwner"
     )
-  
+
   """
   The value for the restrict notifications setting.
   """
@@ -55450,7 +55453,7 @@ type UpdateNotificationRestrictionSettingPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The owner on which the setting was updated.
   """
@@ -55465,12 +55468,12 @@ input UpdateOrganizationAllowPrivateRepositoryForkingSettingInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   Enable forking of private repositories in the organization?
   """
   forkingEnabled: Boolean!
-  
+
   """
   The ID of the organization on which to set the allow private repository forking setting.
   """
@@ -55485,12 +55488,12 @@ type UpdateOrganizationAllowPrivateRepositoryForkingSettingPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   A message confirming the result of updating the allow private repository forking setting.
   """
   message: String
-  
+
   """
   The organization with the updated allow private repository forking setting.
   """
@@ -55505,12 +55508,12 @@ input UpdateOrganizationWebCommitSignoffSettingInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The ID of the organization on which to set the web commit signoff setting.
   """
   organizationId: ID! @possibleTypes(concreteTypes: ["Organization"])
-  
+
   """
   Enable signoff on web-based commits for repositories in the organization?
   """
@@ -55525,12 +55528,12 @@ type UpdateOrganizationWebCommitSignoffSettingPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   A message confirming the result of updating the web commit signoff setting.
   """
   message: String
-  
+
   """
   The organization with the updated web commit signoff setting.
   """
@@ -55565,17 +55568,17 @@ input UpdateProjectCardInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   Whether or not the ProjectCard should be archived
   """
   isArchived: Boolean
-  
+
   """
   The note of ProjectCard.
   """
   note: String
-  
+
   """
   The ProjectCard ID to update.
   """
@@ -55590,7 +55593,7 @@ type UpdateProjectCardPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The updated ProjectCard.
   """
@@ -55605,12 +55608,12 @@ input UpdateProjectColumnInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The name of project column.
   """
   name: String!
-  
+
   """
   The ProjectColumn ID to update.
   """
@@ -55625,7 +55628,7 @@ type UpdateProjectColumnPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The updated project column.
   """
@@ -55640,27 +55643,27 @@ input UpdateProjectInput {
   The description of project.
   """
   body: String
-  
+
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The name of project.
   """
   name: String
-  
+
   """
   The Project ID to update.
   """
   projectId: ID! @possibleTypes(concreteTypes: ["Project"])
-  
+
   """
   Whether the project is public or not.
   """
   public: Boolean
-  
+
   """
   Whether the project is open or closed.
   """
@@ -55675,7 +55678,7 @@ type UpdateProjectPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The updated project.
   """
@@ -55690,12 +55693,12 @@ input UpdateProjectV2CollaboratorsInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The collaborators to update.
   """
   collaborators: [ProjectV2Collaborator!]!
-  
+
   """
   The ID of the project to update the collaborators for.
   """
@@ -55710,7 +55713,7 @@ type UpdateProjectV2CollaboratorsPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The collaborators granted a role
   """
@@ -55719,17 +55722,17 @@ type UpdateProjectV2CollaboratorsPayload {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
@@ -55745,22 +55748,22 @@ input UpdateProjectV2DraftIssueInput {
   The IDs of the assignees of the draft issue.
   """
   assigneeIds: [ID!] @possibleTypes(concreteTypes: ["User"])
-  
+
   """
   The body of the draft issue.
   """
   body: String
-  
+
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The ID of the draft issue to update.
   """
   draftIssueId: ID! @possibleTypes(concreteTypes: ["DraftIssue"])
-  
+
   """
   The title of the draft issue.
   """
@@ -55775,7 +55778,7 @@ type UpdateProjectV2DraftIssuePayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The draft issue updated in the project.
   """
@@ -55790,32 +55793,32 @@ input UpdateProjectV2Input {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   Set the project to closed or open.
   """
   closed: Boolean
-  
+
   """
   The ID of the Project to update.
   """
   projectId: ID! @possibleTypes(concreteTypes: ["ProjectV2"])
-  
+
   """
   Set the project to public or private.
   """
   public: Boolean
-  
+
   """
   Set the readme description of the project.
   """
   readme: String
-  
+
   """
   Set the short description of the project.
   """
   shortDescription: String
-  
+
   """
   Set the title of the project.
   """
@@ -55830,7 +55833,7 @@ input UpdateProjectV2ItemFieldValueInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The ID of the field to be updated.
   """
@@ -55843,17 +55846,17 @@ input UpdateProjectV2ItemFieldValueInput {
       ]
       abstractType: "ProjectV2FieldConfiguration"
     )
-  
+
   """
   The ID of the item to be updated.
   """
   itemId: ID! @possibleTypes(concreteTypes: ["ProjectV2Item"])
-  
+
   """
   The ID of the Project.
   """
   projectId: ID! @possibleTypes(concreteTypes: ["ProjectV2"])
-  
+
   """
   The value which will be set on the field.
   """
@@ -55868,7 +55871,7 @@ type UpdateProjectV2ItemFieldValuePayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The updated item.
   """
@@ -55883,17 +55886,17 @@ input UpdateProjectV2ItemPositionInput {
   The ID of the item to position this item after. If omitted or set to null the item will be moved to top.
   """
   afterId: ID @possibleTypes(concreteTypes: ["ProjectV2Item"])
-  
+
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The ID of the item to be moved.
   """
   itemId: ID! @possibleTypes(concreteTypes: ["ProjectV2Item"])
-  
+
   """
   The ID of the Project.
   """
@@ -55908,7 +55911,7 @@ type UpdateProjectV2ItemPositionPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The items in the new order
   """
@@ -55917,17 +55920,17 @@ type UpdateProjectV2ItemPositionPayload {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
@@ -55943,7 +55946,7 @@ type UpdateProjectV2Payload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The updated Project.
   """
@@ -55958,17 +55961,17 @@ input UpdatePullRequestBranchInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The head ref oid for the upstream branch.
   """
   expectedHeadOid: GitObjectID
-  
+
   """
   The Node ID of the pull request.
   """
   pullRequestId: ID! @possibleTypes(concreteTypes: ["PullRequest"])
-  
+
   """
   The update branch method to use. If omitted, defaults to 'MERGE'
   """
@@ -55983,7 +55986,7 @@ type UpdatePullRequestBranchPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The updated pull request.
   """
@@ -55998,53 +56001,53 @@ input UpdatePullRequestInput {
   An array of Node IDs of users for this pull request.
   """
   assigneeIds: [ID!] @possibleTypes(concreteTypes: ["User"])
-  
+
   """
   The name of the branch you want your changes pulled into. This should be an existing branch
   on the current repository.
   """
   baseRefName: String
-  
+
   """
   The contents of the pull request.
   """
   body: String
-  
+
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   An array of Node IDs of labels for this pull request.
   """
   labelIds: [ID!] @possibleTypes(concreteTypes: ["Label"])
-  
+
   """
   Indicates whether maintainers can modify the pull request.
   """
   maintainerCanModify: Boolean
-  
+
   """
   The Node ID of the milestone for this pull request.
   """
   milestoneId: ID @possibleTypes(concreteTypes: ["Milestone"])
-  
+
   """
   An array of Node IDs for projects associated with this pull request.
   """
   projectIds: [ID!]
-  
+
   """
   The Node ID of the pull request.
   """
   pullRequestId: ID! @possibleTypes(concreteTypes: ["PullRequest"])
-  
+
   """
   The target state of the pull request.
   """
   state: PullRequestUpdateState
-  
+
   """
   The title of the pull request.
   """
@@ -56059,12 +56062,12 @@ type UpdatePullRequestPayload {
   Identifies the actor who performed the event.
   """
   actor: Actor
-  
+
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The updated pull request.
   """
@@ -56079,12 +56082,12 @@ input UpdatePullRequestReviewCommentInput {
   The text of the comment.
   """
   body: String!
-  
+
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The Node ID of the comment to modify.
   """
@@ -56100,7 +56103,7 @@ type UpdatePullRequestReviewCommentPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The updated comment.
   """
@@ -56115,12 +56118,12 @@ input UpdatePullRequestReviewInput {
   The contents of the pull request review body.
   """
   body: String!
-  
+
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The Node ID of the pull request review to modify.
   """
@@ -56135,7 +56138,7 @@ type UpdatePullRequestReviewPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The updated pull request review.
   """
@@ -56150,17 +56153,17 @@ input UpdateRefInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   Permit updates of branch Refs that are not fast-forwards?
   """
   force: Boolean = false
-  
+
   """
   The GitObjectID that the Ref shall be updated to target.
   """
   oid: GitObjectID!
-  
+
   """
   The Node ID of the Ref to be updated.
   """
@@ -56175,7 +56178,7 @@ type UpdateRefPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The updated Ref.
   """
@@ -56190,12 +56193,12 @@ input UpdateRefsInput @preview(toggledBy: "update-refs-preview") {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   A list of ref updates.
   """
   refUpdates: [RefUpdate!]!
-  
+
   """
   The Node ID of the repository.
   """
@@ -56220,47 +56223,47 @@ input UpdateRepositoryInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   A new description for the repository. Pass an empty string to erase the existing description.
   """
   description: String
-  
+
   """
   Indicates if the repository should have the discussions feature enabled.
   """
   hasDiscussionsEnabled: Boolean
-  
+
   """
   Indicates if the repository should have the issues feature enabled.
   """
   hasIssuesEnabled: Boolean
-  
+
   """
   Indicates if the repository should have the project boards feature enabled.
   """
   hasProjectsEnabled: Boolean
-  
+
   """
   Indicates if the repository should have the wiki feature enabled.
   """
   hasWikiEnabled: Boolean
-  
+
   """
   The URL for a web page about this repository. Pass an empty string to erase the existing URL.
   """
   homepageUrl: URI
-  
+
   """
   The new name of the repository.
   """
   name: String
-  
+
   """
   The ID of the repository to update.
   """
   repositoryId: ID! @possibleTypes(concreteTypes: ["Repository"])
-  
+
   """
   Whether this repository should be marked as a template such that anyone who
   can access it can create new repositories with the same files and directory structure.
@@ -56276,7 +56279,7 @@ type UpdateRepositoryPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The updated repository.
   """
@@ -56291,37 +56294,37 @@ input UpdateRepositoryRulesetInput {
   A list of actors that are allowed to bypass rules in this ruleset.
   """
   bypassActors: [RepositoryRulesetBypassActorInput!]
-  
+
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The list of conditions for this ruleset
   """
   conditions: RepositoryRuleConditionsInput
-  
+
   """
   The enforcement level for this ruleset
   """
   enforcement: RuleEnforcement
-  
+
   """
   The name of the ruleset.
   """
   name: String
-  
+
   """
   The global relay id of the repository ruleset to be updated.
   """
   repositoryRulesetId: ID! @possibleTypes(concreteTypes: ["RepositoryRuleset"])
-  
+
   """
   The list of rules for this ruleset
   """
   rules: [RepositoryRuleInput!]
-  
+
   """
   The target of the ruleset.
   """
@@ -56336,7 +56339,7 @@ type UpdateRepositoryRulesetPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The newly created Ruleset.
   """
@@ -56351,12 +56354,12 @@ input UpdateRepositoryWebCommitSignoffSettingInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The ID of the repository to update.
   """
   repositoryId: ID! @possibleTypes(concreteTypes: ["Repository"])
-  
+
   """
   Indicates if the repository should require signoff on web-based commits.
   """
@@ -56371,12 +56374,12 @@ type UpdateRepositoryWebCommitSignoffSettingPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   A message confirming the result of updating the web commit signoff setting.
   """
   message: String
-  
+
   """
   The updated repository.
   """
@@ -56391,18 +56394,18 @@ input UpdateSponsorshipPreferencesInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   Specify whether others should be able to see that the sponsor is sponsoring
   the sponsorable. Public visibility still does not reveal which tier is used.
   """
   privacyLevel: SponsorshipPrivacy = PUBLIC
-  
+
   """
   Whether the sponsor should receive email updates from the sponsorable.
   """
   receiveEmails: Boolean = true
-  
+
   """
   The ID of the user or organization who is acting as the sponsor, paying for
   the sponsorship. Required if sponsorLogin is not given.
@@ -56412,13 +56415,13 @@ input UpdateSponsorshipPreferencesInput {
       concreteTypes: ["Organization", "User"]
       abstractType: "Sponsor"
     )
-  
+
   """
   The username of the user or organization who is acting as the sponsor, paying
   for the sponsorship. Required if sponsorId is not given.
   """
   sponsorLogin: String
-  
+
   """
   The ID of the user or organization who is receiving the sponsorship. Required if sponsorableLogin is not given.
   """
@@ -56427,7 +56430,7 @@ input UpdateSponsorshipPreferencesInput {
       concreteTypes: ["Organization", "User"]
       abstractType: "Sponsorable"
     )
-  
+
   """
   The username of the user or organization who is receiving the sponsorship. Required if sponsorableId is not given.
   """
@@ -56442,7 +56445,7 @@ type UpdateSponsorshipPreferencesPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The sponsorship that was updated.
   """
@@ -56457,12 +56460,12 @@ input UpdateSubscriptionInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The new state of the subscription.
   """
   state: SubscriptionState!
-  
+
   """
   The Node ID of the subscribable object to modify.
   """
@@ -56489,7 +56492,7 @@ type UpdateSubscriptionPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The input subscribable entity.
   """
@@ -56504,17 +56507,17 @@ input UpdateTeamDiscussionCommentInput {
   The updated text of the comment.
   """
   body: String!
-  
+
   """
   The current version of the body content.
   """
   bodyVersion: String
-  
+
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The ID of the comment to modify.
   """
@@ -56529,7 +56532,7 @@ type UpdateTeamDiscussionCommentPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The updated comment.
   """
@@ -56544,28 +56547,28 @@ input UpdateTeamDiscussionInput {
   The updated text of the discussion.
   """
   body: String
-  
+
   """
   The current version of the body content. If provided, this update operation
   will be rejected if the given version does not match the latest version on the server.
   """
   bodyVersion: String
-  
+
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The Node ID of the discussion to modify.
   """
   id: ID! @possibleTypes(concreteTypes: ["TeamDiscussion"])
-  
+
   """
   If provided, sets the pinned state of the updated discussion.
   """
   pinned: Boolean
-  
+
   """
   The updated title of the discussion.
   """
@@ -56580,7 +56583,7 @@ type UpdateTeamDiscussionPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The updated discussion.
   """
@@ -56596,32 +56599,32 @@ input UpdateTeamReviewAssignmentInput
   The algorithm to use for review assignment
   """
   algorithm: TeamReviewAssignmentAlgorithm = ROUND_ROBIN
-  
+
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   Turn on or off review assignment
   """
   enabled: Boolean!
-  
+
   """
   An array of team member IDs to exclude
   """
   excludedTeamMemberIds: [ID!] @possibleTypes(concreteTypes: ["User"])
-  
+
   """
   The Node ID of the team to update review assignments of
   """
   id: ID! @possibleTypes(concreteTypes: ["Team"])
-  
+
   """
   Notify the entire team of the PR if it is delegated
   """
   notifyTeam: Boolean = true
-  
+
   """
   The number of team members to assign
   """
@@ -56636,7 +56639,7 @@ type UpdateTeamReviewAssignmentPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The team that was modified
   """
@@ -56651,17 +56654,17 @@ input UpdateTeamsRepositoryInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   Permission that should be granted to the teams.
   """
   permission: RepositoryPermission!
-  
+
   """
   Repository ID being granted access to.
   """
   repositoryId: ID! @possibleTypes(concreteTypes: ["Repository"])
-  
+
   """
   A list of teams being granted access. Limit: 10
   """
@@ -56676,12 +56679,12 @@ type UpdateTeamsRepositoryPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The repository that was updated.
   """
   repository: Repository
-  
+
   """
   The teams granted permission on the repository.
   """
@@ -56696,12 +56699,12 @@ input UpdateTopicsInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The Node ID of the repository.
   """
   repositoryId: ID! @possibleTypes(concreteTypes: ["Repository"])
-  
+
   """
   An array of topic names.
   """
@@ -56716,12 +56719,12 @@ type UpdateTopicsPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   Names of the provided topics that are not valid.
   """
   invalidTopicNames: [String!]
-  
+
   """
   The updated repository.
   """
@@ -56741,7 +56744,7 @@ type User implements Actor & Node & PackageOwner & ProfileOwner & ProjectOwner &
     """
     type: PinnableItemType
   ): Boolean!
-  
+
   """
   A URL pointing to the user's public avatar.
   """
@@ -56751,17 +56754,17 @@ type User implements Actor & Node & PackageOwner & ProfileOwner & ProjectOwner &
     """
     size: Int
   ): URI!
-  
+
   """
   The user's public profile bio.
   """
   bio: String
-  
+
   """
   The user's public profile bio as HTML.
   """
   bioHTML: HTML!
-  
+
   """
   Could this user receive email notifications, if the organization had notification restrictions enabled?
   """
@@ -56771,7 +56774,7 @@ type User implements Actor & Node & PackageOwner & ProfileOwner & ProjectOwner &
     """
     login: String!
   ): Boolean!
-  
+
   """
   A list of commit comments made by this user.
   """
@@ -56780,33 +56783,33 @@ type User implements Actor & Node & PackageOwner & ProfileOwner & ProjectOwner &
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): CommitCommentConnection!
-  
+
   """
   The user's public profile company.
   """
   company: String
-  
+
   """
   The user's public profile company as HTML.
   """
   companyHTML: HTML!
-  
+
   """
   The collection of contributions this user has made to different repositories.
   """
@@ -56815,12 +56818,12 @@ type User implements Actor & Node & PackageOwner & ProfileOwner & ProjectOwner &
     Only contributions made at this time or later will be counted. If omitted, defaults to a year ago.
     """
     from: DateTime
-    
+
     """
     The ID of the organization used to filter contributions.
     """
     organizationID: ID
-    
+
     """
     Only contributions made before and up to (including) this time will be
     counted. If omitted, defaults to the current time or one year from the
@@ -56828,22 +56831,22 @@ type User implements Actor & Node & PackageOwner & ProfileOwner & ProjectOwner &
     """
     to: DateTime
   ): ContributionsCollection!
-  
+
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
-  
+
   """
   Identifies the primary key from the database.
   """
   databaseId: Int
-  
+
   """
   The user's publicly visible profile email.
   """
   email: String!
-  
+
   """
   A list of enterprises that the user belongs to.
   """
@@ -56852,38 +56855,38 @@ type User implements Actor & Node & PackageOwner & ProfileOwner & ProjectOwner &
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Filter enterprises returned based on the user's membership type.
     """
     membershipType: EnterpriseMembershipType = ALL
-    
+
     """
     Ordering options for the User's enterprises.
     """
     orderBy: EnterpriseOrder = { field: NAME, direction: ASC }
   ): EnterpriseConnection
-  
+
   """
   The estimated next GitHub Sponsors payout for this user/organization in cents (USD).
   """
   estimatedNextSponsorsPayoutInCents: Int!
-  
+
   """
   A list of users the given user is followed by.
   """
@@ -56892,23 +56895,23 @@ type User implements Actor & Node & PackageOwner & ProfileOwner & ProjectOwner &
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): FollowerConnection!
-  
+
   """
   A list of users the given user is following.
   """
@@ -56917,23 +56920,23 @@ type User implements Actor & Node & PackageOwner & ProfileOwner & ProjectOwner &
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): FollowingConnection!
-  
+
   """
   Find gist by repo name.
   """
@@ -56943,7 +56946,7 @@ type User implements Actor & Node & PackageOwner & ProfileOwner & ProjectOwner &
     """
     name: String!
   ): Gist
-  
+
   """
   A list of gist comments made by this user.
   """
@@ -56952,23 +56955,23 @@ type User implements Actor & Node & PackageOwner & ProfileOwner & ProjectOwner &
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): GistCommentConnection!
-  
+
   """
   A list of the Gists the user has created.
   """
@@ -56977,38 +56980,38 @@ type User implements Actor & Node & PackageOwner & ProfileOwner & ProjectOwner &
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for gists returned from the connection
     """
     orderBy: GistOrder
-    
+
     """
     Filters Gists according to privacy.
     """
     privacy: GistPrivacy
   ): GistConnection!
-  
+
   """
   True if this user/organization has a GitHub Sponsors listing.
   """
   hasSponsorsListing: Boolean!
-  
+
   """
   The hovercard information for this user in a given context
   """
@@ -57019,52 +57022,52 @@ type User implements Actor & Node & PackageOwner & ProfileOwner & ProjectOwner &
     primarySubjectId: ID
   ): Hovercard!
   id: ID!
-  
+
   """
   The interaction ability settings for this user.
   """
   interactionAbility: RepositoryInteractionAbility
-  
+
   """
   Whether or not this user is a participant in the GitHub Security Bug Bounty.
   """
   isBountyHunter: Boolean!
-  
+
   """
   Whether or not this user is a participant in the GitHub Campus Experts Program.
   """
   isCampusExpert: Boolean!
-  
+
   """
   Whether or not this user is a GitHub Developer Program member.
   """
   isDeveloperProgramMember: Boolean!
-  
+
   """
   Whether or not this user is a GitHub employee.
   """
   isEmployee: Boolean!
-  
+
   """
   Whether or not this user is following the viewer. Inverse of viewerIsFollowing
   """
   isFollowingViewer: Boolean!
-  
+
   """
   Whether or not this user is a member of the GitHub Stars Program.
   """
   isGitHubStar: Boolean!
-  
+
   """
   Whether or not the user has marked themselves as for hire.
   """
   isHireable: Boolean!
-  
+
   """
   Whether or not this user is a site administrator.
   """
   isSiteAdmin: Boolean!
-  
+
   """
   Whether the given account is sponsoring this user/organization.
   """
@@ -57074,17 +57077,17 @@ type User implements Actor & Node & PackageOwner & ProfileOwner & ProjectOwner &
     """
     accountLogin: String!
   ): Boolean!
-  
+
   """
   True if the viewer is sponsored by this user/organization.
   """
   isSponsoringViewer: Boolean!
-  
+
   """
   Whether or not this user is the viewing user.
   """
   isViewer: Boolean!
-  
+
   """
   A list of issue comments made by this user.
   """
@@ -57093,28 +57096,28 @@ type User implements Actor & Node & PackageOwner & ProfileOwner & ProjectOwner &
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for issue comments returned from the connection.
     """
     orderBy: IssueCommentOrder
   ): IssueCommentConnection!
-  
+
   """
   A list of issues associated with this user.
   """
@@ -57123,69 +57126,69 @@ type User implements Actor & Node & PackageOwner & ProfileOwner & ProjectOwner &
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Filtering options for issues returned from the connection.
     """
     filterBy: IssueFilters
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     A list of label names to filter the pull requests by.
     """
     labels: [String!]
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for issues returned from the connection.
     """
     orderBy: IssueOrder
-    
+
     """
     A list of states to filter the issues by.
     """
     states: [IssueState!]
   ): IssueConnection!
-  
+
   """
   Showcases a selection of repositories and gists that the profile owner has
   either curated or that have been selected automatically based on popularity.
   """
   itemShowcase: ProfileItemShowcase!
-  
+
   """
   The user's public profile location.
   """
   location: String
-  
+
   """
   The username used to login.
   """
   login: String!
-  
+
   """
   The estimated monthly GitHub Sponsors income for this user/organization in cents (USD).
   """
   monthlyEstimatedSponsorsIncomeInCents: Int!
-  
+
   """
   The user's public profile name.
   """
   name: String
-  
+
   """
   Find an organization by its login that the user belongs to.
   """
@@ -57195,7 +57198,7 @@ type User implements Actor & Node & PackageOwner & ProfileOwner & ProjectOwner &
     """
     login: String!
   ): Organization
-  
+
   """
   Verified email addresses that match verified domains for a specified organization the user is a member of.
   """
@@ -57205,7 +57208,7 @@ type User implements Actor & Node & PackageOwner & ProfileOwner & ProjectOwner &
     """
     login: String!
   ): [String!]!
-  
+
   """
   A list of organizations the user belongs to.
   """
@@ -57214,28 +57217,28 @@ type User implements Actor & Node & PackageOwner & ProfileOwner & ProjectOwner &
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for the User's organizations.
     """
     orderBy: OrganizationOrder = null
   ): OrganizationConnection!
-  
+
   """
   A list of packages under the owner.
   """
@@ -57244,43 +57247,43 @@ type User implements Actor & Node & PackageOwner & ProfileOwner & ProjectOwner &
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Find packages by their names.
     """
     names: [String]
-    
+
     """
     Ordering of the returned packages.
     """
     orderBy: PackageOrder = { field: CREATED_AT, direction: DESC }
-    
+
     """
     Filter registry package by type.
     """
     packageType: PackageType
-    
+
     """
     Find packages in a repository by ID.
     """
     repositoryId: ID
   ): PackageConnection!
-  
+
   """
   A list of repositories and gists this profile owner can pin to their profile.
   """
@@ -57289,28 +57292,28 @@ type User implements Actor & Node & PackageOwner & ProfileOwner & ProjectOwner &
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Filter the types of pinnable items that are returned.
     """
     types: [PinnableItemType!]
   ): PinnableItemConnection!
-  
+
   """
   A list of repositories and gists this profile owner has pinned to their profile
   """
@@ -57319,33 +57322,33 @@ type User implements Actor & Node & PackageOwner & ProfileOwner & ProjectOwner &
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Filter the types of pinned items that are returned.
     """
     types: [PinnableItemType!]
   ): PinnableItemConnection!
-  
+
   """
   Returns how many more items this profile owner can pin to their profile.
   """
   pinnedItemsRemaining: Int!
-  
+
   """
   Find project by number.
   """
@@ -57355,7 +57358,7 @@ type User implements Actor & Node & PackageOwner & ProfileOwner & ProjectOwner &
     """
     number: Int!
   ): Project
-  
+
   """
   Find a project by number.
   """
@@ -57365,7 +57368,7 @@ type User implements Actor & Node & PackageOwner & ProfileOwner & ProjectOwner &
     """
     number: Int!
   ): ProjectV2
-  
+
   """
   A list of projects under the owner.
   """
@@ -57374,48 +57377,48 @@ type User implements Actor & Node & PackageOwner & ProfileOwner & ProjectOwner &
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for projects returned from the connection
     """
     orderBy: ProjectOrder
-    
+
     """
     Query to search projects by, currently only searching by name.
     """
     search: String
-    
+
     """
     A list of states to filter the projects by.
     """
     states: [ProjectState!]
   ): ProjectConnection!
-  
+
   """
   The HTTP path listing user's projects
   """
   projectsResourcePath: URI!
-  
+
   """
   The HTTP URL listing user's projects
   """
   projectsUrl: URI!
-  
+
   """
   A list of projects under the owner.
   """
@@ -57424,38 +57427,38 @@ type User implements Actor & Node & PackageOwner & ProfileOwner & ProjectOwner &
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     How to order the returned projects.
     """
     orderBy: ProjectV2Order = { field: NUMBER, direction: DESC }
-    
+
     """
     A project to search for under the the owner.
     """
     query: String
   ): ProjectV2Connection!
-  
+
   """
   The user's profile pronouns
   """
   pronouns: String
-  
+
   """
   A list of public keys associated with this user.
   """
@@ -57464,23 +57467,23 @@ type User implements Actor & Node & PackageOwner & ProfileOwner & ProjectOwner &
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): PublicKeyConnection!
-  
+
   """
   A list of pull requests associated with this user.
   """
@@ -57489,48 +57492,48 @@ type User implements Actor & Node & PackageOwner & ProfileOwner & ProjectOwner &
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     The base ref name to filter the pull requests by.
     """
     baseRefName: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     The head ref name to filter the pull requests by.
     """
     headRefName: String
-    
+
     """
     A list of label names to filter the pull requests by.
     """
     labels: [String!]
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for pull requests returned from the connection.
     """
     orderBy: IssueOrder
-    
+
     """
     A list of states to filter the pull requests by.
     """
     states: [PullRequestState!]
   ): PullRequestConnection!
-  
+
   """
   Recent projects that this user has modified in the context of the owner.
   """
@@ -57539,23 +57542,23 @@ type User implements Actor & Node & PackageOwner & ProfileOwner & ProjectOwner &
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): ProjectV2Connection!
-  
+
   """
   A list of repositories that the user owns.
   """
@@ -57566,65 +57569,65 @@ type User implements Actor & Node & PackageOwner & ProfileOwner & ProjectOwner &
     current viewer owns.
     """
     affiliations: [RepositoryAffiliation]
-    
+
     """
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     If non-null, filters repositories according to whether they have issues enabled
     """
     hasIssuesEnabled: Boolean
-    
+
     """
     If non-null, filters repositories according to whether they are archived and not maintained
     """
     isArchived: Boolean
-    
+
     """
     If non-null, filters repositories according to whether they are forks of another repository
     """
     isFork: Boolean
-    
+
     """
     If non-null, filters repositories according to whether they have been locked
     """
     isLocked: Boolean
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for repositories returned from the connection
     """
     orderBy: RepositoryOrder
-    
+
     """
     Array of owner's affiliation options for repositories returned from the
     connection. For example, OWNER will include only repositories that the
     organization or user being viewed owns.
     """
     ownerAffiliations: [RepositoryAffiliation] = [OWNER, COLLABORATOR]
-    
+
     """
     If non-null, filters repositories according to privacy
     """
     privacy: RepositoryPrivacy
   ): RepositoryConnection!
-  
+
   """
   A list of repositories that the user recently contributed to.
   """
@@ -57633,54 +57636,54 @@ type User implements Actor & Node & PackageOwner & ProfileOwner & ProjectOwner &
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     If non-null, include only the specified types of contributions. The
     GitHub.com UI uses [COMMIT, ISSUE, PULL_REQUEST, REPOSITORY]
     """
     contributionTypes: [RepositoryContributionType]
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     If non-null, filters repositories according to whether they have issues enabled
     """
     hasIssues: Boolean
-    
+
     """
     If true, include user repositories
     """
     includeUserRepositories: Boolean
-    
+
     """
     If non-null, filters repositories according to whether they have been locked
     """
     isLocked: Boolean
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for repositories returned from the connection
     """
     orderBy: RepositoryOrder
-    
+
     """
     If non-null, filters repositories according to privacy
     """
     privacy: RepositoryPrivacy
   ): RepositoryConnection!
-  
+
   """
   Find Repository.
   """
@@ -57689,13 +57692,13 @@ type User implements Actor & Node & PackageOwner & ProfileOwner & ProjectOwner &
     Follow repository renames. If disabled, a repository referenced by its old name will return an error.
     """
     followRenames: Boolean = true
-    
+
     """
     Name of Repository to find.
     """
     name: String!
   ): Repository
-  
+
   """
   Discussion comments this user has authored.
   """
@@ -57704,33 +57707,33 @@ type User implements Actor & Node & PackageOwner & ProfileOwner & ProjectOwner &
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Filter discussion comments to only those that were marked as the answer
     """
     onlyAnswers: Boolean = false
-    
+
     """
     Filter discussion comments to only those in a specific repository.
     """
     repositoryId: ID
   ): DiscussionCommentConnection!
-  
+
   """
   Discussions this user has started.
   """
@@ -57739,49 +57742,49 @@ type User implements Actor & Node & PackageOwner & ProfileOwner & ProjectOwner &
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Filter discussions to only those that have been answered or not. Defaults to
     including both answered and unanswered discussions.
     """
     answered: Boolean = null
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for discussions returned from the connection.
     """
     orderBy: DiscussionOrder = { field: CREATED_AT, direction: DESC }
-    
+
     """
     Filter discussions to only those in a specific repository.
     """
     repositoryId: ID
-    
+
     """
     A list of states to filter the discussions by.
     """
     states: [DiscussionState!] = []
   ): DiscussionConnection!
-  
+
   """
   The HTTP path for this user
   """
   resourcePath: URI!
-  
+
   """
   Replies this user has saved
   """
@@ -57790,28 +57793,28 @@ type User implements Actor & Node & PackageOwner & ProfileOwner & ProjectOwner &
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     The field to order saved replies by.
     """
     orderBy: SavedReplyOrder = { field: UPDATED_AT, direction: DESC }
   ): SavedReplyConnection
-  
+
   """
   The user's social media accounts, ordered as they appear on the user's profile.
   """
@@ -57820,23 +57823,23 @@ type User implements Actor & Node & PackageOwner & ProfileOwner & ProjectOwner &
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): SocialAccountConnection!
-  
+
   """
   List of users and organizations this entity is sponsoring.
   """
@@ -57845,28 +57848,28 @@ type User implements Actor & Node & PackageOwner & ProfileOwner & ProjectOwner &
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for the users and organizations returned from the connection.
     """
     orderBy: SponsorOrder = { field: RELEVANCE, direction: DESC }
   ): SponsorConnection!
-  
+
   """
   List of sponsors for this user or organization.
   """
@@ -57875,34 +57878,34 @@ type User implements Actor & Node & PackageOwner & ProfileOwner & ProjectOwner &
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for sponsors returned from the connection.
     """
     orderBy: SponsorOrder = { field: RELEVANCE, direction: DESC }
-    
+
     """
     If given, will filter for sponsors at the given tier. Will only return
     sponsors whose tier the viewer is permitted to see.
     """
     tierId: ID
   ): SponsorConnection!
-  
+
   """
   Events involving this sponsorable, such as new sponsorships.
   """
@@ -57911,67 +57914,67 @@ type User implements Actor & Node & PackageOwner & ProfileOwner & ProjectOwner &
     Filter activities to only the specified actions.
     """
     actions: [SponsorsActivityAction!] = []
-    
+
     """
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Whether to include those events where this sponsorable acted as the sponsor.
     Defaults to only including events where this sponsorable was the recipient
     of a sponsorship.
     """
     includeAsSponsor: Boolean = false
-    
+
     """
     Whether or not to include private activities in the result set. Defaults to including public and private activities.
     """
     includePrivate: Boolean = true
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for activity returned from the connection.
     """
     orderBy: SponsorsActivityOrder = { field: TIMESTAMP, direction: DESC }
-    
+
     """
     Filter activities returned to only those that occurred in the most recent
     specified time period. Set to ALL to avoid filtering by when the activity
     occurred. Will be ignored if `since` or `until` is given.
     """
     period: SponsorsActivityPeriod = MONTH
-    
+
     """
     Filter activities to those that occurred on or after this time.
     """
     since: DateTime
-    
+
     """
     Filter activities to those that occurred before this time.
     """
     until: DateTime
   ): SponsorsActivityConnection!
-  
+
   """
   The GitHub Sponsors listing for this user or organization.
   """
   sponsorsListing: SponsorsListing
-  
+
   """
   The sponsorship from the viewer to this user/organization; that is, the sponsorship where you're the sponsor.
   """
@@ -57982,7 +57985,7 @@ type User implements Actor & Node & PackageOwner & ProfileOwner & ProjectOwner &
     """
     activeOnly: Boolean = true
   ): Sponsorship
-  
+
   """
   The sponsorship from this user/organization to the viewer; that is, the sponsorship you're receiving.
   """
@@ -57993,7 +57996,7 @@ type User implements Actor & Node & PackageOwner & ProfileOwner & ProjectOwner &
     """
     activeOnly: Boolean = true
   ): Sponsorship
-  
+
   """
   List of sponsorship updates sent from this sponsorable to sponsors.
   """
@@ -58002,28 +58005,28 @@ type User implements Actor & Node & PackageOwner & ProfileOwner & ProjectOwner &
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for sponsorship updates returned from the connection.
     """
     orderBy: SponsorshipNewsletterOrder = { field: CREATED_AT, direction: DESC }
   ): SponsorshipNewsletterConnection!
-  
+
   """
   The sponsorships where this user or organization is the maintainer receiving the funds.
   """
@@ -58033,39 +58036,39 @@ type User implements Actor & Node & PackageOwner & ProfileOwner & ProjectOwner &
     sponsorships this maintainer has ever received.
     """
     activeOnly: Boolean = true
-    
+
     """
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Whether or not to include private sponsorships in the result set
     """
     includePrivate: Boolean = false
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for sponsorships returned from this connection. If left
     blank, the sponsorships will be ordered based on relevancy to the viewer.
     """
     orderBy: SponsorshipOrder
   ): SponsorshipConnection!
-  
+
   """
   The sponsorships where this user or organization is the funder.
   """
@@ -58074,41 +58077,41 @@ type User implements Actor & Node & PackageOwner & ProfileOwner & ProjectOwner &
     Whether to include only sponsorships that are active right now, versus all sponsorships this sponsor has ever made.
     """
     activeOnly: Boolean = true
-    
+
     """
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Filter sponsorships returned to those for the specified maintainers. That
     is, the recipient of the sponsorship is a user or organization with one of
     the given logins.
     """
     maintainerLogins: [String!]
-    
+
     """
     Ordering options for sponsorships returned from this connection. If left
     blank, the sponsorships will be ordered based on relevancy to the viewer.
     """
     orderBy: SponsorshipOrder
   ): SponsorshipConnection!
-  
+
   """
   Repositories the user has starred.
   """
@@ -58117,38 +58120,38 @@ type User implements Actor & Node & PackageOwner & ProfileOwner & ProjectOwner &
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Order for connection
     """
     orderBy: StarOrder
-    
+
     """
     Filters starred repositories to only return repositories owned by the viewer.
     """
     ownedByViewer: Boolean
   ): StarredRepositoryConnection!
-  
+
   """
   The user's description of what they're currently doing.
   """
   status: UserStatus
-  
+
   """
   Repositories the user has contributed to, ordered by contribution rank, plus repositories the user has created
   """
@@ -58157,33 +58160,33 @@ type User implements Actor & Node & PackageOwner & ProfileOwner & ProjectOwner &
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for repositories returned from the connection
     """
     orderBy: RepositoryOrder!
-    
+
     """
     How far back in time to fetch contributed repositories
     """
     since: DateTime
   ): RepositoryConnection!
-  
+
   """
   The amount in United States cents (e.g., 500 = $5.00 USD) that this entity has
   spent on GitHub to fund sponsorships. Only returns a value when viewed by the
@@ -58194,63 +58197,63 @@ type User implements Actor & Node & PackageOwner & ProfileOwner & ProjectOwner &
     Filter payments to those that occurred on or after this time.
     """
     since: DateTime
-    
+
     """
     Filter payments to those made to the users or organizations with the specified usernames.
     """
     sponsorableLogins: [String!] = []
-    
+
     """
     Filter payments to those that occurred before this time.
     """
     until: DateTime
   ): Int
-  
+
   """
   The user's Twitter username.
   """
   twitterUsername: String
-  
+
   """
   Identifies the date and time when the object was last updated.
   """
   updatedAt: DateTime!
-  
+
   """
   The HTTP URL for this user
   """
   url: URI!
-  
+
   """
   Can the viewer pin repositories and gists to the profile?
   """
   viewerCanChangePinnedItems: Boolean!
-  
+
   """
   Can the current viewer create new projects on this owner.
   """
   viewerCanCreateProjects: Boolean!
-  
+
   """
   Whether or not the viewer is able to follow the user.
   """
   viewerCanFollow: Boolean!
-  
+
   """
   Whether or not the viewer is able to sponsor this user/organization.
   """
   viewerCanSponsor: Boolean!
-  
+
   """
   Whether or not this user is followed by the viewer. Inverse of isFollowingViewer.
   """
   viewerIsFollowing: Boolean!
-  
+
   """
   True if the viewer is sponsoring this user/organization.
   """
   viewerIsSponsoring: Boolean!
-  
+
   """
   A list of repositories the given user is watching.
   """
@@ -58261,55 +58264,55 @@ type User implements Actor & Node & PackageOwner & ProfileOwner & ProjectOwner &
     viewer is an owner or collaborator, or member.
     """
     affiliations: [RepositoryAffiliation]
-    
+
     """
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     If non-null, filters repositories according to whether they have issues enabled
     """
     hasIssuesEnabled: Boolean
-    
+
     """
     If non-null, filters repositories according to whether they have been locked
     """
     isLocked: Boolean
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for repositories returned from the connection
     """
     orderBy: RepositoryOrder
-    
+
     """
     Array of owner's affiliation options for repositories returned from the
     connection. For example, OWNER will include only repositories that the
     organization or user being viewed owns.
     """
     ownerAffiliations: [RepositoryAffiliation] = [OWNER, COLLABORATOR]
-    
+
     """
     If non-null, filters repositories according to privacy
     """
     privacy: RepositoryPrivacy
   ): RepositoryConnection!
-  
+
   """
   A URL pointing to the user's public website/blog.
   """
@@ -58350,18 +58353,18 @@ type UserBlockedEvent implements Node {
   Identifies the actor who performed the event.
   """
   actor: Actor
-  
+
   """
   Number of days that the user was blocked for.
   """
   blockDuration: UserBlockDuration!
-  
+
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
   id: ID!
-  
+
   """
   The user who was blocked.
   """
@@ -58376,17 +58379,17 @@ type UserConnection {
   A list of edges.
   """
   edges: [UserEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [User]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -58401,33 +58404,33 @@ type UserContentEdit implements Node {
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
-  
+
   """
   Identifies the date and time when the object was deleted.
   """
   deletedAt: DateTime
-  
+
   """
   The actor who deleted this content
   """
   deletedBy: Actor
-  
+
   """
   A summary of the changes for this edit
   """
   diff: String
-  
+
   """
   When this content was edited
   """
   editedAt: DateTime!
-  
+
   """
   The actor who edited this content
   """
   editor: Actor
   id: ID!
-  
+
   """
   Identifies the date and time when the object was last updated.
   """
@@ -58442,17 +58445,17 @@ type UserContentEditConnection {
   A list of edges.
   """
   edges: [UserContentEditEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [UserContentEdit]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -58467,7 +58470,7 @@ type UserContentEditEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -58482,7 +58485,7 @@ type UserEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -58497,12 +58500,12 @@ type UserEmailMetadata {
   Boolean to identify primary emails
   """
   primary: Boolean
-  
+
   """
   Type of email
   """
   type: String
-  
+
   """
   Email id
   """
@@ -58517,43 +58520,43 @@ type UserStatus implements Node {
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
-  
+
   """
   An emoji summarizing the user's status.
   """
   emoji: String
-  
+
   """
   The status emoji as HTML.
   """
   emojiHTML: HTML
-  
+
   """
   If set, the status will not be shown after this date.
   """
   expiresAt: DateTime
   id: ID!
-  
+
   """
   Whether this status indicates the user is not fully available on GitHub.
   """
   indicatesLimitedAvailability: Boolean!
-  
+
   """
   A brief message describing what the user is doing.
   """
   message: String
-  
+
   """
   The organization whose members can see this status. If null, this status is publicly visible.
   """
   organization: Organization
-  
+
   """
   Identifies the date and time when the object was last updated.
   """
   updatedAt: DateTime!
-  
+
   """
   The user who has this status.
   """
@@ -58568,17 +58571,17 @@ type UserStatusConnection {
   A list of edges.
   """
   edges: [UserStatusEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [UserStatus]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -58593,7 +58596,7 @@ type UserStatusEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -58608,7 +58611,7 @@ input UserStatusOrder {
   The ordering direction.
   """
   direction: OrderDirection!
-  
+
   """
   The field to order user statuses by.
   """
@@ -58633,68 +58636,68 @@ type VerifiableDomain implements Node {
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
-  
+
   """
   Identifies the primary key from the database.
   """
   databaseId: Int
-  
+
   """
   The DNS host name that should be used for verification.
   """
   dnsHostName: URI
-  
+
   """
   The unicode encoded domain.
   """
   domain: URI!
-  
+
   """
   Whether a TXT record for verification with the expected host name was found.
   """
   hasFoundHostName: Boolean!
-  
+
   """
   Whether a TXT record for verification with the expected verification token was found.
   """
   hasFoundVerificationToken: Boolean!
   id: ID!
-  
+
   """
   Whether or not the domain is approved.
   """
   isApproved: Boolean!
-  
+
   """
   Whether this domain is required to exist for an organization or enterprise policy to be enforced.
   """
   isRequiredForPolicyEnforcement: Boolean!
-  
+
   """
   Whether or not the domain is verified.
   """
   isVerified: Boolean!
-  
+
   """
   The owner of the domain.
   """
   owner: VerifiableDomainOwner!
-  
+
   """
   The punycode encoded domain.
   """
   punycodeEncodedDomain: URI!
-  
+
   """
   The time that the current verification token will expire.
   """
   tokenExpirationTime: DateTime
-  
+
   """
   Identifies the date and time when the object was last updated.
   """
   updatedAt: DateTime!
-  
+
   """
   The current verification token for the domain.
   """
@@ -58709,17 +58712,17 @@ type VerifiableDomainConnection {
   A list of edges.
   """
   edges: [VerifiableDomainEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [VerifiableDomain]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -58734,7 +58737,7 @@ type VerifiableDomainEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -58749,7 +58752,7 @@ input VerifiableDomainOrder {
   The ordering direction.
   """
   direction: OrderDirection!
-  
+
   """
   The field to order verifiable domains by.
   """
@@ -58783,7 +58786,7 @@ input VerifyVerifiableDomainInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The ID of the verifiable domain to verify.
   """
@@ -58798,7 +58801,7 @@ type VerifyVerifiableDomainPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  
+
   """
   The verifiable domain that was verified.
   """
@@ -58813,12 +58816,12 @@ type ViewerHovercardContext implements HovercardContext {
   A string describing this context
   """
   message: String!
-  
+
   """
   An octicon to accompany this context
   """
   octicon: String!
-  
+
   """
   Identifies the user who is related to this context.
   """
@@ -58833,12 +58836,12 @@ interface Votable {
   Number of upvotes that this subject has received.
   """
   upvoteCount: Int!
-  
+
   """
   Whether or not the current user can add or remove an upvote on this subject.
   """
   viewerCanUpvote: Boolean!
-  
+
   """
   Whether or not the current user has already upvoted this subject.
   """
@@ -58853,23 +58856,23 @@ type Workflow implements Node & UniformResourceLocatable {
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
-  
+
   """
   Identifies the primary key from the database.
   """
   databaseId: Int
   id: ID!
-  
+
   """
   The name of the workflow.
   """
   name: String!
-  
+
   """
   The HTTP path for this workflow
   """
   resourcePath: URI!
-  
+
   """
   The runs of the workflow.
   """
@@ -58878,38 +58881,38 @@ type Workflow implements Node & UniformResourceLocatable {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
-    
+
     """
     Ordering options for the connection
     """
     orderBy: WorkflowRunOrder = { field: CREATED_AT, direction: DESC }
   ): WorkflowRunConnection!
-  
+
   """
   The state of the workflow.
   """
   state: WorkflowState!
-  
+
   """
   Identifies the date and time when the object was last updated.
   """
   updatedAt: DateTime!
-  
+
   """
   The HTTP URL for this workflow
   """
@@ -58924,17 +58927,17 @@ type WorkflowRun implements Node & UniformResourceLocatable {
   The check suite this workflow run belongs to.
   """
   checkSuite: CheckSuite!
-  
+
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
-  
+
   """
   Identifies the primary key from the database.
   """
   databaseId: Int
-  
+
   """
   The log of deployment reviews
   """
@@ -58943,34 +58946,34 @@ type WorkflowRun implements Node & UniformResourceLocatable {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): DeploymentReviewConnection!
-  
+
   """
   The event that triggered the workflow run
   """
   event: String!
-  
+
   """
   The workflow file
   """
   file: WorkflowRunFile
   id: ID!
-  
+
   """
   The pending deployment requests of all check runs in this workflow run
   """
@@ -58979,43 +58982,43 @@ type WorkflowRun implements Node & UniformResourceLocatable {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
-    
+
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    
+
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
-    
+
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): DeploymentRequestConnection!
-  
+
   """
   The HTTP path for this workflow run
   """
   resourcePath: URI!
-  
+
   """
   A number that uniquely identifies this workflow run in its parent workflow.
   """
   runNumber: Int!
-  
+
   """
   Identifies the date and time when the object was last updated.
   """
   updatedAt: DateTime!
-  
+
   """
   The HTTP URL for this workflow run
   """
   url: URI!
-  
+
   """
   The workflow executed in this workflow run.
   """
@@ -59030,17 +59033,17 @@ type WorkflowRunConnection {
   A list of edges.
   """
   edges: [WorkflowRunEdge]
-  
+
   """
   A list of nodes.
   """
   nodes: [WorkflowRun]
-  
+
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   Identifies the total count of items in the connection.
   """
@@ -59055,7 +59058,7 @@ type WorkflowRunEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  
+
   """
   The item at the end of the edge.
   """
@@ -59067,42 +59070,42 @@ An executed workflow file for a workflow run.
 """
 type WorkflowRunFile implements Node & UniformResourceLocatable {
   id: ID!
-  
+
   """
   The path of the workflow file relative to its repository.
   """
   path: String!
-  
+
   """
   The direct link to the file in the repository which stores the workflow file.
   """
   repositoryFileUrl: URI!
-  
+
   """
   The repository name and owner which stores the workflow file.
   """
   repositoryName: URI!
-  
+
   """
   The HTTP path for this workflow run file
   """
   resourcePath: URI!
-  
+
   """
   The parent workflow run execution for this file.
   """
   run: WorkflowRun!
-  
+
   """
   The HTTP URL for this workflow run file
   """
   url: URI!
-  
+
   """
   If the viewer has permissions to push to the repository which stores the workflow.
   """
   viewerCanPushRepository: Boolean!
-  
+
   """
   If the viewer has permissions to read the repository which stores the workflow.
   """
@@ -59117,7 +59120,7 @@ input WorkflowRunOrder {
   The direction in which to order workflow runs by the specified field.
   """
   direction: OrderDirection!
-  
+
   """
   The field by which to order workflows.
   """

--- a/cynic-parser/tests/snapshots/actual_schemas__github__snapshot.snap
+++ b/cynic-parser/tests/snapshots/actual_schemas__github__snapshot.snap
@@ -24,6 +24,7 @@ directive @possibleTypes(
   Abstract type of accepted global ID
   """
   abstractType: String
+  
   """
   Accepted types of global IDs.
   """
@@ -38,6 +39,7 @@ input AbortQueuedMigrationsInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The ID of the organization that is running the migrations.
   """
@@ -52,6 +54,7 @@ type AbortQueuedMigrationsPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   Did the operation succeed?
   """
@@ -66,6 +69,7 @@ input AcceptEnterpriseAdministratorInvitationInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The id of the invitation being accepted
   """
@@ -81,10 +85,12 @@ type AcceptEnterpriseAdministratorInvitationPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The invitation that was accepted.
   """
   invitation: EnterpriseAdministratorInvitation
+  
   """
   A message confirming the result of accepting an administrator invitation.
   """
@@ -99,10 +105,12 @@ input AcceptTopicSuggestionInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The name of the suggested topic.
   """
   name: String!
+  
   """
   The Node ID of the repository.
   """
@@ -117,6 +125,7 @@ type AcceptTopicSuggestionPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The accepted topic.
   """
@@ -136,14 +145,17 @@ interface Actor {
     """
     size: Int
   ): URI!
+  
   """
   The username of the actor.
   """
   login: String!
+  
   """
   The HTTP path for this actor.
   """
   resourcePath: URI!
+  
   """
   The HTTP URL for this actor.
   """
@@ -158,18 +170,22 @@ type ActorLocation {
   City
   """
   city: String
+  
   """
   Country name
   """
   country: String
+  
   """
   Country code
   """
   countryCode: String
+  
   """
   Region name
   """
   region: String
+  
   """
   Region or state code
   """
@@ -202,10 +218,12 @@ input AddAssigneesToAssignableInput {
       concreteTypes: ["Issue", "PullRequest"]
       abstractType: "Assignable"
     )
+  
   """
   The id of users to add as assignees.
   """
   assigneeIds: [ID!]! @possibleTypes(concreteTypes: ["User"])
+  
   """
   A unique identifier for the client performing the mutation.
   """
@@ -220,6 +238,7 @@ type AddAssigneesToAssignablePayload {
   The item that was assigned.
   """
   assignable: Assignable
+  
   """
   A unique identifier for the client performing the mutation.
   """
@@ -234,10 +253,12 @@ input AddCommentInput {
   The contents of the comment.
   """
   body: String!
+  
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The Node ID of the subject to modify.
   """
@@ -256,14 +277,17 @@ type AddCommentPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The edge from the subject's comment connection.
   """
   commentEdge: IssueCommentEdge
+  
   """
   The subject
   """
   subject: Node
+  
   """
   The edge from the subject's timeline connection.
   """
@@ -278,14 +302,17 @@ input AddDiscussionCommentInput {
   The contents of the comment.
   """
   body: String!
+  
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The Node ID of the discussion to comment on.
   """
   discussionId: ID! @possibleTypes(concreteTypes: ["Discussion"])
+  
   """
   The Node ID of the discussion comment within this discussion to reply to.
   """
@@ -300,6 +327,7 @@ type AddDiscussionCommentPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The newly created discussion comment.
   """
@@ -314,6 +342,7 @@ input AddDiscussionPollVoteInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The Node ID of the discussion poll option to vote for.
   """
@@ -328,6 +357,7 @@ type AddDiscussionPollVotePayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The poll option that a vote was added to.
   """
@@ -342,18 +372,22 @@ input AddEnterpriseOrganizationMemberInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The ID of the enterprise which owns the organization.
   """
   enterpriseId: ID! @possibleTypes(concreteTypes: ["Enterprise"])
+  
   """
   The ID of the organization the users will be added to.
   """
   organizationId: ID! @possibleTypes(concreteTypes: ["Organization"])
+  
   """
   The role to assign the users in the organization
   """
   role: OrganizationMemberRole
+  
   """
   The IDs of the enterprise members to add.
   """
@@ -368,6 +402,7 @@ type AddEnterpriseOrganizationMemberPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The users who were added to the organization.
   """
@@ -382,10 +417,12 @@ input AddEnterpriseSupportEntitlementInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The ID of the Enterprise which the admin belongs to.
   """
   enterpriseId: ID! @possibleTypes(concreteTypes: ["Enterprise"])
+  
   """
   The login of a member who will receive the support entitlement.
   """
@@ -400,6 +437,7 @@ type AddEnterpriseSupportEntitlementPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   A message confirming the result of adding the support entitlement.
   """
@@ -414,10 +452,12 @@ input AddLabelsToLabelableInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The ids of the labels to add.
   """
   labelIds: [ID!]! @possibleTypes(concreteTypes: ["Label"])
+  
   """
   The id of the labelable object to add labels to.
   """
@@ -436,6 +476,7 @@ type AddLabelsToLabelablePayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The item that was labeled.
   """
@@ -450,6 +491,7 @@ input AddProjectCardInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The content of the card. Must be a member of the ProjectCardItem union
   """
@@ -458,10 +500,12 @@ input AddProjectCardInput {
       concreteTypes: ["Issue", "PullRequest"]
       abstractType: "ProjectCardItem"
     )
+  
   """
   The note on the card.
   """
   note: String
+  
   """
   The Node ID of the ProjectColumn.
   """
@@ -476,10 +520,12 @@ type AddProjectCardPayload {
   The edge from the ProjectColumn's card connection.
   """
   cardEdge: ProjectCardEdge
+  
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The ProjectColumn
   """
@@ -494,10 +540,12 @@ input AddProjectColumnInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The name of the column.
   """
   name: String!
+  
   """
   The Node ID of the project.
   """
@@ -512,10 +560,12 @@ type AddProjectColumnPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The edge from the project's column connection.
   """
   columnEdge: ProjectColumnEdge
+  
   """
   The project
   """
@@ -530,18 +580,22 @@ input AddProjectV2DraftIssueInput {
   The IDs of the assignees of the draft issue.
   """
   assigneeIds: [ID!] @possibleTypes(concreteTypes: ["User"])
+  
   """
   The body of the draft issue.
   """
   body: String
+  
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The ID of the Project to add the draft issue to.
   """
   projectId: ID! @possibleTypes(concreteTypes: ["ProjectV2"])
+  
   """
   The title of the draft issue. A project item can also be created by providing
   the URL of an Issue or Pull Request if you have access.
@@ -557,6 +611,7 @@ type AddProjectV2DraftIssuePayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The draft issue added to the project.
   """
@@ -571,6 +626,7 @@ input AddProjectV2ItemByIdInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The id of the Issue or Pull Request to add.
   """
@@ -579,6 +635,7 @@ input AddProjectV2ItemByIdInput {
       concreteTypes: ["DraftIssue", "Issue", "PullRequest"]
       abstractType: "ProjectV2ItemContent"
     )
+  
   """
   The ID of the Project to add the item to.
   """
@@ -593,6 +650,7 @@ type AddProjectV2ItemByIdPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The item added to the project.
   """
@@ -611,10 +669,12 @@ input AddPullRequestReviewCommentInput {
   **Reason:** We are deprecating the addPullRequestReviewComment mutation
   """
   body: String
+  
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The SHA of the commit to comment on.
 
@@ -623,6 +683,7 @@ input AddPullRequestReviewCommentInput {
   **Reason:** We are deprecating the addPullRequestReviewComment mutation
   """
   commitOID: GitObjectID
+  
   """
   The comment id to reply to.
 
@@ -631,6 +692,7 @@ input AddPullRequestReviewCommentInput {
   **Reason:** We are deprecating the addPullRequestReviewComment mutation
   """
   inReplyTo: ID @possibleTypes(concreteTypes: ["PullRequestReviewComment"])
+  
   """
   The relative path of the file to comment on.
 
@@ -639,6 +701,7 @@ input AddPullRequestReviewCommentInput {
   **Reason:** We are deprecating the addPullRequestReviewComment mutation
   """
   path: String
+  
   """
   The line index in the diff to comment on.
 
@@ -647,6 +710,7 @@ input AddPullRequestReviewCommentInput {
   **Reason:** We are deprecating the addPullRequestReviewComment mutation
   """
   position: Int
+  
   """
   The node ID of the pull request reviewing
 
@@ -656,6 +720,7 @@ input AddPullRequestReviewCommentInput {
   **Reason:** We are deprecating the addPullRequestReviewComment mutation
   """
   pullRequestId: ID @possibleTypes(concreteTypes: ["PullRequest"])
+  
   """
   The Node ID of the review to modify.
 
@@ -675,10 +740,12 @@ type AddPullRequestReviewCommentPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The newly created comment.
   """
   comment: PullRequestReviewComment
+  
   """
   The edge from the review's comment connection.
   """
@@ -693,10 +760,12 @@ input AddPullRequestReviewInput {
   The contents of the review body comment.
   """
   body: String
+  
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The review line comments.
 
@@ -705,18 +774,22 @@ input AddPullRequestReviewInput {
   **Reason:** We are deprecating comment fields that use diff-relative positioning
   """
   comments: [DraftPullRequestReviewComment]
+  
   """
   The commit OID the review pertains to.
   """
   commitOID: GitObjectID
+  
   """
   The event to perform on the pull request review.
   """
   event: PullRequestReviewEvent
+  
   """
   The Node ID of the pull request to modify.
   """
   pullRequestId: ID! @possibleTypes(concreteTypes: ["PullRequest"])
+  
   """
   The review line comment threads.
   """
@@ -731,10 +804,12 @@ type AddPullRequestReviewPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The newly created pull request review.
   """
   pullRequestReview: PullRequestReview
+  
   """
   The edge from the pull request's review connection.
   """
@@ -749,39 +824,48 @@ input AddPullRequestReviewThreadInput {
   Body of the thread's first comment.
   """
   body: String!
+  
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The line of the blob to which the thread refers, required for line-level
   threads. The end of the line range for multi-line comments.
   """
   line: Int
+  
   """
   Path to the file being commented on.
   """
   path: String!
+  
   """
   The node ID of the pull request reviewing
   """
   pullRequestId: ID @possibleTypes(concreteTypes: ["PullRequest"])
+  
   """
   The Node ID of the review to modify.
   """
   pullRequestReviewId: ID @possibleTypes(concreteTypes: ["PullRequestReview"])
+  
   """
   The side of the diff on which the line resides. For multi-line comments, this is the side for the end of the line range.
   """
   side: DiffSide = RIGHT
+  
   """
   The first line of the range to which the comment refers.
   """
   startLine: Int
+  
   """
   The side of the diff on which the start line resides.
   """
   startSide: DiffSide = RIGHT
+  
   """
   The level at which the comments in the corresponding thread are targeted, can be a diff line or a file
   """
@@ -796,6 +880,7 @@ type AddPullRequestReviewThreadPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The newly created thread.
   """
@@ -810,14 +895,17 @@ input AddPullRequestReviewThreadReplyInput {
   The text of the reply.
   """
   body: String!
+  
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The Node ID of the pending review to which the reply will belong.
   """
   pullRequestReviewId: ID @possibleTypes(concreteTypes: ["PullRequestReview"])
+  
   """
   The Node ID of the thread to which this reply is being written.
   """
@@ -833,6 +921,7 @@ type AddPullRequestReviewThreadReplyPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The newly created reply.
   """
@@ -847,10 +936,12 @@ input AddReactionInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The name of the emoji to react with.
   """
   content: ReactionContent!
+  
   """
   The Node ID of the subject to modify.
   """
@@ -881,14 +972,17 @@ type AddReactionPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The reaction object.
   """
   reaction: Reaction
+  
   """
   The reaction groups for the subject.
   """
   reactionGroups: [ReactionGroup!]
+  
   """
   The reactable subject.
   """
@@ -903,6 +997,7 @@ input AddStarInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The Starrable ID to star.
   """
@@ -921,6 +1016,7 @@ type AddStarPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The starrable.
   """
@@ -935,6 +1031,7 @@ input AddUpvoteInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The Node ID of the discussion or comment to upvote.
   """
@@ -953,6 +1050,7 @@ type AddUpvotePayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The votable subject.
   """
@@ -967,10 +1065,12 @@ input AddVerifiableDomainInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The URL of the domain
   """
   domain: URI!
+  
   """
   The ID of the owner to add the domain to
   """
@@ -989,6 +1089,7 @@ type AddVerifiableDomainPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The verifiable domain that was added.
   """
@@ -1003,19 +1104,23 @@ type AddedToMergeQueueEvent implements Node {
   Identifies the actor who performed the event.
   """
   actor: Actor
+  
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
+  
   """
   The user who added this Pull Request to the merge queue
   """
   enqueuer: User
   id: ID!
+  
   """
   The merge queue where this pull request was added to.
   """
   mergeQueue: MergeQueue
+  
   """
   PullRequest referenced by event.
   """
@@ -1030,23 +1135,28 @@ type AddedToProjectEvent implements Node {
   Identifies the actor who performed the event.
   """
   actor: Actor
+  
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
+  
   """
   Identifies the primary key from the database.
   """
   databaseId: Int
   id: ID!
+  
   """
   Project referenced by event.
   """
   project: Project @preview(toggledBy: "starfox-preview")
+  
   """
   Project card referenced by this project event.
   """
   projectCard: ProjectCard @preview(toggledBy: "starfox-preview")
+  
   """
   Column name referenced by this project event.
   """
@@ -1061,10 +1171,12 @@ interface AnnouncementBanner {
   The text of the announcement
   """
   announcement: String
+  
   """
   The expiration date of the announcement, if any
   """
   announcementExpiresAt: DateTime
+  
   """
   Whether the announcement can be dismissed by the user
   """
@@ -1079,15 +1191,18 @@ type App implements Node {
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
+  
   """
   Identifies the primary key from the database.
   """
   databaseId: Int
+  
   """
   The description of the app.
   """
   description: String
   id: ID!
+  
   """
   The IP addresses of the app.
   """
@@ -1096,27 +1211,33 @@ type App implements Node {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for IP allow list entries returned.
     """
     orderBy: IpAllowListEntryOrder = { field: ALLOW_LIST_VALUE, direction: ASC }
   ): IpAllowListEntryConnection!
+  
   """
   The hex color code, without the leading '#', for the logo background.
   """
   logoBackgroundColor: String!
+  
   """
   A URL pointing to the app's logo.
   """
@@ -1126,18 +1247,22 @@ type App implements Node {
     """
     size: Int
   ): URI!
+  
   """
   The name of the app.
   """
   name: String!
+  
   """
   A slug based on the name of the app for use in URLs.
   """
   slug: String!
+  
   """
   Identifies the date and time when the object was last updated.
   """
   updatedAt: DateTime!
+  
   """
   The URL to the app's homepage.
   """
@@ -1152,14 +1277,17 @@ input ApproveDeploymentsInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   Optional comment for approving deployments
   """
   comment: String = ""
+  
   """
   The ids of environments to reject deployments
   """
   environmentIds: [ID!]!
+  
   """
   The node ID of the workflow run containing the pending deployments.
   """
@@ -1174,6 +1302,7 @@ type ApproveDeploymentsPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The affected deployments.
   """
@@ -1188,6 +1317,7 @@ input ApproveVerifiableDomainInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The ID of the verifiable domain to approve.
   """
@@ -1202,6 +1332,7 @@ type ApproveVerifiableDomainPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The verifiable domain that was approved.
   """
@@ -1216,10 +1347,12 @@ input ArchiveProjectV2ItemInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The ID of the ProjectV2Item to archive.
   """
   itemId: ID! @possibleTypes(concreteTypes: ["ProjectV2Item"])
+  
   """
   The ID of the Project to archive the item from.
   """
@@ -1234,6 +1367,7 @@ type ArchiveProjectV2ItemPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The item archived from the project.
   """
@@ -1248,6 +1382,7 @@ input ArchiveRepositoryInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The ID of the repository to mark as archived.
   """
@@ -1262,6 +1397,7 @@ type ArchiveRepositoryPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The repository that was marked as archived.
   """
@@ -1280,14 +1416,17 @@ interface Assignable {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
@@ -1303,19 +1442,23 @@ type AssignedEvent implements Node {
   Identifies the actor who performed the event.
   """
   actor: Actor
+  
   """
   Identifies the assignable associated with the event.
   """
   assignable: Assignable!
+  
   """
   Identifies the user or mannequin that was assigned.
   """
   assignee: Assignee
+  
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
   id: ID!
+  
   """
   Identifies the user who was assigned.
   """
@@ -1338,50 +1481,62 @@ interface AuditEntry {
   The action name
   """
   action: String!
+  
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
+  
   """
   The IP address of the actor
   """
   actorIp: String
+  
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
+  
   """
   The username of the user who initiated the action
   """
   actorLogin: String
+  
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
+  
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
+  
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
+  
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
+  
   """
   The user affected by the action
   """
   user: User
+  
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
+  
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
+  
   """
   The HTTP URL for the user.
   """
@@ -1401,6 +1556,7 @@ input AuditLogOrder {
   The ordering direction.
   """
   direction: OrderDirection
+  
   """
   The field to order Audit Logs by.
   """
@@ -1425,23 +1581,28 @@ type AutoMergeDisabledEvent implements Node {
   Identifies the actor who performed the event.
   """
   actor: Actor
+  
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
+  
   """
   The user who disabled auto-merge for this Pull Request
   """
   disabler: User
   id: ID!
+  
   """
   PullRequest referenced by event
   """
   pullRequest: PullRequest
+  
   """
   The reason auto-merge was disabled
   """
   reason: String
+  
   """
   The reason_code relating to why auto-merge was disabled
   """
@@ -1456,15 +1617,18 @@ type AutoMergeEnabledEvent implements Node {
   Identifies the actor who performed the event.
   """
   actor: Actor
+  
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
+  
   """
   The user who enabled auto-merge for this Pull Request
   """
   enabler: User
   id: ID!
+  
   """
   PullRequest referenced by event.
   """
@@ -1479,29 +1643,35 @@ type AutoMergeRequest {
   The email address of the author of this auto-merge request.
   """
   authorEmail: String
+  
   """
   The commit message of the auto-merge request. If a merge queue is required by
   the base branch, this value will be set by the merge queue when merging.
   """
   commitBody: String
+  
   """
   The commit title of the auto-merge request. If a merge queue is required by
   the base branch, this value will be set by the merge queue when merging
   """
   commitHeadline: String
+  
   """
   When was this auto-merge request was enabled.
   """
   enabledAt: DateTime
+  
   """
   The actor who created the auto-merge request.
   """
   enabledBy: Actor
+  
   """
   The merge method of the auto-merge request. If a merge queue is required by
   the base branch, this value will be set by the merge queue when merging.
   """
   mergeMethod: PullRequestMergeMethod!
+  
   """
   The pull request that this auto-merge request is set against.
   """
@@ -1516,15 +1686,18 @@ type AutoRebaseEnabledEvent implements Node {
   Identifies the actor who performed the event.
   """
   actor: Actor
+  
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
+  
   """
   The user who enabled auto-merge (rebase) for this Pull Request
   """
   enabler: User
   id: ID!
+  
   """
   PullRequest referenced by event.
   """
@@ -1539,15 +1712,18 @@ type AutoSquashEnabledEvent implements Node {
   Identifies the actor who performed the event.
   """
   actor: Actor
+  
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
+  
   """
   The user who enabled auto-merge (squash) for this Pull Request
   """
   enabler: User
   id: ID!
+  
   """
   PullRequest referenced by event.
   """
@@ -1562,19 +1738,23 @@ type AutomaticBaseChangeFailedEvent implements Node {
   Identifies the actor who performed the event.
   """
   actor: Actor
+  
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
   id: ID!
+  
   """
   The new base for this PR
   """
   newBase: String!
+  
   """
   The old base for this PR
   """
   oldBase: String!
+  
   """
   PullRequest referenced by event.
   """
@@ -1589,19 +1769,23 @@ type AutomaticBaseChangeSucceededEvent implements Node {
   Identifies the actor who performed the event.
   """
   actor: Actor
+  
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
   id: ID!
+  
   """
   The new base for this PR
   """
   newBase: String!
+  
   """
   The old base for this PR
   """
   oldBase: String!
+  
   """
   PullRequest referenced by event.
   """
@@ -1621,23 +1805,28 @@ type BaseRefChangedEvent implements Node {
   Identifies the actor who performed the event.
   """
   actor: Actor
+  
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
+  
   """
   Identifies the name of the base ref for the pull request after it was changed.
   """
   currentRefName: String!
+  
   """
   Identifies the primary key from the database.
   """
   databaseId: Int
   id: ID!
+  
   """
   Identifies the name of the base ref for the pull request before it was changed.
   """
   previousRefName: String!
+  
   """
   PullRequest referenced by event.
   """
@@ -1652,15 +1841,18 @@ type BaseRefDeletedEvent implements Node {
   Identifies the actor who performed the event.
   """
   actor: Actor
+  
   """
   Identifies the name of the Ref associated with the `base_ref_deleted` event.
   """
   baseRefName: String
+  
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
   id: ID!
+  
   """
   PullRequest referenced by event.
   """
@@ -1675,23 +1867,28 @@ type BaseRefForcePushedEvent implements Node {
   Identifies the actor who performed the event.
   """
   actor: Actor
+  
   """
   Identifies the after commit SHA for the 'base_ref_force_pushed' event.
   """
   afterCommit: Commit
+  
   """
   Identifies the before commit SHA for the 'base_ref_force_pushed' event.
   """
   beforeCommit: Commit
+  
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
   id: ID!
+  
   """
   PullRequest referenced by event.
   """
   pullRequest: PullRequest!
+  
   """
   Identifies the fully qualified ref name for the 'base_ref_force_pushed' event.
   """
@@ -1725,14 +1922,17 @@ type BlameRange {
   range's change.
   """
   age: Int!
+  
   """
   Identifies the line author
   """
   commit: Commit!
+  
   """
   The ending line for the range
   """
   endingLine: Int!
+  
   """
   The starting line for the range
   """
@@ -1747,35 +1947,43 @@ type Blob implements GitObject & Node {
   An abbreviated version of the Git object ID
   """
   abbreviatedOid: String!
+  
   """
   Byte size of Blob object
   """
   byteSize: Int!
+  
   """
   The HTTP path for this Git object
   """
   commitResourcePath: URI!
+  
   """
   The HTTP URL for this Git object
   """
   commitUrl: URI!
   id: ID!
+  
   """
   Indicates whether the Blob is binary or text. Returns null if unable to determine the encoding.
   """
   isBinary: Boolean
+  
   """
   Indicates whether the contents is truncated
   """
   isTruncated: Boolean!
+  
   """
   The Git object ID
   """
   oid: GitObjectID!
+  
   """
   The Repository the Git object belongs to
   """
   repository: Repository!
+  
   """
   UTF8 text data or null if the Blob is binary
   """
@@ -1795,27 +2003,33 @@ type Bot implements Actor & Node & UniformResourceLocatable {
     """
     size: Int
   ): URI!
+  
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
+  
   """
   Identifies the primary key from the database.
   """
   databaseId: Int
   id: ID!
+  
   """
   The username of the actor.
   """
   login: String!
+  
   """
   The HTTP path for this bot
   """
   resourcePath: URI!
+  
   """
   Identifies the date and time when the object was last updated.
   """
   updatedAt: DateTime!
+  
   """
   The HTTP URL for this bot
   """
@@ -1835,14 +2049,17 @@ type BranchNamePatternParameters {
   How this rule will appear to users.
   """
   name: String
+  
   """
   If true, the rule will fail if the pattern matches.
   """
   negate: Boolean!
+  
   """
   The operator to use for matching.
   """
   operator: String!
+  
   """
   The pattern to match with.
   """
@@ -1857,14 +2074,17 @@ input BranchNamePatternParametersInput {
   How this rule will appear to users.
   """
   name: String
+  
   """
   If true, the rule will fail if the pattern matches.
   """
   negate: Boolean
+  
   """
   The operator to use for matching.
   """
   operator: String!
+  
   """
   The pattern to match with.
   """
@@ -1879,14 +2099,17 @@ type BranchProtectionRule implements Node {
   Can this branch be deleted.
   """
   allowsDeletions: Boolean!
+  
   """
   Are force pushes allowed on this branch.
   """
   allowsForcePushes: Boolean!
+  
   """
   Is branch creation a protected operation.
   """
   blocksCreations: Boolean!
+  
   """
   A list of conflicts matching branches protection rule and other branch protection rules
   """
@@ -1895,19 +2118,23 @@ type BranchProtectionRule implements Node {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): BranchProtectionRuleConflictConnection!
+  
   """
   A list of actors able to force push for this branch protection rule.
   """
@@ -1916,19 +2143,23 @@ type BranchProtectionRule implements Node {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): BypassForcePushAllowanceConnection!
+  
   """
   A list of actors able to bypass PRs for this branch protection rule.
   """
@@ -1937,45 +2168,55 @@ type BranchProtectionRule implements Node {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): BypassPullRequestAllowanceConnection!
+  
   """
   The actor who created this branch protection rule.
   """
   creator: Actor
+  
   """
   Identifies the primary key from the database.
   """
   databaseId: Int
+  
   """
   Will new commits pushed to matching branches dismiss pull request review approvals.
   """
   dismissesStaleReviews: Boolean!
   id: ID!
+  
   """
   Can admins overwrite branch protection.
   """
   isAdminEnforced: Boolean!
+  
   """
   Whether users can pull changes from upstream when the branch is locked. Set to
   `true` to allow fork syncing. Set to `false` to prevent fork syncing.
   """
   lockAllowsFetchAndMerge: Boolean!
+  
   """
   Whether to set the branch as read-only. If this is true, users will not be able to push to the branch.
   """
   lockBranch: Boolean!
+  
   """
   Repository refs that are protected by this rule
   """
@@ -1984,27 +2225,33 @@ type BranchProtectionRule implements Node {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Filters refs with query on name
     """
     query: String
   ): RefConnection!
+  
   """
   Identifies the protection rule pattern.
   """
   pattern: String!
+  
   """
   A list push allowances for this branch protection rule.
   """
@@ -2013,83 +2260,103 @@ type BranchProtectionRule implements Node {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): PushAllowanceConnection!
+  
   """
   The repository associated with this branch protection rule.
   """
   repository: Repository
+  
   """
   Whether the most recent push must be approved by someone other than the person who pushed it
   """
   requireLastPushApproval: Boolean!
+  
   """
   Number of approving reviews required to update matching branches.
   """
   requiredApprovingReviewCount: Int
+  
   """
   List of required deployment environments that must be deployed successfully to update matching branches
   """
   requiredDeploymentEnvironments: [String]
+  
   """
   List of required status check contexts that must pass for commits to be accepted to matching branches.
   """
   requiredStatusCheckContexts: [String]
+  
   """
   List of required status checks that must pass for commits to be accepted to matching branches.
   """
   requiredStatusChecks: [RequiredStatusCheckDescription!]
+  
   """
   Are approving reviews required to update matching branches.
   """
   requiresApprovingReviews: Boolean!
+  
   """
   Are reviews from code owners required to update matching branches.
   """
   requiresCodeOwnerReviews: Boolean!
+  
   """
   Are commits required to be signed.
   """
   requiresCommitSignatures: Boolean!
+  
   """
   Are conversations required to be resolved before merging.
   """
   requiresConversationResolution: Boolean!
+  
   """
   Does this branch require deployment to specific environments before merging
   """
   requiresDeployments: Boolean!
+  
   """
   Are merge commits prohibited from being pushed to this branch.
   """
   requiresLinearHistory: Boolean!
+  
   """
   Are status checks required to update matching branches.
   """
   requiresStatusChecks: Boolean!
+  
   """
   Are branches required to be up to date before merging.
   """
   requiresStrictStatusChecks: Boolean!
+  
   """
   Is pushing to matching branches restricted.
   """
   restrictsPushes: Boolean!
+  
   """
   Is dismissal of pull request reviews restricted.
   """
   restrictsReviewDismissals: Boolean!
+  
   """
   A list review dismissal allowances for this branch protection rule.
   """
@@ -2098,14 +2365,17 @@ type BranchProtectionRule implements Node {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
@@ -2121,10 +2391,12 @@ type BranchProtectionRuleConflict {
   Identifies the branch protection rule.
   """
   branchProtectionRule: BranchProtectionRule
+  
   """
   Identifies the conflicting branch protection rule.
   """
   conflictingBranchProtectionRule: BranchProtectionRule
+  
   """
   Identifies the branch ref that has conflicting rules
   """
@@ -2139,14 +2411,17 @@ type BranchProtectionRuleConflictConnection {
   A list of edges.
   """
   edges: [BranchProtectionRuleConflictEdge]
+  
   """
   A list of nodes.
   """
   nodes: [BranchProtectionRuleConflict]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -2161,6 +2436,7 @@ type BranchProtectionRuleConflictEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -2175,14 +2451,17 @@ type BranchProtectionRuleConnection {
   A list of edges.
   """
   edges: [BranchProtectionRuleEdge]
+  
   """
   A list of nodes.
   """
   nodes: [BranchProtectionRule]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -2197,6 +2476,7 @@ type BranchProtectionRuleEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -2212,6 +2492,7 @@ input BulkSponsorship {
   The amount to pay to the sponsorable in US dollars. Valid values: 1-12000.
   """
   amount: Int!
+  
   """
   The ID of the user or organization who is receiving the sponsorship. Required if sponsorableLogin is not given.
   """
@@ -2220,6 +2501,7 @@ input BulkSponsorship {
       concreteTypes: ["Organization", "User"]
       abstractType: "Sponsorable"
     )
+  
   """
   The username of the user or organization who is receiving the sponsorship. Required if sponsorableId is not given.
   """
@@ -2239,6 +2521,7 @@ type BypassForcePushAllowance implements Node {
   The actor that can force push.
   """
   actor: BranchActorAllowanceActor
+  
   """
   Identifies the branch protection rule associated with the allowed user, team, or app.
   """
@@ -2254,14 +2537,17 @@ type BypassForcePushAllowanceConnection {
   A list of edges.
   """
   edges: [BypassForcePushAllowanceEdge]
+  
   """
   A list of nodes.
   """
   nodes: [BypassForcePushAllowance]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -2276,6 +2562,7 @@ type BypassForcePushAllowanceEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -2290,6 +2577,7 @@ type BypassPullRequestAllowance implements Node {
   The actor that can bypass.
   """
   actor: BranchActorAllowanceActor
+  
   """
   Identifies the branch protection rule associated with the allowed user, team, or app.
   """
@@ -2305,14 +2593,17 @@ type BypassPullRequestAllowanceConnection {
   A list of edges.
   """
   edges: [BypassPullRequestAllowanceEdge]
+  
   """
   A list of nodes.
   """
   nodes: [BypassPullRequestAllowance]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -2327,6 +2618,7 @@ type BypassPullRequestAllowanceEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -2341,6 +2633,7 @@ type CVSS {
   The CVSS score associated with this advisory
   """
   score: Float!
+  
   """
   The CVSS vector string associated with this advisory
   """
@@ -2355,11 +2648,13 @@ type CWE implements Node {
   The id of the CWE
   """
   cweId: String!
+  
   """
   A detailed description of this CWE
   """
   description: String!
   id: ID!
+  
   """
   The name of this CWE
   """
@@ -2374,14 +2669,17 @@ type CWEConnection {
   A list of edges.
   """
   edges: [CWEEdge]
+  
   """
   A list of nodes.
   """
   nodes: [CWE]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -2396,6 +2694,7 @@ type CWEEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -2410,6 +2709,7 @@ input CancelEnterpriseAdminInvitationInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The Node ID of the pending enterprise administrator invitation.
   """
@@ -2425,10 +2725,12 @@ type CancelEnterpriseAdminInvitationPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The invitation that was canceled.
   """
   invitation: EnterpriseAdministratorInvitation
+  
   """
   A message confirming the result of canceling an administrator invitation.
   """
@@ -2443,6 +2745,7 @@ input CancelSponsorshipInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The ID of the user or organization who is acting as the sponsor, paying for
   the sponsorship. Required if sponsorLogin is not given.
@@ -2452,11 +2755,13 @@ input CancelSponsorshipInput {
       concreteTypes: ["Organization", "User"]
       abstractType: "Sponsor"
     )
+  
   """
   The username of the user or organization who is acting as the sponsor, paying
   for the sponsorship. Required if sponsorId is not given.
   """
   sponsorLogin: String
+  
   """
   The ID of the user or organization who is receiving the sponsorship. Required if sponsorableLogin is not given.
   """
@@ -2465,6 +2770,7 @@ input CancelSponsorshipInput {
       concreteTypes: ["Organization", "User"]
       abstractType: "Sponsorable"
     )
+  
   """
   The username of the user or organization who is receiving the sponsorship. Required if sponsorableId is not given.
   """
@@ -2479,6 +2785,7 @@ type CancelSponsorshipPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The tier that was being used at the time of cancellation.
   """
@@ -2493,22 +2800,27 @@ input ChangeUserStatusInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The emoji to represent your status. Can either be a native Unicode emoji or an emoji name with colons, e.g., :grinning:.
   """
   emoji: String
+  
   """
   If set, the user status will not be shown after this date.
   """
   expiresAt: DateTime
+  
   """
   Whether this status should indicate you are not fully available on GitHub, e.g., you are away.
   """
   limitedAvailability: Boolean = false
+  
   """
   A short description of your current status.
   """
   message: String
+  
   """
   The ID of the organization whose members will be allowed to see the status. If
   omitted, the status will be publicly visible.
@@ -2524,6 +2836,7 @@ type ChangeUserStatusPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   Your updated status.
   """
@@ -2538,30 +2851,37 @@ type CheckAnnotation {
   The annotation's severity level.
   """
   annotationLevel: CheckAnnotationLevel
+  
   """
   The path to the file that this annotation was made on.
   """
   blobUrl: URI!
+  
   """
   Identifies the primary key from the database.
   """
   databaseId: Int
+  
   """
   The position of this annotation.
   """
   location: CheckAnnotationSpan!
+  
   """
   The annotation's message.
   """
   message: String!
+  
   """
   The path that this annotation was made on.
   """
   path: String!
+  
   """
   Additional information about the annotation.
   """
   rawDetails: String
+  
   """
   The annotation's title
   """
@@ -2576,14 +2896,17 @@ type CheckAnnotationConnection {
   A list of edges.
   """
   edges: [CheckAnnotationEdge]
+  
   """
   A list of nodes.
   """
   nodes: [CheckAnnotation]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -2598,22 +2921,27 @@ input CheckAnnotationData {
   Represents an annotation's information level
   """
   annotationLevel: CheckAnnotationLevel!
+  
   """
   The location of the annotation
   """
   location: CheckAnnotationRange!
+  
   """
   A short description of the feedback for these lines of code.
   """
   message: String!
+  
   """
   The path of the file to add an annotation to.
   """
   path: String!
+  
   """
   Details about this annotation.
   """
   rawDetails: String
+  
   """
   The title that represents the annotation.
   """
@@ -2628,6 +2956,7 @@ type CheckAnnotationEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -2660,6 +2989,7 @@ type CheckAnnotationPosition {
   Column number (1 indexed).
   """
   column: Int
+  
   """
   Line number (1 indexed).
   """
@@ -2674,14 +3004,17 @@ input CheckAnnotationRange {
   The ending column of the range.
   """
   endColumn: Int
+  
   """
   The ending line of the range.
   """
   endLine: Int!
+  
   """
   The starting column of the range.
   """
   startColumn: Int
+  
   """
   The starting line of the range.
   """
@@ -2696,6 +3029,7 @@ type CheckAnnotationSpan {
   End position (inclusive).
   """
   end: CheckAnnotationPosition!
+  
   """
   Start position (inclusive).
   """
@@ -2756,48 +3090,59 @@ type CheckRun implements Node & RequirableByPullRequest & UniformResourceLocatab
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): CheckAnnotationConnection
+  
   """
   The check suite that this run is a part of.
   """
   checkSuite: CheckSuite!
+  
   """
   Identifies the date and time when the check run was completed.
   """
   completedAt: DateTime
+  
   """
   The conclusion of the check run.
   """
   conclusion: CheckConclusionState
+  
   """
   Identifies the primary key from the database.
   """
   databaseId: Int
+  
   """
   The corresponding deployment for this job, if any
   """
   deployment: Deployment
+  
   """
   The URL from which to find full details of the check run on the integrator's site.
   """
   detailsUrl: URI
+  
   """
   A reference for the check run on the integrator's system.
   """
   externalId: String
   id: ID!
+  
   """
   Whether this is required to pass before merging for a specific pull request.
   """
@@ -2806,39 +3151,48 @@ type CheckRun implements Node & RequirableByPullRequest & UniformResourceLocatab
     The id of the pull request this is required for
     """
     pullRequestId: ID
+    
     """
     The number of the pull request this is required for
     """
     pullRequestNumber: Int
   ): Boolean!
+  
   """
   The name of the check for this check run.
   """
   name: String!
+  
   """
   Information about a pending deployment, if any, in this check run
   """
   pendingDeploymentRequest: DeploymentRequest
+  
   """
   The permalink to the check run summary.
   """
   permalink: URI!
+  
   """
   The repository associated with this check run.
   """
   repository: Repository!
+  
   """
   The HTTP path for this check run.
   """
   resourcePath: URI!
+  
   """
   Identifies the date and time when the check run was started.
   """
   startedAt: DateTime
+  
   """
   The current status of the check run.
   """
   status: CheckStatusState!
+  
   """
   The check run's steps
   """
@@ -2847,35 +3201,43 @@ type CheckRun implements Node & RequirableByPullRequest & UniformResourceLocatab
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Step number
     """
     number: Int
   ): CheckStepConnection
+  
   """
   A string representing the check run's summary
   """
   summary: String
+  
   """
   A string representing the check run's text
   """
   text: String
+  
   """
   A string representing the check run
   """
   title: String
+  
   """
   The HTTP URL for this check run.
   """
@@ -2890,10 +3252,12 @@ input CheckRunAction {
   A short explanation of what this action would do.
   """
   description: String!
+  
   """
   A reference for the action on the integrator's system.
   """
   identifier: String!
+  
   """
   The text to be displayed on a button in the web UI.
   """
@@ -2908,14 +3272,17 @@ type CheckRunConnection {
   A list of edges.
   """
   edges: [CheckRunEdge]
+  
   """
   A list of nodes.
   """
   nodes: [CheckRun]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -2930,6 +3297,7 @@ type CheckRunEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -2944,22 +3312,27 @@ input CheckRunFilter {
   Filters the check runs created by this application ID.
   """
   appId: Int
+  
   """
   Filters the check runs by this name.
   """
   checkName: String
+  
   """
   Filters the check runs by this type.
   """
   checkType: CheckRunType
+  
   """
   Filters the check runs by these conclusions.
   """
   conclusions: [CheckConclusionState!]
+  
   """
   Filters the check runs by this status. Superceded by statuses.
   """
   status: CheckStatusState
+  
   """
   Filters the check runs by this status. Overrides status.
   """
@@ -2974,18 +3347,22 @@ input CheckRunOutput {
   The annotations that are made as part of the check run.
   """
   annotations: [CheckAnnotationData!]
+  
   """
   Images attached to the check run output displayed in the GitHub pull request UI.
   """
   images: [CheckRunOutputImage!]
+  
   """
   The summary of the check run (supports Commonmark).
   """
   summary: String!
+  
   """
   The details of the check run (supports Commonmark).
   """
   text: String
+  
   """
   A title to provide for this check run.
   """
@@ -3000,10 +3377,12 @@ input CheckRunOutputImage {
   The alternative text for the image.
   """
   alt: String!
+  
   """
   A short image description.
   """
   caption: String
+  
   """
   The full URL of the image.
   """
@@ -3080,6 +3459,7 @@ type CheckRunStateCount {
   The number of check runs with this state.
   """
   count: Int!
+  
   """
   The state of a check run.
   """
@@ -3138,30 +3518,37 @@ type CheckStep {
   Identifies the date and time when the check step was completed.
   """
   completedAt: DateTime
+  
   """
   The conclusion of the check step.
   """
   conclusion: CheckConclusionState
+  
   """
   A reference for the check step on the integrator's system.
   """
   externalId: String
+  
   """
   The step's name.
   """
   name: String!
+  
   """
   The index of the step in the list of steps of the parent check run.
   """
   number: Int!
+  
   """
   Number of seconds to completion.
   """
   secondsToCompletion: Int
+  
   """
   Identifies the date and time when the check step was started.
   """
   startedAt: DateTime
+  
   """
   The current status of the check step.
   """
@@ -3176,14 +3563,17 @@ type CheckStepConnection {
   A list of edges.
   """
   edges: [CheckStepEdge]
+  
   """
   A list of nodes.
   """
   nodes: [CheckStep]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -3198,6 +3588,7 @@ type CheckStepEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -3212,10 +3603,12 @@ type CheckSuite implements Node {
   The GitHub App which created this check suite.
   """
   app: App
+  
   """
   The name of the branch for this check suite.
   """
   branch: Ref
+  
   """
   The check runs associated with a check suite.
   """
@@ -3224,44 +3617,54 @@ type CheckSuite implements Node {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Filters the check runs by this type.
     """
     filterBy: CheckRunFilter
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): CheckRunConnection
+  
   """
   The commit for this check suite
   """
   commit: Commit!
+  
   """
   The conclusion of this check suite.
   """
   conclusion: CheckConclusionState
+  
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
+  
   """
   The user who triggered the check suite.
   """
   creator: User
+  
   """
   Identifies the primary key from the database.
   """
   databaseId: Int
   id: ID!
+  
   """
   A list of open pull requests matching the check suite.
   """
@@ -3270,63 +3673,78 @@ type CheckSuite implements Node {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     The base ref name to filter the pull requests by.
     """
     baseRefName: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     The head ref name to filter the pull requests by.
     """
     headRefName: String
+    
     """
     A list of label names to filter the pull requests by.
     """
     labels: [String!]
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for pull requests returned from the connection.
     """
     orderBy: IssueOrder
+    
     """
     A list of states to filter the pull requests by.
     """
     states: [PullRequestState!]
   ): PullRequestConnection
+  
   """
   The push that triggered this check suite.
   """
   push: Push
+  
   """
   The repository associated with this check suite.
   """
   repository: Repository!
+  
   """
   The HTTP path for this check suite
   """
   resourcePath: URI!
+  
   """
   The status of this check suite.
   """
   status: CheckStatusState!
+  
   """
   Identifies the date and time when the object was last updated.
   """
   updatedAt: DateTime!
+  
   """
   The HTTP URL for this check suite
   """
   url: URI!
+  
   """
   The workflow run associated with this check suite.
   """
@@ -3341,6 +3759,7 @@ input CheckSuiteAutoTriggerPreference {
   The node ID of the application that owns the check suite.
   """
   appId: ID!
+  
   """
   Set to `true` to enable automatic creation of CheckSuite events upon pushes to the repository.
   """
@@ -3355,14 +3774,17 @@ type CheckSuiteConnection {
   A list of edges.
   """
   edges: [CheckSuiteEdge]
+  
   """
   A list of nodes.
   """
   nodes: [CheckSuite]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -3377,6 +3799,7 @@ type CheckSuiteEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -3391,6 +3814,7 @@ input CheckSuiteFilter {
   Filters the check suites created by this application ID.
   """
   appId: Int
+  
   """
   Filters the check suites by this name.
   """
@@ -3410,6 +3834,7 @@ input ClearLabelsFromLabelableInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The id of the labelable object to clear the labels from.
   """
@@ -3428,6 +3853,7 @@ type ClearLabelsFromLabelablePayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The item that was unlabeled.
   """
@@ -3442,6 +3868,7 @@ input ClearProjectV2ItemFieldValueInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The ID of the field to be cleared.
   """
@@ -3454,10 +3881,12 @@ input ClearProjectV2ItemFieldValueInput {
       ]
       abstractType: "ProjectV2FieldConfiguration"
     )
+  
   """
   The ID of the item to be cleared.
   """
   itemId: ID! @possibleTypes(concreteTypes: ["ProjectV2Item"])
+  
   """
   The ID of the Project.
   """
@@ -3472,6 +3901,7 @@ type ClearProjectV2ItemFieldValuePayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The updated item.
   """
@@ -3486,26 +3916,32 @@ input CloneProjectInput {
   The description of the project.
   """
   body: String
+  
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   Whether or not to clone the source project's workflows.
   """
   includeWorkflows: Boolean!
+  
   """
   The name of the project.
   """
   name: String!
+  
   """
   The visibility of the project, defaults to false (private).
   """
   public: Boolean
+  
   """
   The source project to clone.
   """
   sourceId: ID! @possibleTypes(concreteTypes: ["Project"])
+  
   """
   The owner ID to create the project under.
   """
@@ -3524,10 +3960,12 @@ type CloneProjectPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The id of the JobStatus for populating cloned fields.
   """
   jobStatusId: String
+  
   """
   The new cloned project.
   """
@@ -3542,19 +3980,23 @@ input CloneTemplateRepositoryInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   A short description of the new repository.
   """
   description: String
+  
   """
   Whether to copy all branches from the template to the new repository. Defaults
   to copying only the default branch of the template.
   """
   includeAllBranches: Boolean = false
+  
   """
   The name of the new repository.
   """
   name: String!
+  
   """
   The ID of the owner for the new repository.
   """
@@ -3563,10 +4005,12 @@ input CloneTemplateRepositoryInput {
       concreteTypes: ["Organization", "User"]
       abstractType: "RepositoryOwner"
     )
+  
   """
   The Node ID of the template repository.
   """
   repositoryId: ID! @possibleTypes(concreteTypes: ["Repository"])
+  
   """
   Indicates the repository's visibility level.
   """
@@ -3581,6 +4025,7 @@ type CloneTemplateRepositoryPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The new repository.
   """
@@ -3595,14 +4040,17 @@ interface Closable {
   Indicates if the object is closed (definition of closed may depend on type)
   """
   closed: Boolean!
+  
   """
   Identifies the date and time when the object was closed.
   """
   closedAt: DateTime
+  
   """
   Indicates if the object can be closed by the viewer.
   """
   viewerCanClose: Boolean!
+  
   """
   Indicates if the object can be reopened by the viewer.
   """
@@ -3617,10 +4065,12 @@ input CloseDiscussionInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   ID of the discussion to be closed.
   """
   discussionId: ID! @possibleTypes(concreteTypes: ["Discussion"])
+  
   """
   The reason why the discussion is being closed.
   """
@@ -3635,6 +4085,7 @@ type CloseDiscussionPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The discussion that was closed.
   """
@@ -3649,10 +4100,12 @@ input CloseIssueInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   ID of the issue to be closed.
   """
   issueId: ID! @possibleTypes(concreteTypes: ["Issue"])
+  
   """
   The reason the issue is to be closed.
   """
@@ -3667,6 +4120,7 @@ type CloseIssuePayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The issue that was closed.
   """
@@ -3681,6 +4135,7 @@ input ClosePullRequestInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   ID of the pull request to be closed.
   """
@@ -3695,6 +4150,7 @@ type ClosePullRequestPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The pull request that was closed.
   """
@@ -3709,27 +4165,33 @@ type ClosedEvent implements Node & UniformResourceLocatable {
   Identifies the actor who performed the event.
   """
   actor: Actor
+  
   """
   Object that was closed.
   """
   closable: Closable!
+  
   """
   Object which triggered the creation of this event.
   """
   closer: Closer
+  
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
   id: ID!
+  
   """
   The HTTP path for this closed event.
   """
   resourcePath: URI!
+  
   """
   The reason the issue state was changed to closed.
   """
   stateReason: IssueStateReason
+  
   """
   The HTTP URL for this closed event.
   """
@@ -3750,18 +4212,22 @@ type CodeOfConduct implements Node {
   """
   body: String
   id: ID!
+  
   """
   The key for the Code of Conduct
   """
   key: String!
+  
   """
   The formal name of the Code of Conduct
   """
   name: String!
+  
   """
   The HTTP path for this Code of Conduct
   """
   resourcePath: URI
+  
   """
   The HTTP URL for this Code of Conduct
   """
@@ -3794,51 +4260,63 @@ interface Comment {
   The actor who authored the comment.
   """
   author: Actor
+  
   """
   Author's association with the subject of the comment.
   """
   authorAssociation: CommentAuthorAssociation!
+  
   """
   The body as Markdown.
   """
   body: String!
+  
   """
   The body rendered to HTML.
   """
   bodyHTML: HTML!
+  
   """
   The body rendered to text.
   """
   bodyText: String!
+  
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
+  
   """
   Check if this comment was created via an email reply.
   """
   createdViaEmail: Boolean!
+  
   """
   The actor who edited the comment.
   """
   editor: Actor
   id: ID!
+  
   """
   Check if this comment was edited and includes an edit with the creation data
   """
   includesCreatedEdit: Boolean!
+  
   """
   The moment the editor made the last edit
   """
   lastEditedAt: DateTime
+  
   """
   Identifies when the comment was published at.
   """
   publishedAt: DateTime
+  
   """
   Identifies the date and time when the object was last updated.
   """
   updatedAt: DateTime!
+  
   """
   A list of edits to this content.
   """
@@ -3847,19 +4325,23 @@ interface Comment {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): UserContentEditConnection
+  
   """
   Did the viewer author this comment.
   """
@@ -3946,14 +4428,17 @@ type CommentDeletedEvent implements Node {
   Identifies the actor who performed the event.
   """
   actor: Actor
+  
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
+  
   """
   Identifies the primary key from the database.
   """
   databaseId: Int
+  
   """
   The user who authored the deleted comment.
   """
@@ -3969,10 +4454,12 @@ type Commit implements GitObject & Node & Subscribable & UniformResourceLocatabl
   An abbreviated version of the Git object ID
   """
   abbreviatedOid: String!
+  
   """
   The number of additions in this commit.
   """
   additions: Int!
+  
   """
   The merged Pull Request that introduced the commit to the repository. If the
   commit is not present in the default branch, additionally returns open Pull
@@ -3983,35 +4470,43 @@ type Commit implements GitObject & Node & Subscribable & UniformResourceLocatabl
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for pull requests.
     """
     orderBy: PullRequestOrder = { field: CREATED_AT, direction: ASC }
   ): PullRequestConnection
+  
   """
   Authorship details of the commit.
   """
   author: GitActor
+  
   """
   Check if the committer and the author match.
   """
   authoredByCommitter: Boolean!
+  
   """
   The datetime when this commit was authored.
   """
   authoredDate: DateTime!
+  
   """
   The list of authors for this commit based on the git author and the Co-authored-by
   message trailer. The git author will always be first.
@@ -4021,19 +4516,23 @@ type Commit implements GitObject & Node & Subscribable & UniformResourceLocatabl
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): GitActorConnection!
+  
   """
   Fetches `git blame` information.
   """
@@ -4043,6 +4542,7 @@ type Commit implements GitObject & Node & Subscribable & UniformResourceLocatabl
     """
     path: String!
   ): Blame!
+  
   """
   We recommend using the `changedFilesIfAvailable` field instead of
   `changedFiles`, as `changedFiles` will cause your request to return an error
@@ -4052,12 +4552,14 @@ type Commit implements GitObject & Node & Subscribable & UniformResourceLocatabl
     @deprecated(
       reason: "`changedFiles` will be removed. Use `changedFilesIfAvailable` instead. Removal on 2023-01-01 UTC."
     )
+  
   """
   The number of changed files in this commit. If GitHub is unable to calculate
   the number of changed files (for example due to a timeout), this will return
   `null`. We recommend using this field instead of `changedFiles`.
   """
   changedFilesIfAvailable: Int
+  
   """
   The check suites associated with a commit.
   """
@@ -4066,23 +4568,28 @@ type Commit implements GitObject & Node & Subscribable & UniformResourceLocatabl
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Filters the check suites by this type.
     """
     filterBy: CheckSuiteFilter
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): CheckSuiteConnection
+  
   """
   Comments made on the commit.
   """
@@ -4091,43 +4598,53 @@ type Commit implements GitObject & Node & Subscribable & UniformResourceLocatabl
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): CommitCommentConnection!
+  
   """
   The HTTP path for this Git object
   """
   commitResourcePath: URI!
+  
   """
   The HTTP URL for this Git object
   """
   commitUrl: URI!
+  
   """
   The datetime when this commit was committed.
   """
   committedDate: DateTime!
+  
   """
   Check if committed via GitHub web UI.
   """
   committedViaWeb: Boolean!
+  
   """
   Committer details of the commit.
   """
   committer: GitActor
+  
   """
   The number of deletions in this commit.
   """
   deletions: Int!
+  
   """
   The deployments associated with a commit.
   """
@@ -4136,27 +4653,33 @@ type Commit implements GitObject & Node & Subscribable & UniformResourceLocatabl
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Environments to list deployments for
     """
     environments: [String!]
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for deployments returned from the connection.
     """
     orderBy: DeploymentOrder = { field: CREATED_AT, direction: ASC }
   ): DeploymentConnection
+  
   """
   The tree entry representing the file located at the given path.
   """
@@ -4166,6 +4689,7 @@ type Commit implements GitObject & Node & Subscribable & UniformResourceLocatabl
     """
     path: String!
   ): TreeEntry
+  
   """
   The linear commit history starting from (and including) this commit, in the same order as `git log`.
   """
@@ -4174,64 +4698,79 @@ type Commit implements GitObject & Node & Subscribable & UniformResourceLocatabl
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     If non-null, filters history to only show commits with matching authorship.
     """
     author: CommitAuthor
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     If non-null, filters history to only show commits touching files under this path.
     """
     path: String
+    
     """
     Allows specifying a beginning time or date for fetching commits.
     """
     since: GitTimestamp
+    
     """
     Allows specifying an ending time or date for fetching commits.
     """
     until: GitTimestamp
   ): CommitHistoryConnection!
   id: ID!
+  
   """
   The Git commit message
   """
   message: String!
+  
   """
   The Git commit message body
   """
   messageBody: String!
+  
   """
   The commit message body rendered to HTML.
   """
   messageBodyHTML: HTML!
+  
   """
   The Git commit message headline
   """
   messageHeadline: String!
+  
   """
   The commit message headline rendered to HTML.
   """
   messageHeadlineHTML: HTML!
+  
   """
   The Git object ID
   """
   oid: GitObjectID!
+  
   """
   The organization this commit was made on behalf of.
   """
   onBehalfOf: Organization
+  
   """
   The parents of a commit.
   """
@@ -4240,19 +4779,23 @@ type Commit implements GitObject & Node & Subscribable & UniformResourceLocatabl
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): CommitConnection!
+  
   """
   The datetime when this commit was pushed.
   """
@@ -4260,26 +4803,32 @@ type Commit implements GitObject & Node & Subscribable & UniformResourceLocatabl
     @deprecated(
       reason: "`pushedDate` is no longer supported. Removal on 2023-07-01 UTC."
     )
+  
   """
   The Repository this commit belongs to
   """
   repository: Repository!
+  
   """
   The HTTP path for this commit
   """
   resourcePath: URI!
+  
   """
   Commit signing information, if present.
   """
   signature: GitSignature
+  
   """
   Status information for this commit
   """
   status: Status
+  
   """
   Check and Status rollup information for this commit.
   """
   statusCheckRollup: StatusCheckRollup
+  
   """
   Returns a list of all submodules in this repository as of this Commit parsed from the .gitmodules file.
   """
@@ -4288,48 +4837,59 @@ type Commit implements GitObject & Node & Subscribable & UniformResourceLocatabl
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): SubmoduleConnection!
+  
   """
   Returns a URL to download a tarball archive for a repository.
   Note: For private repositories, these links are temporary and expire after five minutes.
   """
   tarballUrl: URI!
+  
   """
   Commit's root Tree
   """
   tree: Tree!
+  
   """
   The HTTP path for the tree of this commit
   """
   treeResourcePath: URI!
+  
   """
   The HTTP URL for the tree of this commit
   """
   treeUrl: URI!
+  
   """
   The HTTP URL for this commit
   """
   url: URI!
+  
   """
   Check if the viewer is able to change their subscription status for the repository.
   """
   viewerCanSubscribe: Boolean!
+  
   """
   Identifies if the viewer is watching, not watching, or ignoring the subscribable entity.
   """
   viewerSubscription: SubscriptionState
+  
   """
   Returns a URL to download a zipball archive for a repository.
   Note: For private repositories, these links are temporary and expire after five minutes.
@@ -4345,6 +4905,7 @@ input CommitAuthor {
   Email addresses to filter by. Commits authored by any of the specified email addresses will be returned.
   """
   emails: [String!]
+  
   """
   ID of a User to filter by. If non-null, only commits authored by this user
   will be returned. This field takes precedence over emails.
@@ -4360,14 +4921,17 @@ type CommitAuthorEmailPatternParameters {
   How this rule will appear to users.
   """
   name: String
+  
   """
   If true, the rule will fail if the pattern matches.
   """
   negate: Boolean!
+  
   """
   The operator to use for matching.
   """
   operator: String!
+  
   """
   The pattern to match with.
   """
@@ -4382,14 +4946,17 @@ input CommitAuthorEmailPatternParametersInput {
   How this rule will appear to users.
   """
   name: String
+  
   """
   If true, the rule will fail if the pattern matches.
   """
   negate: Boolean
+  
   """
   The operator to use for matching.
   """
   operator: String!
+  
   """
   The pattern to match with.
   """
@@ -4404,77 +4971,95 @@ type CommitComment implements Comment & Deletable & Minimizable & Node & Reactab
   The actor who authored the comment.
   """
   author: Actor
+  
   """
   Author's association with the subject of the comment.
   """
   authorAssociation: CommentAuthorAssociation!
+  
   """
   Identifies the comment body.
   """
   body: String!
+  
   """
   The body rendered to HTML.
   """
   bodyHTML: HTML!
+  
   """
   The body rendered to text.
   """
   bodyText: String!
+  
   """
   Identifies the commit associated with the comment, if the commit exists.
   """
   commit: Commit
+  
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
+  
   """
   Check if this comment was created via an email reply.
   """
   createdViaEmail: Boolean!
+  
   """
   Identifies the primary key from the database.
   """
   databaseId: Int
+  
   """
   The actor who edited the comment.
   """
   editor: Actor
   id: ID!
+  
   """
   Check if this comment was edited and includes an edit with the creation data
   """
   includesCreatedEdit: Boolean!
+  
   """
   Returns whether or not a comment has been minimized.
   """
   isMinimized: Boolean!
+  
   """
   The moment the editor made the last edit
   """
   lastEditedAt: DateTime
+  
   """
   Returns why the comment was minimized. One of `abuse`, `off-topic`,
   `outdated`, `resolved`, `duplicate` and `spam`. Note that the case and
   formatting of these values differs from the inputs to the `MinimizeComment` mutation.
   """
   minimizedReason: String
+  
   """
   Identifies the file path associated with the comment.
   """
   path: String
+  
   """
   Identifies the line position associated with the comment.
   """
   position: Int
+  
   """
   Identifies when the comment was published at.
   """
   publishedAt: DateTime
+  
   """
   A list of reactions grouped by content left on the subject.
   """
   reactionGroups: [ReactionGroup!]
+  
   """
   A list of Reactions left on the Issue.
   """
@@ -4483,43 +5068,53 @@ type CommitComment implements Comment & Deletable & Minimizable & Node & Reactab
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Allows filtering Reactions by emoji.
     """
     content: ReactionContent
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Allows specifying the order in which reactions are returned.
     """
     orderBy: ReactionOrder
   ): ReactionConnection!
+  
   """
   The repository associated with this node.
   """
   repository: Repository!
+  
   """
   The HTTP path permalink for this commit comment.
   """
   resourcePath: URI!
+  
   """
   Identifies the date and time when the object was last updated.
   """
   updatedAt: DateTime!
+  
   """
   The HTTP URL permalink for this commit comment.
   """
   url: URI!
+  
   """
   A list of edits to this content.
   """
@@ -4528,39 +5123,48 @@ type CommitComment implements Comment & Deletable & Minimizable & Node & Reactab
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): UserContentEditConnection
+  
   """
   Check if the current viewer can delete this object.
   """
   viewerCanDelete: Boolean!
+  
   """
   Check if the current viewer can minimize this object.
   """
   viewerCanMinimize: Boolean!
+  
   """
   Can user react to this subject
   """
   viewerCanReact: Boolean!
+  
   """
   Check if the current viewer can update this object.
   """
   viewerCanUpdate: Boolean!
+  
   """
   Reasons why the current viewer can not update this comment.
   """
   viewerCannotUpdateReasons: [CommentCannotUpdateReason!]!
+  
   """
   Did the viewer author this comment.
   """
@@ -4575,14 +5179,17 @@ type CommitCommentConnection {
   A list of edges.
   """
   edges: [CommitCommentEdge]
+  
   """
   A list of nodes.
   """
   nodes: [CommitComment]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -4597,6 +5204,7 @@ type CommitCommentEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -4615,32 +5223,39 @@ type CommitCommentThread implements Node & RepositoryNode {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): CommitCommentConnection!
+  
   """
   The commit the comments were made on.
   """
   commit: Commit
   id: ID!
+  
   """
   The file the comments were made on.
   """
   path: String
+  
   """
   The position in the diff for the commit that the comment was made on.
   """
   position: Int
+  
   """
   The repository associated with this node.
   """
@@ -4655,14 +5270,17 @@ type CommitConnection {
   A list of edges.
   """
   edges: [CommitEdge]
+  
   """
   A list of nodes.
   """
   nodes: [Commit]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -4677,6 +5295,7 @@ input CommitContributionOrder {
   The ordering direction.
   """
   direction: OrderDirection!
+  
   """
   The field by which to order commit contributions.
   """
@@ -4709,31 +5328,38 @@ type CommitContributionsByRepository {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for commit contributions returned from the connection.
     """
     orderBy: CommitContributionOrder = { field: OCCURRED_AT, direction: DESC }
   ): CreatedCommitContributionConnection!
+  
   """
   The repository in which the commits were made.
   """
   repository: Repository!
+  
   """
   The HTTP path for the user's commits to the repository in this time range.
   """
   resourcePath: URI!
+  
   """
   The HTTP URL for the user's commits to the repository in this time range.
   """
@@ -4748,6 +5374,7 @@ type CommitEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -4762,14 +5389,17 @@ type CommitHistoryConnection {
   A list of edges.
   """
   edges: [CommitEdge]
+  
   """
   A list of nodes.
   """
   nodes: [Commit]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -4784,6 +5414,7 @@ input CommitMessage {
   The body of the message.
   """
   body: String
+  
   """
   The headline of the message.
   """
@@ -4798,14 +5429,17 @@ type CommitMessagePatternParameters {
   How this rule will appear to users.
   """
   name: String
+  
   """
   If true, the rule will fail if the pattern matches.
   """
   negate: Boolean!
+  
   """
   The operator to use for matching.
   """
   operator: String!
+  
   """
   The pattern to match with.
   """
@@ -4820,14 +5454,17 @@ input CommitMessagePatternParametersInput {
   How this rule will appear to users.
   """
   name: String
+  
   """
   If true, the rule will fail if the pattern matches.
   """
   negate: Boolean
+  
   """
   The operator to use for matching.
   """
   operator: String!
+  
   """
   The pattern to match with.
   """
@@ -4862,10 +5499,12 @@ input CommittableBranch {
   The unqualified name of the branch to append the commit to.
   """
   branchName: String
+  
   """
   The Node ID of the Ref to be updated.
   """
   id: ID
+  
   """
   The nameWithOwner of the repository to commit to.
   """
@@ -4880,14 +5519,17 @@ type CommitterEmailPatternParameters {
   How this rule will appear to users.
   """
   name: String
+  
   """
   If true, the rule will fail if the pattern matches.
   """
   negate: Boolean!
+  
   """
   The operator to use for matching.
   """
   operator: String!
+  
   """
   The pattern to match with.
   """
@@ -4902,14 +5544,17 @@ input CommitterEmailPatternParametersInput {
   How this rule will appear to users.
   """
   name: String
+  
   """
   If true, the rule will fail if the pattern matches.
   """
   negate: Boolean
+  
   """
   The operator to use for matching.
   """
   operator: String!
+  
   """
   The pattern to match with.
   """
@@ -4924,14 +5569,17 @@ type Comparison implements Node {
   The number of commits ahead of the base branch.
   """
   aheadBy: Int!
+  
   """
   The base revision of this comparison.
   """
   baseTarget: GitObject!
+  
   """
   The number of commits behind the base branch.
   """
   behindBy: Int!
+  
   """
   The commits which compose this comparison.
   """
@@ -4940,24 +5588,29 @@ type Comparison implements Node {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): ComparisonCommitConnection!
+  
   """
   The head revision of this comparison.
   """
   headTarget: GitObject!
   id: ID!
+  
   """
   The status of this comparison.
   """
@@ -4972,18 +5625,22 @@ type ComparisonCommitConnection {
   The total count of authors and co-authors across all commits.
   """
   authorCount: Int!
+  
   """
   A list of edges.
   """
   edges: [CommitEdge]
+  
   """
   A list of nodes.
   """
   nodes: [Commit]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -5020,19 +5677,23 @@ type ConnectedEvent implements Node {
   Identifies the actor who performed the event.
   """
   actor: Actor
+  
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
   id: ID!
+  
   """
   Reference originated in a different repository.
   """
   isCrossRepository: Boolean!
+  
   """
   Issue or pull request that made the reference.
   """
   source: ReferencedSubject!
+  
   """
   Issue or pull request which was connected.
   """
@@ -5047,10 +5708,12 @@ type ContributingGuidelines {
   The body of the Contributing Guidelines.
   """
   body: String
+  
   """
   The HTTP path for the Contributing Guidelines.
   """
   resourcePath: URI
+  
   """
   The HTTP URL for the Contributing Guidelines.
   """
@@ -5067,18 +5730,22 @@ interface Contribution {
   longer access.
   """
   isRestricted: Boolean!
+  
   """
   When this contribution was made.
   """
   occurredAt: DateTime!
+  
   """
   The HTTP path for this contribution.
   """
   resourcePath: URI!
+  
   """
   The HTTP URL for this contribution.
   """
   url: URI!
+  
   """
   The user who made this contribution.
   """
@@ -5093,18 +5760,22 @@ type ContributionCalendar {
   A list of hex color codes used in this calendar. The darker the color, the more contributions it represents.
   """
   colors: [String!]!
+  
   """
   Determine if the color set was chosen because it's currently Halloween.
   """
   isHalloween: Boolean!
+  
   """
   A list of the months of contributions in this calendar.
   """
   months: [ContributionCalendarMonth!]!
+  
   """
   The count of total contributions in the calendar.
   """
   totalContributions: Int!
+  
   """
   A list of the weeks of contributions in this calendar.
   """
@@ -5119,19 +5790,23 @@ type ContributionCalendarDay {
   The hex color code that represents how many contributions were made on this day compared to others in the calendar.
   """
   color: String!
+  
   """
   How many contributions were made by the user on this day.
   """
   contributionCount: Int!
+  
   """
   Indication of contributions, relative to other days. Can be used to indicate
   which color to represent this day on a calendar.
   """
   contributionLevel: ContributionLevel!
+  
   """
   The day this square represents.
   """
   date: Date!
+  
   """
   A number representing which day of the week this square represents, e.g., 1 is Monday.
   """
@@ -5146,14 +5821,17 @@ type ContributionCalendarMonth {
   The date of the first day of this month.
   """
   firstDay: Date!
+  
   """
   The name of the month.
   """
   name: String!
+  
   """
   How many weeks started in this month.
   """
   totalWeeks: Int!
+  
   """
   The year the month occurred in.
   """
@@ -5168,6 +5846,7 @@ type ContributionCalendarWeek {
   The days of contributions in this week.
   """
   contributionDays: [ContributionCalendarDay!]!
+  
   """
   The date of the earliest square in this week.
   """
@@ -5223,27 +5902,33 @@ type ContributionsCollection {
     """
     maxRepositories: Int = 25
   ): [CommitContributionsByRepository!]!
+  
   """
   A calendar of this user's contributions on GitHub.
   """
   contributionCalendar: ContributionCalendar!
+  
   """
   The years the user has been making contributions with the most recent year first.
   """
   contributionYears: [Int!]!
+  
   """
   Determine if this collection's time span ends in the current month.
   """
   doesEndInCurrentMonth: Boolean!
+  
   """
   The date of the first restricted contribution the user made in this time
   period. Can only be non-null when the user has enabled private contribution counts.
   """
   earliestRestrictedContributionDate: Date
+  
   """
   The ending date and time of this collection.
   """
   endedAt: DateTime!
+  
   """
   The first issue the user opened on GitHub. This will be null if that issue was
   opened outside the collection's time range and ignoreTimeRange is false. If
@@ -5251,6 +5936,7 @@ type ContributionsCollection {
   a RestrictedContribution will be returned.
   """
   firstIssueContribution: CreatedIssueOrRestrictedContribution
+  
   """
   The first pull request the user opened on GitHub. This will be null if that
   pull request was opened outside the collection's time range and
@@ -5258,6 +5944,7 @@ type ContributionsCollection {
   has opted to show private contributions, a RestrictedContribution will be returned.
   """
   firstPullRequestContribution: CreatedPullRequestOrRestrictedContribution
+  
   """
   The first repository the user created on GitHub. This will be null if that
   first repository was created outside the collection's time range and
@@ -5265,24 +5952,29 @@ type ContributionsCollection {
   RestrictedContribution is returned.
   """
   firstRepositoryContribution: CreatedRepositoryOrRestrictedContribution
+  
   """
   Does the user have any more activity in the timeline that occurred prior to the collection's time range?
   """
   hasActivityInThePast: Boolean!
+  
   """
   Determine if there are any contributions in this collection.
   """
   hasAnyContributions: Boolean!
+  
   """
   Determine if the user made any contributions in this time frame whose details
   are not visible because they were made in a private repository. Can only be
   true if the user enabled private contribution counts.
   """
   hasAnyRestrictedContributions: Boolean!
+  
   """
   Whether or not the collector's time span is all within the same day.
   """
   isSingleDay: Boolean!
+  
   """
   A list of issues the user opened.
   """
@@ -5291,31 +5983,38 @@ type ContributionsCollection {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Should the user's first issue ever be excluded from the result.
     """
     excludeFirst: Boolean = false
+    
     """
     Should the user's most commented issue be excluded from the result.
     """
     excludePopular: Boolean = false
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for contributions returned from the connection.
     """
     orderBy: ContributionOrder = { direction: DESC }
   ): CreatedIssueContributionConnection!
+  
   """
   Issue contributions made by the user, grouped by repository.
   """
@@ -5324,45 +6023,54 @@ type ContributionsCollection {
     Should the user's first issue ever be excluded from the result.
     """
     excludeFirst: Boolean = false
+    
     """
     Should the user's most commented issue be excluded from the result.
     """
     excludePopular: Boolean = false
+    
     """
     How many repositories should be included.
     """
     maxRepositories: Int = 25
   ): [IssueContributionsByRepository!]!
+  
   """
   When the user signed up for GitHub. This will be null if that sign up date
   falls outside the collection's time range and ignoreTimeRange is false.
   """
   joinedGitHubContribution: JoinedGitHubContribution
+  
   """
   The date of the most recent restricted contribution the user made in this time
   period. Can only be non-null when the user has enabled private contribution counts.
   """
   latestRestrictedContributionDate: Date
+  
   """
   When this collection's time range does not include any activity from the user, use this
   to get a different collection from an earlier time range that does have activity.
   """
   mostRecentCollectionWithActivity: ContributionsCollection
+  
   """
   Returns a different contributions collection from an earlier time range than this one
   that does not have any contributions.
   """
   mostRecentCollectionWithoutActivity: ContributionsCollection
+  
   """
   The issue the user opened on GitHub that received the most comments in the specified
   time frame.
   """
   popularIssueContribution: CreatedIssueContribution
+  
   """
   The pull request the user opened on GitHub that received the most comments in the
   specified time frame.
   """
   popularPullRequestContribution: CreatedPullRequestContribution
+  
   """
   Pull request contributions made by the user.
   """
@@ -5371,31 +6079,38 @@ type ContributionsCollection {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Should the user's first pull request ever be excluded from the result.
     """
     excludeFirst: Boolean = false
+    
     """
     Should the user's most commented pull request be excluded from the result.
     """
     excludePopular: Boolean = false
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for contributions returned from the connection.
     """
     orderBy: ContributionOrder = { direction: DESC }
   ): CreatedPullRequestContributionConnection!
+  
   """
   Pull request contributions made by the user, grouped by repository.
   """
@@ -5404,15 +6119,18 @@ type ContributionsCollection {
     Should the user's first pull request ever be excluded from the result.
     """
     excludeFirst: Boolean = false
+    
     """
     Should the user's most commented pull request be excluded from the result.
     """
     excludePopular: Boolean = false
+    
     """
     How many repositories should be included.
     """
     maxRepositories: Int = 25
   ): [PullRequestContributionsByRepository!]!
+  
   """
   Pull request review contributions made by the user. Returns the most recently
   submitted review for each PR reviewed by the user.
@@ -5422,23 +6140,28 @@ type ContributionsCollection {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for contributions returned from the connection.
     """
     orderBy: ContributionOrder = { direction: DESC }
   ): CreatedPullRequestReviewContributionConnection!
+  
   """
   Pull request review contributions made by the user, grouped by repository.
   """
@@ -5448,6 +6171,7 @@ type ContributionsCollection {
     """
     maxRepositories: Int = 25
   ): [PullRequestReviewContributionsByRepository!]!
+  
   """
   A list of repositories owned by the user that the user created in this time range.
   """
@@ -5456,40 +6180,49 @@ type ContributionsCollection {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Should the user's first repository ever be excluded from the result.
     """
     excludeFirst: Boolean = false
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for contributions returned from the connection.
     """
     orderBy: ContributionOrder = { direction: DESC }
   ): CreatedRepositoryContributionConnection!
+  
   """
   A count of contributions made by the user that the viewer cannot access. Only
   non-zero when the user has chosen to share their private contribution counts.
   """
   restrictedContributionsCount: Int!
+  
   """
   The beginning date and time of this collection.
   """
   startedAt: DateTime!
+  
   """
   How many commits were made by the user in this time span.
   """
   totalCommitContributions: Int!
+  
   """
   How many issues the user opened.
   """
@@ -5498,11 +6231,13 @@ type ContributionsCollection {
     Should the user's first issue ever be excluded from this count.
     """
     excludeFirst: Boolean = false
+    
     """
     Should the user's most commented issue be excluded from this count.
     """
     excludePopular: Boolean = false
   ): Int!
+  
   """
   How many pull requests the user opened.
   """
@@ -5511,19 +6246,23 @@ type ContributionsCollection {
     Should the user's first pull request ever be excluded from this count.
     """
     excludeFirst: Boolean = false
+    
     """
     Should the user's most commented pull request be excluded from this count.
     """
     excludePopular: Boolean = false
   ): Int!
+  
   """
   How many pull request reviews the user left.
   """
   totalPullRequestReviewContributions: Int!
+  
   """
   How many different repositories the user committed to.
   """
   totalRepositoriesWithContributedCommits: Int!
+  
   """
   How many different repositories the user opened issues in.
   """
@@ -5532,15 +6271,18 @@ type ContributionsCollection {
     Should the user's first issue ever be excluded from this count.
     """
     excludeFirst: Boolean = false
+    
     """
     Should the user's most commented issue be excluded from this count.
     """
     excludePopular: Boolean = false
   ): Int!
+  
   """
   How many different repositories the user left pull request reviews in.
   """
   totalRepositoriesWithContributedPullRequestReviews: Int!
+  
   """
   How many different repositories the user opened pull requests in.
   """
@@ -5549,11 +6291,13 @@ type ContributionsCollection {
     Should the user's first pull request ever be excluded from this count.
     """
     excludeFirst: Boolean = false
+    
     """
     Should the user's most commented pull request be excluded from this count.
     """
     excludePopular: Boolean = false
   ): Int!
+  
   """
   How many repositories the user created.
   """
@@ -5563,6 +6307,7 @@ type ContributionsCollection {
     """
     excludeFirst: Boolean = false
   ): Int!
+  
   """
   The user who made the contributions in this collection.
   """
@@ -5577,18 +6322,22 @@ input ConvertProjectCardNoteToIssueInput {
   The body of the newly created issue.
   """
   body: String
+  
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The ProjectCard ID to convert.
   """
   projectCardId: ID! @possibleTypes(concreteTypes: ["ProjectCard"])
+  
   """
   The ID of the repository to create the issue in.
   """
   repositoryId: ID! @possibleTypes(concreteTypes: ["Repository"])
+  
   """
   The title of the newly created issue. Defaults to the card's note text.
   """
@@ -5603,6 +6352,7 @@ type ConvertProjectCardNoteToIssuePayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The updated ProjectCard.
   """
@@ -5617,6 +6367,7 @@ input ConvertPullRequestToDraftInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   ID of the pull request to convert to draft
   """
@@ -5631,6 +6382,7 @@ type ConvertPullRequestToDraftPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The pull request that is now a draft.
   """
@@ -5645,19 +6397,23 @@ type ConvertToDraftEvent implements Node & UniformResourceLocatable {
   Identifies the actor who performed the event.
   """
   actor: Actor
+  
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
   id: ID!
+  
   """
   PullRequest referenced by event.
   """
   pullRequest: PullRequest!
+  
   """
   The HTTP path for this convert to draft event.
   """
   resourcePath: URI!
+  
   """
   The HTTP URL for this convert to draft event.
   """
@@ -5672,23 +6428,28 @@ type ConvertedNoteToIssueEvent implements Node {
   Identifies the actor who performed the event.
   """
   actor: Actor
+  
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
+  
   """
   Identifies the primary key from the database.
   """
   databaseId: Int
   id: ID!
+  
   """
   Project referenced by event.
   """
   project: Project @preview(toggledBy: "starfox-preview")
+  
   """
   Project card referenced by this project event.
   """
   projectCard: ProjectCard @preview(toggledBy: "starfox-preview")
+  
   """
   Column name referenced by this project event.
   """
@@ -5703,10 +6464,12 @@ type ConvertedToDiscussionEvent implements Node {
   Identifies the actor who performed the event.
   """
   actor: Actor
+  
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
+  
   """
   The discussion that the issue was converted into.
   """
@@ -5722,10 +6485,12 @@ input CopyProjectV2Input {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   Include draft issues in the new project
   """
   includeDraftIssues: Boolean = false
+  
   """
   The owner ID of the new project.
   """
@@ -5734,10 +6499,12 @@ input CopyProjectV2Input {
       concreteTypes: ["Organization", "User"]
       abstractType: "OrganizationOrUser"
     )
+  
   """
   The ID of the source Project to copy.
   """
   projectId: ID! @possibleTypes(concreteTypes: ["ProjectV2"])
+  
   """
   The title of the project.
   """
@@ -5752,6 +6519,7 @@ type CopyProjectV2Payload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The copied project.
   """
@@ -5766,6 +6534,7 @@ input CreateAttributionInvitationInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The Node ID of the owner scoping the reattributable data.
   """
@@ -5773,6 +6542,7 @@ input CreateAttributionInvitationInput {
     @possibleTypes(
       concreteTypes: ["Bot", "Enterprise", "Mannequin", "Organization", "User"]
     )
+  
   """
   The Node ID of the account owning the data to reattribute.
   """
@@ -5780,6 +6550,7 @@ input CreateAttributionInvitationInput {
     @possibleTypes(
       concreteTypes: ["Bot", "Enterprise", "Mannequin", "Organization", "User"]
     )
+  
   """
   The Node ID of the account which may claim the data.
   """
@@ -5797,14 +6568,17 @@ type CreateAttributionInvitationPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The owner scoping the reattributable data.
   """
   owner: Organization
+  
   """
   The account owning the data to reattribute.
   """
   source: Claimable
+  
   """
   The account which may claim the data.
   """
@@ -5819,115 +6593,143 @@ input CreateBranchProtectionRuleInput {
   Can this branch be deleted.
   """
   allowsDeletions: Boolean
+  
   """
   Are force pushes allowed on this branch.
   """
   allowsForcePushes: Boolean
+  
   """
   Is branch creation a protected operation.
   """
   blocksCreations: Boolean
+  
   """
   A list of User, Team, or App IDs allowed to bypass force push targeting matching branches.
   """
   bypassForcePushActorIds: [ID!]
+  
   """
   A list of User, Team, or App IDs allowed to bypass pull requests targeting matching branches.
   """
   bypassPullRequestActorIds: [ID!]
+  
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   Will new commits pushed to matching branches dismiss pull request review approvals.
   """
   dismissesStaleReviews: Boolean
+  
   """
   Can admins overwrite branch protection.
   """
   isAdminEnforced: Boolean
+  
   """
   Whether users can pull changes from upstream when the branch is locked. Set to
   `true` to allow fork syncing. Set to `false` to prevent fork syncing.
   """
   lockAllowsFetchAndMerge: Boolean
+  
   """
   Whether to set the branch as read-only. If this is true, users will not be able to push to the branch.
   """
   lockBranch: Boolean
+  
   """
   The glob-like pattern used to determine matching branches.
   """
   pattern: String!
+  
   """
   A list of User, Team, or App IDs allowed to push to matching branches.
   """
   pushActorIds: [ID!]
+  
   """
   The global relay id of the repository in which a new branch protection rule should be created in.
   """
   repositoryId: ID! @possibleTypes(concreteTypes: ["Repository"])
+  
   """
   Whether the most recent push must be approved by someone other than the person who pushed it
   """
   requireLastPushApproval: Boolean
+  
   """
   Number of approving reviews required to update matching branches.
   """
   requiredApprovingReviewCount: Int
+  
   """
   The list of required deployment environments
   """
   requiredDeploymentEnvironments: [String!]
+  
   """
   List of required status check contexts that must pass for commits to be accepted to matching branches.
   """
   requiredStatusCheckContexts: [String!]
+  
   """
   The list of required status checks
   """
   requiredStatusChecks: [RequiredStatusCheckInput!]
+  
   """
   Are approving reviews required to update matching branches.
   """
   requiresApprovingReviews: Boolean
+  
   """
   Are reviews from code owners required to update matching branches.
   """
   requiresCodeOwnerReviews: Boolean
+  
   """
   Are commits required to be signed.
   """
   requiresCommitSignatures: Boolean
+  
   """
   Are conversations required to be resolved before merging.
   """
   requiresConversationResolution: Boolean
+  
   """
   Are successful deployments required before merging.
   """
   requiresDeployments: Boolean
+  
   """
   Are merge commits prohibited from being pushed to this branch.
   """
   requiresLinearHistory: Boolean
+  
   """
   Are status checks required to update matching branches.
   """
   requiresStatusChecks: Boolean
+  
   """
   Are branches required to be up to date before merging.
   """
   requiresStrictStatusChecks: Boolean
+  
   """
   Is pushing to matching branches restricted.
   """
   restrictsPushes: Boolean
+  
   """
   Is dismissal of pull request reviews restricted.
   """
   restrictsReviewDismissals: Boolean
+  
   """
   A list of User, Team, or App IDs allowed to dismiss reviews on pull requests targeting matching branches.
   """
@@ -5942,6 +6744,7 @@ type CreateBranchProtectionRulePayload {
   The newly created BranchProtectionRule.
   """
   branchProtectionRule: BranchProtectionRule
+  
   """
   A unique identifier for the client performing the mutation.
   """
@@ -5956,46 +6759,57 @@ input CreateCheckRunInput {
   Possible further actions the integrator can perform, which a user may trigger.
   """
   actions: [CheckRunAction!]
+  
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The time that the check run finished.
   """
   completedAt: DateTime
+  
   """
   The final conclusion of the check.
   """
   conclusion: CheckConclusionState
+  
   """
   The URL of the integrator's site that has the full details of the check.
   """
   detailsUrl: URI
+  
   """
   A reference for the run on the integrator's system.
   """
   externalId: String
+  
   """
   The SHA of the head commit.
   """
   headSha: GitObjectID!
+  
   """
   The name of the check.
   """
   name: String!
+  
   """
   Descriptive details about the run.
   """
   output: CheckRunOutput
+  
   """
   The node ID of the repository.
   """
   repositoryId: ID! @possibleTypes(concreteTypes: ["Repository"])
+  
   """
   The time that the check run began.
   """
   startedAt: DateTime
+  
   """
   The current status.
   """
@@ -6010,6 +6824,7 @@ type CreateCheckRunPayload {
   The newly created check run.
   """
   checkRun: CheckRun
+  
   """
   A unique identifier for the client performing the mutation.
   """
@@ -6024,10 +6839,12 @@ input CreateCheckSuiteInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The SHA of the head commit.
   """
   headSha: GitObjectID!
+  
   """
   The Node ID of the repository.
   """
@@ -6042,6 +6859,7 @@ type CreateCheckSuitePayload {
   The newly created check suite.
   """
   checkSuite: CheckSuite
+  
   """
   A unique identifier for the client performing the mutation.
   """
@@ -6056,18 +6874,22 @@ input CreateCommitOnBranchInput {
   The Ref to be updated.  Must be a branch.
   """
   branch: CommittableBranch!
+  
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The git commit oid expected at the head of the branch prior to the commit
   """
   expectedHeadOid: GitObjectID!
+  
   """
   A description of changes to files in this commit.
   """
   fileChanges: FileChanges
+  
   """
   The commit message the be included with the commit.
   """
@@ -6082,10 +6904,12 @@ type CreateCommitOnBranchPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The new commit.
   """
   commit: Commit
+  
   """
   The ref which has been updated to point to the new commit.
   """
@@ -6100,35 +6924,43 @@ input CreateDeploymentInput @preview(toggledBy: "flash-preview") {
   Attempt to automatically merge the default branch into the requested ref, defaults to true.
   """
   autoMerge: Boolean = true
+  
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   Short description of the deployment.
   """
   description: String = ""
+  
   """
   Name for the target deployment environment.
   """
   environment: String = "production"
+  
   """
   JSON payload with extra information about the deployment.
   """
   payload: String = "{}"
+  
   """
   The node ID of the ref to be deployed.
   """
   refId: ID! @possibleTypes(concreteTypes: ["Ref"])
+  
   """
   The node ID of the repository.
   """
   repositoryId: ID! @possibleTypes(concreteTypes: ["Repository"])
+  
   """
   The status contexts to verify against commit status checks. To bypass required
   contexts, pass an empty array. Defaults to all unique contexts.
   """
   requiredContexts: [String!]
+  
   """
   Specifies a task to execute.
   """
@@ -6143,10 +6975,12 @@ type CreateDeploymentPayload @preview(toggledBy: "flash-preview") {
   True if the default branch has been auto-merged into the deployment ref.
   """
   autoMerged: Boolean
+  
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The new deployment.
   """
@@ -6163,32 +6997,39 @@ input CreateDeploymentStatusInput @preview(toggledBy: "flash-preview") {
   status's deployment.
   """
   autoInactive: Boolean = true
+  
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The node ID of the deployment.
   """
   deploymentId: ID! @possibleTypes(concreteTypes: ["Deployment"])
+  
   """
   A short description of the status. Maximum length of 140 characters.
   """
   description: String = ""
+  
   """
   If provided, updates the environment of the deploy. Otherwise, does not modify the environment.
   """
   environment: String
+  
   """
   Sets the URL for accessing your environment.
   """
   environmentUrl: String = ""
+  
   """
   The log URL to associate with this status.       This URL should contain
   output to keep the user updated while the task is running       or serve as
   historical information for what happened in the deployment.
   """
   logUrl: String = ""
+  
   """
   The state of the deployment.
   """
@@ -6203,6 +7044,7 @@ type CreateDeploymentStatusPayload @preview(toggledBy: "flash-preview") {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The new deployment status.
   """
@@ -6217,18 +7059,22 @@ input CreateDiscussionInput {
   The body of the discussion.
   """
   body: String!
+  
   """
   The id of the discussion category to associate with this discussion.
   """
   categoryId: ID! @possibleTypes(concreteTypes: ["DiscussionCategory"])
+  
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The id of the repository on which to create the discussion.
   """
   repositoryId: ID! @possibleTypes(concreteTypes: ["Repository"])
+  
   """
   The title of the discussion.
   """
@@ -6243,6 +7089,7 @@ type CreateDiscussionPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The discussion that was just created.
   """
@@ -6257,22 +7104,27 @@ input CreateEnterpriseOrganizationInput {
   The logins for the administrators of the new organization.
   """
   adminLogins: [String!]!
+  
   """
   The email used for sending billing receipts.
   """
   billingEmail: String!
+  
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The ID of the enterprise owning the new organization.
   """
   enterpriseId: ID! @possibleTypes(concreteTypes: ["Enterprise"])
+  
   """
   The login of the new organization.
   """
   login: String!
+  
   """
   The profile name of the new organization.
   """
@@ -6287,10 +7139,12 @@ type CreateEnterpriseOrganizationPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The enterprise that owns the created organization.
   """
   enterprise: Enterprise
+  
   """
   The organization that was created.
   """
@@ -6305,10 +7159,12 @@ input CreateEnvironmentInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The name of the environment.
   """
   name: String!
+  
   """
   The node ID of the repository.
   """
@@ -6323,6 +7179,7 @@ type CreateEnvironmentPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The new or existing environment.
   """
@@ -6337,18 +7194,22 @@ input CreateIpAllowListEntryInput {
   An IP address or range of addresses in CIDR notation.
   """
   allowListValue: String!
+  
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   Whether the IP allow list entry is active when an IP allow list is enabled.
   """
   isActive: Boolean!
+  
   """
   An optional name for the IP allow list entry.
   """
   name: String
+  
   """
   The ID of the owner for which to create the new IP allow list entry.
   """
@@ -6367,6 +7228,7 @@ type CreateIpAllowListEntryPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The IP allow list entry that was created.
   """
@@ -6381,34 +7243,42 @@ input CreateIssueInput {
   The Node ID for the user assignee for this issue.
   """
   assigneeIds: [ID!] @possibleTypes(concreteTypes: ["User"])
+  
   """
   The body for the issue description.
   """
   body: String
+  
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The name of an issue template in the repository, assigns labels and assignees from the template to the issue
   """
   issueTemplate: String
+  
   """
   An array of Node IDs of labels for this issue.
   """
   labelIds: [ID!] @possibleTypes(concreteTypes: ["Label"])
+  
   """
   The Node ID of the milestone for this issue.
   """
   milestoneId: ID @possibleTypes(concreteTypes: ["Milestone"])
+  
   """
   An array of Node IDs for projects associated with this issue.
   """
   projectIds: [ID!] @possibleTypes(concreteTypes: ["Project"])
+  
   """
   The Node ID of the repository.
   """
   repositoryId: ID! @possibleTypes(concreteTypes: ["Repository"])
+  
   """
   The title for the issue.
   """
@@ -6423,6 +7293,7 @@ type CreateIssuePayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The new issue.
   """
@@ -6437,18 +7308,22 @@ input CreateLabelInput @preview(toggledBy: "bane-preview") {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   A 6 character hex code, without the leading #, identifying the color of the label.
   """
   color: String!
+  
   """
   A brief description of the label, such as its purpose.
   """
   description: String
+  
   """
   The name of the label.
   """
   name: String!
+  
   """
   The Node ID of the repository.
   """
@@ -6463,6 +7338,7 @@ type CreateLabelPayload @preview(toggledBy: "bane-preview") {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The new label.
   """
@@ -6477,18 +7353,22 @@ input CreateLinkedBranchInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   ID of the issue to link to.
   """
   issueId: ID! @possibleTypes(concreteTypes: ["Issue"])
+  
   """
   The name of the new branch. Defaults to issue number and title.
   """
   name: String
+  
   """
   The commit SHA to base the new branch on.
   """
   oid: GitObjectID!
+  
   """
   ID of the repository to create the branch in. Defaults to the issue repository.
   """
@@ -6503,10 +7383,12 @@ type CreateLinkedBranchPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The issue that was linked to.
   """
   issue: Issue
+  
   """
   The new branch issue reference.
   """
@@ -6521,26 +7403,32 @@ input CreateMigrationSourceInput {
   The migration source access token.
   """
   accessToken: String
+  
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The GitHub personal access token of the user importing to the target repository.
   """
   githubPat: String
+  
   """
   The migration source name.
   """
   name: String!
+  
   """
   The ID of the organization that will own the migration source.
   """
   ownerId: ID! @possibleTypes(concreteTypes: ["Organization"])
+  
   """
   The migration source type.
   """
   type: MigrationSourceType!
+  
   """
   The migration source URL, for example `https://github.com` or `https://monalisa.ghe.com`.
   """
@@ -6555,6 +7443,7 @@ type CreateMigrationSourcePayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The created migration source.
   """
@@ -6569,14 +7458,17 @@ input CreateProjectInput {
   The description of project.
   """
   body: String
+  
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The name of project.
   """
   name: String!
+  
   """
   The owner ID to create the project under.
   """
@@ -6585,10 +7477,12 @@ input CreateProjectInput {
       concreteTypes: ["Organization", "Repository", "User"]
       abstractType: "ProjectOwner"
     )
+  
   """
   A list of repository IDs to create as linked repositories for the project
   """
   repositoryIds: [ID!] @possibleTypes(concreteTypes: ["Repository"])
+  
   """
   The name of the GitHub-provided template.
   """
@@ -6603,6 +7497,7 @@ type CreateProjectPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The new project.
   """
@@ -6617,18 +7512,22 @@ input CreateProjectV2FieldInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The data type of the field.
   """
   dataType: ProjectV2CustomFieldType!
+  
   """
   The name of the field.
   """
   name: String!
+  
   """
   The ID of the Project to create the field in.
   """
   projectId: ID! @possibleTypes(concreteTypes: ["ProjectV2"])
+  
   """
   Options for a single select field. At least one value is required if data_type is SINGLE_SELECT
   """
@@ -6643,6 +7542,7 @@ type CreateProjectV2FieldPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The new field.
   """
@@ -6657,6 +7557,7 @@ input CreateProjectV2Input {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The owner ID to create the project under.
   """
@@ -6665,14 +7566,17 @@ input CreateProjectV2Input {
       concreteTypes: ["Organization", "User"]
       abstractType: "OrganizationOrUser"
     )
+  
   """
   The repository to link the project to.
   """
   repositoryId: ID @possibleTypes(concreteTypes: ["Repository"])
+  
   """
   The team to link the project to. The team will be granted read permissions.
   """
   teamId: ID @possibleTypes(concreteTypes: ["Team"])
+  
   """
   The title of the project.
   """
@@ -6687,6 +7591,7 @@ type CreateProjectV2Payload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The new project.
   """
@@ -6703,35 +7608,43 @@ input CreatePullRequestInput {
   to another repository.
   """
   baseRefName: String!
+  
   """
   The contents of the pull request.
   """
   body: String
+  
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   Indicates whether this pull request should be a draft.
   """
   draft: Boolean = false
+  
   """
   The name of the branch where your changes are implemented. For cross-repository pull requests
   in the same network, namespace `head_ref_name` with a user like this: `username:branch`.
   """
   headRefName: String!
+  
   """
   The Node ID of the head repository.
   """
   headRepositoryId: ID @possibleTypes(concreteTypes: ["Repository"])
+  
   """
   Indicates whether maintainers can modify the pull request.
   """
   maintainerCanModify: Boolean = true
+  
   """
   The Node ID of the repository.
   """
   repositoryId: ID! @possibleTypes(concreteTypes: ["Repository"])
+  
   """
   The title of the pull request.
   """
@@ -6746,6 +7659,7 @@ type CreatePullRequestPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The new pull request.
   """
@@ -6760,14 +7674,17 @@ input CreateRefInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The fully qualified name of the new Ref (ie: `refs/heads/my_new_branch`).
   """
   name: String!
+  
   """
   The GitObjectID that the new Ref shall target. Must point to a commit.
   """
   oid: GitObjectID!
+  
   """
   The Node ID of the Repository to create the Ref in.
   """
@@ -6782,6 +7699,7 @@ type CreateRefPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The newly created ref.
   """
@@ -6796,26 +7714,32 @@ input CreateRepositoryInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   A short description of the new repository.
   """
   description: String
+  
   """
   Indicates if the repository should have the issues feature enabled.
   """
   hasIssuesEnabled: Boolean = true
+  
   """
   Indicates if the repository should have the wiki feature enabled.
   """
   hasWikiEnabled: Boolean = false
+  
   """
   The URL for a web page about this repository.
   """
   homepageUrl: URI
+  
   """
   The name of the new repository.
   """
   name: String!
+  
   """
   The ID of the owner for the new repository.
   """
@@ -6824,16 +7748,19 @@ input CreateRepositoryInput {
       concreteTypes: ["Organization", "User"]
       abstractType: "RepositoryOwner"
     )
+  
   """
   When an organization is specified as the owner, this ID identifies the team
   that should be granted access to the new repository.
   """
   teamId: ID @possibleTypes(concreteTypes: ["Team"])
+  
   """
   Whether this repository should be marked as a template such that anyone who
   can access it can create new repositories with the same files and directory structure.
   """
   template: Boolean = false
+  
   """
   Indicates the repository's visibility level.
   """
@@ -6848,6 +7775,7 @@ type CreateRepositoryPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The new repository.
   """
@@ -6862,26 +7790,32 @@ input CreateRepositoryRulesetInput {
   A list of actors that are allowed to bypass rules in this ruleset.
   """
   bypassActors: [RepositoryRulesetBypassActorInput!]
+  
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The set of conditions for this ruleset
   """
   conditions: RepositoryRuleConditionsInput!
+  
   """
   The enforcement level for this ruleset
   """
   enforcement: RuleEnforcement!
+  
   """
   The name of the ruleset.
   """
   name: String!
+  
   """
   The list of rules for this ruleset
   """
   rules: [RepositoryRuleInput!]
+  
   """
   The global relay id of the source in which a new ruleset should be created in.
   """
@@ -6890,6 +7824,7 @@ input CreateRepositoryRulesetInput {
       concreteTypes: ["Organization", "Repository"]
       abstractType: "RuleSource"
     )
+  
   """
   The target of the ruleset.
   """
@@ -6904,6 +7839,7 @@ type CreateRepositoryRulesetPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The newly created Ruleset.
   """
@@ -6919,10 +7855,12 @@ input CreateSponsorsListingInput {
   Required if fiscalHostLogin is not specified, ignored when fiscalHostLogin is specified.
   """
   billingCountryOrRegionCode: SponsorsCountryOrRegionCode
+  
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The email address we should use to contact you about the GitHub Sponsors
   profile being created. This will not be shared publicly. Must be a verified
@@ -6930,6 +7868,7 @@ input CreateSponsorsListingInput {
   sponsorable is yourself. Defaults to your primary email address on file if omitted.
   """
   contactEmail: String
+  
   """
   The username of the supported fiscal host's GitHub organization, if you want
   to receive sponsorship payouts through a fiscal host rather than directly to a
@@ -6938,12 +7877,14 @@ input CreateSponsorsListingInput {
   for more information.
   """
   fiscalHostLogin: String
+  
   """
   The URL for your profile page on the fiscal host's website, e.g.,
   https://opencollective.com/babel or https://numfocus.org/project/bokeh.
   Required if fiscalHostLogin is specified.
   """
   fiscallyHostedProjectProfileUrl: String
+  
   """
   Provide an introduction to serve as the main focus that appears on your GitHub
   Sponsors profile. It's a great opportunity to help potential sponsors learn
@@ -6951,12 +7892,14 @@ input CreateSponsorsListingInput {
   GitHub-flavored Markdown is supported.
   """
   fullDescription: String
+  
   """
   The country or region where the sponsorable resides. This is for tax purposes.
   Required if the sponsorable is yourself, ignored when sponsorableLogin
   specifies an organization.
   """
   residenceCountryOrRegionCode: SponsorsCountryOrRegionCode
+  
   """
   The username of the organization to create a GitHub Sponsors profile for, if
   desired. Defaults to creating a GitHub Sponsors profile for the authenticated
@@ -6973,6 +7916,7 @@ type CreateSponsorsListingPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The new GitHub Sponsors profile.
   """
@@ -6987,40 +7931,48 @@ input CreateSponsorsTierInput {
   The value of the new tier in US dollars. Valid values: 1-12000.
   """
   amount: Int!
+  
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   A description of what this tier is, what perks sponsors might receive, what a sponsorship at this tier means for you, etc.
   """
   description: String!
+  
   """
   Whether sponsorships using this tier should happen monthly/yearly or just once.
   """
   isRecurring: Boolean = true
+  
   """
   Whether to make the tier available immediately for sponsors to choose.
   Defaults to creating a draft tier that will not be publicly visible.
   """
   publish: Boolean = false
+  
   """
   Optional ID of the private repository that sponsors at this tier should gain
   read-only access to. Must be owned by an organization.
   """
   repositoryId: ID @possibleTypes(concreteTypes: ["Repository"])
+  
   """
   Optional name of the private repository that sponsors at this tier should gain
   read-only access to. Must be owned by an organization. Necessary if
   repositoryOwnerLogin is given. Will be ignored if repositoryId is given.
   """
   repositoryName: String
+  
   """
   Optional login of the organization owner of the private repository that
   sponsors at this tier should gain read-only access to. Necessary if
   repositoryName is given. Will be ignored if repositoryId is given.
   """
   repositoryOwnerLogin: String
+  
   """
   The ID of the user or organization who owns the GitHub Sponsors profile.
   Defaults to the current user if omitted and sponsorableLogin is not given.
@@ -7030,11 +7982,13 @@ input CreateSponsorsTierInput {
       concreteTypes: ["Organization", "User"]
       abstractType: "Sponsorable"
     )
+  
   """
   The username of the user or organization who owns the GitHub Sponsors profile.
   Defaults to the current user if omitted and sponsorableId is not given.
   """
   sponsorableLogin: String
+  
   """
   Optional message new sponsors at this tier will receive.
   """
@@ -7049,6 +8003,7 @@ type CreateSponsorsTierPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The new tier.
   """
@@ -7063,23 +8018,28 @@ input CreateSponsorshipInput {
   The amount to pay to the sponsorable in US dollars. Required if a tierId is not specified. Valid values: 1-12000.
   """
   amount: Int
+  
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   Whether the sponsorship should happen monthly/yearly or just this one time. Required if a tierId is not specified.
   """
   isRecurring: Boolean
+  
   """
   Specify whether others should be able to see that the sponsor is sponsoring
   the sponsorable. Public visibility still does not reveal which tier is used.
   """
   privacyLevel: SponsorshipPrivacy = PUBLIC
+  
   """
   Whether the sponsor should receive email updates from the sponsorable.
   """
   receiveEmails: Boolean = true
+  
   """
   The ID of the user or organization who is acting as the sponsor, paying for
   the sponsorship. Required if sponsorLogin is not given.
@@ -7089,11 +8049,13 @@ input CreateSponsorshipInput {
       concreteTypes: ["Organization", "User"]
       abstractType: "Sponsor"
     )
+  
   """
   The username of the user or organization who is acting as the sponsor, paying
   for the sponsorship. Required if sponsorId is not given.
   """
   sponsorLogin: String
+  
   """
   The ID of the user or organization who is receiving the sponsorship. Required if sponsorableLogin is not given.
   """
@@ -7102,10 +8064,12 @@ input CreateSponsorshipInput {
       concreteTypes: ["Organization", "User"]
       abstractType: "Sponsorable"
     )
+  
   """
   The username of the user or organization who is receiving the sponsorship. Required if sponsorableId is not given.
   """
   sponsorableLogin: String
+  
   """
   The ID of one of sponsorable's existing tiers to sponsor at. Required if amount is not specified.
   """
@@ -7120,6 +8084,7 @@ type CreateSponsorshipPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The sponsorship that was started.
   """
@@ -7134,20 +8099,24 @@ input CreateSponsorshipsInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   Specify whether others should be able to see that the sponsor is sponsoring
   the sponsorables. Public visibility still does not reveal the dollar value of
   the sponsorship.
   """
   privacyLevel: SponsorshipPrivacy = PUBLIC
+  
   """
   Whether the sponsor should receive email updates from the sponsorables.
   """
   receiveEmails: Boolean = false
+  
   """
   The username of the user or organization who is acting as the sponsor, paying for the sponsorships.
   """
   sponsorLogin: String!
+  
   """
   The list of maintainers to sponsor and for how much apiece.
   """
@@ -7162,6 +8131,7 @@ type CreateSponsorshipsPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The users and organizations who received a sponsorship.
   """
@@ -7182,10 +8152,12 @@ input CreateTeamDiscussionCommentInput {
   **Reason:** The Team Discussions feature is deprecated in favor of Organization Discussions.
   """
   body: String
+  
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The ID of the discussion to which the comment belongs. This field is required.
 
@@ -7206,6 +8178,7 @@ type CreateTeamDiscussionCommentPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The new comment.
   """
@@ -7229,10 +8202,12 @@ input CreateTeamDiscussionInput {
   **Reason:** The Team Discussions feature is deprecated in favor of Organization Discussions.
   """
   body: String
+  
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   If true, restricts the visibility of this discussion to team members and
   organization admins. If false or not specified, allows any organization member
@@ -7245,6 +8220,7 @@ input CreateTeamDiscussionInput {
   **Reason:** The Team Discussions feature is deprecated in favor of Organization Discussions.
   """
   private: Boolean
+  
   """
   The ID of the team to which the discussion belongs. This field is required.
 
@@ -7255,6 +8231,7 @@ input CreateTeamDiscussionInput {
   **Reason:** The Team Discussions feature is deprecated in favor of Organization Discussions.
   """
   teamId: ID @possibleTypes(concreteTypes: ["Team"])
+  
   """
   The title of the discussion. This field is required.
 
@@ -7275,6 +8252,7 @@ type CreateTeamDiscussionPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The new discussion.
   """
@@ -7292,28 +8270,34 @@ type CreatedCommitContribution implements Contribution {
   How many commits were made on this day to this repository by the user.
   """
   commitCount: Int!
+  
   """
   Whether this contribution is associated with a record you do not have access to. For
   example, your own 'first issue' contribution may have been made on a repository you can no
   longer access.
   """
   isRestricted: Boolean!
+  
   """
   When this contribution was made.
   """
   occurredAt: DateTime!
+  
   """
   The repository the user made a commit in.
   """
   repository: Repository!
+  
   """
   The HTTP path for this contribution.
   """
   resourcePath: URI!
+  
   """
   The HTTP URL for this contribution.
   """
   url: URI!
+  
   """
   The user who made this contribution.
   """
@@ -7328,14 +8312,17 @@ type CreatedCommitContributionConnection {
   A list of edges.
   """
   edges: [CreatedCommitContributionEdge]
+  
   """
   A list of nodes.
   """
   nodes: [CreatedCommitContribution]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of commits across days and repositories in the connection.
   """
@@ -7350,6 +8337,7 @@ type CreatedCommitContributionEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -7366,22 +8354,27 @@ type CreatedIssueContribution implements Contribution {
   longer access.
   """
   isRestricted: Boolean!
+  
   """
   The issue that was opened.
   """
   issue: Issue!
+  
   """
   When this contribution was made.
   """
   occurredAt: DateTime!
+  
   """
   The HTTP path for this contribution.
   """
   resourcePath: URI!
+  
   """
   The HTTP URL for this contribution.
   """
   url: URI!
+  
   """
   The user who made this contribution.
   """
@@ -7396,14 +8389,17 @@ type CreatedIssueContributionConnection {
   A list of edges.
   """
   edges: [CreatedIssueContributionEdge]
+  
   """
   A list of nodes.
   """
   nodes: [CreatedIssueContribution]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -7418,6 +8414,7 @@ type CreatedIssueContributionEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -7440,22 +8437,27 @@ type CreatedPullRequestContribution implements Contribution {
   longer access.
   """
   isRestricted: Boolean!
+  
   """
   When this contribution was made.
   """
   occurredAt: DateTime!
+  
   """
   The pull request that was opened.
   """
   pullRequest: PullRequest!
+  
   """
   The HTTP path for this contribution.
   """
   resourcePath: URI!
+  
   """
   The HTTP URL for this contribution.
   """
   url: URI!
+  
   """
   The user who made this contribution.
   """
@@ -7470,14 +8472,17 @@ type CreatedPullRequestContributionConnection {
   A list of edges.
   """
   edges: [CreatedPullRequestContributionEdge]
+  
   """
   A list of nodes.
   """
   nodes: [CreatedPullRequestContribution]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -7492,6 +8497,7 @@ type CreatedPullRequestContributionEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -7514,30 +8520,37 @@ type CreatedPullRequestReviewContribution implements Contribution {
   longer access.
   """
   isRestricted: Boolean!
+  
   """
   When this contribution was made.
   """
   occurredAt: DateTime!
+  
   """
   The pull request the user reviewed.
   """
   pullRequest: PullRequest!
+  
   """
   The review the user left on the pull request.
   """
   pullRequestReview: PullRequestReview!
+  
   """
   The repository containing the pull request that the user reviewed.
   """
   repository: Repository!
+  
   """
   The HTTP path for this contribution.
   """
   resourcePath: URI!
+  
   """
   The HTTP URL for this contribution.
   """
   url: URI!
+  
   """
   The user who made this contribution.
   """
@@ -7552,14 +8565,17 @@ type CreatedPullRequestReviewContributionConnection {
   A list of edges.
   """
   edges: [CreatedPullRequestReviewContributionEdge]
+  
   """
   A list of nodes.
   """
   nodes: [CreatedPullRequestReviewContribution]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -7574,6 +8590,7 @@ type CreatedPullRequestReviewContributionEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -7590,22 +8607,27 @@ type CreatedRepositoryContribution implements Contribution {
   longer access.
   """
   isRestricted: Boolean!
+  
   """
   When this contribution was made.
   """
   occurredAt: DateTime!
+  
   """
   The repository that was created.
   """
   repository: Repository!
+  
   """
   The HTTP path for this contribution.
   """
   resourcePath: URI!
+  
   """
   The HTTP URL for this contribution.
   """
   url: URI!
+  
   """
   The user who made this contribution.
   """
@@ -7620,14 +8642,17 @@ type CreatedRepositoryContributionConnection {
   A list of edges.
   """
   edges: [CreatedRepositoryContributionEdge]
+  
   """
   A list of nodes.
   """
   nodes: [CreatedRepositoryContribution]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -7642,6 +8667,7 @@ type CreatedRepositoryContributionEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -7662,35 +8688,43 @@ type CrossReferencedEvent implements Node & UniformResourceLocatable {
   Identifies the actor who performed the event.
   """
   actor: Actor
+  
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
   id: ID!
+  
   """
   Reference originated in a different repository.
   """
   isCrossRepository: Boolean!
+  
   """
   Identifies when the reference was made.
   """
   referencedAt: DateTime!
+  
   """
   The HTTP path for this pull request.
   """
   resourcePath: URI!
+  
   """
   Issue or pull request that made the reference.
   """
   source: ReferencedSubject!
+  
   """
   Issue or pull request to which the reference was made.
   """
   target: ReferencedSubject!
+  
   """
   The HTTP URL for this pull request.
   """
   url: URI!
+  
   """
   Checks if the target will be closed when the source is merged.
   """
@@ -7715,14 +8749,17 @@ input DeclineTopicSuggestionInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The name of the suggested topic.
   """
   name: String!
+  
   """
   The reason why the suggested topic is declined.
   """
   reason: TopicSuggestionDeclineReason!
+  
   """
   The Node ID of the repository.
   """
@@ -7737,6 +8774,7 @@ type DeclineTopicSuggestionPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The declined topic.
   """
@@ -7784,6 +8822,7 @@ input DeleteBranchProtectionRuleInput {
   """
   branchProtectionRuleId: ID!
     @possibleTypes(concreteTypes: ["BranchProtectionRule"])
+  
   """
   A unique identifier for the client performing the mutation.
   """
@@ -7808,6 +8847,7 @@ input DeleteDeploymentInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The Node ID of the deployment to be deleted.
   """
@@ -7832,6 +8872,7 @@ input DeleteDiscussionCommentInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The Node id of the discussion comment to delete.
   """
@@ -7846,6 +8887,7 @@ type DeleteDiscussionCommentPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The discussion comment that was just deleted.
   """
@@ -7860,6 +8902,7 @@ input DeleteDiscussionInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The id of the discussion to delete.
   """
@@ -7874,6 +8917,7 @@ type DeleteDiscussionPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The discussion that was just deleted.
   """
@@ -7888,6 +8932,7 @@ input DeleteEnvironmentInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The Node ID of the environment to be deleted.
   """
@@ -7912,6 +8957,7 @@ input DeleteIpAllowListEntryInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The ID of the IP allow list entry to delete.
   """
@@ -7926,6 +8972,7 @@ type DeleteIpAllowListEntryPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The IP allow list entry that was deleted.
   """
@@ -7940,6 +8987,7 @@ input DeleteIssueCommentInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The ID of the comment to delete.
   """
@@ -7964,6 +9012,7 @@ input DeleteIssueInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The ID of the issue to delete.
   """
@@ -7978,6 +9027,7 @@ type DeleteIssuePayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The repository the issue belonged to
   """
@@ -7992,6 +9042,7 @@ input DeleteLabelInput @preview(toggledBy: "bane-preview") {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The Node ID of the label to be deleted.
   """
@@ -8016,6 +9067,7 @@ input DeleteLinkedBranchInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The ID of the linked branch
   """
@@ -8030,6 +9082,7 @@ type DeleteLinkedBranchPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The issue the linked branch was unlinked from.
   """
@@ -8044,6 +9097,7 @@ input DeletePackageVersionInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The ID of the package version to be deleted.
   """
@@ -8058,6 +9112,7 @@ type DeletePackageVersionPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   Whether or not the operation succeeded.
   """
@@ -8072,6 +9127,7 @@ input DeleteProjectCardInput {
   The id of the card to delete.
   """
   cardId: ID! @possibleTypes(concreteTypes: ["ProjectCard"])
+  
   """
   A unique identifier for the client performing the mutation.
   """
@@ -8086,10 +9142,12 @@ type DeleteProjectCardPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The column the deleted card was in.
   """
   column: ProjectColumn
+  
   """
   The deleted card ID.
   """
@@ -8104,6 +9162,7 @@ input DeleteProjectColumnInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The id of the column to delete.
   """
@@ -8118,10 +9177,12 @@ type DeleteProjectColumnPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The deleted column ID.
   """
   deletedColumnId: ID
+  
   """
   The project the deleted column was in.
   """
@@ -8136,6 +9197,7 @@ input DeleteProjectInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The Project ID to update.
   """
@@ -8150,6 +9212,7 @@ type DeleteProjectPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The repository or organization the project was removed from.
   """
@@ -8164,6 +9227,7 @@ input DeleteProjectV2FieldInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The ID of the field to delete.
   """
@@ -8186,6 +9250,7 @@ type DeleteProjectV2FieldPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The deleted field.
   """
@@ -8200,6 +9265,7 @@ input DeleteProjectV2Input {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The ID of the Project to delete.
   """
@@ -8214,10 +9280,12 @@ input DeleteProjectV2ItemInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The ID of the item to be removed.
   """
   itemId: ID! @possibleTypes(concreteTypes: ["ProjectV2Item"])
+  
   """
   The ID of the Project from which the item should be removed.
   """
@@ -8232,6 +9300,7 @@ type DeleteProjectV2ItemPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The ID of the deleted item.
   """
@@ -8246,6 +9315,7 @@ type DeleteProjectV2Payload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The deleted Project.
   """
@@ -8260,6 +9330,7 @@ input DeleteProjectV2WorkflowInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The ID of the workflow to be removed.
   """
@@ -8274,10 +9345,12 @@ type DeleteProjectV2WorkflowPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The ID of the deleted workflow.
   """
   deletedWorkflowId: ID
+  
   """
   The project the deleted workflow was in.
   """
@@ -8292,6 +9365,7 @@ input DeletePullRequestReviewCommentInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The ID of the comment to delete.
   """
@@ -8306,10 +9380,12 @@ type DeletePullRequestReviewCommentPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The pull request review the deleted comment belonged to.
   """
   pullRequestReview: PullRequestReview
+  
   """
   The deleted pull request review comment.
   """
@@ -8324,6 +9400,7 @@ input DeletePullRequestReviewInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The Node ID of the pull request review to delete.
   """
@@ -8338,6 +9415,7 @@ type DeletePullRequestReviewPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The deleted pull request review.
   """
@@ -8352,6 +9430,7 @@ input DeleteRefInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The Node ID of the Ref to be deleted.
   """
@@ -8376,6 +9455,7 @@ input DeleteRepositoryRulesetInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The global relay id of the repository ruleset to be deleted.
   """
@@ -8400,6 +9480,7 @@ input DeleteTeamDiscussionCommentInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The ID of the comment to delete.
   """
@@ -8424,6 +9505,7 @@ input DeleteTeamDiscussionInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The discussion ID to delete.
   """
@@ -8448,6 +9530,7 @@ input DeleteVerifiableDomainInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The ID of the verifiable domain to delete.
   """
@@ -8462,6 +9545,7 @@ type DeleteVerifiableDomainPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The owning account from which the domain was deleted.
   """
@@ -8476,15 +9560,18 @@ type DemilestonedEvent implements Node {
   Identifies the actor who performed the event.
   """
   actor: Actor
+  
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
   id: ID!
+  
   """
   Identifies the milestone title associated with the 'demilestoned' event.
   """
   milestoneTitle: String!
+  
   """
   Object referenced by event.
   """
@@ -8499,10 +9586,12 @@ type DependabotUpdate implements RepositoryNode {
   The error from a dependency update
   """
   error: DependabotUpdateError
+  
   """
   The associated pull request
   """
   pullRequest: PullRequest
+  
   """
   The repository associated with this node.
   """
@@ -8517,10 +9606,12 @@ type DependabotUpdateError {
   The body of the error
   """
   body: String!
+  
   """
   The error code
   """
   errorType: String!
+  
   """
   The title of the error
   """
@@ -8535,6 +9626,7 @@ type DependencyGraphDependency @preview(toggledBy: "hawkgirl-preview") {
   Does the dependency itself have dependencies?
   """
   hasDependencies: Boolean!
+  
   """
   The original name of the package, as it appears in the manifest.
   """
@@ -8542,18 +9634,22 @@ type DependencyGraphDependency @preview(toggledBy: "hawkgirl-preview") {
     @deprecated(
       reason: "`packageLabel` will be removed. Use normalized `packageName` field instead. Removal on 2022-10-01 UTC."
     )
+  
   """
   The dependency package manager
   """
   packageManager: String
+  
   """
   The name of the package in the canonical form used by the package manager.
   """
   packageName: String!
+  
   """
   The repository containing the package
   """
   repository: Repository
+  
   """
   The dependency version requirements
   """
@@ -8569,14 +9665,17 @@ type DependencyGraphDependencyConnection
   A list of edges.
   """
   edges: [DependencyGraphDependencyEdge]
+  
   """
   A list of nodes.
   """
   nodes: [DependencyGraphDependency]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -8591,6 +9690,7 @@ type DependencyGraphDependencyEdge @preview(toggledBy: "hawkgirl-preview") {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -8656,6 +9756,7 @@ type DependencyGraphManifest implements Node
   Path to view the manifest file blob
   """
   blobPath: String!
+  
   """
   A list of manifest dependencies
   """
@@ -8664,36 +9765,44 @@ type DependencyGraphManifest implements Node
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): DependencyGraphDependencyConnection
+  
   """
   The number of dependencies listed in the manifest
   """
   dependenciesCount: Int
+  
   """
   Is the manifest too big to parse?
   """
   exceedsMaxSize: Boolean!
+  
   """
   Fully qualified manifest filename
   """
   filename: String!
   id: ID!
+  
   """
   Were we able to parse the manifest?
   """
   parseable: Boolean!
+  
   """
   The repository containing the manifest
   """
@@ -8708,14 +9817,17 @@ type DependencyGraphManifestConnection @preview(toggledBy: "hawkgirl-preview") {
   A list of edges.
   """
   edges: [DependencyGraphManifestEdge]
+  
   """
   A list of nodes.
   """
   nodes: [DependencyGraphManifest]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -8730,6 +9842,7 @@ type DependencyGraphManifestEdge @preview(toggledBy: "hawkgirl-preview") {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -8745,18 +9858,22 @@ type DeployKey implements Node {
   """
   createdAt: DateTime!
   id: ID!
+  
   """
   The deploy key.
   """
   key: String!
+  
   """
   Whether or not the deploy key is read only.
   """
   readOnly: Boolean!
+  
   """
   The deploy key title.
   """
   title: String!
+  
   """
   Whether or not the deploy key has been verified.
   """
@@ -8771,14 +9888,17 @@ type DeployKeyConnection {
   A list of edges.
   """
   edges: [DeployKeyEdge]
+  
   """
   A list of nodes.
   """
   nodes: [DeployKey]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -8793,6 +9913,7 @@ type DeployKeyEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -8807,23 +9928,28 @@ type DeployedEvent implements Node {
   Identifies the actor who performed the event.
   """
   actor: Actor
+  
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
+  
   """
   Identifies the primary key from the database.
   """
   databaseId: Int
+  
   """
   The deployment associated with the 'deployed' event.
   """
   deployment: Deployment!
   id: ID!
+  
   """
   PullRequest referenced by event.
   """
   pullRequest: PullRequest!
+  
   """
   The ref associated with the 'deployed' event.
   """
@@ -8838,59 +9964,73 @@ type Deployment implements Node {
   Identifies the commit sha of the deployment.
   """
   commit: Commit
+  
   """
   Identifies the oid of the deployment commit, even if the commit has been deleted.
   """
   commitOid: String!
+  
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
+  
   """
   Identifies the actor who triggered the deployment.
   """
   creator: Actor!
+  
   """
   Identifies the primary key from the database.
   """
   databaseId: Int
+  
   """
   The deployment description.
   """
   description: String
+  
   """
   The latest environment to which this deployment was made.
   """
   environment: String
   id: ID!
+  
   """
   The latest environment to which this deployment was made.
   """
   latestEnvironment: String
+  
   """
   The latest status of this deployment.
   """
   latestStatus: DeploymentStatus
+  
   """
   The original environment to which this deployment was made.
   """
   originalEnvironment: String
+  
   """
   Extra information that a deployment system might need.
   """
   payload: String
+  
   """
   Identifies the Ref of the deployment, if the deployment was created by ref.
   """
   ref: Ref
+  
   """
   Identifies the repository associated with the deployment.
   """
   repository: Repository!
+  
   """
   The current state of the deployment.
   """
   state: DeploymentState
+  
   """
   A list of statuses associated with the deployment.
   """
@@ -8899,23 +10039,28 @@ type Deployment implements Node {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): DeploymentStatusConnection
+  
   """
   The deployment task.
   """
   task: String
+  
   """
   Identifies the date and time when the object was last updated.
   """
@@ -8930,14 +10075,17 @@ type DeploymentConnection {
   A list of edges.
   """
   edges: [DeploymentEdge]
+  
   """
   A list of nodes.
   """
   nodes: [Deployment]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -8952,6 +10100,7 @@ type DeploymentEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -8966,15 +10115,18 @@ type DeploymentEnvironmentChangedEvent implements Node {
   Identifies the actor who performed the event.
   """
   actor: Actor
+  
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
+  
   """
   The deployment status that updated the deployment environment.
   """
   deploymentStatus: DeploymentStatus!
   id: ID!
+  
   """
   PullRequest referenced by event.
   """
@@ -8989,6 +10141,7 @@ input DeploymentOrder {
   The ordering direction.
   """
   direction: OrderDirection!
+  
   """
   The field to order deployments by.
   """
@@ -9013,6 +10166,7 @@ type DeploymentProtectionRule {
   Identifies the primary key from the database.
   """
   databaseId: Int
+  
   """
   The teams or users that can review the deployment
   """
@@ -9021,23 +10175,28 @@ type DeploymentProtectionRule {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): DeploymentReviewerConnection!
+  
   """
   The timeout in minutes for this protection rule.
   """
   timeout: Int!
+  
   """
   The type of protection rule.
   """
@@ -9052,14 +10211,17 @@ type DeploymentProtectionRuleConnection {
   A list of edges.
   """
   edges: [DeploymentProtectionRuleEdge]
+  
   """
   A list of nodes.
   """
   nodes: [DeploymentProtectionRule]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -9074,6 +10236,7 @@ type DeploymentProtectionRuleEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -9102,10 +10265,12 @@ type DeploymentRequest {
   Whether or not the current user can approve the deployment
   """
   currentUserCanApprove: Boolean!
+  
   """
   The target environment of the deployment
   """
   environment: Environment!
+  
   """
   The teams or users that can review the deployment
   """
@@ -9114,23 +10279,28 @@ type DeploymentRequest {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): DeploymentReviewerConnection!
+  
   """
   The wait timer in minutes configured in the environment
   """
   waitTimer: Int!
+  
   """
   The wait timer in minutes configured in the environment
   """
@@ -9145,14 +10315,17 @@ type DeploymentRequestConnection {
   A list of edges.
   """
   edges: [DeploymentRequestEdge]
+  
   """
   A list of nodes.
   """
   nodes: [DeploymentRequest]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -9167,6 +10340,7 @@ type DeploymentRequestEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -9181,10 +10355,12 @@ type DeploymentReview implements Node {
   The comment the user left.
   """
   comment: String!
+  
   """
   Identifies the primary key from the database.
   """
   databaseId: Int
+  
   """
   The environments approved or rejected
   """
@@ -9193,24 +10369,29 @@ type DeploymentReview implements Node {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): EnvironmentConnection!
   id: ID!
+  
   """
   The decision of the user.
   """
   state: DeploymentReviewState!
+  
   """
   The user that reviewed the deployment.
   """
@@ -9225,14 +10406,17 @@ type DeploymentReviewConnection {
   A list of edges.
   """
   edges: [DeploymentReviewEdge]
+  
   """
   A list of nodes.
   """
   nodes: [DeploymentReview]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -9247,6 +10431,7 @@ type DeploymentReviewEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -9280,14 +10465,17 @@ type DeploymentReviewerConnection {
   A list of edges.
   """
   edges: [DeploymentReviewerEdge]
+  
   """
   A list of nodes.
   """
   nodes: [DeploymentReviewer]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -9302,6 +10490,7 @@ type DeploymentReviewerEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -9366,35 +10555,43 @@ type DeploymentStatus implements Node {
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
+  
   """
   Identifies the actor who triggered the deployment.
   """
   creator: Actor!
+  
   """
   Identifies the deployment associated with status.
   """
   deployment: Deployment!
+  
   """
   Identifies the description of the deployment.
   """
   description: String
+  
   """
   Identifies the environment of the deployment at the time of this deployment status
   """
   environment: String @preview(toggledBy: "flash-preview")
+  
   """
   Identifies the environment URL of the deployment.
   """
   environmentUrl: URI
   id: ID!
+  
   """
   Identifies the log URL of the deployment.
   """
   logUrl: URI
+  
   """
   Identifies the current state of the deployment.
   """
   state: DeploymentStatusState!
+  
   """
   Identifies the date and time when the object was last updated.
   """
@@ -9409,14 +10606,17 @@ type DeploymentStatusConnection {
   A list of edges.
   """
   edges: [DeploymentStatusEdge]
+  
   """
   A list of nodes.
   """
   nodes: [DeploymentStatus]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -9431,6 +10631,7 @@ type DeploymentStatusEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -9483,6 +10684,7 @@ input DequeuePullRequestInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The ID of the pull request to be dequeued.
   """
@@ -9497,6 +10699,7 @@ type DequeuePullRequestPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The merge queue entry of the dequeued pull request.
   """
@@ -9525,6 +10728,7 @@ input DisablePullRequestAutoMergeInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   ID of the pull request to disable auto merge on.
   """
@@ -9539,10 +10743,12 @@ type DisablePullRequestAutoMergePayload {
   Identifies the actor who performed the event.
   """
   actor: Actor
+  
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The pull request auto merge was disabled on.
   """
@@ -9557,19 +10763,23 @@ type DisconnectedEvent implements Node {
   Identifies the actor who performed the event.
   """
   actor: Actor
+  
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
   id: ID!
+  
   """
   Reference originated in a different repository.
   """
   isCrossRepository: Boolean!
+  
   """
   Issue or pull request from which the issue was disconnected.
   """
   source: ReferencedSubject!
+  
   """
   Issue or pull request which was disconnected.
   """
@@ -9584,50 +10794,62 @@ type Discussion implements Closable & Comment & Deletable & Labelable & Lockable
   Reason that the conversation was locked.
   """
   activeLockReason: LockReason
+  
   """
   The comment chosen as this discussion's answer, if any.
   """
   answer: DiscussionComment
+  
   """
   The time when a user chose this discussion's answer, if answered.
   """
   answerChosenAt: DateTime
+  
   """
   The user who chose this discussion's answer, if answered.
   """
   answerChosenBy: Actor
+  
   """
   The actor who authored the comment.
   """
   author: Actor
+  
   """
   Author's association with the subject of the comment.
   """
   authorAssociation: CommentAuthorAssociation!
+  
   """
   The main text of the discussion post.
   """
   body: String!
+  
   """
   The body rendered to HTML.
   """
   bodyHTML: HTML!
+  
   """
   The body rendered to text.
   """
   bodyText: String!
+  
   """
   The category for this discussion.
   """
   category: DiscussionCategory!
+  
   """
   Indicates if the object is closed (definition of closed may depend on type)
   """
   closed: Boolean!
+  
   """
   Identifies the date and time when the object was closed.
   """
   closedAt: DateTime
+  
   """
   The replies to the discussion.
   """
@@ -9636,44 +10858,54 @@ type Discussion implements Closable & Comment & Deletable & Labelable & Lockable
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): DiscussionCommentConnection!
+  
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
+  
   """
   Check if this comment was created via an email reply.
   """
   createdViaEmail: Boolean!
+  
   """
   Identifies the primary key from the database.
   """
   databaseId: Int
+  
   """
   The actor who edited the comment.
   """
   editor: Actor
   id: ID!
+  
   """
   Check if this comment was edited and includes an edit with the creation data
   """
   includesCreatedEdit: Boolean!
+  
   """
   Only return answered/unanswered discussions
   """
   isAnswered: Boolean
+  
   """
   A list of labels associated with the object.
   """
@@ -9682,47 +10914,58 @@ type Discussion implements Closable & Comment & Deletable & Labelable & Lockable
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for labels returned from the connection.
     """
     orderBy: LabelOrder = { field: CREATED_AT, direction: ASC }
   ): LabelConnection
+  
   """
   The moment the editor made the last edit
   """
   lastEditedAt: DateTime
+  
   """
   `true` if the object is locked
   """
   locked: Boolean!
+  
   """
   The number identifying this discussion within the repository.
   """
   number: Int!
+  
   """
   The poll associated with this discussion, if one exists.
   """
   poll: DiscussionPoll
+  
   """
   Identifies when the comment was published at.
   """
   publishedAt: DateTime
+  
   """
   A list of reactions grouped by content left on the subject.
   """
   reactionGroups: [ReactionGroup!]
+  
   """
   A list of Reactions left on the Issue.
   """
@@ -9731,55 +10974,68 @@ type Discussion implements Closable & Comment & Deletable & Labelable & Lockable
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Allows filtering Reactions by emoji.
     """
     content: ReactionContent
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Allows specifying the order in which reactions are returned.
     """
     orderBy: ReactionOrder
   ): ReactionConnection!
+  
   """
   The repository associated with this node.
   """
   repository: Repository!
+  
   """
   The path for this discussion.
   """
   resourcePath: URI!
+  
   """
   Identifies the reason for the discussion's state.
   """
   stateReason: DiscussionStateReason
+  
   """
   The title of this discussion.
   """
   title: String!
+  
   """
   Identifies the date and time when the object was last updated.
   """
   updatedAt: DateTime!
+  
   """
   Number of upvotes that this subject has received.
   """
   upvoteCount: Int!
+  
   """
   The URL for this discussion.
   """
   url: URI!
+  
   """
   A list of edits to this content.
   """
@@ -9788,55 +11044,68 @@ type Discussion implements Closable & Comment & Deletable & Labelable & Lockable
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): UserContentEditConnection
+  
   """
   Indicates if the object can be closed by the viewer.
   """
   viewerCanClose: Boolean!
+  
   """
   Check if the current viewer can delete this object.
   """
   viewerCanDelete: Boolean!
+  
   """
   Can user react to this subject
   """
   viewerCanReact: Boolean!
+  
   """
   Indicates if the object can be reopened by the viewer.
   """
   viewerCanReopen: Boolean!
+  
   """
   Check if the viewer is able to change their subscription status for the repository.
   """
   viewerCanSubscribe: Boolean!
+  
   """
   Check if the current viewer can update this object.
   """
   viewerCanUpdate: Boolean!
+  
   """
   Whether or not the current user can add or remove an upvote on this subject.
   """
   viewerCanUpvote: Boolean!
+  
   """
   Did the viewer author this comment.
   """
   viewerDidAuthor: Boolean!
+  
   """
   Whether or not the current user has already upvoted this subject.
   """
   viewerHasUpvoted: Boolean!
+  
   """
   Identifies if the viewer is watching, not watching, or ignoring the subscribable entity.
   """
@@ -9851,35 +11120,43 @@ type DiscussionCategory implements Node & RepositoryNode {
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
+  
   """
   A description of this category.
   """
   description: String
+  
   """
   An emoji representing this category.
   """
   emoji: String!
+  
   """
   This category's emoji rendered as HTML.
   """
   emojiHTML: HTML!
   id: ID!
+  
   """
   Whether or not discussions in this category support choosing an answer with the markDiscussionCommentAsAnswer mutation.
   """
   isAnswerable: Boolean!
+  
   """
   The name of this category.
   """
   name: String!
+  
   """
   The repository associated with this node.
   """
   repository: Repository!
+  
   """
   The slug of this category.
   """
   slug: String!
+  
   """
   Identifies the date and time when the object was last updated.
   """
@@ -9894,14 +11171,17 @@ type DiscussionCategoryConnection {
   A list of edges.
   """
   edges: [DiscussionCategoryEdge]
+  
   """
   A list of nodes.
   """
   nodes: [DiscussionCategory]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -9916,6 +11196,7 @@ type DiscussionCategoryEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -9948,77 +11229,95 @@ type DiscussionComment implements Comment & Deletable & Minimizable & Node & Rea
   The actor who authored the comment.
   """
   author: Actor
+  
   """
   Author's association with the subject of the comment.
   """
   authorAssociation: CommentAuthorAssociation!
+  
   """
   The body as Markdown.
   """
   body: String!
+  
   """
   The body rendered to HTML.
   """
   bodyHTML: HTML!
+  
   """
   The body rendered to text.
   """
   bodyText: String!
+  
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
+  
   """
   Check if this comment was created via an email reply.
   """
   createdViaEmail: Boolean!
+  
   """
   Identifies the primary key from the database.
   """
   databaseId: Int
+  
   """
   The time when this replied-to comment was deleted
   """
   deletedAt: DateTime
+  
   """
   The discussion this comment was created in
   """
   discussion: Discussion
+  
   """
   The actor who edited the comment.
   """
   editor: Actor
   id: ID!
+  
   """
   Check if this comment was edited and includes an edit with the creation data
   """
   includesCreatedEdit: Boolean!
+  
   """
   Has this comment been chosen as the answer of its discussion?
   """
   isAnswer: Boolean!
+  
   """
   Returns whether or not a comment has been minimized.
   """
   isMinimized: Boolean!
+  
   """
   The moment the editor made the last edit
   """
   lastEditedAt: DateTime
+  
   """
   Returns why the comment was minimized. One of `abuse`, `off-topic`,
   `outdated`, `resolved`, `duplicate` and `spam`. Note that the case and
   formatting of these values differs from the inputs to the `MinimizeComment` mutation.
   """
   minimizedReason: String
+  
   """
   Identifies when the comment was published at.
   """
   publishedAt: DateTime
+  
   """
   A list of reactions grouped by content left on the subject.
   """
   reactionGroups: [ReactionGroup!]
+  
   """
   A list of Reactions left on the Issue.
   """
@@ -10027,27 +11326,33 @@ type DiscussionComment implements Comment & Deletable & Minimizable & Node & Rea
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Allows filtering Reactions by emoji.
     """
     content: ReactionContent
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Allows specifying the order in which reactions are returned.
     """
     orderBy: ReactionOrder
   ): ReactionConnection!
+  
   """
   The threaded replies to this comment.
   """
@@ -10056,39 +11361,48 @@ type DiscussionComment implements Comment & Deletable & Minimizable & Node & Rea
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): DiscussionCommentConnection!
+  
   """
   The discussion comment this comment is a reply to
   """
   replyTo: DiscussionComment
+  
   """
   The path for this discussion comment.
   """
   resourcePath: URI!
+  
   """
   Identifies the date and time when the object was last updated.
   """
   updatedAt: DateTime!
+  
   """
   Number of upvotes that this subject has received.
   """
   upvoteCount: Int!
+  
   """
   The URL for this discussion comment.
   """
   url: URI!
+  
   """
   A list of edits to this content.
   """
@@ -10097,55 +11411,68 @@ type DiscussionComment implements Comment & Deletable & Minimizable & Node & Rea
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): UserContentEditConnection
+  
   """
   Check if the current viewer can delete this object.
   """
   viewerCanDelete: Boolean!
+  
   """
   Can the current user mark this comment as an answer?
   """
   viewerCanMarkAsAnswer: Boolean!
+  
   """
   Check if the current viewer can minimize this object.
   """
   viewerCanMinimize: Boolean!
+  
   """
   Can user react to this subject
   """
   viewerCanReact: Boolean!
+  
   """
   Can the current user unmark this comment as an answer?
   """
   viewerCanUnmarkAsAnswer: Boolean!
+  
   """
   Check if the current viewer can update this object.
   """
   viewerCanUpdate: Boolean!
+  
   """
   Whether or not the current user can add or remove an upvote on this subject.
   """
   viewerCanUpvote: Boolean!
+  
   """
   Reasons why the current viewer can not update this comment.
   """
   viewerCannotUpdateReasons: [CommentCannotUpdateReason!]!
+  
   """
   Did the viewer author this comment.
   """
   viewerDidAuthor: Boolean!
+  
   """
   Whether or not the current user has already upvoted this subject.
   """
@@ -10160,14 +11487,17 @@ type DiscussionCommentConnection {
   A list of edges.
   """
   edges: [DiscussionCommentEdge]
+  
   """
   A list of nodes.
   """
   nodes: [DiscussionComment]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -10182,6 +11512,7 @@ type DiscussionCommentEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -10196,14 +11527,17 @@ type DiscussionConnection {
   A list of edges.
   """
   edges: [DiscussionEdge]
+  
   """
   A list of nodes.
   """
   nodes: [Discussion]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -10218,6 +11552,7 @@ type DiscussionEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -10232,6 +11567,7 @@ input DiscussionOrder {
   The direction in which to order discussions by the specified field.
   """
   direction: OrderDirection!
+  
   """
   The field by which to order discussions.
   """
@@ -10261,6 +11597,7 @@ type DiscussionPoll implements Node {
   """
   discussion: Discussion
   id: ID!
+  
   """
   The options for this poll.
   """
@@ -10269,36 +11606,44 @@ type DiscussionPoll implements Node {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     How to order the options for the discussion poll.
     """
     orderBy: DiscussionPollOptionOrder = { field: AUTHORED_ORDER, direction: ASC
     }
   ): DiscussionPollOptionConnection
+  
   """
   The question that is being asked by this poll.
   """
   question: String!
+  
   """
   The total number of votes that have been cast for this poll.
   """
   totalVoteCount: Int!
+  
   """
   Indicates if the viewer has permission to vote in this poll.
   """
   viewerCanVote: Boolean!
+  
   """
   Indicates if the viewer has voted for any option in this poll.
   """
@@ -10310,18 +11655,22 @@ An option for a discussion poll.
 """
 type DiscussionPollOption implements Node {
   id: ID!
+  
   """
   The text for this option.
   """
   option: String!
+  
   """
   The discussion poll that this option belongs to.
   """
   poll: DiscussionPoll
+  
   """
   The total number of votes that have been cast for this option.
   """
   totalVoteCount: Int!
+  
   """
   Indicates if the viewer has voted for this option in the poll.
   """
@@ -10336,14 +11685,17 @@ type DiscussionPollOptionConnection {
   A list of edges.
   """
   edges: [DiscussionPollOptionEdge]
+  
   """
   A list of nodes.
   """
   nodes: [DiscussionPollOption]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -10358,6 +11710,7 @@ type DiscussionPollOptionEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -10372,6 +11725,7 @@ input DiscussionPollOptionOrder {
   The ordering direction.
   """
   direction: OrderDirection!
+  
   """
   The field to order poll options by.
   """
@@ -10436,10 +11790,12 @@ input DismissPullRequestReviewInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The contents of the pull request review dismissal message.
   """
   message: String!
+  
   """
   The Node ID of the pull request review to modify.
   """
@@ -10454,6 +11810,7 @@ type DismissPullRequestReviewPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The dismissed pull request review.
   """
@@ -10494,10 +11851,12 @@ input DismissRepositoryVulnerabilityAlertInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The reason the Dependabot alert is being dismissed.
   """
   dismissReason: DismissReason!
+  
   """
   The Dependabot alert ID to dismiss.
   """
@@ -10513,6 +11872,7 @@ type DismissRepositoryVulnerabilityAlertPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The Dependabot alert that was dismissed
   """
@@ -10531,40 +11891,49 @@ type DraftIssue implements Node {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): UserConnection!
+  
   """
   The body of the draft issue.
   """
   body: String!
+  
   """
   The body of the draft issue rendered to HTML.
   """
   bodyHTML: HTML!
+  
   """
   The body of the draft issue rendered to text.
   """
   bodyText: String!
+  
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
+  
   """
   The actor who created this draft issue.
   """
   creator: Actor
   id: ID!
+  
   """
   List of items linked with the draft issue (currently draft issue can be linked to only one item).
   """
@@ -10573,19 +11942,23 @@ type DraftIssue implements Node {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): ProjectV2ItemConnection!
+  
   """
   Projects that link to this draft issue (currently draft issue can be linked to only one project).
   """
@@ -10594,23 +11967,28 @@ type DraftIssue implements Node {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): ProjectV2Connection!
+  
   """
   The title of the draft issue
   """
   title: String!
+  
   """
   Identifies the date and time when the object was last updated.
   """
@@ -10625,10 +12003,12 @@ input DraftPullRequestReviewComment {
   Body of the comment to leave.
   """
   body: String!
+  
   """
   Path to the file being commented on.
   """
   path: String!
+  
   """
   Position in the file to leave a comment on.
   """
@@ -10643,22 +12023,27 @@ input DraftPullRequestReviewThread {
   Body of the comment to leave.
   """
   body: String!
+  
   """
   The line of the blob to which the thread refers. The end of the line range for multi-line comments.
   """
   line: Int!
+  
   """
   Path to the file being commented on.
   """
   path: String!
+  
   """
   The side of the diff on which the line resides. For multi-line comments, this is the side for the end of the line range.
   """
   side: DiffSide = RIGHT
+  
   """
   The first line of the range to which the comment refers.
   """
   startLine: Int
+  
   """
   The side of the diff on which the start line resides.
   """
@@ -10673,31 +12058,37 @@ input EnablePullRequestAutoMergeInput {
   The email address to associate with this merge.
   """
   authorEmail: String
+  
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   Commit body to use for the commit when the PR is mergable; if omitted, a
   default message will be used. NOTE: when merging with a merge queue any input
   value for commit message is ignored.
   """
   commitBody: String
+  
   """
   Commit headline to use for the commit when the PR is mergable; if omitted, a
   default message will be used. NOTE: when merging with a merge queue any input
   value for commit headline is ignored.
   """
   commitHeadline: String
+  
   """
   The expected head OID of the pull request.
   """
   expectedHeadOid: GitObjectID
+  
   """
   The merge method to use. If omitted, defaults to `MERGE`. NOTE: when merging
   with a merge queue any input value for merge method is ignored.
   """
   mergeMethod: PullRequestMergeMethod = MERGE
+  
   """
   ID of the pull request to enable auto-merge on.
   """
@@ -10712,10 +12103,12 @@ type EnablePullRequestAutoMergePayload {
   Identifies the actor who performed the event.
   """
   actor: Actor
+  
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The pull request auto-merge was enabled on.
   """
@@ -10730,14 +12123,17 @@ input EnqueuePullRequestInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The expected head OID of the pull request.
   """
   expectedHeadOid: GitObjectID
+  
   """
   Add the pull request to the front of the queue.
   """
   jump: Boolean
+  
   """
   The ID of the pull request to enqueue.
   """
@@ -10752,6 +12148,7 @@ type EnqueuePullRequestPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The merge queue entry for the enqueued pull request.
   """
@@ -10766,14 +12163,17 @@ type Enterprise implements AnnouncementBanner & Node {
   The text of the announcement
   """
   announcement: String
+  
   """
   The expiration date of the announcement, if any
   """
   announcementExpiresAt: DateTime
+  
   """
   Whether the announcement can be dismissed by the user
   """
   announcementUserDismissible: Boolean
+  
   """
   A URL pointing to the enterprise's public avatar.
   """
@@ -10783,31 +12183,38 @@ type Enterprise implements AnnouncementBanner & Node {
     """
     size: Int
   ): URI!
+  
   """
   Enterprise billing information visible to enterprise billing managers.
   """
   billingInfo: EnterpriseBillingInfo
+  
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
+  
   """
   Identifies the primary key from the database.
   """
   databaseId: Int
+  
   """
   The description of the enterprise.
   """
   description: String
+  
   """
   The description of the enterprise as HTML.
   """
   descriptionHTML: HTML!
   id: ID!
+  
   """
   The location of the enterprise.
   """
   location: String
+  
   """
   A list of users who are members of this enterprise.
   """
@@ -10816,48 +12223,59 @@ type Enterprise implements AnnouncementBanner & Node {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Only return members within the selected GitHub Enterprise deployment
     """
     deployment: EnterpriseUserDeployment
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Only return members with this two-factor authentication status. Does not
     include members who only have an account on a GitHub Enterprise Server instance.
     """
     hasTwoFactorEnabled: Boolean = null
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for members returned from the connection.
     """
     orderBy: EnterpriseMemberOrder = { field: LOGIN, direction: ASC }
+    
     """
     Only return members within the organizations with these logins
     """
     organizationLogins: [String!]
+    
     """
     The search string to look for.
     """
     query: String
+    
     """
     The role of the user in the enterprise organization or server.
     """
     role: EnterpriseUserAccountMembershipRole
   ): EnterpriseMemberConnection!
+  
   """
   The name of the enterprise.
   """
   name: String!
+  
   """
   A list of organizations that belong to this enterprise.
   """
@@ -10866,52 +12284,64 @@ type Enterprise implements AnnouncementBanner & Node {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for organizations returned from the connection.
     """
     orderBy: OrganizationOrder = { field: LOGIN, direction: ASC }
+    
     """
     The search string to look for.
     """
     query: String
+    
     """
     The viewer's role in an organization.
     """
     viewerOrganizationRole: RoleInOrganization
   ): OrganizationConnection!
+  
   """
   Enterprise information visible to enterprise owners or enterprise owners'
   personal access tokens (classic) with read:enterprise or admin:enterprise scope.
   """
   ownerInfo: EnterpriseOwnerInfo
+  
   """
   The HTTP path for this enterprise.
   """
   resourcePath: URI!
+  
   """
   The URL-friendly identifier for the enterprise.
   """
   slug: String!
+  
   """
   The HTTP URL for this enterprise.
   """
   url: URI!
+  
   """
   Is the current viewer an admin of this enterprise?
   """
   viewerIsAdmin: Boolean!
+  
   """
   The URL of the enterprise website.
   """
@@ -10926,14 +12356,17 @@ type EnterpriseAdministratorConnection {
   A list of edges.
   """
   edges: [EnterpriseAdministratorEdge]
+  
   """
   A list of nodes.
   """
   nodes: [User]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -10948,10 +12381,12 @@ type EnterpriseAdministratorEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
   node: User
+  
   """
   The role of the administrator.
   """
@@ -10966,23 +12401,28 @@ type EnterpriseAdministratorInvitation implements Node {
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
+  
   """
   The email of the person who was invited to the enterprise.
   """
   email: String
+  
   """
   The enterprise the invitation is for.
   """
   enterprise: Enterprise!
   id: ID!
+  
   """
   The user who was invited to the enterprise.
   """
   invitee: User
+  
   """
   The user who created the invitation.
   """
   inviter: User
+  
   """
   The invitee's pending role in the enterprise (owner or billing_manager).
   """
@@ -10997,14 +12437,17 @@ type EnterpriseAdministratorInvitationConnection {
   A list of edges.
   """
   edges: [EnterpriseAdministratorInvitationEdge]
+  
   """
   A list of nodes.
   """
   nodes: [EnterpriseAdministratorInvitation]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -11019,6 +12462,7 @@ type EnterpriseAdministratorInvitationEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -11033,6 +12477,7 @@ input EnterpriseAdministratorInvitationOrder {
   The ordering direction.
   """
   direction: OrderDirection!
+  
   """
   The field to order enterprise administrator invitations by.
   """
@@ -11101,10 +12546,12 @@ interface EnterpriseAuditEntryData {
   The HTTP path for this enterprise.
   """
   enterpriseResourcePath: URI
+  
   """
   The slug of the enterprise.
   """
   enterpriseSlug: String
+  
   """
   The HTTP URL for this enterprise.
   """
@@ -11119,38 +12566,47 @@ type EnterpriseBillingInfo {
   The number of licenseable users/emails across the enterprise.
   """
   allLicensableUsersCount: Int!
+  
   """
   The number of data packs used by all organizations owned by the enterprise.
   """
   assetPacks: Int!
+  
   """
   The bandwidth quota in GB for all organizations owned by the enterprise.
   """
   bandwidthQuota: Float!
+  
   """
   The bandwidth usage in GB for all organizations owned by the enterprise.
   """
   bandwidthUsage: Float!
+  
   """
   The bandwidth usage as a percentage of the bandwidth quota.
   """
   bandwidthUsagePercentage: Int!
+  
   """
   The storage quota in GB for all organizations owned by the enterprise.
   """
   storageQuota: Float!
+  
   """
   The storage usage in GB for all organizations owned by the enterprise.
   """
   storageUsage: Float!
+  
   """
   The storage usage as a percentage of the storage quota.
   """
   storageUsagePercentage: Int!
+  
   """
   The number of available licenses across all owned organizations based on the unique number of billable users.
   """
   totalAvailableLicenses: Int!
+  
   """
   The total number of licenses allocated.
   """
@@ -11165,14 +12621,17 @@ type EnterpriseConnection {
   A list of edges.
   """
   edges: [EnterpriseEdge]
+  
   """
   A list of nodes.
   """
   nodes: [Enterprise]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -11213,6 +12672,7 @@ type EnterpriseEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -11259,18 +12719,22 @@ type EnterpriseFailedInvitationConnection {
   A list of edges.
   """
   edges: [EnterpriseFailedInvitationEdge]
+  
   """
   A list of nodes.
   """
   nodes: [OrganizationInvitation]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
   totalCount: Int!
+  
   """
   Identifies the total count of unique users in the connection.
   """
@@ -11285,6 +12749,7 @@ type EnterpriseFailedInvitationEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -11301,10 +12766,12 @@ type EnterpriseIdentityProvider implements Node {
   The digest algorithm used to sign SAML requests for the identity provider.
   """
   digestMethod: SamlDigestAlgorithm
+  
   """
   The enterprise this identity provider belongs to.
   """
   enterprise: Enterprise
+  
   """
   ExternalIdentities provisioned by this identity provider.
   """
@@ -11313,48 +12780,59 @@ type EnterpriseIdentityProvider implements Node {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Filter to external identities with the users login
     """
     login: String
+    
     """
     Filter to external identities with valid org membership only
     """
     membersOnly: Boolean
+    
     """
     Filter to external identities with the users userName/NameID attribute
     """
     userName: String
   ): ExternalIdentityConnection!
   id: ID!
+  
   """
   The x509 certificate used by the identity provider to sign assertions and responses.
   """
   idpCertificate: X509Certificate
+  
   """
   The Issuer Entity ID for the SAML identity provider.
   """
   issuer: String
+  
   """
   Recovery codes that can be used by admins to access the enterprise if the identity provider is unavailable.
   """
   recoveryCodes: [String!]
+  
   """
   The signature algorithm used to sign SAML requests for the identity provider.
   """
   signatureMethod: SamlSignatureAlgorithm
+  
   """
   The URL endpoint for the identity provider's SAML SSO.
   """
@@ -11374,14 +12852,17 @@ type EnterpriseMemberConnection {
   A list of edges.
   """
   edges: [EnterpriseMemberEdge]
+  
   """
   A list of nodes.
   """
   nodes: [EnterpriseMember]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -11396,6 +12877,7 @@ type EnterpriseMemberEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -11410,6 +12892,7 @@ input EnterpriseMemberOrder {
   The ordering direction.
   """
   direction: OrderDirection!
+  
   """
   The field to order enterprise members by.
   """
@@ -11500,6 +12983,7 @@ input EnterpriseOrder {
   The ordering direction.
   """
   direction: OrderDirection!
+  
   """
   The field to order enterprises by.
   """
@@ -11524,14 +13008,17 @@ type EnterpriseOrganizationMembershipConnection {
   A list of edges.
   """
   edges: [EnterpriseOrganizationMembershipEdge]
+  
   """
   A list of nodes.
   """
   nodes: [Organization]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -11546,10 +13033,12 @@ type EnterpriseOrganizationMembershipEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
   node: Organization
+  
   """
   The role of the user in the enterprise membership.
   """
@@ -11564,14 +13053,17 @@ type EnterpriseOutsideCollaboratorConnection {
   A list of edges.
   """
   edges: [EnterpriseOutsideCollaboratorEdge]
+  
   """
   A list of nodes.
   """
   nodes: [User]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -11586,10 +13078,12 @@ type EnterpriseOutsideCollaboratorEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
   node: User
+  
   """
   The enterprise organization repositories this user is a member of.
   """
@@ -11598,18 +13092,22 @@ type EnterpriseOutsideCollaboratorEdge {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for repositories.
     """
@@ -11630,39 +13128,48 @@ type EnterpriseOwnerInfo {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Only return administrators with this two-factor authentication status.
     """
     hasTwoFactorEnabled: Boolean = null
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for administrators returned from the connection.
     """
     orderBy: EnterpriseMemberOrder = { field: LOGIN, direction: ASC }
+    
     """
     Only return members within the organizations with these logins
     """
     organizationLogins: [String!]
+    
     """
     The search string to look for.
     """
     query: String
+    
     """
     The role to filter by.
     """
     role: EnterpriseAdministratorRole
   ): EnterpriseAdministratorConnection!
+  
   """
   A list of users in the enterprise who currently have two-factor authentication disabled.
   """
@@ -11671,27 +13178,33 @@ type EnterpriseOwnerInfo {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): UserConnection!
+  
   """
   Whether or not affiliated users with two-factor authentication disabled exist in the enterprise.
   """
   affiliatedUsersWithTwoFactorDisabledExist: Boolean!
+  
   """
   The setting value for whether private repository forking is enabled for repositories in organizations in this enterprise.
   """
   allowPrivateRepositoryForkingSetting: EnterpriseEnabledDisabledSettingValue!
+  
   """
   A list of enterprise organizations configured with the provided private repository forking setting value.
   """
@@ -11700,35 +13213,43 @@ type EnterpriseOwnerInfo {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for organizations with this setting.
     """
     orderBy: OrganizationOrder = { field: LOGIN, direction: ASC }
+    
     """
     The setting value to find organizations for.
     """
     value: Boolean!
   ): OrganizationConnection!
+  
   """
   The value for the allow private repository forking policy on the enterprise.
   """
   allowPrivateRepositoryForkingSettingPolicyValue: EnterpriseAllowPrivateRepositoryForkingPolicyValue
+  
   """
   The setting value for base repository permissions for organizations in this enterprise.
   """
   defaultRepositoryPermissionSetting: EnterpriseDefaultRepositoryPermissionSettingValue!
+  
   """
   A list of enterprise organizations configured with the provided base repository permission.
   """
@@ -11737,27 +13258,33 @@ type EnterpriseOwnerInfo {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for organizations with this setting.
     """
     orderBy: OrganizationOrder = { field: LOGIN, direction: ASC }
+    
     """
     The permission to find organizations for.
     """
     value: DefaultRepositoryPermissionField!
   ): OrganizationConnection!
+  
   """
   A list of domains owned by the enterprise. Visible to enterprise owners or
   enterprise owners' personal access tokens (classic) with admin:enterprise scope.
@@ -11767,31 +13294,38 @@ type EnterpriseOwnerInfo {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Filter whether or not the domain is approved.
     """
     isApproved: Boolean = null
+    
     """
     Filter whether or not the domain is verified.
     """
     isVerified: Boolean = null
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for verifiable domains returned.
     """
     orderBy: VerifiableDomainOrder = { field: DOMAIN, direction: ASC }
   ): VerifiableDomainConnection!
+  
   """
   Enterprise Server installations owned by the enterprise.
   """
@@ -11800,28 +13334,34 @@ type EnterpriseOwnerInfo {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Whether or not to only return installations discovered via GitHub Connect.
     """
     connectedOnly: Boolean = false
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for Enterprise Server installations returned.
     """
     orderBy: EnterpriseServerInstallationOrder = {
     field: HOST_NAME, direction: ASC }
   ): EnterpriseServerInstallationConnection!
+  
   """
   A list of failed invitations in the enterprise.
   """
@@ -11830,27 +13370,33 @@ type EnterpriseOwnerInfo {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     The search string to look for.
     """
     query: String
   ): EnterpriseFailedInvitationConnection!
+  
   """
   The setting value for whether the enterprise has an IP allow list enabled.
   """
   ipAllowListEnabledSetting: IpAllowListEnabledSettingValue!
+  
   """
   The IP addresses that are allowed to access resources owned by the enterprise.
   Visible to enterprise owners or enterprise owners' personal access tokens
@@ -11861,40 +13407,49 @@ type EnterpriseOwnerInfo {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for IP allow list entries returned.
     """
     orderBy: IpAllowListEntryOrder = { field: ALLOW_LIST_VALUE, direction: ASC }
   ): IpAllowListEntryConnection!
+  
   """
   The setting value for whether the enterprise has IP allow list configuration for installed GitHub Apps enabled.
   """
   ipAllowListForInstalledAppsEnabledSetting: IpAllowListForInstalledAppsEnabledSettingValue!
+  
   """
   Whether or not the base repository permission is currently being updated.
   """
   isUpdatingDefaultRepositoryPermission: Boolean!
+  
   """
   Whether the two-factor authentication requirement is currently being enforced.
   """
   isUpdatingTwoFactorRequirement: Boolean!
+  
   """
   The setting value for whether organization members with admin permissions on a
   repository can change repository visibility.
   """
   membersCanChangeRepositoryVisibilitySetting: EnterpriseEnabledDisabledSettingValue!
+  
   """
   A list of enterprise organizations configured with the provided can change repository visibility setting value.
   """
@@ -11903,43 +13458,53 @@ type EnterpriseOwnerInfo {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for organizations with this setting.
     """
     orderBy: OrganizationOrder = { field: LOGIN, direction: ASC }
+    
     """
     The setting value to find organizations for.
     """
     value: Boolean!
   ): OrganizationConnection!
+  
   """
   The setting value for whether members of organizations in the enterprise can create internal repositories.
   """
   membersCanCreateInternalRepositoriesSetting: Boolean
+  
   """
   The setting value for whether members of organizations in the enterprise can create private repositories.
   """
   membersCanCreatePrivateRepositoriesSetting: Boolean
+  
   """
   The setting value for whether members of organizations in the enterprise can create public repositories.
   """
   membersCanCreatePublicRepositoriesSetting: Boolean
+  
   """
   The setting value for whether members of organizations in the enterprise can create repositories.
   """
   membersCanCreateRepositoriesSetting: EnterpriseMembersCanCreateRepositoriesSettingValue
+  
   """
   A list of enterprise organizations configured with the provided repository creation setting value.
   """
@@ -11948,31 +13513,38 @@ type EnterpriseOwnerInfo {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for organizations with this setting.
     """
     orderBy: OrganizationOrder = { field: LOGIN, direction: ASC }
+    
     """
     The setting to find organizations for.
     """
     value: OrganizationMembersCanCreateRepositoriesSettingValue!
   ): OrganizationConnection!
+  
   """
   The setting value for whether members with admin permissions for repositories can delete issues.
   """
   membersCanDeleteIssuesSetting: EnterpriseEnabledDisabledSettingValue!
+  
   """
   A list of enterprise organizations configured with the provided members can delete issues setting value.
   """
@@ -11981,31 +13553,38 @@ type EnterpriseOwnerInfo {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for organizations with this setting.
     """
     orderBy: OrganizationOrder = { field: LOGIN, direction: ASC }
+    
     """
     The setting value to find organizations for.
     """
     value: Boolean!
   ): OrganizationConnection!
+  
   """
   The setting value for whether members with admin permissions for repositories can delete or transfer repositories.
   """
   membersCanDeleteRepositoriesSetting: EnterpriseEnabledDisabledSettingValue!
+  
   """
   A list of enterprise organizations configured with the provided members can delete repositories setting value.
   """
@@ -12014,31 +13593,38 @@ type EnterpriseOwnerInfo {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for organizations with this setting.
     """
     orderBy: OrganizationOrder = { field: LOGIN, direction: ASC }
+    
     """
     The setting value to find organizations for.
     """
     value: Boolean!
   ): OrganizationConnection!
+  
   """
   The setting value for whether members of organizations in the enterprise can invite outside collaborators.
   """
   membersCanInviteCollaboratorsSetting: EnterpriseEnabledDisabledSettingValue!
+  
   """
   A list of enterprise organizations configured with the provided members can invite collaborators setting value.
   """
@@ -12047,35 +13633,43 @@ type EnterpriseOwnerInfo {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for organizations with this setting.
     """
     orderBy: OrganizationOrder = { field: LOGIN, direction: ASC }
+    
     """
     The setting value to find organizations for.
     """
     value: Boolean!
   ): OrganizationConnection!
+  
   """
   Indicates whether members of this enterprise's organizations can purchase additional services for those organizations.
   """
   membersCanMakePurchasesSetting: EnterpriseMembersCanMakePurchasesSettingValue!
+  
   """
   The setting value for whether members with admin permissions for repositories can update protected branches.
   """
   membersCanUpdateProtectedBranchesSetting: EnterpriseEnabledDisabledSettingValue!
+  
   """
   A list of enterprise organizations configured with the provided members can update protected branches setting value.
   """
@@ -12084,31 +13678,38 @@ type EnterpriseOwnerInfo {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for organizations with this setting.
     """
     orderBy: OrganizationOrder = { field: LOGIN, direction: ASC }
+    
     """
     The setting value to find organizations for.
     """
     value: Boolean!
   ): OrganizationConnection!
+  
   """
   The setting value for whether members can view dependency insights.
   """
   membersCanViewDependencyInsightsSetting: EnterpriseEnabledDisabledSettingValue!
+  
   """
   A list of enterprise organizations configured with the provided members can view dependency insights setting value.
   """
@@ -12117,39 +13718,48 @@ type EnterpriseOwnerInfo {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for organizations with this setting.
     """
     orderBy: OrganizationOrder = { field: LOGIN, direction: ASC }
+    
     """
     The setting value to find organizations for.
     """
     value: Boolean!
   ): OrganizationConnection!
+  
   """
   Indicates if email notification delivery for this enterprise is restricted to verified or approved domains.
   """
   notificationDeliveryRestrictionEnabledSetting: NotificationRestrictionSettingValue!
+  
   """
   The OIDC Identity Provider for the enterprise.
   """
   oidcProvider: OIDCProvider
+  
   """
   The setting value for whether organization projects are enabled for organizations in this enterprise.
   """
   organizationProjectsSetting: EnterpriseEnabledDisabledSettingValue!
+  
   """
   A list of enterprise organizations configured with the provided organization projects setting value.
   """
@@ -12158,27 +13768,33 @@ type EnterpriseOwnerInfo {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for organizations with this setting.
     """
     orderBy: OrganizationOrder = { field: LOGIN, direction: ASC }
+    
     """
     The setting value to find organizations for.
     """
     value: Boolean!
   ): OrganizationConnection!
+  
   """
   A list of outside collaborators across the repositories in the enterprise.
   """
@@ -12187,43 +13803,53 @@ type EnterpriseOwnerInfo {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Only return outside collaborators with this two-factor authentication status.
     """
     hasTwoFactorEnabled: Boolean = null
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     The login of one specific outside collaborator.
     """
     login: String
+    
     """
     Ordering options for outside collaborators returned from the connection.
     """
     orderBy: EnterpriseMemberOrder = { field: LOGIN, direction: ASC }
+    
     """
     Only return outside collaborators within the organizations with these logins
     """
     organizationLogins: [String!]
+    
     """
     The search string to look for.
     """
     query: String
+    
     """
     Only return outside collaborators on repositories with this visibility.
     """
     visibility: RepositoryVisibility
   ): EnterpriseOutsideCollaboratorConnection!
+  
   """
   A list of pending administrator invitations for the enterprise.
   """
@@ -12232,32 +13858,39 @@ type EnterpriseOwnerInfo {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for pending enterprise administrator invitations returned from the connection.
     """
     orderBy: EnterpriseAdministratorInvitationOrder = {
     field: CREATED_AT, direction: DESC }
+    
     """
     The search string to look for.
     """
     query: String
+    
     """
     The role to filter by.
     """
     role: EnterpriseAdministratorRole
   ): EnterpriseAdministratorInvitationConnection!
+  
   """
   A list of pending collaborator invitations across the repositories in the enterprise.
   """
@@ -12266,27 +13899,33 @@ type EnterpriseOwnerInfo {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for pending repository collaborator invitations returned from the connection.
     """
     orderBy: RepositoryInvitationOrder = { field: CREATED_AT, direction: DESC }
+    
     """
     The search string to look for.
     """
     query: String
   ): RepositoryInvitationConnection!
+  
   """
   A list of pending member invitations for organizations in the enterprise.
   """
@@ -12295,35 +13934,43 @@ type EnterpriseOwnerInfo {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Only return invitations matching this invitation source
     """
     invitationSource: OrganizationInvitationSource
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Only return invitations within the organizations with these logins
     """
     organizationLogins: [String!]
+    
     """
     The search string to look for.
     """
     query: String
   ): EnterprisePendingMemberInvitationConnection!
+  
   """
   The setting value for whether repository projects are enabled in this enterprise.
   """
   repositoryProjectsSetting: EnterpriseEnabledDisabledSettingValue!
+  
   """
   A list of enterprise organizations configured with the provided repository projects setting value.
   """
@@ -12332,31 +13979,38 @@ type EnterpriseOwnerInfo {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for organizations with this setting.
     """
     orderBy: OrganizationOrder = { field: LOGIN, direction: ASC }
+    
     """
     The setting value to find organizations for.
     """
     value: Boolean!
   ): OrganizationConnection!
+  
   """
   The SAML Identity Provider for the enterprise.
   """
   samlIdentityProvider: EnterpriseIdentityProvider
+  
   """
   A list of enterprise organizations configured with the SAML single sign-on setting value.
   """
@@ -12365,27 +14019,33 @@ type EnterpriseOwnerInfo {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for organizations with this setting.
     """
     orderBy: OrganizationOrder = { field: LOGIN, direction: ASC }
+    
     """
     The setting value to find organizations for.
     """
     value: IdentityProviderConfigurationState!
   ): OrganizationConnection!
+  
   """
   A list of members with a support entitlement.
   """
@@ -12394,27 +14054,33 @@ type EnterpriseOwnerInfo {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for support entitlement users returned from the connection.
     """
     orderBy: EnterpriseMemberOrder = { field: LOGIN, direction: ASC }
   ): EnterpriseMemberConnection!
+  
   """
   The setting value for whether team discussions are enabled for organizations in this enterprise.
   """
   teamDiscussionsSetting: EnterpriseEnabledDisabledSettingValue!
+  
   """
   A list of enterprise organizations configured with the provided team discussions setting value.
   """
@@ -12423,31 +14089,38 @@ type EnterpriseOwnerInfo {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for organizations with this setting.
     """
     orderBy: OrganizationOrder = { field: LOGIN, direction: ASC }
+    
     """
     The setting value to find organizations for.
     """
     value: Boolean!
   ): OrganizationConnection!
+  
   """
   The setting value for whether the enterprise requires two-factor authentication for its organizations and users.
   """
   twoFactorRequiredSetting: EnterpriseEnabledSettingValue!
+  
   """
   A list of enterprise organizations configured with the two-factor authentication setting value.
   """
@@ -12456,22 +14129,27 @@ type EnterpriseOwnerInfo {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for organizations with this setting.
     """
     orderBy: OrganizationOrder = { field: LOGIN, direction: ASC }
+    
     """
     The setting value to find organizations for.
     """
@@ -12487,18 +14165,22 @@ type EnterprisePendingMemberInvitationConnection {
   A list of edges.
   """
   edges: [EnterprisePendingMemberInvitationEdge]
+  
   """
   A list of nodes.
   """
   nodes: [OrganizationInvitation]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
   totalCount: Int!
+  
   """
   Identifies the total count of unique users in the connection.
   """
@@ -12513,6 +14195,7 @@ type EnterprisePendingMemberInvitationEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -12524,14 +14207,17 @@ A subset of repository information queryable from an enterprise.
 """
 type EnterpriseRepositoryInfo implements Node {
   id: ID!
+  
   """
   Identifies if the repository is private or internal.
   """
   isPrivate: Boolean!
+  
   """
   The repository's name.
   """
   name: String!
+  
   """
   The repository's name with owner.
   """
@@ -12546,14 +14232,17 @@ type EnterpriseRepositoryInfoConnection {
   A list of edges.
   """
   edges: [EnterpriseRepositoryInfoEdge]
+  
   """
   A list of nodes.
   """
   nodes: [EnterpriseRepositoryInfo]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -12568,6 +14257,7 @@ type EnterpriseRepositoryInfoEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -12582,23 +14272,28 @@ type EnterpriseServerInstallation implements Node {
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
+  
   """
   The customer name to which the Enterprise Server installation belongs.
   """
   customerName: String!
+  
   """
   The host name of the Enterprise Server installation.
   """
   hostName: String!
   id: ID!
+  
   """
   Whether or not the installation is connected to an Enterprise Server installation via GitHub Connect.
   """
   isConnected: Boolean!
+  
   """
   Identifies the date and time when the object was last updated.
   """
   updatedAt: DateTime!
+  
   """
   User accounts on this Enterprise Server installation.
   """
@@ -12607,23 +14302,28 @@ type EnterpriseServerInstallation implements Node {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for Enterprise Server user accounts returned from the connection.
     """
     orderBy: EnterpriseServerUserAccountOrder = { field: LOGIN, direction: ASC }
   ): EnterpriseServerUserAccountConnection!
+  
   """
   User accounts uploads for the Enterprise Server installation.
   """
@@ -12632,18 +14332,22 @@ type EnterpriseServerInstallation implements Node {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for Enterprise Server user accounts uploads returned from the connection.
     """
@@ -12660,14 +14364,17 @@ type EnterpriseServerInstallationConnection {
   A list of edges.
   """
   edges: [EnterpriseServerInstallationEdge]
+  
   """
   A list of nodes.
   """
   nodes: [EnterpriseServerInstallation]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -12682,6 +14389,7 @@ type EnterpriseServerInstallationEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -12696,14 +14404,17 @@ type EnterpriseServerInstallationMembershipConnection {
   A list of edges.
   """
   edges: [EnterpriseServerInstallationMembershipEdge]
+  
   """
   A list of nodes.
   """
   nodes: [EnterpriseServerInstallation]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -12718,10 +14429,12 @@ type EnterpriseServerInstallationMembershipEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
   node: EnterpriseServerInstallation
+  
   """
   The role of the user in the enterprise membership.
   """
@@ -12736,6 +14449,7 @@ input EnterpriseServerInstallationOrder {
   The ordering direction.
   """
   direction: OrderDirection!
+  
   """
   The field to order Enterprise Server installations by.
   """
@@ -12768,6 +14482,7 @@ type EnterpriseServerUserAccount implements Node {
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
+  
   """
   User emails belonging to this user account.
   """
@@ -12776,49 +14491,60 @@ type EnterpriseServerUserAccount implements Node {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for Enterprise Server user account emails returned from the connection.
     """
     orderBy: EnterpriseServerUserAccountEmailOrder = {
     field: EMAIL, direction: ASC }
   ): EnterpriseServerUserAccountEmailConnection!
+  
   """
   The Enterprise Server installation on which this user account exists.
   """
   enterpriseServerInstallation: EnterpriseServerInstallation!
   id: ID!
+  
   """
   Whether the user account is a site administrator on the Enterprise Server installation.
   """
   isSiteAdmin: Boolean!
+  
   """
   The login of the user account on the Enterprise Server installation.
   """
   login: String!
+  
   """
   The profile name of the user account on the Enterprise Server installation.
   """
   profileName: String
+  
   """
   The date and time when the user account was created on the Enterprise Server installation.
   """
   remoteCreatedAt: DateTime!
+  
   """
   The ID of the user account on the Enterprise Server installation.
   """
   remoteUserId: Int!
+  
   """
   Identifies the date and time when the object was last updated.
   """
@@ -12833,14 +14559,17 @@ type EnterpriseServerUserAccountConnection {
   A list of edges.
   """
   edges: [EnterpriseServerUserAccountEdge]
+  
   """
   A list of nodes.
   """
   nodes: [EnterpriseServerUserAccount]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -12855,6 +14584,7 @@ type EnterpriseServerUserAccountEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -12869,19 +14599,23 @@ type EnterpriseServerUserAccountEmail implements Node {
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
+  
   """
   The email address.
   """
   email: String!
   id: ID!
+  
   """
   Indicates whether this is the primary email of the associated user account.
   """
   isPrimary: Boolean!
+  
   """
   Identifies the date and time when the object was last updated.
   """
   updatedAt: DateTime!
+  
   """
   The user account to which the email belongs.
   """
@@ -12896,14 +14630,17 @@ type EnterpriseServerUserAccountEmailConnection {
   A list of edges.
   """
   edges: [EnterpriseServerUserAccountEmailEdge]
+  
   """
   A list of nodes.
   """
   nodes: [EnterpriseServerUserAccountEmail]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -12918,6 +14655,7 @@ type EnterpriseServerUserAccountEmailEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -12932,6 +14670,7 @@ input EnterpriseServerUserAccountEmailOrder {
   The ordering direction.
   """
   direction: OrderDirection!
+  
   """
   The field to order emails by.
   """
@@ -12956,6 +14695,7 @@ input EnterpriseServerUserAccountOrder {
   The ordering direction.
   """
   direction: OrderDirection!
+  
   """
   The field to order user accounts by.
   """
@@ -12984,23 +14724,28 @@ type EnterpriseServerUserAccountsUpload implements Node {
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
+  
   """
   The enterprise to which this upload belongs.
   """
   enterprise: Enterprise!
+  
   """
   The Enterprise Server installation for which this upload was generated.
   """
   enterpriseServerInstallation: EnterpriseServerInstallation!
   id: ID!
+  
   """
   The name of the file uploaded.
   """
   name: String!
+  
   """
   The synchronization state of the upload
   """
   syncState: EnterpriseServerUserAccountsUploadSyncState!
+  
   """
   Identifies the date and time when the object was last updated.
   """
@@ -13015,14 +14760,17 @@ type EnterpriseServerUserAccountsUploadConnection {
   A list of edges.
   """
   edges: [EnterpriseServerUserAccountsUploadEdge]
+  
   """
   A list of nodes.
   """
   nodes: [EnterpriseServerUserAccountsUpload]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -13037,6 +14785,7 @@ type EnterpriseServerUserAccountsUploadEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -13051,6 +14800,7 @@ input EnterpriseServerUserAccountsUploadOrder {
   The ordering direction.
   """
   direction: OrderDirection!
+  
   """
   The field to order user accounts uploads by.
   """
@@ -13098,14 +14848,17 @@ type EnterpriseUserAccount implements Actor & Node {
     """
     size: Int
   ): URI!
+  
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
+  
   """
   The enterprise in which this user account exists.
   """
   enterprise: Enterprise!
+  
   """
   A list of Enterprise Server installations this user is a member of.
   """
@@ -13114,41 +14867,50 @@ type EnterpriseUserAccount implements Actor & Node {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for installations returned from the connection.
     """
     orderBy: EnterpriseServerInstallationOrder = {
     field: HOST_NAME, direction: ASC }
+    
     """
     The search string to look for.
     """
     query: String
+    
     """
     The role of the user in the installation.
     """
     role: EnterpriseUserAccountMembershipRole
   ): EnterpriseServerInstallationMembershipConnection!
   id: ID!
+  
   """
   An identifier for the enterprise user account, a login or email address
   """
   login: String!
+  
   """
   The name of the enterprise user account
   """
   name: String
+  
   """
   A list of enterprise organizations this user is a member of.
   """
@@ -13157,43 +14919,53 @@ type EnterpriseUserAccount implements Actor & Node {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for organizations returned from the connection.
     """
     orderBy: OrganizationOrder = { field: LOGIN, direction: ASC }
+    
     """
     The search string to look for.
     """
     query: String
+    
     """
     The role of the user in the enterprise organization.
     """
     role: EnterpriseUserAccountMembershipRole
   ): EnterpriseOrganizationMembershipConnection!
+  
   """
   The HTTP path for this user.
   """
   resourcePath: URI!
+  
   """
   Identifies the date and time when the object was last updated.
   """
   updatedAt: DateTime!
+  
   """
   The HTTP URL for this user.
   """
   url: URI!
+  
   """
   The user within the enterprise.
   """
@@ -13242,10 +15014,12 @@ type Environment implements Node {
   """
   databaseId: Int
   id: ID!
+  
   """
   The name of the environment
   """
   name: String!
+  
   """
   The protection rules defined for this environment
   """
@@ -13254,14 +15028,17 @@ type Environment implements Node {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
@@ -13277,14 +15054,17 @@ type EnvironmentConnection {
   A list of edges.
   """
   edges: [EnvironmentEdge]
+  
   """
   A list of nodes.
   """
   nodes: [Environment]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -13299,6 +15079,7 @@ type EnvironmentEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -13323,6 +15104,7 @@ input Environments {
   The direction in which to order environments by the specified field.
   """
   direction: OrderDirection!
+  
   """
   The field to order environments by.
   """
@@ -13344,18 +15126,22 @@ type ExternalIdentity implements Node {
   """
   guid: String!
   id: ID!
+  
   """
   Organization invitation for this SCIM-provisioned external identity
   """
   organizationInvitation: OrganizationInvitation
+  
   """
   SAML Identity attributes
   """
   samlIdentity: ExternalIdentitySamlAttributes
+  
   """
   SCIM Identity attributes
   """
   scimIdentity: ExternalIdentityScimAttributes
+  
   """
   User linked to this external identity. Will be NULL if this identity has not been claimed by an organization member.
   """
@@ -13370,10 +15156,12 @@ type ExternalIdentityAttribute {
   The attribute metadata as JSON
   """
   metadata: String
+  
   """
   The attribute name
   """
   name: String!
+  
   """
   The attribute value
   """
@@ -13388,14 +15176,17 @@ type ExternalIdentityConnection {
   A list of edges.
   """
   edges: [ExternalIdentityEdge]
+  
   """
   A list of nodes.
   """
   nodes: [ExternalIdentity]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -13410,6 +15201,7 @@ type ExternalIdentityEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -13424,26 +15216,32 @@ type ExternalIdentitySamlAttributes {
   SAML Identity attributes
   """
   attributes: [ExternalIdentityAttribute!]!
+  
   """
   The emails associated with the SAML identity
   """
   emails: [UserEmailMetadata!]
+  
   """
   Family name of the SAML identity
   """
   familyName: String
+  
   """
   Given name of the SAML identity
   """
   givenName: String
+  
   """
   The groups linked to this identity in IDP
   """
   groups: [String!]
+  
   """
   The NameID of the SAML identity
   """
   nameId: String
+  
   """
   The userName of the SAML identity
   """
@@ -13458,18 +15256,22 @@ type ExternalIdentityScimAttributes {
   The emails associated with the SCIM identity
   """
   emails: [UserEmailMetadata!]
+  
   """
   Family name of the SCIM identity
   """
   familyName: String
+  
   """
   Given name of the SCIM identity
   """
   givenName: String
+  
   """
   The groups linked to this identity in IDP
   """
   groups: [String!]
+  
   """
   The userName of the SCIM identity
   """
@@ -13485,6 +15287,7 @@ input FileAddition {
   The base64 encoded contents of the file
   """
   contents: Base64String!
+  
   """
   The path in the repository where the file will be located
   """
@@ -13611,6 +15414,7 @@ input FileChanges {
   File to add or change.
   """
   additions: [FileAddition!] = []
+  
   """
   Files to delete.
   """
@@ -13653,6 +15457,7 @@ input FollowOrganizationInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   ID of the organization to follow.
   """
@@ -13667,6 +15472,7 @@ type FollowOrganizationPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The organization that was followed.
   """
@@ -13681,6 +15487,7 @@ input FollowUserInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   ID of the user to follow.
   """
@@ -13695,6 +15502,7 @@ type FollowUserPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The user that was followed.
   """
@@ -13709,14 +15517,17 @@ type FollowerConnection {
   A list of edges.
   """
   edges: [UserEdge]
+  
   """
   A list of nodes.
   """
   nodes: [User]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -13731,14 +15542,17 @@ type FollowingConnection {
   A list of edges.
   """
   edges: [UserEdge]
+  
   """
   A list of nodes.
   """
   nodes: [User]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -13753,6 +15567,7 @@ type FundingLink {
   The funding platform this link is for.
   """
   platform: FundingPlatform!
+  
   """
   The configured URL for this funding link.
   """
@@ -13817,6 +15632,7 @@ type GenericHovercardContext implements HovercardContext {
   A string describing this context
   """
   message: String!
+  
   """
   An octicon to accompany this context
   """
@@ -13835,27 +15651,33 @@ type Gist implements Node & Starrable & UniformResourceLocatable {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): GistCommentConnection!
+  
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
+  
   """
   The gist description.
   """
   description: String
+  
   """
   The files in this gist.
   """
@@ -13864,11 +15686,13 @@ type Gist implements Node & Starrable & UniformResourceLocatable {
     The maximum number of files to return.
     """
     limit: Int = 10
+    
     """
     The oid of the files to return
     """
     oid: GitObjectID
   ): [GistFile]
+  
   """
   A list of forks associated with the gist
   """
@@ -13877,52 +15701,64 @@ type Gist implements Node & Starrable & UniformResourceLocatable {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for gists returned from the connection
     """
     orderBy: GistOrder
   ): GistConnection!
   id: ID!
+  
   """
   Identifies if the gist is a fork.
   """
   isFork: Boolean!
+  
   """
   Whether the gist is public or not.
   """
   isPublic: Boolean!
+  
   """
   The gist name.
   """
   name: String!
+  
   """
   The gist owner.
   """
   owner: RepositoryOwner
+  
   """
   Identifies when the gist was last pushed to.
   """
   pushedAt: DateTime
+  
   """
   The HTML path to this resource.
   """
   resourcePath: URI!
+  
   """
   Returns a count of how many stargazers there are on this object
   """
   stargazerCount: Int!
+  
   """
   A list of users who have starred this starrable.
   """
@@ -13931,31 +15767,38 @@ type Gist implements Node & Starrable & UniformResourceLocatable {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Order for connection
     """
     orderBy: StarOrder
   ): StargazerConnection!
+  
   """
   Identifies the date and time when the object was last updated.
   """
   updatedAt: DateTime!
+  
   """
   The HTTP URL for this Gist.
   """
   url: URI!
+  
   """
   Returns a boolean indicating whether the viewing user has starred this starrable.
   """
@@ -13970,69 +15813,85 @@ type GistComment implements Comment & Deletable & Minimizable & Node & Updatable
   The actor who authored the comment.
   """
   author: Actor
+  
   """
   Author's association with the gist.
   """
   authorAssociation: CommentAuthorAssociation!
+  
   """
   Identifies the comment body.
   """
   body: String!
+  
   """
   The body rendered to HTML.
   """
   bodyHTML: HTML!
+  
   """
   The body rendered to text.
   """
   bodyText: String!
+  
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
+  
   """
   Check if this comment was created via an email reply.
   """
   createdViaEmail: Boolean!
+  
   """
   Identifies the primary key from the database.
   """
   databaseId: Int
+  
   """
   The actor who edited the comment.
   """
   editor: Actor
+  
   """
   The associated gist.
   """
   gist: Gist!
   id: ID!
+  
   """
   Check if this comment was edited and includes an edit with the creation data
   """
   includesCreatedEdit: Boolean!
+  
   """
   Returns whether or not a comment has been minimized.
   """
   isMinimized: Boolean!
+  
   """
   The moment the editor made the last edit
   """
   lastEditedAt: DateTime
+  
   """
   Returns why the comment was minimized. One of `abuse`, `off-topic`,
   `outdated`, `resolved`, `duplicate` and `spam`. Note that the case and
   formatting of these values differs from the inputs to the `MinimizeComment` mutation.
   """
   minimizedReason: String
+  
   """
   Identifies when the comment was published at.
   """
   publishedAt: DateTime
+  
   """
   Identifies the date and time when the object was last updated.
   """
   updatedAt: DateTime!
+  
   """
   A list of edits to this content.
   """
@@ -14041,35 +15900,43 @@ type GistComment implements Comment & Deletable & Minimizable & Node & Updatable
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): UserContentEditConnection
+  
   """
   Check if the current viewer can delete this object.
   """
   viewerCanDelete: Boolean!
+  
   """
   Check if the current viewer can minimize this object.
   """
   viewerCanMinimize: Boolean!
+  
   """
   Check if the current viewer can update this object.
   """
   viewerCanUpdate: Boolean!
+  
   """
   Reasons why the current viewer can not update this comment.
   """
   viewerCannotUpdateReasons: [CommentCannotUpdateReason!]!
+  
   """
   Did the viewer author this comment.
   """
@@ -14084,14 +15951,17 @@ type GistCommentConnection {
   A list of edges.
   """
   edges: [GistCommentEdge]
+  
   """
   A list of nodes.
   """
   nodes: [GistComment]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -14106,6 +15976,7 @@ type GistCommentEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -14120,14 +15991,17 @@ type GistConnection {
   A list of edges.
   """
   edges: [GistEdge]
+  
   """
   A list of nodes.
   """
   nodes: [Gist]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -14142,6 +16016,7 @@ type GistEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -14156,34 +16031,42 @@ type GistFile {
   The file name encoded to remove characters that are invalid in URL paths.
   """
   encodedName: String
+  
   """
   The gist file encoding.
   """
   encoding: String
+  
   """
   The file extension from the file name.
   """
   extension: String
+  
   """
   Indicates if this file is an image.
   """
   isImage: Boolean!
+  
   """
   Whether the file's contents were truncated.
   """
   isTruncated: Boolean!
+  
   """
   The programming language this file is written in.
   """
   language: Language
+  
   """
   The gist file name.
   """
   name: String
+  
   """
   The gist file size in bytes.
   """
   size: Int
+  
   """
   UTF8 text data or null if the file is binary
   """
@@ -14203,6 +16086,7 @@ input GistOrder {
   The ordering direction.
   """
   direction: OrderDirection!
+  
   """
   The field to order repositories by.
   """
@@ -14258,18 +16142,22 @@ type GitActor {
     """
     size: Int
   ): URI!
+  
   """
   The timestamp of the Git action (authoring or committing).
   """
   date: GitTimestamp
+  
   """
   The email in the Git commit.
   """
   email: String
+  
   """
   The name in the Git commit.
   """
   name: String
+  
   """
   The GitHub user corresponding to the email field. Null if no such user exists.
   """
@@ -14284,14 +16172,17 @@ type GitActorConnection {
   A list of edges.
   """
   edges: [GitActorEdge]
+  
   """
   A list of nodes.
   """
   nodes: [GitActor]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -14306,6 +16197,7 @@ type GitActorEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -14320,26 +16212,32 @@ type GitHubMetadata {
   Returns a String that's a SHA of `github-services`
   """
   gitHubServicesSha: GitObjectID!
+  
   """
   IP addresses that users connect to for git operations
   """
   gitIpAddresses: [String!]
+  
   """
   IP addresses that GitHub Enterprise Importer uses for outbound connections
   """
   githubEnterpriseImporterIpAddresses: [String!]
+  
   """
   IP addresses that service hooks are sent from
   """
   hookIpAddresses: [String!]
+  
   """
   IP addresses that the importer connects from
   """
   importerIpAddresses: [String!]
+  
   """
   Whether or not users are verified
   """
   isPasswordAuthenticationVerifiable: Boolean!
+  
   """
   IP addresses for GitHub Pages' A records
   """
@@ -14354,19 +16252,23 @@ interface GitObject {
   An abbreviated version of the Git object ID
   """
   abbreviatedOid: String!
+  
   """
   The HTTP path for this Git object
   """
   commitResourcePath: URI!
+  
   """
   The HTTP URL for this Git object
   """
   commitUrl: URI!
   id: ID!
+  
   """
   The Git object ID
   """
   oid: GitObjectID!
+  
   """
   The Repository the Git object belongs to
   """
@@ -14396,27 +16298,33 @@ interface GitSignature {
   Email used to sign this object.
   """
   email: String!
+  
   """
   True if the signature is valid and verified by GitHub.
   """
   isValid: Boolean!
+  
   """
   Payload for GPG signing object. Raw ODB object without the signature header.
   """
   payload: String!
+  
   """
   ASCII-armored signature header from object.
   """
   signature: String!
+  
   """
   GitHub user corresponding to the email signing this commit.
   """
   signer: User
+  
   """
   The state of this signature. `VALID` if signature is valid and verified by
   GitHub, otherwise represents reason why signature is considered invalid.
   """
   state: GitSignatureState!
+  
   """
   True if the signature was made with GitHub's signing key.
   """
@@ -14510,31 +16418,38 @@ type GpgSignature implements GitSignature {
   Email used to sign this object.
   """
   email: String!
+  
   """
   True if the signature is valid and verified by GitHub.
   """
   isValid: Boolean!
+  
   """
   Hex-encoded ID of the key that signed this object.
   """
   keyId: String
+  
   """
   Payload for GPG signing object. Raw ODB object without the signature header.
   """
   payload: String!
+  
   """
   ASCII-armored signature header from object.
   """
   signature: String!
+  
   """
   GitHub user corresponding to the email signing this commit.
   """
   signer: User
+  
   """
   The state of this signature. `VALID` if signature is valid and verified by
   GitHub, otherwise represents reason why signature is considered invalid.
   """
   state: GitSignatureState!
+  
   """
   True if the signature was made with GitHub's signing key.
   """
@@ -14549,10 +16464,12 @@ input GrantEnterpriseOrganizationsMigratorRoleInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The ID of the enterprise to which all organizations managed by it will be granted the migrator role.
   """
   enterpriseId: ID! @possibleTypes(concreteTypes: ["Enterprise"])
+  
   """
   The login of the user to grant the migrator role
   """
@@ -14567,6 +16484,7 @@ type GrantEnterpriseOrganizationsMigratorRolePayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The organizations that had the migrator role applied to for the given user.
   """
@@ -14575,14 +16493,17 @@ type GrantEnterpriseOrganizationsMigratorRolePayload {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
@@ -14598,14 +16519,17 @@ input GrantMigratorRoleInput {
   The user login or Team slug to grant the migrator role.
   """
   actor: String!
+  
   """
   Specifies the type of the actor, can be either USER or TEAM.
   """
   actorType: ActorType!
+  
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The ID of the organization that the user/team belongs to.
   """
@@ -14620,6 +16544,7 @@ type GrantMigratorRolePayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   Did the operation succeed?
   """
@@ -14639,19 +16564,23 @@ type HeadRefDeletedEvent implements Node {
   Identifies the actor who performed the event.
   """
   actor: Actor
+  
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
+  
   """
   Identifies the Ref associated with the `head_ref_deleted` event.
   """
   headRef: Ref
+  
   """
   Identifies the name of the Ref associated with the `head_ref_deleted` event.
   """
   headRefName: String!
   id: ID!
+  
   """
   PullRequest referenced by event.
   """
@@ -14666,23 +16595,28 @@ type HeadRefForcePushedEvent implements Node {
   Identifies the actor who performed the event.
   """
   actor: Actor
+  
   """
   Identifies the after commit SHA for the 'head_ref_force_pushed' event.
   """
   afterCommit: Commit
+  
   """
   Identifies the before commit SHA for the 'head_ref_force_pushed' event.
   """
   beforeCommit: Commit
+  
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
   id: ID!
+  
   """
   PullRequest referenced by event.
   """
   pullRequest: PullRequest!
+  
   """
   Identifies the fully qualified ref name for the 'head_ref_force_pushed' event.
   """
@@ -14697,11 +16631,13 @@ type HeadRefRestoredEvent implements Node {
   Identifies the actor who performed the event.
   """
   actor: Actor
+  
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
   id: ID!
+  
   """
   PullRequest referenced by event.
   """
@@ -14726,6 +16662,7 @@ interface HovercardContext {
   A string describing this context
   """
   message: String!
+  
   """
   An octicon to accompany this context
   """
@@ -14758,22 +16695,27 @@ input ImportProjectInput {
   The description of Project.
   """
   body: String
+  
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   A list of columns containing issues and pull requests.
   """
   columnImports: [ProjectColumnImport!]!
+  
   """
   The name of Project.
   """
   name: String!
+  
   """
   The name of the Organization or User to create the Project under.
   """
   ownerName: String!
+  
   """
   Whether the Project is public or not.
   """
@@ -14788,6 +16730,7 @@ type ImportProjectPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The new Project!
   """
@@ -14802,18 +16745,22 @@ input InviteEnterpriseAdminInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The email of the person to invite as an administrator.
   """
   email: String
+  
   """
   The ID of the enterprise to which you want to invite an administrator.
   """
   enterpriseId: ID! @possibleTypes(concreteTypes: ["Enterprise"])
+  
   """
   The login of a user to invite as an administrator.
   """
   invitee: String
+  
   """
   The role of the administrator.
   """
@@ -14828,6 +16775,7 @@ type InviteEnterpriseAdminPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The created enterprise administrator invitation.
   """
@@ -14856,23 +16804,28 @@ type IpAllowListEntry implements Node {
   A single IP address or range of IP addresses in CIDR notation.
   """
   allowListValue: String!
+  
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
   id: ID!
+  
   """
   Whether the entry is currently active.
   """
   isActive: Boolean!
+  
   """
   The name of the IP allow list entry.
   """
   name: String
+  
   """
   The owner of the IP allow list entry.
   """
   owner: IpAllowListOwner!
+  
   """
   Identifies the date and time when the object was last updated.
   """
@@ -14887,14 +16840,17 @@ type IpAllowListEntryConnection {
   A list of edges.
   """
   edges: [IpAllowListEntryEdge]
+  
   """
   A list of nodes.
   """
   nodes: [IpAllowListEntry]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -14909,6 +16865,7 @@ type IpAllowListEntryEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -14923,6 +16880,7 @@ input IpAllowListEntryOrder {
   The ordering direction.
   """
   direction: OrderDirection!
+  
   """
   The field to order IP allow list entries by.
   """
@@ -14970,6 +16928,7 @@ type Issue implements Assignable & Closable & Comment & Deletable & Labelable & 
   Reason that the conversation was locked.
   """
   activeLockReason: LockReason
+  
   """
   A list of Users assigned to this object.
   """
@@ -14978,55 +16937,68 @@ type Issue implements Assignable & Closable & Comment & Deletable & Labelable & 
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): UserConnection!
+  
   """
   The actor who authored the comment.
   """
   author: Actor
+  
   """
   Author's association with the subject of the comment.
   """
   authorAssociation: CommentAuthorAssociation!
+  
   """
   Identifies the body of the issue.
   """
   body: String!
+  
   """
   The body rendered to HTML.
   """
   bodyHTML: HTML!
+  
   """
   The http path for this issue body
   """
   bodyResourcePath: URI!
+  
   """
   Identifies the body of the issue rendered to text.
   """
   bodyText: String!
+  
   """
   The http URL for this issue body
   """
   bodyUrl: URI!
+  
   """
   Indicates if the object is closed (definition of closed may depend on type)
   """
   closed: Boolean!
+  
   """
   Identifies the date and time when the object was closed.
   """
   closedAt: DateTime
+  
   """
   A list of comments associated with the Issue.
   """
@@ -15035,43 +17007,53 @@ type Issue implements Assignable & Closable & Comment & Deletable & Labelable & 
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for issue comments returned from the connection.
     """
     orderBy: IssueCommentOrder
   ): IssueCommentConnection!
+  
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
+  
   """
   Check if this comment was created via an email reply.
   """
   createdViaEmail: Boolean!
+  
   """
   Identifies the primary key from the database.
   """
   databaseId: Int
+  
   """
   The actor who edited the comment.
   """
   editor: Actor
+  
   """
   Identifies the primary key from the database as a BigInt.
   """
   fullDatabaseId: BigInt
+  
   """
   The hovercard information for this issue
   """
@@ -15082,18 +17064,22 @@ type Issue implements Assignable & Closable & Comment & Deletable & Labelable & 
     includeNotificationContexts: Boolean = true
   ): Hovercard!
   id: ID!
+  
   """
   Check if this comment was edited and includes an edit with the creation data
   """
   includesCreatedEdit: Boolean!
+  
   """
   Indicates whether or not this issue is currently pinned to the repository issues list
   """
   isPinned: Boolean
+  
   """
   Is this issue read by the viewer
   """
   isReadByViewer: Boolean
+  
   """
   A list of labels associated with the object.
   """
@@ -15102,27 +17088,33 @@ type Issue implements Assignable & Closable & Comment & Deletable & Labelable & 
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for labels returned from the connection.
     """
     orderBy: LabelOrder = { field: CREATED_AT, direction: ASC }
   ): LabelConnection
+  
   """
   The moment the editor made the last edit
   """
   lastEditedAt: DateTime
+  
   """
   Branches linked to this issue.
   """
@@ -15131,31 +17123,38 @@ type Issue implements Assignable & Closable & Comment & Deletable & Labelable & 
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): LinkedBranchConnection!
+  
   """
   `true` if the object is locked
   """
   locked: Boolean!
+  
   """
   Identifies the milestone associated with the issue.
   """
   milestone: Milestone
+  
   """
   Identifies the issue number.
   """
   number: Int!
+  
   """
   A list of Users that are participating in the Issue conversation.
   """
@@ -15164,19 +17163,23 @@ type Issue implements Assignable & Closable & Comment & Deletable & Labelable & 
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): UserConnection!
+  
   """
   List of project cards associated with this issue.
   """
@@ -15185,23 +17188,28 @@ type Issue implements Assignable & Closable & Comment & Deletable & Labelable & 
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     A list of archived states to filter the cards by
     """
     archivedStates: [ProjectCardArchivedState] = [ARCHIVED, NOT_ARCHIVED]
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): ProjectCardConnection!
+  
   """
   List of project items associated with this issue.
   """
@@ -15210,23 +17218,28 @@ type Issue implements Assignable & Closable & Comment & Deletable & Labelable & 
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Include archived items.
     """
     includeArchived: Boolean = true
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): ProjectV2ItemConnection!
+  
   """
   Find a project by number.
   """
@@ -15236,6 +17249,7 @@ type Issue implements Assignable & Closable & Comment & Deletable & Labelable & 
     """
     number: Int!
   ): ProjectV2
+  
   """
   A list of projects under the owner.
   """
@@ -15244,35 +17258,43 @@ type Issue implements Assignable & Closable & Comment & Deletable & Labelable & 
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     How to order the returned projects.
     """
     orderBy: ProjectV2Order = { field: NUMBER, direction: DESC }
+    
     """
     A project to search for under the the owner.
     """
     query: String
   ): ProjectV2Connection!
+  
   """
   Identifies when the comment was published at.
   """
   publishedAt: DateTime
+  
   """
   A list of reactions grouped by content left on the subject.
   """
   reactionGroups: [ReactionGroup!]
+  
   """
   A list of Reactions left on the Issue.
   """
@@ -15281,43 +17303,53 @@ type Issue implements Assignable & Closable & Comment & Deletable & Labelable & 
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Allows filtering Reactions by emoji.
     """
     content: ReactionContent
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Allows specifying the order in which reactions are returned.
     """
     orderBy: ReactionOrder
   ): ReactionConnection!
+  
   """
   The repository associated with this node.
   """
   repository: Repository!
+  
   """
   The HTTP path for this issue
   """
   resourcePath: URI!
+  
   """
   Identifies the state of the issue.
   """
   state: IssueState!
+  
   """
   Identifies the reason for the issue state.
   """
   stateReason: IssueStateReason
+  
   """
   A list of events, comments, commits, etc. associated with the issue.
   """
@@ -15326,18 +17358,22 @@ type Issue implements Assignable & Closable & Comment & Deletable & Labelable & 
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Allows filtering timeline events by a `since` timestamp.
     """
@@ -15346,6 +17382,7 @@ type Issue implements Assignable & Closable & Comment & Deletable & Labelable & 
     @deprecated(
       reason: "`timeline` will be removed Use Issue.timelineItems instead. Removal on 2020-10-01 UTC."
     )
+  
   """
   A list of events, comments, commits, etc. associated with the issue.
   """
@@ -15354,39 +17391,48 @@ type Issue implements Assignable & Closable & Comment & Deletable & Labelable & 
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Filter timeline items by type.
     """
     itemTypes: [IssueTimelineItemsItemType!]
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Filter timeline items by a `since` timestamp.
     """
     since: DateTime
+    
     """
     Skips the first _n_ elements in the list.
     """
     skip: Int
   ): IssueTimelineItemsConnection!
+  
   """
   Identifies the issue title.
   """
   title: String!
+  
   """
   Identifies the issue title rendered to HTML.
   """
   titleHTML: String!
+  
   """
   A list of issues that track this issue
   """
@@ -15395,19 +17441,23 @@ type Issue implements Assignable & Closable & Comment & Deletable & Labelable & 
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): IssueConnection!
+  
   """
   A list of issues tracked inside the current issue
   """
@@ -15416,19 +17466,23 @@ type Issue implements Assignable & Closable & Comment & Deletable & Labelable & 
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): IssueConnection!
+  
   """
   The number of tracked issues for this issue
   """
@@ -15438,14 +17492,17 @@ type Issue implements Assignable & Closable & Comment & Deletable & Labelable & 
     """
     states: [TrackedIssueStates]
   ): Int!
+  
   """
   Identifies the date and time when the object was last updated.
   """
   updatedAt: DateTime!
+  
   """
   The HTTP URL for this issue
   """
   url: URI!
+  
   """
   A list of edits to this content.
   """
@@ -15454,59 +17511,73 @@ type Issue implements Assignable & Closable & Comment & Deletable & Labelable & 
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): UserContentEditConnection
+  
   """
   Indicates if the object can be closed by the viewer.
   """
   viewerCanClose: Boolean!
+  
   """
   Check if the current viewer can delete this object.
   """
   viewerCanDelete: Boolean!
+  
   """
   Can user react to this subject
   """
   viewerCanReact: Boolean!
+  
   """
   Indicates if the object can be reopened by the viewer.
   """
   viewerCanReopen: Boolean!
+  
   """
   Check if the viewer is able to change their subscription status for the repository.
   """
   viewerCanSubscribe: Boolean!
+  
   """
   Check if the current viewer can update this object.
   """
   viewerCanUpdate: Boolean!
+  
   """
   Reasons why the current viewer can not update this comment.
   """
   viewerCannotUpdateReasons: [CommentCannotUpdateReason!]!
+  
   """
   Did the viewer author this comment.
   """
   viewerDidAuthor: Boolean!
+  
   """
   Identifies if the viewer is watching, not watching, or ignoring the subscribable entity.
   """
   viewerSubscription: SubscriptionState
+  
   """
   Identifies the viewer's thread subscription form action.
   """
   viewerThreadSubscriptionFormAction: ThreadSubscriptionFormAction
+  
   """
   Identifies the viewer's thread subscription status.
   """
@@ -15535,78 +17606,96 @@ type IssueComment implements Comment & Deletable & Minimizable & Node & Reactabl
   The actor who authored the comment.
   """
   author: Actor
+  
   """
   Author's association with the subject of the comment.
   """
   authorAssociation: CommentAuthorAssociation!
+  
   """
   The body as Markdown.
   """
   body: String!
+  
   """
   The body rendered to HTML.
   """
   bodyHTML: HTML!
+  
   """
   The body rendered to text.
   """
   bodyText: String!
+  
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
+  
   """
   Check if this comment was created via an email reply.
   """
   createdViaEmail: Boolean!
+  
   """
   Identifies the primary key from the database.
   """
   databaseId: Int
+  
   """
   The actor who edited the comment.
   """
   editor: Actor
+  
   """
   Identifies the primary key from the database as a BigInt.
   """
   fullDatabaseId: BigInt
   id: ID!
+  
   """
   Check if this comment was edited and includes an edit with the creation data
   """
   includesCreatedEdit: Boolean!
+  
   """
   Returns whether or not a comment has been minimized.
   """
   isMinimized: Boolean!
+  
   """
   Identifies the issue associated with the comment.
   """
   issue: Issue!
+  
   """
   The moment the editor made the last edit
   """
   lastEditedAt: DateTime
+  
   """
   Returns why the comment was minimized. One of `abuse`, `off-topic`,
   `outdated`, `resolved`, `duplicate` and `spam`. Note that the case and
   formatting of these values differs from the inputs to the `MinimizeComment` mutation.
   """
   minimizedReason: String
+  
   """
   Identifies when the comment was published at.
   """
   publishedAt: DateTime
+  
   """
   Returns the pull request associated with the comment, if this comment was made on a
   pull request.
   """
   pullRequest: PullRequest
+  
   """
   A list of reactions grouped by content left on the subject.
   """
   reactionGroups: [ReactionGroup!]
+  
   """
   A list of Reactions left on the Issue.
   """
@@ -15615,43 +17704,53 @@ type IssueComment implements Comment & Deletable & Minimizable & Node & Reactabl
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Allows filtering Reactions by emoji.
     """
     content: ReactionContent
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Allows specifying the order in which reactions are returned.
     """
     orderBy: ReactionOrder
   ): ReactionConnection!
+  
   """
   The repository associated with this node.
   """
   repository: Repository!
+  
   """
   The HTTP path for this issue comment
   """
   resourcePath: URI!
+  
   """
   Identifies the date and time when the object was last updated.
   """
   updatedAt: DateTime!
+  
   """
   The HTTP URL for this issue comment
   """
   url: URI!
+  
   """
   A list of edits to this content.
   """
@@ -15660,39 +17759,48 @@ type IssueComment implements Comment & Deletable & Minimizable & Node & Reactabl
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): UserContentEditConnection
+  
   """
   Check if the current viewer can delete this object.
   """
   viewerCanDelete: Boolean!
+  
   """
   Check if the current viewer can minimize this object.
   """
   viewerCanMinimize: Boolean!
+  
   """
   Can user react to this subject
   """
   viewerCanReact: Boolean!
+  
   """
   Check if the current viewer can update this object.
   """
   viewerCanUpdate: Boolean!
+  
   """
   Reasons why the current viewer can not update this comment.
   """
   viewerCannotUpdateReasons: [CommentCannotUpdateReason!]!
+  
   """
   Did the viewer author this comment.
   """
@@ -15707,14 +17815,17 @@ type IssueCommentConnection {
   A list of edges.
   """
   edges: [IssueCommentEdge]
+  
   """
   A list of nodes.
   """
   nodes: [IssueComment]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -15729,6 +17840,7 @@ type IssueCommentEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -15743,6 +17855,7 @@ input IssueCommentOrder {
   The direction in which to order issue comments by the specified field.
   """
   direction: OrderDirection!
+  
   """
   The field in which to order issue comments by.
   """
@@ -15767,14 +17880,17 @@ type IssueConnection {
   A list of edges.
   """
   edges: [IssueEdge]
+  
   """
   A list of nodes.
   """
   nodes: [Issue]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -15793,23 +17909,28 @@ type IssueContributionsByRepository {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for contributions returned from the connection.
     """
     orderBy: ContributionOrder = { direction: DESC }
   ): CreatedIssueContributionConnection!
+  
   """
   The repository in which the issues were opened.
   """
@@ -15824,6 +17945,7 @@ type IssueEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -15839,38 +17961,46 @@ input IssueFilters {
   user, and `*` for issues assigned to any user.
   """
   assignee: String
+  
   """
   List issues created by given name.
   """
   createdBy: String
+  
   """
   List issues where the list of label names exist on the issue.
   """
   labels: [String!]
+  
   """
   List issues where the given name is mentioned in the issue.
   """
   mentioned: String
+  
   """
   List issues by given milestone argument. If an string representation of an
   integer is passed, it should refer to a milestone by its database ID. Pass in
   `null` for issues with no milestone, and `*` for issues that are assigned to any milestone.
   """
   milestone: String
+  
   """
   List issues by given milestone argument. If an string representation of an
   integer is passed, it should refer to a milestone by its number field. Pass in
   `null` for issues with no milestone, and `*` for issues that are assigned to any milestone.
   """
   milestoneNumber: String
+  
   """
   List issues that have been updated at or after the given date.
   """
   since: DateTime
+  
   """
   List issues filtered by the list of states given.
   """
   states: [IssueState!]
+  
   """
   List issues subscribed to by viewer.
   """
@@ -15890,6 +18020,7 @@ input IssueOrder {
   The direction in which to order issues by the specified field.
   """
   direction: OrderDirection!
+  
   """
   The field in which to order issues by.
   """
@@ -15954,6 +18085,7 @@ type IssueTemplate {
   The template purpose.
   """
   about: String
+  
   """
   The suggested assignees.
   """
@@ -15962,27 +18094,33 @@ type IssueTemplate {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): UserConnection!
+  
   """
   The suggested issue body.
   """
   body: String
+  
   """
   The template filename.
   """
   filename: String!
+  
   """
   The suggested issue labels
   """
@@ -15991,27 +18129,33 @@ type IssueTemplate {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for labels returned from the connection.
     """
     orderBy: LabelOrder = { field: CREATED_AT, direction: ASC }
   ): LabelConnection
+  
   """
   The template name.
   """
   name: String!
+  
   """
   The suggested issue title.
   """
@@ -16026,14 +18170,17 @@ type IssueTimelineConnection {
   A list of edges.
   """
   edges: [IssueTimelineItemEdge]
+  
   """
   A list of nodes.
   """
   nodes: [IssueTimelineItem]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -16071,6 +18218,7 @@ type IssueTimelineItemEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -16120,26 +18268,32 @@ type IssueTimelineItemsConnection {
   A list of edges.
   """
   edges: [IssueTimelineItemsEdge]
+  
   """
   Identifies the count of items after applying `before` and `after` filters.
   """
   filteredCount: Int!
+  
   """
   A list of nodes.
   """
   nodes: [IssueTimelineItems]
+  
   """
   Identifies the count of items after applying `before`/`after` filters and `first`/`last`/`skip` slicing.
   """
   pageCount: Int!
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
   totalCount: Int!
+  
   """
   Identifies the date and time when the timeline was last updated.
   """
@@ -16154,6 +18308,7 @@ type IssueTimelineItemsEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -16300,18 +18455,22 @@ type JoinedGitHubContribution implements Contribution {
   longer access.
   """
   isRestricted: Boolean!
+  
   """
   When this contribution was made.
   """
   occurredAt: DateTime!
+  
   """
   The HTTP path for this contribution.
   """
   resourcePath: URI!
+  
   """
   The HTTP URL for this contribution.
   """
   url: URI!
+  
   """
   The user who made this contribution.
   """
@@ -16326,19 +18485,23 @@ type Label implements Node {
   Identifies the label color.
   """
   color: String!
+  
   """
   Identifies the date and time when the label was created.
   """
   createdAt: DateTime
+  
   """
   A brief description of this label.
   """
   description: String
   id: ID!
+  
   """
   Indicates whether or not this is a default label.
   """
   isDefault: Boolean!
+  
   """
   A list of issues associated with this label.
   """
@@ -16347,39 +18510,48 @@ type Label implements Node {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Filtering options for issues returned from the connection.
     """
     filterBy: IssueFilters
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     A list of label names to filter the pull requests by.
     """
     labels: [String!]
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for issues returned from the connection.
     """
     orderBy: IssueOrder
+    
     """
     A list of states to filter the issues by.
     """
     states: [IssueState!]
   ): IssueConnection!
+  
   """
   Identifies the label name.
   """
   name: String!
+  
   """
   A list of pull requests associated with this label.
   """
@@ -16388,51 +18560,63 @@ type Label implements Node {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     The base ref name to filter the pull requests by.
     """
     baseRefName: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     The head ref name to filter the pull requests by.
     """
     headRefName: String
+    
     """
     A list of label names to filter the pull requests by.
     """
     labels: [String!]
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for pull requests returned from the connection.
     """
     orderBy: IssueOrder
+    
     """
     A list of states to filter the pull requests by.
     """
     states: [PullRequestState!]
   ): PullRequestConnection!
+  
   """
   The repository associated with this label.
   """
   repository: Repository!
+  
   """
   The HTTP path for this label.
   """
   resourcePath: URI!
+  
   """
   Identifies the date and time when the label was last updated.
   """
   updatedAt: DateTime
+  
   """
   The HTTP URL for this label.
   """
@@ -16447,14 +18631,17 @@ type LabelConnection {
   A list of edges.
   """
   edges: [LabelEdge]
+  
   """
   A list of nodes.
   """
   nodes: [Label]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -16469,6 +18656,7 @@ type LabelEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -16483,6 +18671,7 @@ input LabelOrder {
   The direction in which to order labels by the specified field.
   """
   direction: OrderDirection!
+  
   """
   The field in which to order labels by.
   """
@@ -16515,18 +18704,22 @@ interface Labelable {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for labels returned from the connection.
     """
@@ -16542,15 +18735,18 @@ type LabeledEvent implements Node {
   Identifies the actor who performed the event.
   """
   actor: Actor
+  
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
   id: ID!
+  
   """
   Identifies the label associated with the 'labeled' event.
   """
   label: Label!
+  
   """
   Identifies the `Labelable` associated with the event.
   """
@@ -16566,6 +18762,7 @@ type Language implements Node {
   """
   color: String
   id: ID!
+  
   """
   The name of the current language.
   """
@@ -16580,18 +18777,22 @@ type LanguageConnection {
   A list of edges.
   """
   edges: [LanguageEdge]
+  
   """
   A list of nodes.
   """
   nodes: [Language]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
   totalCount: Int!
+  
   """
   The total size in bytes of files written in that language.
   """
@@ -16604,6 +18805,7 @@ Represents the language of a repository.
 type LanguageEdge {
   cursor: String!
   node: Language!
+  
   """
   The number of bytes of code written in the language.
   """
@@ -16618,6 +18820,7 @@ input LanguageOrder {
   The ordering direction.
   """
   direction: OrderDirection!
+  
   """
   The field to order languages by.
   """
@@ -16642,55 +18845,68 @@ type License implements Node {
   The full text of the license
   """
   body: String!
+  
   """
   The conditions set by the license
   """
   conditions: [LicenseRule]!
+  
   """
   A human-readable description of the license
   """
   description: String
+  
   """
   Whether the license should be featured
   """
   featured: Boolean!
+  
   """
   Whether the license should be displayed in license pickers
   """
   hidden: Boolean!
   id: ID!
+  
   """
   Instructions on how to implement the license
   """
   implementation: String
+  
   """
   The lowercased SPDX ID of the license
   """
   key: String!
+  
   """
   The limitations set by the license
   """
   limitations: [LicenseRule]!
+  
   """
   The license full name specified by <https://spdx.org/licenses>
   """
   name: String!
+  
   """
   Customary short name if applicable (e.g, GPLv3)
   """
   nickname: String
+  
   """
   The permissions set by the license
   """
   permissions: [LicenseRule]!
+  
   """
   Whether the license is a pseudo-license placeholder (e.g., other, no-license)
   """
   pseudoLicense: Boolean!
+  
   """
   Short identifier specified by <https://spdx.org/licenses>
   """
   spdxId: String
+  
   """
   URL to the license on <https://choosealicense.com>
   """
@@ -16705,10 +18921,12 @@ type LicenseRule {
   A description of the rule
   """
   description: String!
+  
   """
   The machine-readable rule key
   """
   key: String!
+  
   """
   The human-readable rule label
   """
@@ -16723,10 +18941,12 @@ input LinkProjectV2ToRepositoryInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The ID of the project to link to the repository.
   """
   projectId: ID! @possibleTypes(concreteTypes: ["ProjectV2"])
+  
   """
   The ID of the repository to link to the project.
   """
@@ -16741,6 +18961,7 @@ type LinkProjectV2ToRepositoryPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The repository the project is linked to.
   """
@@ -16755,10 +18976,12 @@ input LinkProjectV2ToTeamInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The ID of the project to link to the team.
   """
   projectId: ID! @possibleTypes(concreteTypes: ["ProjectV2"])
+  
   """
   The ID of the team to link to the project.
   """
@@ -16773,6 +18996,7 @@ type LinkProjectV2ToTeamPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The team the project is linked to
   """
@@ -16787,10 +19011,12 @@ input LinkRepositoryToProjectInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The ID of the Project to link to a Repository
   """
   projectId: ID! @possibleTypes(concreteTypes: ["Project"])
+  
   """
   The ID of the Repository to link to a Project.
   """
@@ -16805,10 +19031,12 @@ type LinkRepositoryToProjectPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The linked Project.
   """
   project: Project
+  
   """
   The linked Repository.
   """
@@ -16820,6 +19048,7 @@ A branch linked to an issue.
 """
 type LinkedBranch implements Node {
   id: ID!
+  
   """
   The branch's ref.
   """
@@ -16834,14 +19063,17 @@ type LinkedBranchConnection {
   A list of edges.
   """
   edges: [LinkedBranchEdge]
+  
   """
   A list of nodes.
   """
   nodes: [LinkedBranch]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -16856,6 +19088,7 @@ type LinkedBranchEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -16870,10 +19103,12 @@ input LockLockableInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   A reason for why the item will be locked.
   """
   lockReason: LockReason
+  
   """
   ID of the item to be locked.
   """
@@ -16892,10 +19127,12 @@ type LockLockablePayload {
   Identifies the actor who performed the event.
   """
   actor: Actor
+  
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The item that was locked.
   """
@@ -16932,6 +19169,7 @@ interface Lockable {
   Reason that the conversation was locked.
   """
   activeLockReason: LockReason
+  
   """
   `true` if the object is locked
   """
@@ -16946,15 +19184,18 @@ type LockedEvent implements Node {
   Identifies the actor who performed the event.
   """
   actor: Actor
+  
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
   id: ID!
+  
   """
   Reason that the conversation was locked (optional).
   """
   lockReason: LockReason
+  
   """
   Object that was locked.
   """
@@ -16974,35 +19215,43 @@ type Mannequin implements Actor & Node & UniformResourceLocatable {
     """
     size: Int
   ): URI!
+  
   """
   The user that has claimed the data attributed to this mannequin.
   """
   claimant: User
+  
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
+  
   """
   Identifies the primary key from the database.
   """
   databaseId: Int
+  
   """
   The mannequin's email on the source instance.
   """
   email: String
   id: ID!
+  
   """
   The username of the actor.
   """
   login: String!
+  
   """
   The HTML path to this resource.
   """
   resourcePath: URI!
+  
   """
   Identifies the date and time when the object was last updated.
   """
   updatedAt: DateTime!
+  
   """
   The URL to this resource.
   """
@@ -17017,14 +19266,17 @@ type MannequinConnection {
   A list of edges.
   """
   edges: [MannequinEdge]
+  
   """
   A list of nodes.
   """
   nodes: [Mannequin]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -17039,6 +19291,7 @@ type MannequinEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -17053,6 +19306,7 @@ input MannequinOrder {
   The ordering direction.
   """
   direction: OrderDirection!
+  
   """
   The field to order mannequins by.
   """
@@ -17081,6 +19335,7 @@ input MarkDiscussionCommentAsAnswerInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The Node ID of the discussion comment to mark as an answer.
   """
@@ -17095,6 +19350,7 @@ type MarkDiscussionCommentAsAnswerPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The discussion that includes the chosen comment.
   """
@@ -17109,10 +19365,12 @@ input MarkFileAsViewedInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The path of the file to mark as viewed
   """
   path: String!
+  
   """
   The Node ID of the pull request.
   """
@@ -17127,6 +19385,7 @@ type MarkFileAsViewedPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The updated pull request.
   """
@@ -17141,6 +19400,7 @@ input MarkProjectV2AsTemplateInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The ID of the Project to mark as a template.
   """
@@ -17155,6 +19415,7 @@ type MarkProjectV2AsTemplatePayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The project.
   """
@@ -17169,6 +19430,7 @@ input MarkPullRequestReadyForReviewInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   ID of the pull request to be marked as ready for review.
   """
@@ -17183,6 +19445,7 @@ type MarkPullRequestReadyForReviewPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The pull request that is ready for review.
   """
@@ -17197,19 +19460,23 @@ type MarkedAsDuplicateEvent implements Node {
   Identifies the actor who performed the event.
   """
   actor: Actor
+  
   """
   The authoritative issue or pull request which has been duplicated by another.
   """
   canonical: IssueOrPullRequest
+  
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
+  
   """
   The issue or pull request which has been marked as a duplicate of another.
   """
   duplicate: IssueOrPullRequest
   id: ID!
+  
   """
   Canonical and duplicate belong to different repositories.
   """
@@ -17224,31 +19491,38 @@ type MarketplaceCategory implements Node {
   The category's description.
   """
   description: String
+  
   """
   The technical description of how apps listed in this category work with GitHub.
   """
   howItWorks: String
   id: ID!
+  
   """
   The category's name.
   """
   name: String!
+  
   """
   How many Marketplace listings have this as their primary category.
   """
   primaryListingCount: Int!
+  
   """
   The HTTP path for this Marketplace category.
   """
   resourcePath: URI!
+  
   """
   How many Marketplace listings have this as their secondary category.
   """
   secondaryListingCount: Int!
+  
   """
   The short name of the category used in its URL.
   """
   slug: String!
+  
   """
   The HTTP URL for this Marketplace category.
   """
@@ -17263,112 +19537,139 @@ type MarketplaceListing implements Node {
   The GitHub App this listing represents.
   """
   app: App
+  
   """
   URL to the listing owner's company site.
   """
   companyUrl: URI
+  
   """
   The HTTP path for configuring access to the listing's integration or OAuth app
   """
   configurationResourcePath: URI!
+  
   """
   The HTTP URL for configuring access to the listing's integration or OAuth app
   """
   configurationUrl: URI!
+  
   """
   URL to the listing's documentation.
   """
   documentationUrl: URI
+  
   """
   The listing's detailed description.
   """
   extendedDescription: String
+  
   """
   The listing's detailed description rendered to HTML.
   """
   extendedDescriptionHTML: HTML!
+  
   """
   The listing's introductory description.
   """
   fullDescription: String!
+  
   """
   The listing's introductory description rendered to HTML.
   """
   fullDescriptionHTML: HTML!
+  
   """
   Does this listing have any plans with a free trial?
   """
   hasPublishedFreeTrialPlans: Boolean!
+  
   """
   Does this listing have a terms of service link?
   """
   hasTermsOfService: Boolean!
+  
   """
   Whether the creator of the app is a verified org
   """
   hasVerifiedOwner: Boolean!
+  
   """
   A technical description of how this app works with GitHub.
   """
   howItWorks: String
+  
   """
   The listing's technical description rendered to HTML.
   """
   howItWorksHTML: HTML!
   id: ID!
+  
   """
   URL to install the product to the viewer's account or organization.
   """
   installationUrl: URI
+  
   """
   Whether this listing's app has been installed for the current viewer
   """
   installedForViewer: Boolean!
+  
   """
   Whether this listing has been removed from the Marketplace.
   """
   isArchived: Boolean!
+  
   """
   Whether this listing is still an editable draft that has not been submitted
   for review and is not publicly visible in the Marketplace.
   """
   isDraft: Boolean!
+  
   """
   Whether the product this listing represents is available as part of a paid plan.
   """
   isPaid: Boolean!
+  
   """
   Whether this listing has been approved for display in the Marketplace.
   """
   isPublic: Boolean!
+  
   """
   Whether this listing has been rejected by GitHub for display in the Marketplace.
   """
   isRejected: Boolean!
+  
   """
   Whether this listing has been approved for unverified display in the Marketplace.
   """
   isUnverified: Boolean!
+  
   """
   Whether this draft listing has been submitted for review for approval to be unverified in the Marketplace.
   """
   isUnverifiedPending: Boolean!
+  
   """
   Whether this draft listing has been submitted for review from GitHub for approval to be verified in the Marketplace.
   """
   isVerificationPendingFromDraft: Boolean!
+  
   """
   Whether this unverified listing has been submitted for review from GitHub for approval to be verified in the Marketplace.
   """
   isVerificationPendingFromUnverified: Boolean!
+  
   """
   Whether this listing has been approved for verified display in the Marketplace.
   """
   isVerified: Boolean!
+  
   """
   The hex color code, without the leading '#', for the logo background.
   """
   logoBackgroundColor: String!
+  
   """
   URL for the listing's logo image.
   """
@@ -17378,116 +19679,143 @@ type MarketplaceListing implements Node {
     """
     size: Int = 400
   ): URI
+  
   """
   The listing's full name.
   """
   name: String!
+  
   """
   The listing's very short description without a trailing period or ampersands.
   """
   normalizedShortDescription: String!
+  
   """
   URL to the listing's detailed pricing.
   """
   pricingUrl: URI
+  
   """
   The category that best describes the listing.
   """
   primaryCategory: MarketplaceCategory!
+  
   """
   URL to the listing's privacy policy, may return an empty string for listings that do not require a privacy policy URL.
   """
   privacyPolicyUrl: URI!
+  
   """
   The HTTP path for the Marketplace listing.
   """
   resourcePath: URI!
+  
   """
   The URLs for the listing's screenshots.
   """
   screenshotUrls: [String]!
+  
   """
   An alternate category that describes the listing.
   """
   secondaryCategory: MarketplaceCategory
+  
   """
   The listing's very short description.
   """
   shortDescription: String!
+  
   """
   The short name of the listing used in its URL.
   """
   slug: String!
+  
   """
   URL to the listing's status page.
   """
   statusUrl: URI
+  
   """
   An email address for support for this listing's app.
   """
   supportEmail: String
+  
   """
   Either a URL or an email address for support for this listing's app, may
   return an empty string for listings that do not require a support URL.
   """
   supportUrl: URI!
+  
   """
   URL to the listing's terms of service.
   """
   termsOfServiceUrl: URI
+  
   """
   The HTTP URL for the Marketplace listing.
   """
   url: URI!
+  
   """
   Can the current viewer add plans for this Marketplace listing.
   """
   viewerCanAddPlans: Boolean!
+  
   """
   Can the current viewer approve this Marketplace listing.
   """
   viewerCanApprove: Boolean!
+  
   """
   Can the current viewer delist this Marketplace listing.
   """
   viewerCanDelist: Boolean!
+  
   """
   Can the current viewer edit this Marketplace listing.
   """
   viewerCanEdit: Boolean!
+  
   """
   Can the current viewer edit the primary and secondary category of this
   Marketplace listing.
   """
   viewerCanEditCategories: Boolean!
+  
   """
   Can the current viewer edit the plans for this Marketplace listing.
   """
   viewerCanEditPlans: Boolean!
+  
   """
   Can the current viewer return this Marketplace listing to draft state
   so it becomes editable again.
   """
   viewerCanRedraft: Boolean!
+  
   """
   Can the current viewer reject this Marketplace listing by returning it to
   an editable draft state or rejecting it entirely.
   """
   viewerCanReject: Boolean!
+  
   """
   Can the current viewer request this listing be reviewed for display in
   the Marketplace as verified.
   """
   viewerCanRequestApproval: Boolean!
+  
   """
   Indicates whether the current user has an active subscription to this Marketplace listing.
   """
   viewerHasPurchased: Boolean!
+  
   """
   Indicates if the current user has purchased a subscription to this Marketplace listing
   for all of the organizations the user owns.
   """
   viewerHasPurchasedForAllOrganizations: Boolean!
+  
   """
   Does the current viewer role allow them to administer this Marketplace listing.
   """
@@ -17502,14 +19830,17 @@ type MarketplaceListingConnection {
   A list of edges.
   """
   edges: [MarketplaceListingEdge]
+  
   """
   A list of nodes.
   """
   nodes: [MarketplaceListing]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -17524,6 +19855,7 @@ type MarketplaceListingEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -17542,18 +19874,22 @@ interface MemberStatusable {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for user statuses returned from the connection.
     """
@@ -17569,79 +19905,98 @@ type MembersCanDeleteReposClearAuditEntry implements AuditEntry & EnterpriseAudi
   The action name
   """
   action: String!
+  
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
+  
   """
   The IP address of the actor
   """
   actorIp: String
+  
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
+  
   """
   The username of the user who initiated the action
   """
   actorLogin: String
+  
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
+  
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
+  
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
+  
   """
   The HTTP path for this enterprise.
   """
   enterpriseResourcePath: URI
+  
   """
   The slug of the enterprise.
   """
   enterpriseSlug: String
+  
   """
   The HTTP URL for this enterprise.
   """
   enterpriseUrl: URI
   id: ID!
+  
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
+  
   """
   The Organization associated with the Audit Entry.
   """
   organization: Organization
+  
   """
   The name of the Organization.
   """
   organizationName: String
+  
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
+  
   """
   The HTTP URL for the organization
   """
   organizationUrl: URI
+  
   """
   The user affected by the action
   """
   user: User
+  
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
+  
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
+  
   """
   The HTTP URL for the user.
   """
@@ -17656,79 +20011,98 @@ type MembersCanDeleteReposDisableAuditEntry implements AuditEntry & EnterpriseAu
   The action name
   """
   action: String!
+  
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
+  
   """
   The IP address of the actor
   """
   actorIp: String
+  
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
+  
   """
   The username of the user who initiated the action
   """
   actorLogin: String
+  
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
+  
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
+  
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
+  
   """
   The HTTP path for this enterprise.
   """
   enterpriseResourcePath: URI
+  
   """
   The slug of the enterprise.
   """
   enterpriseSlug: String
+  
   """
   The HTTP URL for this enterprise.
   """
   enterpriseUrl: URI
   id: ID!
+  
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
+  
   """
   The Organization associated with the Audit Entry.
   """
   organization: Organization
+  
   """
   The name of the Organization.
   """
   organizationName: String
+  
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
+  
   """
   The HTTP URL for the organization
   """
   organizationUrl: URI
+  
   """
   The user affected by the action
   """
   user: User
+  
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
+  
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
+  
   """
   The HTTP URL for the user.
   """
@@ -17743,79 +20117,98 @@ type MembersCanDeleteReposEnableAuditEntry implements AuditEntry & EnterpriseAud
   The action name
   """
   action: String!
+  
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
+  
   """
   The IP address of the actor
   """
   actorIp: String
+  
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
+  
   """
   The username of the user who initiated the action
   """
   actorLogin: String
+  
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
+  
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
+  
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
+  
   """
   The HTTP path for this enterprise.
   """
   enterpriseResourcePath: URI
+  
   """
   The slug of the enterprise.
   """
   enterpriseSlug: String
+  
   """
   The HTTP URL for this enterprise.
   """
   enterpriseUrl: URI
   id: ID!
+  
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
+  
   """
   The Organization associated with the Audit Entry.
   """
   organization: Organization
+  
   """
   The name of the Organization.
   """
   organizationName: String
+  
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
+  
   """
   The HTTP URL for the organization
   """
   organizationUrl: URI
+  
   """
   The user affected by the action
   """
   user: User
+  
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
+  
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
+  
   """
   The HTTP URL for the user.
   """
@@ -17830,10 +20223,12 @@ type MentionedEvent implements Node {
   Identifies the actor who performed the event.
   """
   actor: Actor
+  
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
+  
   """
   Identifies the primary key from the database.
   """
@@ -17849,22 +20244,27 @@ input MergeBranchInput {
   The email address to associate with this commit.
   """
   authorEmail: String
+  
   """
   The name of the base branch that the provided head will be merged into.
   """
   base: String!
+  
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   Message to use for the merge commit. If omitted, a default will be used.
   """
   commitMessage: String
+  
   """
   The head to merge into the base branch. This can be a branch name or a commit GitObjectID.
   """
   head: String!
+  
   """
   The Node ID of the Repository containing the base branch that will be modified.
   """
@@ -17879,6 +20279,7 @@ type MergeBranchPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The resulting merge Commit.
   """
@@ -17925,26 +20326,32 @@ input MergePullRequestInput {
   The email address to associate with this merge.
   """
   authorEmail: String
+  
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   Commit body to use for the merge commit; if omitted, a default message will be used
   """
   commitBody: String
+  
   """
   Commit headline to use for the merge commit; if omitted, a default message will be used.
   """
   commitHeadline: String
+  
   """
   OID that the pull request head ref must match to allow merge; if omitted, no check is performed.
   """
   expectedHeadOid: GitObjectID
+  
   """
   The merge method to use. If omitted, defaults to 'MERGE'
   """
   mergeMethod: PullRequestMergeMethod = MERGE
+  
   """
   ID of the pull request to be merged.
   """
@@ -17959,10 +20366,12 @@ type MergePullRequestPayload {
   Identifies the actor who performed the event.
   """
   actor: Actor
+  
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The pull request that was merged.
   """
@@ -17977,6 +20386,7 @@ type MergeQueue implements Node {
   The configuration for this merge queue
   """
   configuration: MergeQueueConfiguration
+  
   """
   The entries in the queue
   """
@@ -17985,32 +20395,39 @@ type MergeQueue implements Node {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): MergeQueueEntryConnection
   id: ID!
+  
   """
   The estimated time in seconds until a newly added entry would be merged
   """
   nextEntryEstimatedTimeToMerge: Int
+  
   """
   The repository this merge queue belongs to
   """
   repository: Repository
+  
   """
   The HTTP path for this merge queue
   """
   resourcePath: URI!
+  
   """
   The HTTP URL for this merge queue
   """
@@ -18025,26 +20442,32 @@ type MergeQueueConfiguration {
   The amount of time in minutes to wait for a check response before considering it a failure.
   """
   checkResponseTimeout: Int
+  
   """
   The maximum number of entries to build at once.
   """
   maximumEntriesToBuild: Int
+  
   """
   The maximum number of entries to merge at once.
   """
   maximumEntriesToMerge: Int
+  
   """
   The merge method to use for this queue.
   """
   mergeMethod: PullRequestMergeMethod
+  
   """
   The strategy to use when merging entries.
   """
   mergingStrategy: MergeQueueMergingStrategy
+  
   """
   The minimum number of entries required to merge at once.
   """
   minimumEntriesToMerge: Int
+  
   """
   The amount of time in minutes to wait before ignoring the minumum number of
   entries in the queue requirement and merging a collection of entries
@@ -18060,43 +20483,53 @@ type MergeQueueEntry implements Node {
   The base commit for this entry
   """
   baseCommit: Commit
+  
   """
   The date and time this entry was added to the merge queue
   """
   enqueuedAt: DateTime!
+  
   """
   The actor that enqueued this entry
   """
   enqueuer: Actor!
+  
   """
   The estimated time in seconds until this entry will be merged
   """
   estimatedTimeToMerge: Int
+  
   """
   The head commit for this entry
   """
   headCommit: Commit
   id: ID!
+  
   """
   Whether this pull request should jump the queue
   """
   jump: Boolean!
+  
   """
   The merge queue that this entry belongs to
   """
   mergeQueue: MergeQueue
+  
   """
   The position of this entry in the queue
   """
   position: Int!
+  
   """
   The pull request that will be added to a merge group
   """
   pullRequest: PullRequest
+  
   """
   Does this pull request need to be deployed on its own
   """
   solo: Boolean!
+  
   """
   The state of this entry in the queue
   """
@@ -18111,14 +20544,17 @@ type MergeQueueEntryConnection {
   A list of edges.
   """
   edges: [MergeQueueEntryEdge]
+  
   """
   A list of nodes.
   """
   nodes: [MergeQueueEntry]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -18133,6 +20569,7 @@ type MergeQueueEntryEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -18245,31 +20682,38 @@ type MergedEvent implements Node & UniformResourceLocatable {
   Identifies the actor who performed the event.
   """
   actor: Actor
+  
   """
   Identifies the commit associated with the `merge` event.
   """
   commit: Commit
+  
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
   id: ID!
+  
   """
   Identifies the Ref associated with the `merge` event.
   """
   mergeRef: Ref
+  
   """
   Identifies the name of the Ref associated with the `merge` event.
   """
   mergeRefName: String!
+  
   """
   PullRequest referenced by event.
   """
   pullRequest: PullRequest!
+  
   """
   The HTTP path for this merged event.
   """
   resourcePath: URI!
+  
   """
   The HTTP URL for this merged event.
   """
@@ -18284,39 +20728,48 @@ interface Migration {
   The migration flag to continue on error.
   """
   continueOnError: Boolean!
+  
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
+  
   """
   Identifies the primary key from the database.
   """
   databaseId: String
+  
   """
   The reason the migration failed.
   """
   failureReason: String
   id: ID!
+  
   """
   The URL for the migration log (expires 1 day after migration completes).
   """
   migrationLogUrl: URI
+  
   """
   The migration source.
   """
   migrationSource: MigrationSource!
+  
   """
   The target repository name.
   """
   repositoryName: String!
+  
   """
   The migration source URL, for example `https://github.com` or `https://monalisa.ghe.com`.
   """
   sourceUrl: URI!
+  
   """
   The migration state.
   """
   state: MigrationState!
+  
   """
   The number of warnings encountered for this migration. To review the warnings,
   check the [Migration Log](https://docs.github.com/en/migrations/using-github-enterprise-importer/completing-your-migration-with-github-enterprise-importer/accessing-your-migration-logs-for-github-enterprise-importer).
@@ -18329,14 +20782,17 @@ A GitHub Enterprise Importer (GEI) migration source.
 """
 type MigrationSource implements Node {
   id: ID!
+  
   """
   The migration source name.
   """
   name: String!
+  
   """
   The migration source type.
   """
   type: MigrationSourceType!
+  
   """
   The migration source URL, for example `https://github.com` or `https://monalisa.ghe.com`.
   """
@@ -18403,27 +20859,33 @@ type Milestone implements Closable & Node & UniformResourceLocatable {
   Indicates if the object is closed (definition of closed may depend on type)
   """
   closed: Boolean!
+  
   """
   Identifies the date and time when the object was closed.
   """
   closedAt: DateTime
+  
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
+  
   """
   Identifies the actor who created the milestone.
   """
   creator: Actor
+  
   """
   Identifies the description of the milestone.
   """
   description: String
+  
   """
   Identifies the due date of the milestone.
   """
   dueOn: DateTime
   id: ID!
+  
   """
   A list of issues associated with the milestone.
   """
@@ -18432,43 +20894,53 @@ type Milestone implements Closable & Node & UniformResourceLocatable {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Filtering options for issues returned from the connection.
     """
     filterBy: IssueFilters
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     A list of label names to filter the pull requests by.
     """
     labels: [String!]
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for issues returned from the connection.
     """
     orderBy: IssueOrder
+    
     """
     A list of states to filter the issues by.
     """
     states: [IssueState!]
   ): IssueConnection!
+  
   """
   Identifies the number of the milestone.
   """
   number: Int!
+  
   """
   Identifies the percentage complete for the milestone
   """
   progressPercentage: Float!
+  
   """
   A list of pull requests associated with the milestone.
   """
@@ -18477,67 +20949,83 @@ type Milestone implements Closable & Node & UniformResourceLocatable {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     The base ref name to filter the pull requests by.
     """
     baseRefName: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     The head ref name to filter the pull requests by.
     """
     headRefName: String
+    
     """
     A list of label names to filter the pull requests by.
     """
     labels: [String!]
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for pull requests returned from the connection.
     """
     orderBy: IssueOrder
+    
     """
     A list of states to filter the pull requests by.
     """
     states: [PullRequestState!]
   ): PullRequestConnection!
+  
   """
   The repository associated with this milestone.
   """
   repository: Repository!
+  
   """
   The HTTP path for this milestone
   """
   resourcePath: URI!
+  
   """
   Identifies the state of the milestone.
   """
   state: MilestoneState!
+  
   """
   Identifies the title of the milestone.
   """
   title: String!
+  
   """
   Identifies the date and time when the object was last updated.
   """
   updatedAt: DateTime!
+  
   """
   The HTTP URL for this milestone
   """
   url: URI!
+  
   """
   Indicates if the object can be closed by the viewer.
   """
   viewerCanClose: Boolean!
+  
   """
   Indicates if the object can be reopened by the viewer.
   """
@@ -18552,14 +21040,17 @@ type MilestoneConnection {
   A list of edges.
   """
   edges: [MilestoneEdge]
+  
   """
   A list of nodes.
   """
   nodes: [Milestone]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -18574,6 +21065,7 @@ type MilestoneEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -18593,6 +21085,7 @@ input MilestoneOrder {
   The ordering direction.
   """
   direction: OrderDirection!
+  
   """
   The field to order milestones by.
   """
@@ -18643,15 +21136,18 @@ type MilestonedEvent implements Node {
   Identifies the actor who performed the event.
   """
   actor: Actor
+  
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
   id: ID!
+  
   """
   Identifies the milestone title associated with the 'milestoned' event.
   """
   milestoneTitle: String!
+  
   """
   Object referenced by event.
   """
@@ -18666,12 +21162,14 @@ interface Minimizable {
   Returns whether or not a comment has been minimized.
   """
   isMinimized: Boolean!
+  
   """
   Returns why the comment was minimized. One of `abuse`, `off-topic`,
   `outdated`, `resolved`, `duplicate` and `spam`. Note that the case and
   formatting of these values differs from the inputs to the `MinimizeComment` mutation.
   """
   minimizedReason: String
+  
   """
   Check if the current viewer can minimize this object.
   """
@@ -18686,10 +21184,12 @@ input MinimizeCommentInput {
   The classification of comment
   """
   classifier: ReportedContentClassifiers!
+  
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The Node ID of the subject to modify.
   """
@@ -18714,6 +21214,7 @@ type MinimizeCommentPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The comment that was minimized.
   """
@@ -18728,14 +21229,17 @@ input MoveProjectCardInput {
   Place the new card after the card with this id. Pass null to place it at the top.
   """
   afterCardId: ID @possibleTypes(concreteTypes: ["ProjectCard"])
+  
   """
   The id of the card to move.
   """
   cardId: ID! @possibleTypes(concreteTypes: ["ProjectCard"])
+  
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The id of the column to move it into.
   """
@@ -18750,6 +21254,7 @@ type MoveProjectCardPayload {
   The new edge of the moved card.
   """
   cardEdge: ProjectCardEdge
+  
   """
   A unique identifier for the client performing the mutation.
   """
@@ -18764,10 +21269,12 @@ input MoveProjectColumnInput {
   Place the new column after the column with this id. Pass null to place it at the front.
   """
   afterColumnId: ID @possibleTypes(concreteTypes: ["ProjectColumn"])
+  
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The id of the column to move.
   """
@@ -18782,6 +21289,7 @@ type MoveProjectColumnPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The new edge of the moved column.
   """
@@ -18796,27 +21304,33 @@ type MovedColumnsInProjectEvent implements Node {
   Identifies the actor who performed the event.
   """
   actor: Actor
+  
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
+  
   """
   Identifies the primary key from the database.
   """
   databaseId: Int
   id: ID!
+  
   """
   Column name the issue or pull request was moved from.
   """
   previousProjectColumnName: String! @preview(toggledBy: "starfox-preview")
+  
   """
   Project referenced by event.
   """
   project: Project @preview(toggledBy: "starfox-preview")
+  
   """
   Project card referenced by this project event.
   """
   projectCard: ProjectCard @preview(toggledBy: "starfox-preview")
+  
   """
   Column name the issue or pull request was moved to.
   """
@@ -18836,6 +21350,7 @@ type Mutation {
     """
     input: AbortQueuedMigrationsInput!
   ): AbortQueuedMigrationsPayload
+  
   """
   Accepts a pending invitation for a user to become an administrator of an enterprise.
   """
@@ -18845,6 +21360,7 @@ type Mutation {
     """
     input: AcceptEnterpriseAdministratorInvitationInput!
   ): AcceptEnterpriseAdministratorInvitationPayload
+  
   """
   Applies a suggested topic to the repository.
   """
@@ -18854,6 +21370,7 @@ type Mutation {
     """
     input: AcceptTopicSuggestionInput!
   ): AcceptTopicSuggestionPayload
+  
   """
   Adds assignees to an assignable object.
   """
@@ -18863,6 +21380,7 @@ type Mutation {
     """
     input: AddAssigneesToAssignableInput!
   ): AddAssigneesToAssignablePayload
+  
   """
   Adds a comment to an Issue or Pull Request.
   """
@@ -18872,6 +21390,7 @@ type Mutation {
     """
     input: AddCommentInput!
   ): AddCommentPayload
+  
   """
   Adds a comment to a Discussion, possibly as a reply to another comment.
   """
@@ -18881,6 +21400,7 @@ type Mutation {
     """
     input: AddDiscussionCommentInput!
   ): AddDiscussionCommentPayload
+  
   """
   Vote for an option in a discussion poll.
   """
@@ -18890,6 +21410,7 @@ type Mutation {
     """
     input: AddDiscussionPollVoteInput!
   ): AddDiscussionPollVotePayload
+  
   """
   Adds enterprise members to an organization within the enterprise.
   """
@@ -18899,6 +21420,7 @@ type Mutation {
     """
     input: AddEnterpriseOrganizationMemberInput!
   ): AddEnterpriseOrganizationMemberPayload
+  
   """
   Adds a support entitlement to an enterprise member.
   """
@@ -18908,6 +21430,7 @@ type Mutation {
     """
     input: AddEnterpriseSupportEntitlementInput!
   ): AddEnterpriseSupportEntitlementPayload
+  
   """
   Adds labels to a labelable object.
   """
@@ -18917,6 +21440,7 @@ type Mutation {
     """
     input: AddLabelsToLabelableInput!
   ): AddLabelsToLabelablePayload
+  
   """
   Adds a card to a ProjectColumn. Either `contentId` or `note` must be provided but **not** both.
   """
@@ -18926,6 +21450,7 @@ type Mutation {
     """
     input: AddProjectCardInput!
   ): AddProjectCardPayload
+  
   """
   Adds a column to a Project.
   """
@@ -18935,6 +21460,7 @@ type Mutation {
     """
     input: AddProjectColumnInput!
   ): AddProjectColumnPayload
+  
   """
   Creates a new draft issue and add it to a Project.
   """
@@ -18944,6 +21470,7 @@ type Mutation {
     """
     input: AddProjectV2DraftIssueInput!
   ): AddProjectV2DraftIssuePayload
+  
   """
   Links an existing content instance to a Project.
   """
@@ -18953,6 +21480,7 @@ type Mutation {
     """
     input: AddProjectV2ItemByIdInput!
   ): AddProjectV2ItemByIdPayload
+  
   """
   Adds a review to a Pull Request.
   """
@@ -18962,6 +21490,7 @@ type Mutation {
     """
     input: AddPullRequestReviewInput!
   ): AddPullRequestReviewPayload
+  
   """
   Adds a comment to a review.
   """
@@ -18971,6 +21500,7 @@ type Mutation {
     """
     input: AddPullRequestReviewCommentInput!
   ): AddPullRequestReviewCommentPayload
+  
   """
   Adds a new thread to a pending Pull Request Review.
   """
@@ -18980,6 +21510,7 @@ type Mutation {
     """
     input: AddPullRequestReviewThreadInput!
   ): AddPullRequestReviewThreadPayload
+  
   """
   Adds a reply to an existing Pull Request Review Thread.
   """
@@ -18989,6 +21520,7 @@ type Mutation {
     """
     input: AddPullRequestReviewThreadReplyInput!
   ): AddPullRequestReviewThreadReplyPayload
+  
   """
   Adds a reaction to a subject.
   """
@@ -18998,6 +21530,7 @@ type Mutation {
     """
     input: AddReactionInput!
   ): AddReactionPayload
+  
   """
   Adds a star to a Starrable.
   """
@@ -19007,6 +21540,7 @@ type Mutation {
     """
     input: AddStarInput!
   ): AddStarPayload
+  
   """
   Add an upvote to a discussion or discussion comment.
   """
@@ -19016,6 +21550,7 @@ type Mutation {
     """
     input: AddUpvoteInput!
   ): AddUpvotePayload
+  
   """
   Adds a verifiable domain to an owning account.
   """
@@ -19025,6 +21560,7 @@ type Mutation {
     """
     input: AddVerifiableDomainInput!
   ): AddVerifiableDomainPayload
+  
   """
   Approve all pending deployments under one or more environments
   """
@@ -19034,6 +21570,7 @@ type Mutation {
     """
     input: ApproveDeploymentsInput!
   ): ApproveDeploymentsPayload
+  
   """
   Approve a verifiable domain for notification delivery.
   """
@@ -19043,6 +21580,7 @@ type Mutation {
     """
     input: ApproveVerifiableDomainInput!
   ): ApproveVerifiableDomainPayload
+  
   """
   Archives a ProjectV2Item
   """
@@ -19052,6 +21590,7 @@ type Mutation {
     """
     input: ArchiveProjectV2ItemInput!
   ): ArchiveProjectV2ItemPayload
+  
   """
   Marks a repository as archived.
   """
@@ -19061,6 +21600,7 @@ type Mutation {
     """
     input: ArchiveRepositoryInput!
   ): ArchiveRepositoryPayload
+  
   """
   Cancels a pending invitation for an administrator to join an enterprise.
   """
@@ -19070,6 +21610,7 @@ type Mutation {
     """
     input: CancelEnterpriseAdminInvitationInput!
   ): CancelEnterpriseAdminInvitationPayload
+  
   """
   Cancel an active sponsorship.
   """
@@ -19079,6 +21620,7 @@ type Mutation {
     """
     input: CancelSponsorshipInput!
   ): CancelSponsorshipPayload
+  
   """
   Update your status on GitHub.
   """
@@ -19088,6 +21630,7 @@ type Mutation {
     """
     input: ChangeUserStatusInput!
   ): ChangeUserStatusPayload
+  
   """
   Clears all labels from a labelable object.
   """
@@ -19097,6 +21640,7 @@ type Mutation {
     """
     input: ClearLabelsFromLabelableInput!
   ): ClearLabelsFromLabelablePayload
+  
   """
   This mutation clears the value of a field for an item in a Project. Currently
   only text, number, date, assignees, labels, single-select, iteration and
@@ -19108,6 +21652,7 @@ type Mutation {
     """
     input: ClearProjectV2ItemFieldValueInput!
   ): ClearProjectV2ItemFieldValuePayload
+  
   """
   Creates a new project by cloning configuration from an existing project.
   """
@@ -19117,6 +21662,7 @@ type Mutation {
     """
     input: CloneProjectInput!
   ): CloneProjectPayload
+  
   """
   Create a new repository with the same files and directory structure as a template repository.
   """
@@ -19126,6 +21672,7 @@ type Mutation {
     """
     input: CloneTemplateRepositoryInput!
   ): CloneTemplateRepositoryPayload
+  
   """
   Close a discussion.
   """
@@ -19135,6 +21682,7 @@ type Mutation {
     """
     input: CloseDiscussionInput!
   ): CloseDiscussionPayload
+  
   """
   Close an issue.
   """
@@ -19144,6 +21692,7 @@ type Mutation {
     """
     input: CloseIssueInput!
   ): CloseIssuePayload
+  
   """
   Close a pull request.
   """
@@ -19153,6 +21702,7 @@ type Mutation {
     """
     input: ClosePullRequestInput!
   ): ClosePullRequestPayload
+  
   """
   Convert a project note card to one associated with a newly created issue.
   """
@@ -19162,6 +21712,7 @@ type Mutation {
     """
     input: ConvertProjectCardNoteToIssueInput!
   ): ConvertProjectCardNoteToIssuePayload
+  
   """
   Converts a pull request to draft
   """
@@ -19171,6 +21722,7 @@ type Mutation {
     """
     input: ConvertPullRequestToDraftInput!
   ): ConvertPullRequestToDraftPayload
+  
   """
   Copy a project.
   """
@@ -19180,6 +21732,7 @@ type Mutation {
     """
     input: CopyProjectV2Input!
   ): CopyProjectV2Payload
+  
   """
   Invites a user to claim reattributable data
   """
@@ -19189,6 +21742,7 @@ type Mutation {
     """
     input: CreateAttributionInvitationInput!
   ): CreateAttributionInvitationPayload
+  
   """
   Create a new branch protection rule
   """
@@ -19198,6 +21752,7 @@ type Mutation {
     """
     input: CreateBranchProtectionRuleInput!
   ): CreateBranchProtectionRulePayload
+  
   """
   Create a check run.
   """
@@ -19207,6 +21762,7 @@ type Mutation {
     """
     input: CreateCheckRunInput!
   ): CreateCheckRunPayload
+  
   """
   Create a check suite
   """
@@ -19216,6 +21772,7 @@ type Mutation {
     """
     input: CreateCheckSuiteInput!
   ): CreateCheckSuitePayload
+  
   """
   Appends a commit to the given branch as the authenticated user.
 
@@ -19266,6 +21823,7 @@ type Mutation {
     """
     input: CreateCommitOnBranchInput!
   ): CreateCommitOnBranchPayload
+  
   """
   Creates a new deployment event.
   """
@@ -19275,6 +21833,7 @@ type Mutation {
     """
     input: CreateDeploymentInput!
   ): CreateDeploymentPayload @preview(toggledBy: "flash-preview")
+  
   """
   Create a deployment status.
   """
@@ -19284,6 +21843,7 @@ type Mutation {
     """
     input: CreateDeploymentStatusInput!
   ): CreateDeploymentStatusPayload @preview(toggledBy: "flash-preview")
+  
   """
   Create a discussion.
   """
@@ -19293,6 +21853,7 @@ type Mutation {
     """
     input: CreateDiscussionInput!
   ): CreateDiscussionPayload
+  
   """
   Creates an organization as part of an enterprise account.
   """
@@ -19302,6 +21863,7 @@ type Mutation {
     """
     input: CreateEnterpriseOrganizationInput!
   ): CreateEnterpriseOrganizationPayload
+  
   """
   Creates an environment or simply returns it if already exists.
   """
@@ -19311,6 +21873,7 @@ type Mutation {
     """
     input: CreateEnvironmentInput!
   ): CreateEnvironmentPayload
+  
   """
   Creates a new IP allow list entry.
   """
@@ -19320,6 +21883,7 @@ type Mutation {
     """
     input: CreateIpAllowListEntryInput!
   ): CreateIpAllowListEntryPayload
+  
   """
   Creates a new issue.
   """
@@ -19329,6 +21893,7 @@ type Mutation {
     """
     input: CreateIssueInput!
   ): CreateIssuePayload
+  
   """
   Creates a new label.
   """
@@ -19338,6 +21903,7 @@ type Mutation {
     """
     input: CreateLabelInput!
   ): CreateLabelPayload @preview(toggledBy: "bane-preview")
+  
   """
   Create a branch linked to an issue.
   """
@@ -19347,6 +21913,7 @@ type Mutation {
     """
     input: CreateLinkedBranchInput!
   ): CreateLinkedBranchPayload
+  
   """
   Creates a GitHub Enterprise Importer (GEI) migration source.
   """
@@ -19356,6 +21923,7 @@ type Mutation {
     """
     input: CreateMigrationSourceInput!
   ): CreateMigrationSourcePayload
+  
   """
   Creates a new project.
   """
@@ -19365,6 +21933,7 @@ type Mutation {
     """
     input: CreateProjectInput!
   ): CreateProjectPayload
+  
   """
   Creates a new project.
   """
@@ -19374,6 +21943,7 @@ type Mutation {
     """
     input: CreateProjectV2Input!
   ): CreateProjectV2Payload
+  
   """
   Create a new project field.
   """
@@ -19383,6 +21953,7 @@ type Mutation {
     """
     input: CreateProjectV2FieldInput!
   ): CreateProjectV2FieldPayload
+  
   """
   Create a new pull request
   """
@@ -19392,6 +21963,7 @@ type Mutation {
     """
     input: CreatePullRequestInput!
   ): CreatePullRequestPayload
+  
   """
   Create a new Git Ref.
   """
@@ -19401,6 +21973,7 @@ type Mutation {
     """
     input: CreateRefInput!
   ): CreateRefPayload
+  
   """
   Create a new repository.
   """
@@ -19410,6 +21983,7 @@ type Mutation {
     """
     input: CreateRepositoryInput!
   ): CreateRepositoryPayload
+  
   """
   Create a repository ruleset
   """
@@ -19419,6 +21993,7 @@ type Mutation {
     """
     input: CreateRepositoryRulesetInput!
   ): CreateRepositoryRulesetPayload
+  
   """
   Create a GitHub Sponsors profile to allow others to sponsor you or your organization.
   """
@@ -19428,6 +22003,7 @@ type Mutation {
     """
     input: CreateSponsorsListingInput!
   ): CreateSponsorsListingPayload
+  
   """
   Create a new payment tier for your GitHub Sponsors profile.
   """
@@ -19437,6 +22013,7 @@ type Mutation {
     """
     input: CreateSponsorsTierInput!
   ): CreateSponsorsTierPayload
+  
   """
   Start a new sponsorship of a maintainer in GitHub Sponsors, or reactivate a past sponsorship.
   """
@@ -19446,6 +22023,7 @@ type Mutation {
     """
     input: CreateSponsorshipInput!
   ): CreateSponsorshipPayload
+  
   """
   Make many one-time sponsorships for different sponsorable users or
   organizations at once. Can only sponsor those who have a public GitHub
@@ -19457,6 +22035,7 @@ type Mutation {
     """
     input: CreateSponsorshipsInput!
   ): CreateSponsorshipsPayload
+  
   """
   Creates a new team discussion.
   """
@@ -19466,6 +22045,7 @@ type Mutation {
     """
     input: CreateTeamDiscussionInput!
   ): CreateTeamDiscussionPayload
+  
   """
   Creates a new team discussion comment.
   """
@@ -19475,6 +22055,7 @@ type Mutation {
     """
     input: CreateTeamDiscussionCommentInput!
   ): CreateTeamDiscussionCommentPayload
+  
   """
   Rejects a suggested topic for the repository.
   """
@@ -19484,6 +22065,7 @@ type Mutation {
     """
     input: DeclineTopicSuggestionInput!
   ): DeclineTopicSuggestionPayload
+  
   """
   Delete a branch protection rule
   """
@@ -19493,6 +22075,7 @@ type Mutation {
     """
     input: DeleteBranchProtectionRuleInput!
   ): DeleteBranchProtectionRulePayload
+  
   """
   Deletes a deployment.
   """
@@ -19502,6 +22085,7 @@ type Mutation {
     """
     input: DeleteDeploymentInput!
   ): DeleteDeploymentPayload
+  
   """
   Delete a discussion and all of its replies.
   """
@@ -19511,6 +22095,7 @@ type Mutation {
     """
     input: DeleteDiscussionInput!
   ): DeleteDiscussionPayload
+  
   """
   Delete a discussion comment. If it has replies, wipe it instead.
   """
@@ -19520,6 +22105,7 @@ type Mutation {
     """
     input: DeleteDiscussionCommentInput!
   ): DeleteDiscussionCommentPayload
+  
   """
   Deletes an environment
   """
@@ -19529,6 +22115,7 @@ type Mutation {
     """
     input: DeleteEnvironmentInput!
   ): DeleteEnvironmentPayload
+  
   """
   Deletes an IP allow list entry.
   """
@@ -19538,6 +22125,7 @@ type Mutation {
     """
     input: DeleteIpAllowListEntryInput!
   ): DeleteIpAllowListEntryPayload
+  
   """
   Deletes an Issue object.
   """
@@ -19547,6 +22135,7 @@ type Mutation {
     """
     input: DeleteIssueInput!
   ): DeleteIssuePayload
+  
   """
   Deletes an IssueComment object.
   """
@@ -19556,6 +22145,7 @@ type Mutation {
     """
     input: DeleteIssueCommentInput!
   ): DeleteIssueCommentPayload
+  
   """
   Deletes a label.
   """
@@ -19565,6 +22155,7 @@ type Mutation {
     """
     input: DeleteLabelInput!
   ): DeleteLabelPayload @preview(toggledBy: "bane-preview")
+  
   """
   Unlink a branch from an issue.
   """
@@ -19574,6 +22165,7 @@ type Mutation {
     """
     input: DeleteLinkedBranchInput!
   ): DeleteLinkedBranchPayload
+  
   """
   Delete a package version.
   """
@@ -19583,6 +22175,7 @@ type Mutation {
     """
     input: DeletePackageVersionInput!
   ): DeletePackageVersionPayload @preview(toggledBy: "package-deletes-preview")
+  
   """
   Deletes a project.
   """
@@ -19592,6 +22185,7 @@ type Mutation {
     """
     input: DeleteProjectInput!
   ): DeleteProjectPayload
+  
   """
   Deletes a project card.
   """
@@ -19601,6 +22195,7 @@ type Mutation {
     """
     input: DeleteProjectCardInput!
   ): DeleteProjectCardPayload
+  
   """
   Deletes a project column.
   """
@@ -19610,6 +22205,7 @@ type Mutation {
     """
     input: DeleteProjectColumnInput!
   ): DeleteProjectColumnPayload
+  
   """
   Delete a project.
   """
@@ -19619,6 +22215,7 @@ type Mutation {
     """
     input: DeleteProjectV2Input!
   ): DeleteProjectV2Payload
+  
   """
   Delete a project field.
   """
@@ -19628,6 +22225,7 @@ type Mutation {
     """
     input: DeleteProjectV2FieldInput!
   ): DeleteProjectV2FieldPayload
+  
   """
   Deletes an item from a Project.
   """
@@ -19637,6 +22235,7 @@ type Mutation {
     """
     input: DeleteProjectV2ItemInput!
   ): DeleteProjectV2ItemPayload
+  
   """
   Deletes a project workflow.
   """
@@ -19646,6 +22245,7 @@ type Mutation {
     """
     input: DeleteProjectV2WorkflowInput!
   ): DeleteProjectV2WorkflowPayload
+  
   """
   Deletes a pull request review.
   """
@@ -19655,6 +22255,7 @@ type Mutation {
     """
     input: DeletePullRequestReviewInput!
   ): DeletePullRequestReviewPayload
+  
   """
   Deletes a pull request review comment.
   """
@@ -19664,6 +22265,7 @@ type Mutation {
     """
     input: DeletePullRequestReviewCommentInput!
   ): DeletePullRequestReviewCommentPayload
+  
   """
   Delete a Git Ref.
   """
@@ -19673,6 +22275,7 @@ type Mutation {
     """
     input: DeleteRefInput!
   ): DeleteRefPayload
+  
   """
   Delete a repository ruleset
   """
@@ -19682,6 +22285,7 @@ type Mutation {
     """
     input: DeleteRepositoryRulesetInput!
   ): DeleteRepositoryRulesetPayload
+  
   """
   Deletes a team discussion.
   """
@@ -19691,6 +22295,7 @@ type Mutation {
     """
     input: DeleteTeamDiscussionInput!
   ): DeleteTeamDiscussionPayload
+  
   """
   Deletes a team discussion comment.
   """
@@ -19700,6 +22305,7 @@ type Mutation {
     """
     input: DeleteTeamDiscussionCommentInput!
   ): DeleteTeamDiscussionCommentPayload
+  
   """
   Deletes a verifiable domain.
   """
@@ -19709,6 +22315,7 @@ type Mutation {
     """
     input: DeleteVerifiableDomainInput!
   ): DeleteVerifiableDomainPayload
+  
   """
   Remove a pull request from the merge queue.
   """
@@ -19718,6 +22325,7 @@ type Mutation {
     """
     input: DequeuePullRequestInput!
   ): DequeuePullRequestPayload
+  
   """
   Disable auto merge on the given pull request
   """
@@ -19727,6 +22335,7 @@ type Mutation {
     """
     input: DisablePullRequestAutoMergeInput!
   ): DisablePullRequestAutoMergePayload
+  
   """
   Dismisses an approved or rejected pull request review.
   """
@@ -19736,6 +22345,7 @@ type Mutation {
     """
     input: DismissPullRequestReviewInput!
   ): DismissPullRequestReviewPayload
+  
   """
   Dismisses the Dependabot alert.
   """
@@ -19745,6 +22355,7 @@ type Mutation {
     """
     input: DismissRepositoryVulnerabilityAlertInput!
   ): DismissRepositoryVulnerabilityAlertPayload
+  
   """
   Enable the default auto-merge on a pull request.
   """
@@ -19754,6 +22365,7 @@ type Mutation {
     """
     input: EnablePullRequestAutoMergeInput!
   ): EnablePullRequestAutoMergePayload
+  
   """
   Add a pull request to the merge queue.
   """
@@ -19763,6 +22375,7 @@ type Mutation {
     """
     input: EnqueuePullRequestInput!
   ): EnqueuePullRequestPayload
+  
   """
   Follow an organization.
   """
@@ -19772,6 +22385,7 @@ type Mutation {
     """
     input: FollowOrganizationInput!
   ): FollowOrganizationPayload
+  
   """
   Follow a user.
   """
@@ -19781,6 +22395,7 @@ type Mutation {
     """
     input: FollowUserInput!
   ): FollowUserPayload
+  
   """
   Grant the migrator role to a user for all organizations under an enterprise account.
   """
@@ -19790,6 +22405,7 @@ type Mutation {
     """
     input: GrantEnterpriseOrganizationsMigratorRoleInput!
   ): GrantEnterpriseOrganizationsMigratorRolePayload
+  
   """
   Grant the migrator role to a user or a team.
   """
@@ -19799,6 +22415,7 @@ type Mutation {
     """
     input: GrantMigratorRoleInput!
   ): GrantMigratorRolePayload
+  
   """
   Creates a new project by importing columns and a list of issues/PRs.
   """
@@ -19808,6 +22425,7 @@ type Mutation {
     """
     input: ImportProjectInput!
   ): ImportProjectPayload @preview(toggledBy: "slothette-preview")
+  
   """
   Invite someone to become an administrator of the enterprise.
   """
@@ -19817,6 +22435,7 @@ type Mutation {
     """
     input: InviteEnterpriseAdminInput!
   ): InviteEnterpriseAdminPayload
+  
   """
   Links a project to a repository.
   """
@@ -19826,6 +22445,7 @@ type Mutation {
     """
     input: LinkProjectV2ToRepositoryInput!
   ): LinkProjectV2ToRepositoryPayload
+  
   """
   Links a project to a team.
   """
@@ -19835,6 +22455,7 @@ type Mutation {
     """
     input: LinkProjectV2ToTeamInput!
   ): LinkProjectV2ToTeamPayload
+  
   """
   Creates a repository link for a project.
   """
@@ -19844,6 +22465,7 @@ type Mutation {
     """
     input: LinkRepositoryToProjectInput!
   ): LinkRepositoryToProjectPayload
+  
   """
   Lock a lockable object
   """
@@ -19853,6 +22475,7 @@ type Mutation {
     """
     input: LockLockableInput!
   ): LockLockablePayload
+  
   """
   Mark a discussion comment as the chosen answer for discussions in an answerable category.
   """
@@ -19862,6 +22485,7 @@ type Mutation {
     """
     input: MarkDiscussionCommentAsAnswerInput!
   ): MarkDiscussionCommentAsAnswerPayload
+  
   """
   Mark a pull request file as viewed
   """
@@ -19871,6 +22495,7 @@ type Mutation {
     """
     input: MarkFileAsViewedInput!
   ): MarkFileAsViewedPayload
+  
   """
   Mark a project as a template. Note that only projects which are owned by an Organization can be marked as a template.
   """
@@ -19880,6 +22505,7 @@ type Mutation {
     """
     input: MarkProjectV2AsTemplateInput!
   ): MarkProjectV2AsTemplatePayload
+  
   """
   Marks a pull request ready for review.
   """
@@ -19889,6 +22515,7 @@ type Mutation {
     """
     input: MarkPullRequestReadyForReviewInput!
   ): MarkPullRequestReadyForReviewPayload
+  
   """
   Merge a head into a branch.
   """
@@ -19898,6 +22525,7 @@ type Mutation {
     """
     input: MergeBranchInput!
   ): MergeBranchPayload
+  
   """
   Merge a pull request.
   """
@@ -19907,6 +22535,7 @@ type Mutation {
     """
     input: MergePullRequestInput!
   ): MergePullRequestPayload
+  
   """
   Minimizes a comment on an Issue, Commit, Pull Request, or Gist
   """
@@ -19916,6 +22545,7 @@ type Mutation {
     """
     input: MinimizeCommentInput!
   ): MinimizeCommentPayload
+  
   """
   Moves a project card to another place.
   """
@@ -19925,6 +22555,7 @@ type Mutation {
     """
     input: MoveProjectCardInput!
   ): MoveProjectCardPayload
+  
   """
   Moves a project column to another place.
   """
@@ -19934,6 +22565,7 @@ type Mutation {
     """
     input: MoveProjectColumnInput!
   ): MoveProjectColumnPayload
+  
   """
   Pin an issue to a repository
   """
@@ -19943,6 +22575,7 @@ type Mutation {
     """
     input: PinIssueInput!
   ): PinIssuePayload
+  
   """
   Publish an existing sponsorship tier that is currently still a draft to a GitHub Sponsors profile.
   """
@@ -19952,6 +22585,7 @@ type Mutation {
     """
     input: PublishSponsorsTierInput!
   ): PublishSponsorsTierPayload
+  
   """
   Regenerates the identity provider recovery codes for an enterprise
   """
@@ -19961,6 +22595,7 @@ type Mutation {
     """
     input: RegenerateEnterpriseIdentityProviderRecoveryCodesInput!
   ): RegenerateEnterpriseIdentityProviderRecoveryCodesPayload
+  
   """
   Regenerates a verifiable domain's verification token.
   """
@@ -19970,6 +22605,7 @@ type Mutation {
     """
     input: RegenerateVerifiableDomainTokenInput!
   ): RegenerateVerifiableDomainTokenPayload
+  
   """
   Reject all pending deployments under one or more environments
   """
@@ -19979,6 +22615,7 @@ type Mutation {
     """
     input: RejectDeploymentsInput!
   ): RejectDeploymentsPayload
+  
   """
   Removes assignees from an assignable object.
   """
@@ -19988,6 +22625,7 @@ type Mutation {
     """
     input: RemoveAssigneesFromAssignableInput!
   ): RemoveAssigneesFromAssignablePayload
+  
   """
   Removes an administrator from the enterprise.
   """
@@ -19997,6 +22635,7 @@ type Mutation {
     """
     input: RemoveEnterpriseAdminInput!
   ): RemoveEnterpriseAdminPayload
+  
   """
   Removes the identity provider from an enterprise
   """
@@ -20006,6 +22645,7 @@ type Mutation {
     """
     input: RemoveEnterpriseIdentityProviderInput!
   ): RemoveEnterpriseIdentityProviderPayload
+  
   """
   Removes a user from all organizations within the enterprise
   """
@@ -20015,6 +22655,7 @@ type Mutation {
     """
     input: RemoveEnterpriseMemberInput!
   ): RemoveEnterpriseMemberPayload
+  
   """
   Removes an organization from the enterprise
   """
@@ -20024,6 +22665,7 @@ type Mutation {
     """
     input: RemoveEnterpriseOrganizationInput!
   ): RemoveEnterpriseOrganizationPayload
+  
   """
   Removes a support entitlement from an enterprise member.
   """
@@ -20033,6 +22675,7 @@ type Mutation {
     """
     input: RemoveEnterpriseSupportEntitlementInput!
   ): RemoveEnterpriseSupportEntitlementPayload
+  
   """
   Removes labels from a Labelable object.
   """
@@ -20042,6 +22685,7 @@ type Mutation {
     """
     input: RemoveLabelsFromLabelableInput!
   ): RemoveLabelsFromLabelablePayload
+  
   """
   Removes outside collaborator from all repositories in an organization.
   """
@@ -20051,6 +22695,7 @@ type Mutation {
     """
     input: RemoveOutsideCollaboratorInput!
   ): RemoveOutsideCollaboratorPayload
+  
   """
   Removes a reaction from a subject.
   """
@@ -20060,6 +22705,7 @@ type Mutation {
     """
     input: RemoveReactionInput!
   ): RemoveReactionPayload
+  
   """
   Removes a star from a Starrable.
   """
@@ -20069,6 +22715,7 @@ type Mutation {
     """
     input: RemoveStarInput!
   ): RemoveStarPayload
+  
   """
   Remove an upvote to a discussion or discussion comment.
   """
@@ -20078,6 +22725,7 @@ type Mutation {
     """
     input: RemoveUpvoteInput!
   ): RemoveUpvotePayload
+  
   """
   Reopen a discussion.
   """
@@ -20087,6 +22735,7 @@ type Mutation {
     """
     input: ReopenDiscussionInput!
   ): ReopenDiscussionPayload
+  
   """
   Reopen a issue.
   """
@@ -20096,6 +22745,7 @@ type Mutation {
     """
     input: ReopenIssueInput!
   ): ReopenIssuePayload
+  
   """
   Reopen a pull request.
   """
@@ -20105,6 +22755,7 @@ type Mutation {
     """
     input: ReopenPullRequestInput!
   ): ReopenPullRequestPayload
+  
   """
   Set review requests on a pull request.
   """
@@ -20114,6 +22765,7 @@ type Mutation {
     """
     input: RequestReviewsInput!
   ): RequestReviewsPayload
+  
   """
   Rerequests an existing check suite.
   """
@@ -20123,6 +22775,7 @@ type Mutation {
     """
     input: RerequestCheckSuiteInput!
   ): RerequestCheckSuitePayload
+  
   """
   Marks a review thread as resolved.
   """
@@ -20132,6 +22785,7 @@ type Mutation {
     """
     input: ResolveReviewThreadInput!
   ): ResolveReviewThreadPayload
+  
   """
   Retire a published payment tier from your GitHub Sponsors profile so it cannot be used to start new sponsorships.
   """
@@ -20141,6 +22795,7 @@ type Mutation {
     """
     input: RetireSponsorsTierInput!
   ): RetireSponsorsTierPayload
+  
   """
   Create a pull request that reverts the changes from a merged pull request.
   """
@@ -20150,6 +22805,7 @@ type Mutation {
     """
     input: RevertPullRequestInput!
   ): RevertPullRequestPayload
+  
   """
   Revoke the migrator role to a user for all organizations under an enterprise account.
   """
@@ -20159,6 +22815,7 @@ type Mutation {
     """
     input: RevokeEnterpriseOrganizationsMigratorRoleInput!
   ): RevokeEnterpriseOrganizationsMigratorRolePayload
+  
   """
   Revoke the migrator role from a user or a team.
   """
@@ -20168,6 +22825,7 @@ type Mutation {
     """
     input: RevokeMigratorRoleInput!
   ): RevokeMigratorRolePayload
+  
   """
   Creates or updates the identity provider for an enterprise.
   """
@@ -20177,6 +22835,7 @@ type Mutation {
     """
     input: SetEnterpriseIdentityProviderInput!
   ): SetEnterpriseIdentityProviderPayload
+  
   """
   Set an organization level interaction limit for an organization's public repositories.
   """
@@ -20186,6 +22845,7 @@ type Mutation {
     """
     input: SetOrganizationInteractionLimitInput!
   ): SetOrganizationInteractionLimitPayload
+  
   """
   Sets an interaction limit setting for a repository.
   """
@@ -20195,6 +22855,7 @@ type Mutation {
     """
     input: SetRepositoryInteractionLimitInput!
   ): SetRepositoryInteractionLimitPayload
+  
   """
   Set a user level interaction limit for an user's public repositories.
   """
@@ -20204,6 +22865,7 @@ type Mutation {
     """
     input: SetUserInteractionLimitInput!
   ): SetUserInteractionLimitPayload
+  
   """
   Starts a GitHub Enterprise Importer organization migration.
   """
@@ -20213,6 +22875,7 @@ type Mutation {
     """
     input: StartOrganizationMigrationInput!
   ): StartOrganizationMigrationPayload
+  
   """
   Starts a GitHub Enterprise Importer (GEI) repository migration.
   """
@@ -20222,6 +22885,7 @@ type Mutation {
     """
     input: StartRepositoryMigrationInput!
   ): StartRepositoryMigrationPayload
+  
   """
   Submits a pending pull request review.
   """
@@ -20231,6 +22895,7 @@ type Mutation {
     """
     input: SubmitPullRequestReviewInput!
   ): SubmitPullRequestReviewPayload
+  
   """
   Transfer an organization from one enterprise to another enterprise.
   """
@@ -20240,6 +22905,7 @@ type Mutation {
     """
     input: TransferEnterpriseOrganizationInput!
   ): TransferEnterpriseOrganizationPayload
+  
   """
   Transfer an issue to a different repository
   """
@@ -20249,6 +22915,7 @@ type Mutation {
     """
     input: TransferIssueInput!
   ): TransferIssuePayload
+  
   """
   Unarchives a ProjectV2Item
   """
@@ -20258,6 +22925,7 @@ type Mutation {
     """
     input: UnarchiveProjectV2ItemInput!
   ): UnarchiveProjectV2ItemPayload
+  
   """
   Unarchives a repository.
   """
@@ -20267,6 +22935,7 @@ type Mutation {
     """
     input: UnarchiveRepositoryInput!
   ): UnarchiveRepositoryPayload
+  
   """
   Unfollow an organization.
   """
@@ -20276,6 +22945,7 @@ type Mutation {
     """
     input: UnfollowOrganizationInput!
   ): UnfollowOrganizationPayload
+  
   """
   Unfollow a user.
   """
@@ -20285,6 +22955,7 @@ type Mutation {
     """
     input: UnfollowUserInput!
   ): UnfollowUserPayload
+  
   """
   Unlinks a project from a repository.
   """
@@ -20294,6 +22965,7 @@ type Mutation {
     """
     input: UnlinkProjectV2FromRepositoryInput!
   ): UnlinkProjectV2FromRepositoryPayload
+  
   """
   Unlinks a project to a team.
   """
@@ -20303,6 +22975,7 @@ type Mutation {
     """
     input: UnlinkProjectV2FromTeamInput!
   ): UnlinkProjectV2FromTeamPayload
+  
   """
   Deletes a repository link from a project.
   """
@@ -20312,6 +22985,7 @@ type Mutation {
     """
     input: UnlinkRepositoryFromProjectInput!
   ): UnlinkRepositoryFromProjectPayload
+  
   """
   Unlock a lockable object
   """
@@ -20321,6 +22995,7 @@ type Mutation {
     """
     input: UnlockLockableInput!
   ): UnlockLockablePayload
+  
   """
   Unmark a discussion comment as the chosen answer for discussions in an answerable category.
   """
@@ -20330,6 +23005,7 @@ type Mutation {
     """
     input: UnmarkDiscussionCommentAsAnswerInput!
   ): UnmarkDiscussionCommentAsAnswerPayload
+  
   """
   Unmark a pull request file as viewed
   """
@@ -20339,6 +23015,7 @@ type Mutation {
     """
     input: UnmarkFileAsViewedInput!
   ): UnmarkFileAsViewedPayload
+  
   """
   Unmark an issue as a duplicate of another issue.
   """
@@ -20348,6 +23025,7 @@ type Mutation {
     """
     input: UnmarkIssueAsDuplicateInput!
   ): UnmarkIssueAsDuplicatePayload
+  
   """
   Unmark a project as a template.
   """
@@ -20357,6 +23035,7 @@ type Mutation {
     """
     input: UnmarkProjectV2AsTemplateInput!
   ): UnmarkProjectV2AsTemplatePayload
+  
   """
   Unminimizes a comment on an Issue, Commit, Pull Request, or Gist
   """
@@ -20366,6 +23045,7 @@ type Mutation {
     """
     input: UnminimizeCommentInput!
   ): UnminimizeCommentPayload
+  
   """
   Unpin a pinned issue from a repository
   """
@@ -20375,6 +23055,7 @@ type Mutation {
     """
     input: UnpinIssueInput!
   ): UnpinIssuePayload
+  
   """
   Marks a review thread as unresolved.
   """
@@ -20384,6 +23065,7 @@ type Mutation {
     """
     input: UnresolveReviewThreadInput!
   ): UnresolveReviewThreadPayload
+  
   """
   Update a branch protection rule
   """
@@ -20393,6 +23075,7 @@ type Mutation {
     """
     input: UpdateBranchProtectionRuleInput!
   ): UpdateBranchProtectionRulePayload
+  
   """
   Update a check run
   """
@@ -20402,6 +23085,7 @@ type Mutation {
     """
     input: UpdateCheckRunInput!
   ): UpdateCheckRunPayload
+  
   """
   Modifies the settings of an existing check suite
   """
@@ -20411,6 +23095,7 @@ type Mutation {
     """
     input: UpdateCheckSuitePreferencesInput!
   ): UpdateCheckSuitePreferencesPayload
+  
   """
   Update a discussion
   """
@@ -20420,6 +23105,7 @@ type Mutation {
     """
     input: UpdateDiscussionInput!
   ): UpdateDiscussionPayload
+  
   """
   Update the contents of a comment on a Discussion
   """
@@ -20429,6 +23115,7 @@ type Mutation {
     """
     input: UpdateDiscussionCommentInput!
   ): UpdateDiscussionCommentPayload
+  
   """
   Updates the role of an enterprise administrator.
   """
@@ -20438,6 +23125,7 @@ type Mutation {
     """
     input: UpdateEnterpriseAdministratorRoleInput!
   ): UpdateEnterpriseAdministratorRolePayload
+  
   """
   Sets whether private repository forks are enabled for an enterprise.
   """
@@ -20447,6 +23135,7 @@ type Mutation {
     """
     input: UpdateEnterpriseAllowPrivateRepositoryForkingSettingInput!
   ): UpdateEnterpriseAllowPrivateRepositoryForkingSettingPayload
+  
   """
   Sets the base repository permission for organizations in an enterprise.
   """
@@ -20456,6 +23145,7 @@ type Mutation {
     """
     input: UpdateEnterpriseDefaultRepositoryPermissionSettingInput!
   ): UpdateEnterpriseDefaultRepositoryPermissionSettingPayload
+  
   """
   Sets whether organization members with admin permissions on a repository can change repository visibility.
   """
@@ -20465,6 +23155,7 @@ type Mutation {
     """
     input: UpdateEnterpriseMembersCanChangeRepositoryVisibilitySettingInput!
   ): UpdateEnterpriseMembersCanChangeRepositoryVisibilitySettingPayload
+  
   """
   Sets the members can create repositories setting for an enterprise.
   """
@@ -20474,6 +23165,7 @@ type Mutation {
     """
     input: UpdateEnterpriseMembersCanCreateRepositoriesSettingInput!
   ): UpdateEnterpriseMembersCanCreateRepositoriesSettingPayload
+  
   """
   Sets the members can delete issues setting for an enterprise.
   """
@@ -20483,6 +23175,7 @@ type Mutation {
     """
     input: UpdateEnterpriseMembersCanDeleteIssuesSettingInput!
   ): UpdateEnterpriseMembersCanDeleteIssuesSettingPayload
+  
   """
   Sets the members can delete repositories setting for an enterprise.
   """
@@ -20492,6 +23185,7 @@ type Mutation {
     """
     input: UpdateEnterpriseMembersCanDeleteRepositoriesSettingInput!
   ): UpdateEnterpriseMembersCanDeleteRepositoriesSettingPayload
+  
   """
   Sets whether members can invite collaborators are enabled for an enterprise.
   """
@@ -20501,6 +23195,7 @@ type Mutation {
     """
     input: UpdateEnterpriseMembersCanInviteCollaboratorsSettingInput!
   ): UpdateEnterpriseMembersCanInviteCollaboratorsSettingPayload
+  
   """
   Sets whether or not an organization admin can make purchases.
   """
@@ -20510,6 +23205,7 @@ type Mutation {
     """
     input: UpdateEnterpriseMembersCanMakePurchasesSettingInput!
   ): UpdateEnterpriseMembersCanMakePurchasesSettingPayload
+  
   """
   Sets the members can update protected branches setting for an enterprise.
   """
@@ -20519,6 +23215,7 @@ type Mutation {
     """
     input: UpdateEnterpriseMembersCanUpdateProtectedBranchesSettingInput!
   ): UpdateEnterpriseMembersCanUpdateProtectedBranchesSettingPayload
+  
   """
   Sets the members can view dependency insights for an enterprise.
   """
@@ -20528,6 +23225,7 @@ type Mutation {
     """
     input: UpdateEnterpriseMembersCanViewDependencyInsightsSettingInput!
   ): UpdateEnterpriseMembersCanViewDependencyInsightsSettingPayload
+  
   """
   Sets whether organization projects are enabled for an enterprise.
   """
@@ -20537,6 +23235,7 @@ type Mutation {
     """
     input: UpdateEnterpriseOrganizationProjectsSettingInput!
   ): UpdateEnterpriseOrganizationProjectsSettingPayload
+  
   """
   Updates the role of an enterprise owner with an organization.
   """
@@ -20546,6 +23245,7 @@ type Mutation {
     """
     input: UpdateEnterpriseOwnerOrganizationRoleInput!
   ): UpdateEnterpriseOwnerOrganizationRolePayload
+  
   """
   Updates an enterprise's profile.
   """
@@ -20555,6 +23255,7 @@ type Mutation {
     """
     input: UpdateEnterpriseProfileInput!
   ): UpdateEnterpriseProfilePayload
+  
   """
   Sets whether repository projects are enabled for a enterprise.
   """
@@ -20564,6 +23265,7 @@ type Mutation {
     """
     input: UpdateEnterpriseRepositoryProjectsSettingInput!
   ): UpdateEnterpriseRepositoryProjectsSettingPayload
+  
   """
   Sets whether team discussions are enabled for an enterprise.
   """
@@ -20573,6 +23275,7 @@ type Mutation {
     """
     input: UpdateEnterpriseTeamDiscussionsSettingInput!
   ): UpdateEnterpriseTeamDiscussionsSettingPayload
+  
   """
   Sets whether two factor authentication is required for all users in an enterprise.
   """
@@ -20582,6 +23285,7 @@ type Mutation {
     """
     input: UpdateEnterpriseTwoFactorAuthenticationRequiredSettingInput!
   ): UpdateEnterpriseTwoFactorAuthenticationRequiredSettingPayload
+  
   """
   Updates an environment.
   """
@@ -20591,6 +23295,7 @@ type Mutation {
     """
     input: UpdateEnvironmentInput!
   ): UpdateEnvironmentPayload
+  
   """
   Sets whether an IP allow list is enabled on an owner.
   """
@@ -20600,6 +23305,7 @@ type Mutation {
     """
     input: UpdateIpAllowListEnabledSettingInput!
   ): UpdateIpAllowListEnabledSettingPayload
+  
   """
   Updates an IP allow list entry.
   """
@@ -20609,6 +23315,7 @@ type Mutation {
     """
     input: UpdateIpAllowListEntryInput!
   ): UpdateIpAllowListEntryPayload
+  
   """
   Sets whether IP allow list configuration for installed GitHub Apps is enabled on an owner.
   """
@@ -20618,6 +23325,7 @@ type Mutation {
     """
     input: UpdateIpAllowListForInstalledAppsEnabledSettingInput!
   ): UpdateIpAllowListForInstalledAppsEnabledSettingPayload
+  
   """
   Updates an Issue.
   """
@@ -20627,6 +23335,7 @@ type Mutation {
     """
     input: UpdateIssueInput!
   ): UpdateIssuePayload
+  
   """
   Updates an IssueComment object.
   """
@@ -20636,6 +23345,7 @@ type Mutation {
     """
     input: UpdateIssueCommentInput!
   ): UpdateIssueCommentPayload
+  
   """
   Updates an existing label.
   """
@@ -20645,6 +23355,7 @@ type Mutation {
     """
     input: UpdateLabelInput!
   ): UpdateLabelPayload @preview(toggledBy: "bane-preview")
+  
   """
   Update the setting to restrict notifications to only verified or approved domains available to an owner.
   """
@@ -20654,6 +23365,7 @@ type Mutation {
     """
     input: UpdateNotificationRestrictionSettingInput!
   ): UpdateNotificationRestrictionSettingPayload
+  
   """
   Sets whether private repository forks are enabled for an organization.
   """
@@ -20663,6 +23375,7 @@ type Mutation {
     """
     input: UpdateOrganizationAllowPrivateRepositoryForkingSettingInput!
   ): UpdateOrganizationAllowPrivateRepositoryForkingSettingPayload
+  
   """
   Sets whether contributors are required to sign off on web-based commits for repositories in an organization.
   """
@@ -20672,6 +23385,7 @@ type Mutation {
     """
     input: UpdateOrganizationWebCommitSignoffSettingInput!
   ): UpdateOrganizationWebCommitSignoffSettingPayload
+  
   """
   Updates an existing project.
   """
@@ -20681,6 +23395,7 @@ type Mutation {
     """
     input: UpdateProjectInput!
   ): UpdateProjectPayload
+  
   """
   Updates an existing project card.
   """
@@ -20690,6 +23405,7 @@ type Mutation {
     """
     input: UpdateProjectCardInput!
   ): UpdateProjectCardPayload
+  
   """
   Updates an existing project column.
   """
@@ -20699,6 +23415,7 @@ type Mutation {
     """
     input: UpdateProjectColumnInput!
   ): UpdateProjectColumnPayload
+  
   """
   Updates an existing project (beta).
   """
@@ -20708,6 +23425,7 @@ type Mutation {
     """
     input: UpdateProjectV2Input!
   ): UpdateProjectV2Payload
+  
   """
   Update the collaborators on a team or a project
   """
@@ -20717,6 +23435,7 @@ type Mutation {
     """
     input: UpdateProjectV2CollaboratorsInput!
   ): UpdateProjectV2CollaboratorsPayload
+  
   """
   Updates a draft issue within a Project.
   """
@@ -20726,6 +23445,7 @@ type Mutation {
     """
     input: UpdateProjectV2DraftIssueInput!
   ): UpdateProjectV2DraftIssuePayload
+  
   """
   This mutation updates the value of a field for an item in a Project. Currently
   only single-select, text, number, date, and iteration fields are supported.
@@ -20736,6 +23456,7 @@ type Mutation {
     """
     input: UpdateProjectV2ItemFieldValueInput!
   ): UpdateProjectV2ItemFieldValuePayload
+  
   """
   This mutation updates the position of the item in the project, where the position represents the priority of an item.
   """
@@ -20745,6 +23466,7 @@ type Mutation {
     """
     input: UpdateProjectV2ItemPositionInput!
   ): UpdateProjectV2ItemPositionPayload
+  
   """
   Update a pull request
   """
@@ -20754,6 +23476,7 @@ type Mutation {
     """
     input: UpdatePullRequestInput!
   ): UpdatePullRequestPayload
+  
   """
   Merge or Rebase HEAD from upstream branch into pull request branch
   """
@@ -20763,6 +23486,7 @@ type Mutation {
     """
     input: UpdatePullRequestBranchInput!
   ): UpdatePullRequestBranchPayload
+  
   """
   Updates the body of a pull request review.
   """
@@ -20772,6 +23496,7 @@ type Mutation {
     """
     input: UpdatePullRequestReviewInput!
   ): UpdatePullRequestReviewPayload
+  
   """
   Updates a pull request review comment.
   """
@@ -20781,6 +23506,7 @@ type Mutation {
     """
     input: UpdatePullRequestReviewCommentInput!
   ): UpdatePullRequestReviewCommentPayload
+  
   """
   Update a Git Ref.
   """
@@ -20790,6 +23516,7 @@ type Mutation {
     """
     input: UpdateRefInput!
   ): UpdateRefPayload
+  
   """
   Creates, updates and/or deletes multiple refs in a repository.
 
@@ -20816,6 +23543,7 @@ type Mutation {
     """
     input: UpdateRefsInput!
   ): UpdateRefsPayload @preview(toggledBy: "update-refs-preview")
+  
   """
   Update information about a repository.
   """
@@ -20825,6 +23553,7 @@ type Mutation {
     """
     input: UpdateRepositoryInput!
   ): UpdateRepositoryPayload
+  
   """
   Update a repository ruleset
   """
@@ -20834,6 +23563,7 @@ type Mutation {
     """
     input: UpdateRepositoryRulesetInput!
   ): UpdateRepositoryRulesetPayload
+  
   """
   Sets whether contributors are required to sign off on web-based commits for a repository.
   """
@@ -20843,6 +23573,7 @@ type Mutation {
     """
     input: UpdateRepositoryWebCommitSignoffSettingInput!
   ): UpdateRepositoryWebCommitSignoffSettingPayload
+  
   """
   Change visibility of your sponsorship and opt in or out of email updates from the maintainer.
   """
@@ -20852,6 +23583,7 @@ type Mutation {
     """
     input: UpdateSponsorshipPreferencesInput!
   ): UpdateSponsorshipPreferencesPayload
+  
   """
   Updates the state for subscribable subjects.
   """
@@ -20861,6 +23593,7 @@ type Mutation {
     """
     input: UpdateSubscriptionInput!
   ): UpdateSubscriptionPayload
+  
   """
   Updates a team discussion.
   """
@@ -20870,6 +23603,7 @@ type Mutation {
     """
     input: UpdateTeamDiscussionInput!
   ): UpdateTeamDiscussionPayload
+  
   """
   Updates a discussion comment.
   """
@@ -20879,6 +23613,7 @@ type Mutation {
     """
     input: UpdateTeamDiscussionCommentInput!
   ): UpdateTeamDiscussionCommentPayload
+  
   """
   Updates team review assignment.
   """
@@ -20888,6 +23623,7 @@ type Mutation {
     """
     input: UpdateTeamReviewAssignmentInput!
   ): UpdateTeamReviewAssignmentPayload @preview(toggledBy: "stone-crop-preview")
+  
   """
   Update team repository.
   """
@@ -20897,6 +23633,7 @@ type Mutation {
     """
     input: UpdateTeamsRepositoryInput!
   ): UpdateTeamsRepositoryPayload
+  
   """
   Replaces the repository's topics with the given topics.
   """
@@ -20906,6 +23643,7 @@ type Mutation {
     """
     input: UpdateTopicsInput!
   ): UpdateTopicsPayload
+  
   """
   Verify that a verifiable domain has the expected DNS record.
   """
@@ -20951,6 +23689,7 @@ type OIDCProvider implements Node {
   The enterprise this identity provider belongs to.
   """
   enterprise: Enterprise
+  
   """
   ExternalIdentities provisioned by this identity provider.
   """
@@ -20959,36 +23698,44 @@ type OIDCProvider implements Node {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Filter to external identities with the users login
     """
     login: String
+    
     """
     Filter to external identities with valid org membership only
     """
     membersOnly: Boolean
+    
     """
     Filter to external identities with the users userName/NameID attribute
     """
     userName: String
   ): ExternalIdentityConnection!
   id: ID!
+  
   """
   The OIDC identity provider type
   """
   providerType: OIDCProviderType!
+  
   """
   The id of the tenant this provider is attached to
   """
@@ -21013,10 +23760,12 @@ interface OauthApplicationAuditEntryData {
   The name of the OAuth application.
   """
   oauthApplicationName: String
+  
   """
   The HTTP path for the OAuth application
   """
   oauthApplicationResourcePath: URI
+  
   """
   The HTTP URL for the OAuth application
   """
@@ -21031,95 +23780,118 @@ type OauthApplicationCreateAuditEntry implements AuditEntry & Node & OauthApplic
   The action name
   """
   action: String!
+  
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
+  
   """
   The IP address of the actor
   """
   actorIp: String
+  
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
+  
   """
   The username of the user who initiated the action
   """
   actorLogin: String
+  
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
+  
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
+  
   """
   The application URL of the OAuth application.
   """
   applicationUrl: URI
+  
   """
   The callback URL of the OAuth application.
   """
   callbackUrl: URI
+  
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
   id: ID!
+  
   """
   The name of the OAuth application.
   """
   oauthApplicationName: String
+  
   """
   The HTTP path for the OAuth application
   """
   oauthApplicationResourcePath: URI
+  
   """
   The HTTP URL for the OAuth application
   """
   oauthApplicationUrl: URI
+  
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
+  
   """
   The Organization associated with the Audit Entry.
   """
   organization: Organization
+  
   """
   The name of the Organization.
   """
   organizationName: String
+  
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
+  
   """
   The HTTP URL for the organization
   """
   organizationUrl: URI
+  
   """
   The rate limit of the OAuth application.
   """
   rateLimit: Int
+  
   """
   The state of the OAuth application.
   """
   state: OauthApplicationCreateAuditEntryState
+  
   """
   The user affected by the action
   """
   user: User
+  
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
+  
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
+  
   """
   The HTTP URL for the user.
   """
@@ -21200,71 +23972,88 @@ type OrgAddBillingManagerAuditEntry implements AuditEntry & Node & OrganizationA
   The action name
   """
   action: String!
+  
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
+  
   """
   The IP address of the actor
   """
   actorIp: String
+  
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
+  
   """
   The username of the user who initiated the action
   """
   actorLogin: String
+  
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
+  
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
+  
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
   id: ID!
+  
   """
   The email address used to invite a billing manager for the organization.
   """
   invitationEmail: String
+  
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
+  
   """
   The Organization associated with the Audit Entry.
   """
   organization: Organization
+  
   """
   The name of the Organization.
   """
   organizationName: String
+  
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
+  
   """
   The HTTP URL for the organization
   """
   organizationUrl: URI
+  
   """
   The user affected by the action
   """
   user: User
+  
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
+  
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
+  
   """
   The HTTP URL for the user.
   """
@@ -21279,71 +24068,88 @@ type OrgAddMemberAuditEntry implements AuditEntry & Node & OrganizationAuditEntr
   The action name
   """
   action: String!
+  
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
+  
   """
   The IP address of the actor
   """
   actorIp: String
+  
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
+  
   """
   The username of the user who initiated the action
   """
   actorLogin: String
+  
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
+  
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
+  
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
   id: ID!
+  
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
+  
   """
   The Organization associated with the Audit Entry.
   """
   organization: Organization
+  
   """
   The name of the Organization.
   """
   organizationName: String
+  
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
+  
   """
   The HTTP URL for the organization
   """
   organizationUrl: URI
+  
   """
   The permission level of the member added to the organization.
   """
   permission: OrgAddMemberAuditEntryPermission
+  
   """
   The user affected by the action
   """
   user: User
+  
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
+  
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
+  
   """
   The HTTP URL for the user.
   """
@@ -21372,83 +24178,103 @@ type OrgBlockUserAuditEntry implements AuditEntry & Node & OrganizationAuditEntr
   The action name
   """
   action: String!
+  
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
+  
   """
   The IP address of the actor
   """
   actorIp: String
+  
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
+  
   """
   The username of the user who initiated the action
   """
   actorLogin: String
+  
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
+  
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
+  
   """
   The blocked user.
   """
   blockedUser: User
+  
   """
   The username of the blocked user.
   """
   blockedUserName: String
+  
   """
   The HTTP path for the blocked user.
   """
   blockedUserResourcePath: URI
+  
   """
   The HTTP URL for the blocked user.
   """
   blockedUserUrl: URI
+  
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
   id: ID!
+  
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
+  
   """
   The Organization associated with the Audit Entry.
   """
   organization: Organization
+  
   """
   The name of the Organization.
   """
   organizationName: String
+  
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
+  
   """
   The HTTP URL for the organization
   """
   organizationUrl: URI
+  
   """
   The user affected by the action
   """
   user: User
+  
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
+  
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
+  
   """
   The HTTP URL for the user.
   """
@@ -21463,67 +24289,83 @@ type OrgConfigDisableCollaboratorsOnlyAuditEntry implements AuditEntry & Node & 
   The action name
   """
   action: String!
+  
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
+  
   """
   The IP address of the actor
   """
   actorIp: String
+  
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
+  
   """
   The username of the user who initiated the action
   """
   actorLogin: String
+  
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
+  
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
+  
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
   id: ID!
+  
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
+  
   """
   The Organization associated with the Audit Entry.
   """
   organization: Organization
+  
   """
   The name of the Organization.
   """
   organizationName: String
+  
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
+  
   """
   The HTTP URL for the organization
   """
   organizationUrl: URI
+  
   """
   The user affected by the action
   """
   user: User
+  
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
+  
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
+  
   """
   The HTTP URL for the user.
   """
@@ -21538,67 +24380,83 @@ type OrgConfigEnableCollaboratorsOnlyAuditEntry implements AuditEntry & Node & O
   The action name
   """
   action: String!
+  
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
+  
   """
   The IP address of the actor
   """
   actorIp: String
+  
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
+  
   """
   The username of the user who initiated the action
   """
   actorLogin: String
+  
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
+  
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
+  
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
   id: ID!
+  
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
+  
   """
   The Organization associated with the Audit Entry.
   """
   organization: Organization
+  
   """
   The name of the Organization.
   """
   organizationName: String
+  
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
+  
   """
   The HTTP URL for the organization
   """
   organizationUrl: URI
+  
   """
   The user affected by the action
   """
   user: User
+  
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
+  
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
+  
   """
   The HTTP URL for the user.
   """
@@ -21613,71 +24471,88 @@ type OrgCreateAuditEntry implements AuditEntry & Node & OrganizationAuditEntryDa
   The action name
   """
   action: String!
+  
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
+  
   """
   The IP address of the actor
   """
   actorIp: String
+  
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
+  
   """
   The username of the user who initiated the action
   """
   actorLogin: String
+  
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
+  
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
+  
   """
   The billing plan for the Organization.
   """
   billingPlan: OrgCreateAuditEntryBillingPlan
+  
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
   id: ID!
+  
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
+  
   """
   The Organization associated with the Audit Entry.
   """
   organization: Organization
+  
   """
   The name of the Organization.
   """
   organizationName: String
+  
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
+  
   """
   The HTTP URL for the organization
   """
   organizationUrl: URI
+  
   """
   The user affected by the action
   """
   user: User
+  
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
+  
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
+  
   """
   The HTTP URL for the user.
   """
@@ -21718,67 +24593,83 @@ type OrgDisableOauthAppRestrictionsAuditEntry implements AuditEntry & Node & Org
   The action name
   """
   action: String!
+  
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
+  
   """
   The IP address of the actor
   """
   actorIp: String
+  
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
+  
   """
   The username of the user who initiated the action
   """
   actorLogin: String
+  
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
+  
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
+  
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
   id: ID!
+  
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
+  
   """
   The Organization associated with the Audit Entry.
   """
   organization: Organization
+  
   """
   The name of the Organization.
   """
   organizationName: String
+  
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
+  
   """
   The HTTP URL for the organization
   """
   organizationUrl: URI
+  
   """
   The user affected by the action
   """
   user: User
+  
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
+  
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
+  
   """
   The HTTP URL for the user.
   """
@@ -21793,83 +24684,103 @@ type OrgDisableSamlAuditEntry implements AuditEntry & Node & OrganizationAuditEn
   The action name
   """
   action: String!
+  
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
+  
   """
   The IP address of the actor
   """
   actorIp: String
+  
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
+  
   """
   The username of the user who initiated the action
   """
   actorLogin: String
+  
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
+  
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
+  
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
+  
   """
   The SAML provider's digest algorithm URL.
   """
   digestMethodUrl: URI
   id: ID!
+  
   """
   The SAML provider's issuer URL.
   """
   issuerUrl: URI
+  
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
+  
   """
   The Organization associated with the Audit Entry.
   """
   organization: Organization
+  
   """
   The name of the Organization.
   """
   organizationName: String
+  
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
+  
   """
   The HTTP URL for the organization
   """
   organizationUrl: URI
+  
   """
   The SAML provider's signature algorithm URL.
   """
   signatureMethodUrl: URI
+  
   """
   The SAML provider's single sign-on URL.
   """
   singleSignOnUrl: URI
+  
   """
   The user affected by the action
   """
   user: User
+  
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
+  
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
+  
   """
   The HTTP URL for the user.
   """
@@ -21884,67 +24795,83 @@ type OrgDisableTwoFactorRequirementAuditEntry implements AuditEntry & Node & Org
   The action name
   """
   action: String!
+  
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
+  
   """
   The IP address of the actor
   """
   actorIp: String
+  
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
+  
   """
   The username of the user who initiated the action
   """
   actorLogin: String
+  
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
+  
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
+  
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
   id: ID!
+  
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
+  
   """
   The Organization associated with the Audit Entry.
   """
   organization: Organization
+  
   """
   The name of the Organization.
   """
   organizationName: String
+  
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
+  
   """
   The HTTP URL for the organization
   """
   organizationUrl: URI
+  
   """
   The user affected by the action
   """
   user: User
+  
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
+  
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
+  
   """
   The HTTP URL for the user.
   """
@@ -21959,67 +24886,83 @@ type OrgEnableOauthAppRestrictionsAuditEntry implements AuditEntry & Node & Orga
   The action name
   """
   action: String!
+  
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
+  
   """
   The IP address of the actor
   """
   actorIp: String
+  
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
+  
   """
   The username of the user who initiated the action
   """
   actorLogin: String
+  
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
+  
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
+  
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
   id: ID!
+  
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
+  
   """
   The Organization associated with the Audit Entry.
   """
   organization: Organization
+  
   """
   The name of the Organization.
   """
   organizationName: String
+  
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
+  
   """
   The HTTP URL for the organization
   """
   organizationUrl: URI
+  
   """
   The user affected by the action
   """
   user: User
+  
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
+  
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
+  
   """
   The HTTP URL for the user.
   """
@@ -22034,83 +24977,103 @@ type OrgEnableSamlAuditEntry implements AuditEntry & Node & OrganizationAuditEnt
   The action name
   """
   action: String!
+  
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
+  
   """
   The IP address of the actor
   """
   actorIp: String
+  
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
+  
   """
   The username of the user who initiated the action
   """
   actorLogin: String
+  
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
+  
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
+  
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
+  
   """
   The SAML provider's digest algorithm URL.
   """
   digestMethodUrl: URI
   id: ID!
+  
   """
   The SAML provider's issuer URL.
   """
   issuerUrl: URI
+  
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
+  
   """
   The Organization associated with the Audit Entry.
   """
   organization: Organization
+  
   """
   The name of the Organization.
   """
   organizationName: String
+  
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
+  
   """
   The HTTP URL for the organization
   """
   organizationUrl: URI
+  
   """
   The SAML provider's signature algorithm URL.
   """
   signatureMethodUrl: URI
+  
   """
   The SAML provider's single sign-on URL.
   """
   singleSignOnUrl: URI
+  
   """
   The user affected by the action
   """
   user: User
+  
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
+  
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
+  
   """
   The HTTP URL for the user.
   """
@@ -22125,67 +25088,83 @@ type OrgEnableTwoFactorRequirementAuditEntry implements AuditEntry & Node & Orga
   The action name
   """
   action: String!
+  
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
+  
   """
   The IP address of the actor
   """
   actorIp: String
+  
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
+  
   """
   The username of the user who initiated the action
   """
   actorLogin: String
+  
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
+  
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
+  
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
   id: ID!
+  
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
+  
   """
   The Organization associated with the Audit Entry.
   """
   organization: Organization
+  
   """
   The name of the Organization.
   """
   organizationName: String
+  
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
+  
   """
   The HTTP URL for the organization
   """
   organizationUrl: URI
+  
   """
   The user affected by the action
   """
   user: User
+  
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
+  
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
+  
   """
   The HTTP URL for the user.
   """
@@ -22200,6 +25179,7 @@ input OrgEnterpriseOwnerOrder {
   The ordering direction.
   """
   direction: OrderDirection!
+  
   """
   The field to order enterprise owners by.
   """
@@ -22224,75 +25204,93 @@ type OrgInviteMemberAuditEntry implements AuditEntry & Node & OrganizationAuditE
   The action name
   """
   action: String!
+  
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
+  
   """
   The IP address of the actor
   """
   actorIp: String
+  
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
+  
   """
   The username of the user who initiated the action
   """
   actorLogin: String
+  
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
+  
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
+  
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
+  
   """
   The email address of the organization invitation.
   """
   email: String
   id: ID!
+  
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
+  
   """
   The Organization associated with the Audit Entry.
   """
   organization: Organization
+  
   """
   The organization invitation.
   """
   organizationInvitation: OrganizationInvitation
+  
   """
   The name of the Organization.
   """
   organizationName: String
+  
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
+  
   """
   The HTTP URL for the organization
   """
   organizationUrl: URI
+  
   """
   The user affected by the action
   """
   user: User
+  
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
+  
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
+  
   """
   The HTTP URL for the user.
   """
@@ -22307,79 +25305,98 @@ type OrgInviteToBusinessAuditEntry implements AuditEntry & EnterpriseAuditEntryD
   The action name
   """
   action: String!
+  
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
+  
   """
   The IP address of the actor
   """
   actorIp: String
+  
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
+  
   """
   The username of the user who initiated the action
   """
   actorLogin: String
+  
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
+  
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
+  
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
+  
   """
   The HTTP path for this enterprise.
   """
   enterpriseResourcePath: URI
+  
   """
   The slug of the enterprise.
   """
   enterpriseSlug: String
+  
   """
   The HTTP URL for this enterprise.
   """
   enterpriseUrl: URI
   id: ID!
+  
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
+  
   """
   The Organization associated with the Audit Entry.
   """
   organization: Organization
+  
   """
   The name of the Organization.
   """
   organizationName: String
+  
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
+  
   """
   The HTTP URL for the organization
   """
   organizationUrl: URI
+  
   """
   The user affected by the action
   """
   user: User
+  
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
+  
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
+  
   """
   The HTTP URL for the user.
   """
@@ -22394,79 +25411,98 @@ type OrgOauthAppAccessApprovedAuditEntry implements AuditEntry & Node & OauthApp
   The action name
   """
   action: String!
+  
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
+  
   """
   The IP address of the actor
   """
   actorIp: String
+  
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
+  
   """
   The username of the user who initiated the action
   """
   actorLogin: String
+  
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
+  
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
+  
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
   id: ID!
+  
   """
   The name of the OAuth application.
   """
   oauthApplicationName: String
+  
   """
   The HTTP path for the OAuth application
   """
   oauthApplicationResourcePath: URI
+  
   """
   The HTTP URL for the OAuth application
   """
   oauthApplicationUrl: URI
+  
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
+  
   """
   The Organization associated with the Audit Entry.
   """
   organization: Organization
+  
   """
   The name of the Organization.
   """
   organizationName: String
+  
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
+  
   """
   The HTTP URL for the organization
   """
   organizationUrl: URI
+  
   """
   The user affected by the action
   """
   user: User
+  
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
+  
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
+  
   """
   The HTTP URL for the user.
   """
@@ -22481,79 +25517,98 @@ type OrgOauthAppAccessBlockedAuditEntry implements AuditEntry & Node & OauthAppl
   The action name
   """
   action: String!
+  
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
+  
   """
   The IP address of the actor
   """
   actorIp: String
+  
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
+  
   """
   The username of the user who initiated the action
   """
   actorLogin: String
+  
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
+  
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
+  
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
   id: ID!
+  
   """
   The name of the OAuth application.
   """
   oauthApplicationName: String
+  
   """
   The HTTP path for the OAuth application
   """
   oauthApplicationResourcePath: URI
+  
   """
   The HTTP URL for the OAuth application
   """
   oauthApplicationUrl: URI
+  
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
+  
   """
   The Organization associated with the Audit Entry.
   """
   organization: Organization
+  
   """
   The name of the Organization.
   """
   organizationName: String
+  
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
+  
   """
   The HTTP URL for the organization
   """
   organizationUrl: URI
+  
   """
   The user affected by the action
   """
   user: User
+  
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
+  
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
+  
   """
   The HTTP URL for the user.
   """
@@ -22568,79 +25623,98 @@ type OrgOauthAppAccessDeniedAuditEntry implements AuditEntry & Node & OauthAppli
   The action name
   """
   action: String!
+  
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
+  
   """
   The IP address of the actor
   """
   actorIp: String
+  
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
+  
   """
   The username of the user who initiated the action
   """
   actorLogin: String
+  
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
+  
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
+  
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
   id: ID!
+  
   """
   The name of the OAuth application.
   """
   oauthApplicationName: String
+  
   """
   The HTTP path for the OAuth application
   """
   oauthApplicationResourcePath: URI
+  
   """
   The HTTP URL for the OAuth application
   """
   oauthApplicationUrl: URI
+  
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
+  
   """
   The Organization associated with the Audit Entry.
   """
   organization: Organization
+  
   """
   The name of the Organization.
   """
   organizationName: String
+  
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
+  
   """
   The HTTP URL for the organization
   """
   organizationUrl: URI
+  
   """
   The user affected by the action
   """
   user: User
+  
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
+  
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
+  
   """
   The HTTP URL for the user.
   """
@@ -22655,79 +25729,98 @@ type OrgOauthAppAccessRequestedAuditEntry implements AuditEntry & Node & OauthAp
   The action name
   """
   action: String!
+  
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
+  
   """
   The IP address of the actor
   """
   actorIp: String
+  
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
+  
   """
   The username of the user who initiated the action
   """
   actorLogin: String
+  
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
+  
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
+  
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
   id: ID!
+  
   """
   The name of the OAuth application.
   """
   oauthApplicationName: String
+  
   """
   The HTTP path for the OAuth application
   """
   oauthApplicationResourcePath: URI
+  
   """
   The HTTP URL for the OAuth application
   """
   oauthApplicationUrl: URI
+  
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
+  
   """
   The Organization associated with the Audit Entry.
   """
   organization: Organization
+  
   """
   The name of the Organization.
   """
   organizationName: String
+  
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
+  
   """
   The HTTP URL for the organization
   """
   organizationUrl: URI
+  
   """
   The user affected by the action
   """
   user: User
+  
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
+  
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
+  
   """
   The HTTP URL for the user.
   """
@@ -22742,79 +25835,98 @@ type OrgOauthAppAccessUnblockedAuditEntry implements AuditEntry & Node & OauthAp
   The action name
   """
   action: String!
+  
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
+  
   """
   The IP address of the actor
   """
   actorIp: String
+  
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
+  
   """
   The username of the user who initiated the action
   """
   actorLogin: String
+  
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
+  
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
+  
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
   id: ID!
+  
   """
   The name of the OAuth application.
   """
   oauthApplicationName: String
+  
   """
   The HTTP path for the OAuth application
   """
   oauthApplicationResourcePath: URI
+  
   """
   The HTTP URL for the OAuth application
   """
   oauthApplicationUrl: URI
+  
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
+  
   """
   The Organization associated with the Audit Entry.
   """
   organization: Organization
+  
   """
   The name of the Organization.
   """
   organizationName: String
+  
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
+  
   """
   The HTTP URL for the organization
   """
   organizationUrl: URI
+  
   """
   The user affected by the action
   """
   user: User
+  
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
+  
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
+  
   """
   The HTTP URL for the user.
   """
@@ -22829,71 +25941,88 @@ type OrgRemoveBillingManagerAuditEntry implements AuditEntry & Node & Organizati
   The action name
   """
   action: String!
+  
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
+  
   """
   The IP address of the actor
   """
   actorIp: String
+  
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
+  
   """
   The username of the user who initiated the action
   """
   actorLogin: String
+  
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
+  
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
+  
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
   id: ID!
+  
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
+  
   """
   The Organization associated with the Audit Entry.
   """
   organization: Organization
+  
   """
   The name of the Organization.
   """
   organizationName: String
+  
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
+  
   """
   The HTTP URL for the organization
   """
   organizationUrl: URI
+  
   """
   The reason for the billing manager being removed.
   """
   reason: OrgRemoveBillingManagerAuditEntryReason
+  
   """
   The user affected by the action
   """
   user: User
+  
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
+  
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
+  
   """
   The HTTP URL for the user.
   """
@@ -22926,75 +26055,93 @@ type OrgRemoveMemberAuditEntry implements AuditEntry & Node & OrganizationAuditE
   The action name
   """
   action: String!
+  
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
+  
   """
   The IP address of the actor
   """
   actorIp: String
+  
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
+  
   """
   The username of the user who initiated the action
   """
   actorLogin: String
+  
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
+  
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
+  
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
   id: ID!
+  
   """
   The types of membership the member has with the organization.
   """
   membershipTypes: [OrgRemoveMemberAuditEntryMembershipType!]
+  
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
+  
   """
   The Organization associated with the Audit Entry.
   """
   organization: Organization
+  
   """
   The name of the Organization.
   """
   organizationName: String
+  
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
+  
   """
   The HTTP URL for the organization
   """
   organizationUrl: URI
+  
   """
   The reason for the member being removed.
   """
   reason: OrgRemoveMemberAuditEntryReason
+  
   """
   The user affected by the action
   """
   user: User
+  
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
+  
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
+  
   """
   The HTTP URL for the user.
   """
@@ -23071,75 +26218,93 @@ type OrgRemoveOutsideCollaboratorAuditEntry implements AuditEntry & Node & Organ
   The action name
   """
   action: String!
+  
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
+  
   """
   The IP address of the actor
   """
   actorIp: String
+  
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
+  
   """
   The username of the user who initiated the action
   """
   actorLogin: String
+  
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
+  
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
+  
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
   id: ID!
+  
   """
   The types of membership the outside collaborator has with the organization.
   """
   membershipTypes: [OrgRemoveOutsideCollaboratorAuditEntryMembershipType!]
+  
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
+  
   """
   The Organization associated with the Audit Entry.
   """
   organization: Organization
+  
   """
   The name of the Organization.
   """
   organizationName: String
+  
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
+  
   """
   The HTTP URL for the organization
   """
   organizationUrl: URI
+  
   """
   The reason for the outside collaborator being removed from the Organization.
   """
   reason: OrgRemoveOutsideCollaboratorAuditEntryReason
+  
   """
   The user affected by the action
   """
   user: User
+  
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
+  
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
+  
   """
   The HTTP URL for the user.
   """
@@ -23189,95 +26354,118 @@ type OrgRestoreMemberAuditEntry implements AuditEntry & Node & OrganizationAudit
   The action name
   """
   action: String!
+  
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
+  
   """
   The IP address of the actor
   """
   actorIp: String
+  
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
+  
   """
   The username of the user who initiated the action
   """
   actorLogin: String
+  
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
+  
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
+  
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
   id: ID!
+  
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
+  
   """
   The Organization associated with the Audit Entry.
   """
   organization: Organization
+  
   """
   The name of the Organization.
   """
   organizationName: String
+  
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
+  
   """
   The HTTP URL for the organization
   """
   organizationUrl: URI
+  
   """
   The number of custom email routings for the restored member.
   """
   restoredCustomEmailRoutingsCount: Int
+  
   """
   The number of issue assignments for the restored member.
   """
   restoredIssueAssignmentsCount: Int
+  
   """
   Restored organization membership objects.
   """
   restoredMemberships: [OrgRestoreMemberAuditEntryMembership!]
+  
   """
   The number of restored memberships.
   """
   restoredMembershipsCount: Int
+  
   """
   The number of repositories of the restored member.
   """
   restoredRepositoriesCount: Int
+  
   """
   The number of starred repositories for the restored member.
   """
   restoredRepositoryStarsCount: Int
+  
   """
   The number of watched repositories for the restored member.
   """
   restoredRepositoryWatchesCount: Int
+  
   """
   The user affected by the action
   """
   user: User
+  
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
+  
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
+  
   """
   The HTTP URL for the user.
   """
@@ -23299,14 +26487,17 @@ type OrgRestoreMemberMembershipOrganizationAuditEntryData implements Organizatio
   The Organization associated with the Audit Entry.
   """
   organization: Organization
+  
   """
   The name of the Organization.
   """
   organizationName: String
+  
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
+  
   """
   The HTTP URL for the organization
   """
@@ -23321,14 +26512,17 @@ type OrgRestoreMemberMembershipRepositoryAuditEntryData implements RepositoryAud
   The repository associated with the action
   """
   repository: Repository
+  
   """
   The name of the repository
   """
   repositoryName: String
+  
   """
   The HTTP path for the repository
   """
   repositoryResourcePath: URI
+  
   """
   The HTTP URL for the repository
   """
@@ -23343,14 +26537,17 @@ type OrgRestoreMemberMembershipTeamAuditEntryData implements TeamAuditEntryData 
   The team associated with the action
   """
   team: Team
+  
   """
   The name of the team
   """
   teamName: String
+  
   """
   The HTTP path for this team
   """
   teamResourcePath: URI
+  
   """
   The HTTP URL for this team
   """
@@ -23365,83 +26562,103 @@ type OrgUnblockUserAuditEntry implements AuditEntry & Node & OrganizationAuditEn
   The action name
   """
   action: String!
+  
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
+  
   """
   The IP address of the actor
   """
   actorIp: String
+  
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
+  
   """
   The username of the user who initiated the action
   """
   actorLogin: String
+  
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
+  
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
+  
   """
   The user being unblocked by the organization.
   """
   blockedUser: User
+  
   """
   The username of the blocked user.
   """
   blockedUserName: String
+  
   """
   The HTTP path for the blocked user.
   """
   blockedUserResourcePath: URI
+  
   """
   The HTTP URL for the blocked user.
   """
   blockedUserUrl: URI
+  
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
   id: ID!
+  
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
+  
   """
   The Organization associated with the Audit Entry.
   """
   organization: Organization
+  
   """
   The name of the Organization.
   """
   organizationName: String
+  
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
+  
   """
   The HTTP URL for the organization
   """
   organizationUrl: URI
+  
   """
   The user affected by the action
   """
   user: User
+  
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
+  
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
+  
   """
   The HTTP URL for the user.
   """
@@ -23456,75 +26673,93 @@ type OrgUpdateDefaultRepositoryPermissionAuditEntry implements AuditEntry & Node
   The action name
   """
   action: String!
+  
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
+  
   """
   The IP address of the actor
   """
   actorIp: String
+  
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
+  
   """
   The username of the user who initiated the action
   """
   actorLogin: String
+  
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
+  
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
+  
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
   id: ID!
+  
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
+  
   """
   The Organization associated with the Audit Entry.
   """
   organization: Organization
+  
   """
   The name of the Organization.
   """
   organizationName: String
+  
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
+  
   """
   The HTTP URL for the organization
   """
   organizationUrl: URI
+  
   """
   The new base repository permission level for the organization.
   """
   permission: OrgUpdateDefaultRepositoryPermissionAuditEntryPermission
+  
   """
   The former base repository permission level for the organization.
   """
   permissionWas: OrgUpdateDefaultRepositoryPermissionAuditEntryPermission
+  
   """
   The user affected by the action
   """
   user: User
+  
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
+  
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
+  
   """
   The HTTP URL for the user.
   """
@@ -23561,75 +26796,93 @@ type OrgUpdateMemberAuditEntry implements AuditEntry & Node & OrganizationAuditE
   The action name
   """
   action: String!
+  
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
+  
   """
   The IP address of the actor
   """
   actorIp: String
+  
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
+  
   """
   The username of the user who initiated the action
   """
   actorLogin: String
+  
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
+  
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
+  
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
   id: ID!
+  
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
+  
   """
   The Organization associated with the Audit Entry.
   """
   organization: Organization
+  
   """
   The name of the Organization.
   """
   organizationName: String
+  
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
+  
   """
   The HTTP URL for the organization
   """
   organizationUrl: URI
+  
   """
   The new member permission level for the organization.
   """
   permission: OrgUpdateMemberAuditEntryPermission
+  
   """
   The former member permission level for the organization.
   """
   permissionWas: OrgUpdateMemberAuditEntryPermission
+  
   """
   The user affected by the action
   """
   user: User
+  
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
+  
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
+  
   """
   The HTTP URL for the user.
   """
@@ -23658,75 +26911,93 @@ type OrgUpdateMemberRepositoryCreationPermissionAuditEntry implements AuditEntry
   The action name
   """
   action: String!
+  
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
+  
   """
   The IP address of the actor
   """
   actorIp: String
+  
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
+  
   """
   The username of the user who initiated the action
   """
   actorLogin: String
+  
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
+  
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
+  
   """
   Can members create repositories in the organization.
   """
   canCreateRepositories: Boolean
+  
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
   id: ID!
+  
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
+  
   """
   The Organization associated with the Audit Entry.
   """
   organization: Organization
+  
   """
   The name of the Organization.
   """
   organizationName: String
+  
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
+  
   """
   The HTTP URL for the organization
   """
   organizationUrl: URI
+  
   """
   The user affected by the action
   """
   user: User
+  
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
+  
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
+  
   """
   The HTTP URL for the user.
   """
   userUrl: URI
+  
   """
   The permission for visibility level of repositories for this organization.
   """
@@ -23779,71 +27050,88 @@ type OrgUpdateMemberRepositoryInvitationPermissionAuditEntry implements AuditEnt
   The action name
   """
   action: String!
+  
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
+  
   """
   The IP address of the actor
   """
   actorIp: String
+  
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
+  
   """
   The username of the user who initiated the action
   """
   actorLogin: String
+  
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
+  
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
+  
   """
   Can outside collaborators be invited to repositories in the organization.
   """
   canInviteOutsideCollaboratorsToRepositories: Boolean
+  
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
   id: ID!
+  
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
+  
   """
   The Organization associated with the Audit Entry.
   """
   organization: Organization
+  
   """
   The name of the Organization.
   """
   organizationName: String
+  
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
+  
   """
   The HTTP URL for the organization
   """
   organizationUrl: URI
+  
   """
   The user affected by the action
   """
   user: User
+  
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
+  
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
+  
   """
   The HTTP URL for the user.
   """
@@ -23858,14 +27146,17 @@ type Organization implements Actor & AnnouncementBanner & MemberStatusable & Nod
   The text of the announcement
   """
   announcement: String
+  
   """
   The expiration date of the announcement, if any
   """
   announcementExpiresAt: DateTime
+  
   """
   Whether the announcement can be dismissed by the user
   """
   announcementUserDismissible: Boolean
+  
   """
   Determine if this repository owner has any items that can be pinned to their profile.
   """
@@ -23875,10 +27166,12 @@ type Organization implements Actor & AnnouncementBanner & MemberStatusable & Nod
     """
     type: PinnableItemType
   ): Boolean!
+  
   """
   Identifies the date and time when the organization was archived.
   """
   archivedAt: DateTime
+  
   """
   Audit log entries of the organization
   """
@@ -23887,27 +27180,33 @@ type Organization implements Actor & AnnouncementBanner & MemberStatusable & Nod
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for the returned audit log entries.
     """
     orderBy: AuditLogOrder = { field: CREATED_AT, direction: DESC }
+    
     """
     The query string to filter audit entries
     """
     query: String
   ): OrganizationAuditEntryConnection!
+  
   """
   A URL pointing to the organization's public avatar.
   """
@@ -23917,22 +27216,27 @@ type Organization implements Actor & AnnouncementBanner & MemberStatusable & Nod
     """
     size: Int
   ): URI!
+  
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
+  
   """
   Identifies the primary key from the database.
   """
   databaseId: Int
+  
   """
   The organization's public profile description.
   """
   description: String
+  
   """
   The organization's public profile description rendered to HTML.
   """
   descriptionHTML: String
+  
   """
   A list of domains owned by the organization.
   """
@@ -23941,35 +27245,43 @@ type Organization implements Actor & AnnouncementBanner & MemberStatusable & Nod
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Filter by if the domain is approved.
     """
     isApproved: Boolean = null
+    
     """
     Filter by if the domain is verified.
     """
     isVerified: Boolean = null
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for verifiable domains returned.
     """
     orderBy: VerifiableDomainOrder = { field: DOMAIN, direction: ASC }
   ): VerifiableDomainConnection
+  
   """
   The organization's public email.
   """
   email: String
+  
   """
   A list of owners of the organization's enterprise account.
   """
@@ -23978,48 +27290,59 @@ type Organization implements Actor & AnnouncementBanner & MemberStatusable & Nod
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for enterprise owners returned from the connection.
     """
     orderBy: OrgEnterpriseOwnerOrder = { field: LOGIN, direction: ASC }
+    
     """
     The organization role to filter by.
     """
     organizationRole: RoleInOrganization
+    
     """
     The search string to look for.
     """
     query: String
   ): OrganizationEnterpriseOwnerConnection!
+  
   """
   The estimated next GitHub Sponsors payout for this user/organization in cents (USD).
   """
   estimatedNextSponsorsPayoutInCents: Int!
+  
   """
   True if this user/organization has a GitHub Sponsors listing.
   """
   hasSponsorsListing: Boolean!
   id: ID!
+  
   """
   The interaction ability settings for this organization.
   """
   interactionAbility: RepositoryInteractionAbility
+  
   """
   The setting value for whether the organization has an IP allow list enabled.
   """
   ipAllowListEnabledSetting: IpAllowListEnabledSettingValue!
+  
   """
   The IP addresses that are allowed to access resources owned by the organization.
   """
@@ -24028,27 +27351,33 @@ type Organization implements Actor & AnnouncementBanner & MemberStatusable & Nod
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for IP allow list entries returned.
     """
     orderBy: IpAllowListEntryOrder = { field: ALLOW_LIST_VALUE, direction: ASC }
   ): IpAllowListEntryConnection!
+  
   """
   The setting value for whether the organization has IP allow list configuration for installed GitHub Apps enabled.
   """
   ipAllowListForInstalledAppsEnabledSetting: IpAllowListForInstalledAppsEnabledSettingValue!
+  
   """
   Whether the given account is sponsoring this user/organization.
   """
@@ -24058,27 +27387,33 @@ type Organization implements Actor & AnnouncementBanner & MemberStatusable & Nod
     """
     accountLogin: String!
   ): Boolean!
+  
   """
   True if the viewer is sponsored by this user/organization.
   """
   isSponsoringViewer: Boolean!
+  
   """
   Whether the organization has verified its profile email and website.
   """
   isVerified: Boolean!
+  
   """
   Showcases a selection of repositories and gists that the profile owner has
   either curated or that have been selected automatically based on popularity.
   """
   itemShowcase: ProfileItemShowcase!
+  
   """
   The organization's public profile location.
   """
   location: String
+  
   """
   The organization's login name.
   """
   login: String!
+  
   """
   A list of all mannequins for this organization.
   """
@@ -24087,27 +27422,33 @@ type Organization implements Actor & AnnouncementBanner & MemberStatusable & Nod
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Filter mannequins by login.
     """
     login: String
+    
     """
     Ordering options for mannequins returned from the connection.
     """
     orderBy: MannequinOrder = { field: CREATED_AT, direction: ASC }
   ): MannequinConnection!
+  
   """
   Get the status messages members of this entity have set that are either public or visible only to the organization.
   """
@@ -24116,27 +27457,33 @@ type Organization implements Actor & AnnouncementBanner & MemberStatusable & Nod
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for user statuses returned from the connection.
     """
     orderBy: UserStatusOrder = { field: UPDATED_AT, direction: DESC }
   ): UserStatusConnection!
+  
   """
   Members can fork private repositories in this organization
   """
   membersCanForkPrivateRepositories: Boolean!
+  
   """
   A list of users who are members of this organization.
   """
@@ -24145,43 +27492,53 @@ type Organization implements Actor & AnnouncementBanner & MemberStatusable & Nod
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): OrganizationMemberConnection!
+  
   """
   The estimated monthly GitHub Sponsors income for this user/organization in cents (USD).
   """
   monthlyEstimatedSponsorsIncomeInCents: Int!
+  
   """
   The organization's public profile name.
   """
   name: String
+  
   """
   The HTTP path creating a new team
   """
   newTeamResourcePath: URI!
+  
   """
   The HTTP URL creating a new team
   """
   newTeamUrl: URI!
+  
   """
   Indicates if email notification delivery for this organization is restricted to verified or approved domains.
   """
   notificationDeliveryRestrictionEnabledSetting: NotificationRestrictionSettingValue!
+  
   """
   The billing email for the organization.
   """
   organizationBillingEmail: String
+  
   """
   A list of packages under the owner.
   """
@@ -24190,35 +27547,43 @@ type Organization implements Actor & AnnouncementBanner & MemberStatusable & Nod
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Find packages by their names.
     """
     names: [String]
+    
     """
     Ordering of the returned packages.
     """
     orderBy: PackageOrder = { field: CREATED_AT, direction: DESC }
+    
     """
     Filter registry package by type.
     """
     packageType: PackageType
+    
     """
     Find packages in a repository by ID.
     """
     repositoryId: ID
   ): PackageConnection!
+  
   """
   A list of users who have been invited to join this organization.
   """
@@ -24227,19 +27592,23 @@ type Organization implements Actor & AnnouncementBanner & MemberStatusable & Nod
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): UserConnection!
+  
   """
   A list of repositories and gists this profile owner can pin to their profile.
   """
@@ -24248,23 +27617,28 @@ type Organization implements Actor & AnnouncementBanner & MemberStatusable & Nod
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Filter the types of pinnable items that are returned.
     """
     types: [PinnableItemType!]
   ): PinnableItemConnection!
+  
   """
   A list of repositories and gists this profile owner has pinned to their profile
   """
@@ -24273,27 +27647,33 @@ type Organization implements Actor & AnnouncementBanner & MemberStatusable & Nod
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Filter the types of pinned items that are returned.
     """
     types: [PinnableItemType!]
   ): PinnableItemConnection!
+  
   """
   Returns how many more items this profile owner can pin to their profile.
   """
   pinnedItemsRemaining: Int!
+  
   """
   Find project by number.
   """
@@ -24303,6 +27683,7 @@ type Organization implements Actor & AnnouncementBanner & MemberStatusable & Nod
     """
     number: Int!
   ): Project
+  
   """
   Find a project by number.
   """
@@ -24312,6 +27693,7 @@ type Organization implements Actor & AnnouncementBanner & MemberStatusable & Nod
     """
     number: Int!
   ): ProjectV2
+  
   """
   A list of projects under the owner.
   """
@@ -24320,39 +27702,48 @@ type Organization implements Actor & AnnouncementBanner & MemberStatusable & Nod
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for projects returned from the connection
     """
     orderBy: ProjectOrder
+    
     """
     Query to search projects by, currently only searching by name.
     """
     search: String
+    
     """
     A list of states to filter the projects by.
     """
     states: [ProjectState!]
   ): ProjectConnection!
+  
   """
   The HTTP path listing organization's projects
   """
   projectsResourcePath: URI!
+  
   """
   The HTTP URL listing organization's projects
   """
   projectsUrl: URI!
+  
   """
   A list of projects under the owner.
   """
@@ -24361,27 +27752,33 @@ type Organization implements Actor & AnnouncementBanner & MemberStatusable & Nod
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     How to order the returned projects.
     """
     orderBy: ProjectV2Order = { field: NUMBER, direction: DESC }
+    
     """
     A project to search for under the the owner.
     """
     query: String
   ): ProjectV2Connection!
+  
   """
   Recent projects that this user has modified in the context of the owner.
   """
@@ -24390,19 +27787,23 @@ type Organization implements Actor & AnnouncementBanner & MemberStatusable & Nod
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): ProjectV2Connection!
+  
   """
   A list of repositories that the user owns.
   """
@@ -24413,53 +27814,65 @@ type Organization implements Actor & AnnouncementBanner & MemberStatusable & Nod
     current viewer owns.
     """
     affiliations: [RepositoryAffiliation]
+    
     """
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     If non-null, filters repositories according to whether they have issues enabled
     """
     hasIssuesEnabled: Boolean
+    
     """
     If non-null, filters repositories according to whether they are archived and not maintained
     """
     isArchived: Boolean
+    
     """
     If non-null, filters repositories according to whether they are forks of another repository
     """
     isFork: Boolean
+    
     """
     If non-null, filters repositories according to whether they have been locked
     """
     isLocked: Boolean
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for repositories returned from the connection
     """
     orderBy: RepositoryOrder
+    
     """
     Array of owner's affiliation options for repositories returned from the
     connection. For example, OWNER will include only repositories that the
     organization or user being viewed owns.
     """
     ownerAffiliations: [RepositoryAffiliation] = [OWNER, COLLABORATOR]
+    
     """
     If non-null, filters repositories according to privacy
     """
     privacy: RepositoryPrivacy
   ): RepositoryConnection!
+  
   """
   Find Repository.
   """
@@ -24468,11 +27881,13 @@ type Organization implements Actor & AnnouncementBanner & MemberStatusable & Nod
     Follow repository renames. If disabled, a repository referenced by its old name will return an error.
     """
     followRenames: Boolean = true
+    
     """
     Name of Repository to find.
     """
     name: String!
   ): Repository
+  
   """
   Discussion comments this user has authored.
   """
@@ -24481,27 +27896,33 @@ type Organization implements Actor & AnnouncementBanner & MemberStatusable & Nod
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Filter discussion comments to only those that were marked as the answer
     """
     onlyAnswers: Boolean = false
+    
     """
     Filter discussion comments to only those in a specific repository.
     """
     repositoryId: ID
   ): DiscussionCommentConnection!
+  
   """
   Discussions this user has started.
   """
@@ -24510,36 +27931,44 @@ type Organization implements Actor & AnnouncementBanner & MemberStatusable & Nod
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Filter discussions to only those that have been answered or not. Defaults to
     including both answered and unanswered discussions.
     """
     answered: Boolean = null
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for discussions returned from the connection.
     """
     orderBy: DiscussionOrder = { field: CREATED_AT, direction: DESC }
+    
     """
     Filter discussions to only those in a specific repository.
     """
     repositoryId: ID
+    
     """
     A list of states to filter the discussions by.
     """
     states: [DiscussionState!] = []
   ): DiscussionConnection!
+  
   """
   A list of all repository migrations for this organization.
   """
@@ -24548,40 +27977,49 @@ type Organization implements Actor & AnnouncementBanner & MemberStatusable & Nod
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for repository migrations returned.
     """
     orderBy: RepositoryMigrationOrder = { field: CREATED_AT, direction: ASC }
+    
     """
     Filter repository migrations by repository name.
     """
     repositoryName: String
+    
     """
     Filter repository migrations by state.
     """
     state: MigrationState
   ): RepositoryMigrationConnection!
+  
   """
   When true the organization requires all members, billing managers, and outside
   collaborators to enable two-factor authentication.
   """
   requiresTwoFactorAuthentication: Boolean
+  
   """
   The HTTP path for this organization.
   """
   resourcePath: URI!
+  
   """
   Returns a single ruleset from the current organization by ID.
   """
@@ -24591,6 +28029,7 @@ type Organization implements Actor & AnnouncementBanner & MemberStatusable & Nod
     """
     databaseId: Int!
   ): RepositoryRuleset
+  
   """
   A list of rulesets for this organization.
   """
@@ -24599,23 +28038,28 @@ type Organization implements Actor & AnnouncementBanner & MemberStatusable & Nod
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Return rulesets configured at higher levels that apply to this organization
     """
     includeParents: Boolean = true
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): RepositoryRulesetConnection
+  
   """
   The Organization's SAML identity provider. Visible to (1) organization owners,
   (2) organization owners' personal access tokens (classic) with read:org or
@@ -24623,6 +28067,7 @@ type Organization implements Actor & AnnouncementBanner & MemberStatusable & Nod
   access to members.
   """
   samlIdentityProvider: OrganizationIdentityProvider
+  
   """
   List of users and organizations this entity is sponsoring.
   """
@@ -24631,23 +28076,28 @@ type Organization implements Actor & AnnouncementBanner & MemberStatusable & Nod
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for the users and organizations returned from the connection.
     """
     orderBy: SponsorOrder = { field: RELEVANCE, direction: DESC }
   ): SponsorConnection!
+  
   """
   List of sponsors for this user or organization.
   """
@@ -24656,28 +28106,34 @@ type Organization implements Actor & AnnouncementBanner & MemberStatusable & Nod
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for sponsors returned from the connection.
     """
     orderBy: SponsorOrder = { field: RELEVANCE, direction: DESC }
+    
     """
     If given, will filter for sponsors at the given tier. Will only return
     sponsors whose tier the viewer is permitted to see.
     """
     tierId: ID
   ): SponsorConnection!
+  
   """
   Events involving this sponsorable, such as new sponsorships.
   """
@@ -24686,55 +28142,67 @@ type Organization implements Actor & AnnouncementBanner & MemberStatusable & Nod
     Filter activities to only the specified actions.
     """
     actions: [SponsorsActivityAction!] = []
+    
     """
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Whether to include those events where this sponsorable acted as the sponsor.
     Defaults to only including events where this sponsorable was the recipient
     of a sponsorship.
     """
     includeAsSponsor: Boolean = false
+    
     """
     Whether or not to include private activities in the result set. Defaults to including public and private activities.
     """
     includePrivate: Boolean = true
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for activity returned from the connection.
     """
     orderBy: SponsorsActivityOrder = { field: TIMESTAMP, direction: DESC }
+    
     """
     Filter activities returned to only those that occurred in the most recent
     specified time period. Set to ALL to avoid filtering by when the activity
     occurred. Will be ignored if `since` or `until` is given.
     """
     period: SponsorsActivityPeriod = MONTH
+    
     """
     Filter activities to those that occurred on or after this time.
     """
     since: DateTime
+    
     """
     Filter activities to those that occurred before this time.
     """
     until: DateTime
   ): SponsorsActivityConnection!
+  
   """
   The GitHub Sponsors listing for this user or organization.
   """
   sponsorsListing: SponsorsListing
+  
   """
   The sponsorship from the viewer to this user/organization; that is, the sponsorship where you're the sponsor.
   """
@@ -24745,6 +28213,7 @@ type Organization implements Actor & AnnouncementBanner & MemberStatusable & Nod
     """
     activeOnly: Boolean = true
   ): Sponsorship
+  
   """
   The sponsorship from this user/organization to the viewer; that is, the sponsorship you're receiving.
   """
@@ -24755,6 +28224,7 @@ type Organization implements Actor & AnnouncementBanner & MemberStatusable & Nod
     """
     activeOnly: Boolean = true
   ): Sponsorship
+  
   """
   List of sponsorship updates sent from this sponsorable to sponsors.
   """
@@ -24763,23 +28233,28 @@ type Organization implements Actor & AnnouncementBanner & MemberStatusable & Nod
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for sponsorship updates returned from the connection.
     """
     orderBy: SponsorshipNewsletterOrder = { field: CREATED_AT, direction: DESC }
   ): SponsorshipNewsletterConnection!
+  
   """
   The sponsorships where this user or organization is the maintainer receiving the funds.
   """
@@ -24789,32 +28264,39 @@ type Organization implements Actor & AnnouncementBanner & MemberStatusable & Nod
     sponsorships this maintainer has ever received.
     """
     activeOnly: Boolean = true
+    
     """
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Whether or not to include private sponsorships in the result set
     """
     includePrivate: Boolean = false
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for sponsorships returned from this connection. If left
     blank, the sponsorships will be ordered based on relevancy to the viewer.
     """
     orderBy: SponsorshipOrder
   ): SponsorshipConnection!
+  
   """
   The sponsorships where this user or organization is the funder.
   """
@@ -24823,34 +28305,41 @@ type Organization implements Actor & AnnouncementBanner & MemberStatusable & Nod
     Whether to include only sponsorships that are active right now, versus all sponsorships this sponsor has ever made.
     """
     activeOnly: Boolean = true
+    
     """
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Filter sponsorships returned to those for the specified maintainers. That
     is, the recipient of the sponsorship is a user or organization with one of
     the given logins.
     """
     maintainerLogins: [String!]
+    
     """
     Ordering options for sponsorships returned from this connection. If left
     blank, the sponsorships will be ordered based on relevancy to the viewer.
     """
     orderBy: SponsorshipOrder
   ): SponsorshipConnection!
+  
   """
   Find an organization's team by its slug.
   """
@@ -24860,6 +28349,7 @@ type Organization implements Actor & AnnouncementBanner & MemberStatusable & Nod
     """
     slug: String!
   ): Team
+  
   """
   A list of teams in this organization.
   """
@@ -24868,59 +28358,73 @@ type Organization implements Actor & AnnouncementBanner & MemberStatusable & Nod
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     If true, filters teams that are mapped to an LDAP Group (Enterprise only)
     """
     ldapMapped: Boolean
+    
     """
     If non-null, filters teams according to notification setting
     """
     notificationSetting: TeamNotificationSetting
+    
     """
     Ordering options for teams returned from the connection
     """
     orderBy: TeamOrder
+    
     """
     If non-null, filters teams according to privacy
     """
     privacy: TeamPrivacy
+    
     """
     If non-null, filters teams with query on team name and team slug
     """
     query: String
+    
     """
     If non-null, filters teams according to whether the viewer is an admin or member on team
     """
     role: TeamRole
+    
     """
     If true, restrict to only root teams
     """
     rootTeamsOnly: Boolean = false
+    
     """
     User logins to filter by
     """
     userLogins: [String!]
   ): TeamConnection!
+  
   """
   The HTTP path listing organization's teams
   """
   teamsResourcePath: URI!
+  
   """
   The HTTP URL listing organization's teams
   """
   teamsUrl: URI!
+  
   """
   The amount in United States cents (e.g., 500 = $5.00 USD) that this entity has
   spent on GitHub to fund sponsorships. Only returns a value when viewed by the
@@ -24931,67 +28435,83 @@ type Organization implements Actor & AnnouncementBanner & MemberStatusable & Nod
     Filter payments to those that occurred on or after this time.
     """
     since: DateTime
+    
     """
     Filter payments to those made to the users or organizations with the specified usernames.
     """
     sponsorableLogins: [String!] = []
+    
     """
     Filter payments to those that occurred before this time.
     """
     until: DateTime
   ): Int
+  
   """
   The organization's Twitter username.
   """
   twitterUsername: String
+  
   """
   Identifies the date and time when the object was last updated.
   """
   updatedAt: DateTime!
+  
   """
   The HTTP URL for this organization.
   """
   url: URI!
+  
   """
   Organization is adminable by the viewer.
   """
   viewerCanAdminister: Boolean!
+  
   """
   Can the viewer pin repositories and gists to the profile?
   """
   viewerCanChangePinnedItems: Boolean!
+  
   """
   Can the current viewer create new projects on this owner.
   """
   viewerCanCreateProjects: Boolean!
+  
   """
   Viewer can create repositories on this organization
   """
   viewerCanCreateRepositories: Boolean!
+  
   """
   Viewer can create teams on this organization.
   """
   viewerCanCreateTeams: Boolean!
+  
   """
   Whether or not the viewer is able to sponsor this user/organization.
   """
   viewerCanSponsor: Boolean!
+  
   """
   Viewer is an active member of this organization.
   """
   viewerIsAMember: Boolean!
+  
   """
   Whether or not this Organization is followed by the viewer.
   """
   viewerIsFollowing: Boolean!
+  
   """
   True if the viewer is sponsoring this user/organization.
   """
   viewerIsSponsoring: Boolean!
+  
   """
   Whether contributors are required to sign off on web-based commits for repositories in this organization.
   """
   webCommitSignoffRequired: Boolean!
+  
   """
   The organization's public profile URL.
   """
@@ -25070,14 +28590,17 @@ type OrganizationAuditEntryConnection {
   A list of edges.
   """
   edges: [OrganizationAuditEntryEdge]
+  
   """
   A list of nodes.
   """
   nodes: [OrganizationAuditEntry]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -25092,14 +28615,17 @@ interface OrganizationAuditEntryData {
   The Organization associated with the Audit Entry.
   """
   organization: Organization
+  
   """
   The name of the Organization.
   """
   organizationName: String
+  
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
+  
   """
   The HTTP URL for the organization
   """
@@ -25114,6 +28640,7 @@ type OrganizationAuditEntryEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -25128,14 +28655,17 @@ type OrganizationConnection {
   A list of edges.
   """
   edges: [OrganizationEdge]
+  
   """
   A list of nodes.
   """
   nodes: [Organization]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -25150,6 +28680,7 @@ type OrganizationEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -25164,14 +28695,17 @@ type OrganizationEnterpriseOwnerConnection {
   A list of edges.
   """
   edges: [OrganizationEnterpriseOwnerEdge]
+  
   """
   A list of nodes.
   """
   nodes: [User]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -25186,10 +28720,12 @@ type OrganizationEnterpriseOwnerEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
   node: User
+  
   """
   The role of the owner with respect to the organization.
   """
@@ -25207,6 +28743,7 @@ type OrganizationIdentityProvider implements Node {
   The digest algorithm used to sign SAML requests for the Identity Provider.
   """
   digestMethod: URI
+  
   """
   External Identities provisioned by this Identity Provider
   """
@@ -25215,48 +28752,59 @@ type OrganizationIdentityProvider implements Node {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Filter to external identities with the users login
     """
     login: String
+    
     """
     Filter to external identities with valid org membership only
     """
     membersOnly: Boolean
+    
     """
     Filter to external identities with the users userName/NameID attribute
     """
     userName: String
   ): ExternalIdentityConnection!
   id: ID!
+  
   """
   The x509 certificate used by the Identity Provider to sign assertions and responses.
   """
   idpCertificate: X509Certificate
+  
   """
   The Issuer Entity ID for the SAML Identity Provider
   """
   issuer: String
+  
   """
   Organization this Identity Provider belongs to
   """
   organization: Organization
+  
   """
   The signature algorithm used to sign SAML requests for the Identity Provider.
   """
   signatureMethod: URI
+  
   """
   The URL endpoint for the Identity Provider's SAML SSO.
   """
@@ -25271,31 +28819,38 @@ type OrganizationInvitation implements Node {
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
+  
   """
   The email address of the user invited to the organization.
   """
   email: String
   id: ID!
+  
   """
   The source of the invitation.
   """
   invitationSource: OrganizationInvitationSource!
+  
   """
   The type of invitation that was sent (e.g. email, user).
   """
   invitationType: OrganizationInvitationType!
+  
   """
   The user who was invited to the organization.
   """
   invitee: User
+  
   """
   The user who created the invitation.
   """
   inviter: User!
+  
   """
   The organization the invite is for
   """
   organization: Organization!
+  
   """
   The user's pending role in the organization (e.g. member, owner).
   """
@@ -25310,14 +28865,17 @@ type OrganizationInvitationConnection {
   A list of edges.
   """
   edges: [OrganizationInvitationEdge]
+  
   """
   A list of nodes.
   """
   nodes: [OrganizationInvitation]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -25332,6 +28890,7 @@ type OrganizationInvitationEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -25400,14 +28959,17 @@ type OrganizationMemberConnection {
   A list of edges.
   """
   edges: [OrganizationMemberEdge]
+  
   """
   A list of nodes.
   """
   nodes: [User]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -25422,14 +28984,17 @@ type OrganizationMemberEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   Whether the organization member has two factor enabled or not. Returns null if information is not available to viewer.
   """
   hasTwoFactorEnabled: Boolean
+  
   """
   The item at the end of the edge.
   """
   node: User
+  
   """
   The role this user has in the organization.
   """
@@ -25480,35 +29045,43 @@ type OrganizationMigration implements Node {
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
+  
   """
   Identifies the primary key from the database.
   """
   databaseId: String
+  
   """
   The reason the organization migration failed.
   """
   failureReason: String
   id: ID!
+  
   """
   The remaining amount of repos to be migrated.
   """
   remainingRepositoriesCount: Int
+  
   """
   The name of the source organization to be migrated.
   """
   sourceOrgName: String!
+  
   """
   The URL of the source organization to migrate.
   """
   sourceOrgUrl: URI!
+  
   """
   The migration state.
   """
   state: OrganizationMigrationState!
+  
   """
   The name of the target organization.
   """
   targetOrgName: String!
+  
   """
   The total amount of repositories to be migrated.
   """
@@ -25574,6 +29147,7 @@ input OrganizationOrder {
   The ordering direction.
   """
   direction: OrderDirection!
+  
   """
   The field to order organizations by.
   """
@@ -25602,10 +29176,12 @@ type OrganizationTeamsHovercardContext implements HovercardContext {
   A string describing this context
   """
   message: String!
+  
   """
   An octicon to accompany this context
   """
   octicon: String!
+  
   """
   Teams in this organization the user is a member of that are relevant
   """
@@ -25614,27 +29190,33 @@ type OrganizationTeamsHovercardContext implements HovercardContext {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): TeamConnection!
+  
   """
   The path for the full team list for this user
   """
   teamsResourcePath: URI!
+  
   """
   The URL for the full team list for this user
   """
   teamsUrl: URI!
+  
   """
   The total number of teams the user is on in the organization
   """
@@ -25649,10 +29231,12 @@ type OrganizationsHovercardContext implements HovercardContext {
   A string describing this context
   """
   message: String!
+  
   """
   An octicon to accompany this context
   """
   octicon: String!
+  
   """
   Organizations this user is a member of that are relevant
   """
@@ -25661,23 +29245,28 @@ type OrganizationsHovercardContext implements HovercardContext {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for the User's organizations.
     """
     orderBy: OrganizationOrder = null
   ): OrganizationConnection!
+  
   """
   The total number of organizations this user is in
   """
@@ -25689,26 +29278,32 @@ Information for an uploaded package.
 """
 type Package implements Node {
   id: ID!
+  
   """
   Find the latest version for the package.
   """
   latestVersion: PackageVersion
+  
   """
   Identifies the name of the package.
   """
   name: String!
+  
   """
   Identifies the type of the package.
   """
   packageType: PackageType!
+  
   """
   The repository this package belongs to.
   """
   repository: Repository
+  
   """
   Statistics about package activity.
   """
   statistics: PackageStatistics
+  
   """
   Find package version by version string.
   """
@@ -25718,6 +29313,7 @@ type Package implements Node {
     """
     version: String!
   ): PackageVersion
+  
   """
   list of versions for this package
   """
@@ -25726,18 +29322,22 @@ type Package implements Node {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering of the returned packages.
     """
@@ -25753,14 +29353,17 @@ type PackageConnection {
   A list of edges.
   """
   edges: [PackageEdge]
+  
   """
   A list of nodes.
   """
   nodes: [Package]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -25775,6 +29378,7 @@ type PackageEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -25786,34 +29390,42 @@ A file in a package version.
 """
 type PackageFile implements Node {
   id: ID!
+  
   """
   MD5 hash of the file.
   """
   md5: String
+  
   """
   Name of the file.
   """
   name: String!
+  
   """
   The package version this file belongs to.
   """
   packageVersion: PackageVersion
+  
   """
   SHA1 hash of the file.
   """
   sha1: String
+  
   """
   SHA256 hash of the file.
   """
   sha256: String
+  
   """
   Size of the file in bytes.
   """
   size: Int
+  
   """
   Identifies the date and time when the object was last updated.
   """
   updatedAt: DateTime!
+  
   """
   URL to download the asset.
   """
@@ -25828,14 +29440,17 @@ type PackageFileConnection {
   A list of edges.
   """
   edges: [PackageFileEdge]
+  
   """
   A list of nodes.
   """
   nodes: [PackageFile]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -25850,6 +29465,7 @@ type PackageFileEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -25864,6 +29480,7 @@ input PackageFileOrder {
   The direction in which to order package files by the specified field.
   """
   direction: OrderDirection
+  
   """
   The field in which to order package files by.
   """
@@ -25888,6 +29505,7 @@ input PackageOrder {
   The direction in which to order packages by the specified field.
   """
   direction: OrderDirection
+  
   """
   The field in which to order packages by.
   """
@@ -25909,6 +29527,7 @@ Represents an owner of a package.
 """
 interface PackageOwner {
   id: ID!
+  
   """
   A list of packages under the owner.
   """
@@ -25917,30 +29536,37 @@ interface PackageOwner {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Find packages by their names.
     """
     names: [String]
+    
     """
     Ordering of the returned packages.
     """
     orderBy: PackageOrder = { field: CREATED_AT, direction: DESC }
+    
     """
     Filter registry package by type.
     """
     packageType: PackageType
+    
     """
     Find packages in a repository by ID.
     """
@@ -25963,10 +29589,12 @@ A version tag contains the mapping between a tag name and a version.
 """
 type PackageTag implements Node {
   id: ID!
+  
   """
   Identifies the tag name of the version.
   """
   name: String!
+  
   """
   Version that the tag is associated with.
   """
@@ -26029,52 +29657,64 @@ type PackageVersion implements Node {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering of the returned package files.
     """
     orderBy: PackageFileOrder = { field: CREATED_AT, direction: ASC }
   ): PackageFileConnection!
   id: ID!
+  
   """
   The package associated with this version.
   """
   package: Package
+  
   """
   The platform this version was built for.
   """
   platform: String
+  
   """
   Whether or not this version is a pre-release.
   """
   preRelease: Boolean!
+  
   """
   The README of this package version.
   """
   readme: String
+  
   """
   The release associated with this package version.
   """
   release: Release
+  
   """
   Statistics about package activity.
   """
   statistics: PackageVersionStatistics
+  
   """
   The package version summary.
   """
   summary: String
+  
   """
   The version string.
   """
@@ -26089,14 +29729,17 @@ type PackageVersionConnection {
   A list of edges.
   """
   edges: [PackageVersionEdge]
+  
   """
   A list of nodes.
   """
   nodes: [PackageVersion]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -26111,6 +29754,7 @@ type PackageVersionEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -26125,6 +29769,7 @@ input PackageVersionOrder {
   The direction in which to order package versions by the specified field.
   """
   direction: OrderDirection
+  
   """
   The field in which to order package versions by.
   """
@@ -26159,14 +29804,17 @@ type PageInfo {
   When paginating forwards, the cursor to continue.
   """
   endCursor: String
+  
   """
   When paginating forwards, are there more items?
   """
   hasNextPage: Boolean!
+  
   """
   When paginating backwards, are there more items?
   """
   hasPreviousPage: Boolean!
+  
   """
   When paginating backwards, the cursor to continue.
   """
@@ -26216,10 +29864,12 @@ type PermissionSource {
   The organization the repository belongs to.
   """
   organization: Organization!
+  
   """
   The level of access this source has granted to the user.
   """
   permission: DefaultRepositoryPermissionField!
+  
   """
   The source of this permission.
   """
@@ -26234,6 +29884,7 @@ input PinIssueInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The ID of the issue to be pinned
   """
@@ -26248,6 +29899,7 @@ type PinIssuePayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The issue that was pinned
   """
@@ -26267,14 +29919,17 @@ type PinnableItemConnection {
   A list of edges.
   """
   edges: [PinnableItemEdge]
+  
   """
   A list of nodes.
   """
   nodes: [PinnableItem]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -26289,6 +29944,7 @@ type PinnableItemEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -26341,35 +29997,43 @@ type PinnedDiscussion implements Node & RepositoryNode {
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
+  
   """
   Identifies the primary key from the database.
   """
   databaseId: Int
+  
   """
   The discussion that was pinned.
   """
   discussion: Discussion!
+  
   """
   Color stops of the chosen gradient
   """
   gradientStopColors: [String!]!
   id: ID!
+  
   """
   Background texture pattern
   """
   pattern: PinnedDiscussionPattern!
+  
   """
   The actor that pinned this discussion.
   """
   pinnedBy: Actor!
+  
   """
   Preconfigured background gradient option
   """
   preconfiguredGradient: PinnedDiscussionGradient
+  
   """
   The repository associated with this node.
   """
   repository: Repository!
+  
   """
   Identifies the date and time when the object was last updated.
   """
@@ -26384,14 +30048,17 @@ type PinnedDiscussionConnection {
   A list of edges.
   """
   edges: [PinnedDiscussionEdge]
+  
   """
   A list of nodes.
   """
   nodes: [PinnedDiscussion]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -26406,6 +30073,7 @@ type PinnedDiscussionEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -26476,11 +30144,13 @@ type PinnedEvent implements Node {
   Identifies the actor who performed the event.
   """
   actor: Actor
+  
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
   id: ID!
+  
   """
   Identifies the issue associated with the event.
   """
@@ -26495,19 +30165,23 @@ type PinnedIssue implements Node {
   Identifies the primary key from the database.
   """
   databaseId: Int
+  
   """
   Identifies the primary key from the database as a BigInt.
   """
   fullDatabaseId: BigInt
   id: ID!
+  
   """
   The issue that was pinned.
   """
   issue: Issue!
+  
   """
   The actor that pinned this issue.
   """
   pinnedBy: Actor!
+  
   """
   The repository that this issue was pinned to.
   """
@@ -26522,14 +30196,17 @@ type PinnedIssueConnection {
   A list of edges.
   """
   edges: [PinnedIssueEdge]
+  
   """
   A list of nodes.
   """
   nodes: [PinnedIssue]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -26544,6 +30221,7 @@ type PinnedIssueEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -26563,95 +30241,118 @@ type PrivateRepositoryForkingDisableAuditEntry implements AuditEntry & Enterpris
   The action name
   """
   action: String!
+  
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
+  
   """
   The IP address of the actor
   """
   actorIp: String
+  
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
+  
   """
   The username of the user who initiated the action
   """
   actorLogin: String
+  
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
+  
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
+  
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
+  
   """
   The HTTP path for this enterprise.
   """
   enterpriseResourcePath: URI
+  
   """
   The slug of the enterprise.
   """
   enterpriseSlug: String
+  
   """
   The HTTP URL for this enterprise.
   """
   enterpriseUrl: URI
   id: ID!
+  
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
+  
   """
   The Organization associated with the Audit Entry.
   """
   organization: Organization
+  
   """
   The name of the Organization.
   """
   organizationName: String
+  
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
+  
   """
   The HTTP URL for the organization
   """
   organizationUrl: URI
+  
   """
   The repository associated with the action
   """
   repository: Repository
+  
   """
   The name of the repository
   """
   repositoryName: String
+  
   """
   The HTTP path for the repository
   """
   repositoryResourcePath: URI
+  
   """
   The HTTP URL for the repository
   """
   repositoryUrl: URI
+  
   """
   The user affected by the action
   """
   user: User
+  
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
+  
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
+  
   """
   The HTTP URL for the user.
   """
@@ -26666,95 +30367,118 @@ type PrivateRepositoryForkingEnableAuditEntry implements AuditEntry & Enterprise
   The action name
   """
   action: String!
+  
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
+  
   """
   The IP address of the actor
   """
   actorIp: String
+  
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
+  
   """
   The username of the user who initiated the action
   """
   actorLogin: String
+  
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
+  
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
+  
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
+  
   """
   The HTTP path for this enterprise.
   """
   enterpriseResourcePath: URI
+  
   """
   The slug of the enterprise.
   """
   enterpriseSlug: String
+  
   """
   The HTTP URL for this enterprise.
   """
   enterpriseUrl: URI
   id: ID!
+  
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
+  
   """
   The Organization associated with the Audit Entry.
   """
   organization: Organization
+  
   """
   The name of the Organization.
   """
   organizationName: String
+  
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
+  
   """
   The HTTP URL for the organization
   """
   organizationUrl: URI
+  
   """
   The repository associated with the action
   """
   repository: Repository
+  
   """
   The name of the repository
   """
   repositoryName: String
+  
   """
   The HTTP path for the repository
   """
   repositoryResourcePath: URI
+  
   """
   The HTTP URL for the repository
   """
   repositoryUrl: URI
+  
   """
   The user affected by the action
   """
   user: User
+  
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
+  
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
+  
   """
   The HTTP URL for the user.
   """
@@ -26770,6 +30494,7 @@ type ProfileItemShowcase {
   Whether or not the owner has pinned any repositories or gists.
   """
   hasPinnedItems: Boolean!
+  
   """
   The repositories and gists in the showcase. If the profile owner has any
   pinned items, those will be returned. Otherwise, the profile owner's popular
@@ -26780,14 +30505,17 @@ type ProfileItemShowcase {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
@@ -26808,28 +30536,34 @@ interface ProfileOwner {
     """
     type: PinnableItemType
   ): Boolean!
+  
   """
   The public profile email.
   """
   email: String
   id: ID!
+  
   """
   Showcases a selection of repositories and gists that the profile owner has
   either curated or that have been selected automatically based on popularity.
   """
   itemShowcase: ProfileItemShowcase!
+  
   """
   The public profile location.
   """
   location: String
+  
   """
   The username used to login.
   """
   login: String!
+  
   """
   The public profile name.
   """
   name: String
+  
   """
   A list of repositories and gists this profile owner can pin to their profile.
   """
@@ -26838,23 +30572,28 @@ interface ProfileOwner {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Filter the types of pinnable items that are returned.
     """
     types: [PinnableItemType!]
   ): PinnableItemConnection!
+  
   """
   A list of repositories and gists this profile owner has pinned to their profile
   """
@@ -26863,31 +30602,38 @@ interface ProfileOwner {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Filter the types of pinned items that are returned.
     """
     types: [PinnableItemType!]
   ): PinnableItemConnection!
+  
   """
   Returns how many more items this profile owner can pin to their profile.
   """
   pinnedItemsRemaining: Int!
+  
   """
   Can the viewer pin repositories and gists to the profile?
   """
   viewerCanChangePinnedItems: Boolean!
+  
   """
   The public profile website URL.
   """
@@ -26902,18 +30648,22 @@ type Project implements Closable & Node & Updatable {
   The project's description body.
   """
   body: String
+  
   """
   The projects description body rendered to HTML.
   """
   bodyHTML: HTML!
+  
   """
   Indicates if the object is closed (definition of closed may depend on type)
   """
   closed: Boolean!
+  
   """
   Identifies the date and time when the object was closed.
   """
   closedAt: DateTime
+  
   """
   List of columns in the project
   """
@@ -26922,44 +30672,54 @@ type Project implements Closable & Node & Updatable {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): ProjectColumnConnection!
+  
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
+  
   """
   The actor who originally created the project.
   """
   creator: Actor
+  
   """
   Identifies the primary key from the database.
   """
   databaseId: Int
   id: ID!
+  
   """
   The project's name.
   """
   name: String!
+  
   """
   The project's number.
   """
   number: Int!
+  
   """
   The project's owner. Currently limited to repositories, organizations, and users.
   """
   owner: ProjectOwner!
+  
   """
   List of pending cards in this project
   """
@@ -26968,51 +30728,63 @@ type Project implements Closable & Node & Updatable {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     A list of archived states to filter the cards by
     """
     archivedStates: [ProjectCardArchivedState] = [ARCHIVED, NOT_ARCHIVED]
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): ProjectCardConnection!
+  
   """
   Project progress details.
   """
   progress: ProjectProgress!
+  
   """
   The HTTP path for this project
   """
   resourcePath: URI!
+  
   """
   Whether the project is open or closed.
   """
   state: ProjectState!
+  
   """
   Identifies the date and time when the object was last updated.
   """
   updatedAt: DateTime!
+  
   """
   The HTTP URL for this project
   """
   url: URI!
+  
   """
   Indicates if the object can be closed by the viewer.
   """
   viewerCanClose: Boolean!
+  
   """
   Indicates if the object can be reopened by the viewer.
   """
   viewerCanReopen: Boolean!
+  
   """
   Check if the current viewer can update this object.
   """
@@ -27030,47 +30802,58 @@ type ProjectCard implements Node {
   associated with a column, they will not become pending in the future.
   """
   column: ProjectColumn
+  
   """
   The card content item
   """
   content: ProjectCardItem
+  
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
+  
   """
   The actor who created this card
   """
   creator: Actor
+  
   """
   Identifies the primary key from the database.
   """
   databaseId: Int
   id: ID!
+  
   """
   Whether the card is archived
   """
   isArchived: Boolean!
+  
   """
   The card note
   """
   note: String
+  
   """
   The project that contains this card.
   """
   project: Project!
+  
   """
   The HTTP path for this card
   """
   resourcePath: URI!
+  
   """
   The state of ProjectCard
   """
   state: ProjectCardState
+  
   """
   Identifies the date and time when the object was last updated.
   """
   updatedAt: DateTime!
+  
   """
   The HTTP URL for this card
   """
@@ -27099,14 +30882,17 @@ type ProjectCardConnection {
   A list of edges.
   """
   edges: [ProjectCardEdge]
+  
   """
   A list of nodes.
   """
   nodes: [ProjectCard]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -27121,6 +30907,7 @@ type ProjectCardEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -27135,6 +30922,7 @@ input ProjectCardImport {
   The issue or pull request number.
   """
   number: Int!
+  
   """
   Repository name with owner (owner/repository).
   """
@@ -27176,52 +30964,64 @@ type ProjectColumn implements Node {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     A list of archived states to filter the cards by
     """
     archivedStates: [ProjectCardArchivedState] = [ARCHIVED, NOT_ARCHIVED]
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): ProjectCardConnection!
+  
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
+  
   """
   Identifies the primary key from the database.
   """
   databaseId: Int
   id: ID!
+  
   """
   The project column's name.
   """
   name: String!
+  
   """
   The project that contains this column.
   """
   project: Project!
+  
   """
   The semantic purpose of the column
   """
   purpose: ProjectColumnPurpose
+  
   """
   The HTTP path for this project column
   """
   resourcePath: URI!
+  
   """
   Identifies the date and time when the object was last updated.
   """
   updatedAt: DateTime!
+  
   """
   The HTTP URL for this project column
   """
@@ -27236,14 +31036,17 @@ type ProjectColumnConnection {
   A list of edges.
   """
   edges: [ProjectColumnEdge]
+  
   """
   A list of nodes.
   """
   nodes: [ProjectColumn]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -27258,6 +31061,7 @@ type ProjectColumnEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -27272,10 +31076,12 @@ input ProjectColumnImport {
   The name of the column.
   """
   columnName: String!
+  
   """
   A list of issues and pull requests in the column.
   """
   issues: [ProjectCardImport!]
+  
   """
   The position of the column, starting from 0.
   """
@@ -27308,14 +31114,17 @@ type ProjectConnection {
   A list of edges.
   """
   edges: [ProjectEdge]
+  
   """
   A list of nodes.
   """
   nodes: [Project]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -27330,6 +31139,7 @@ type ProjectEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -27344,6 +31154,7 @@ input ProjectOrder {
   The direction in which to order projects by the specified field.
   """
   direction: OrderDirection!
+  
   """
   The field in which to order projects by.
   """
@@ -27373,6 +31184,7 @@ Represents an owner of a Project.
 """
 interface ProjectOwner {
   id: ID!
+  
   """
   Find project by number.
   """
@@ -27382,6 +31194,7 @@ interface ProjectOwner {
     """
     number: Int!
   ): Project
+  
   """
   A list of projects under the owner.
   """
@@ -27390,39 +31203,48 @@ interface ProjectOwner {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for projects returned from the connection
     """
     orderBy: ProjectOrder
+    
     """
     Query to search projects by, currently only searching by name.
     """
     search: String
+    
     """
     A list of states to filter the projects by.
     """
     states: [ProjectState!]
   ): ProjectConnection!
+  
   """
   The HTTP path listing owners projects
   """
   projectsResourcePath: URI!
+  
   """
   The HTTP URL listing owners projects
   """
   projectsUrl: URI!
+  
   """
   Can the current viewer create new projects on this owner.
   """
@@ -27437,26 +31259,32 @@ type ProjectProgress {
   The number of done cards.
   """
   doneCount: Int!
+  
   """
   The percentage of done cards.
   """
   donePercentage: Float!
+  
   """
   Whether progress tracking is enabled and cards with purpose exist for this project
   """
   enabled: Boolean!
+  
   """
   The number of in-progress cards.
   """
   inProgressCount: Int!
+  
   """
   The percentage of in-progress cards.
   """
   inProgressPercentage: Float!
+  
   """
   The number of to do cards.
   """
   todoCount: Int!
+  
   """
   The percentage of to do cards.
   """
@@ -27507,22 +31335,27 @@ type ProjectV2 implements Closable & Node & Updatable {
   Returns true if the project is closed.
   """
   closed: Boolean!
+  
   """
   Identifies the date and time when the object was closed.
   """
   closedAt: DateTime
+  
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
+  
   """
   The actor who originally created the project.
   """
   creator: Actor
+  
   """
   Identifies the primary key from the database.
   """
   databaseId: Int
+  
   """
   A field of the project
   """
@@ -27532,6 +31365,7 @@ type ProjectV2 implements Closable & Node & Updatable {
     """
     name: String!
   ): ProjectV2FieldConfiguration
+  
   """
   List of fields and their constraints in the project
   """
@@ -27540,24 +31374,29 @@ type ProjectV2 implements Closable & Node & Updatable {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for project v2 fields returned from the connection
     """
     orderBy: ProjectV2FieldOrder = { field: POSITION, direction: ASC }
   ): ProjectV2FieldConfigurationConnection!
   id: ID!
+  
   """
   List of items in the project
   """
@@ -27566,39 +31405,48 @@ type ProjectV2 implements Closable & Node & Updatable {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for project v2 items returned from the connection
     """
     orderBy: ProjectV2ItemOrder = { field: POSITION, direction: ASC }
   ): ProjectV2ItemConnection!
+  
   """
   The project's number.
   """
   number: Int!
+  
   """
   The project's owner. Currently limited to organizations and users.
   """
   owner: ProjectV2Owner!
+  
   """
   Returns true if the project is public.
   """
   public: Boolean!
+  
   """
   The project's readme.
   """
   readme: String
+  
   """
   The repositories the project is linked to.
   """
@@ -27607,31 +31455,38 @@ type ProjectV2 implements Closable & Node & Updatable {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for repositories returned from the connection
     """
     orderBy: RepositoryOrder = { field: CREATED_AT, direction: DESC }
   ): RepositoryConnection!
+  
   """
   The HTTP path for this project
   """
   resourcePath: URI!
+  
   """
   The project's short description.
   """
   shortDescription: String
+  
   """
   The teams the project is linked to.
   """
@@ -27640,39 +31495,48 @@ type ProjectV2 implements Closable & Node & Updatable {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for teams returned from this connection.
     """
     orderBy: TeamOrder = { field: NAME, direction: ASC }
   ): TeamConnection!
+  
   """
   Returns true if this project is a template.
   """
   template: Boolean!
+  
   """
   The project's name.
   """
   title: String!
+  
   """
   Identifies the date and time when the object was last updated.
   """
   updatedAt: DateTime!
+  
   """
   The HTTP URL for this project
   """
   url: URI!
+  
   """
   A view of the project
   """
@@ -27682,18 +31546,22 @@ type ProjectV2 implements Closable & Node & Updatable {
     """
     number: Int!
   ): ProjectV2View
+  
   """
   Indicates if the object can be closed by the viewer.
   """
   viewerCanClose: Boolean!
+  
   """
   Indicates if the object can be reopened by the viewer.
   """
   viewerCanReopen: Boolean!
+  
   """
   Check if the current viewer can update this object.
   """
   viewerCanUpdate: Boolean!
+  
   """
   List of views in the project
   """
@@ -27702,23 +31570,28 @@ type ProjectV2 implements Closable & Node & Updatable {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for project v2 views returned from the connection
     """
     orderBy: ProjectV2ViewOrder = { field: POSITION, direction: ASC }
   ): ProjectV2ViewConnection!
+  
   """
   A workflow of the project
   """
@@ -27728,6 +31601,7 @@ type ProjectV2 implements Closable & Node & Updatable {
     """
     number: Int!
   ): ProjectV2Workflow
+  
   """
   List of the workflows in the project
   """
@@ -27736,18 +31610,22 @@ type ProjectV2 implements Closable & Node & Updatable {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for project v2 workflows returned from the connection
     """
@@ -27768,14 +31646,17 @@ type ProjectV2ActorConnection {
   A list of edges.
   """
   edges: [ProjectV2ActorEdge]
+  
   """
   A list of nodes.
   """
   nodes: [ProjectV2Actor]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -27790,6 +31671,7 @@ type ProjectV2ActorEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -27804,10 +31686,12 @@ input ProjectV2Collaborator {
   The role to grant the collaborator
   """
   role: ProjectV2Roles!
+  
   """
   The ID of the team as a collaborator.
   """
   teamId: ID @possibleTypes(concreteTypes: ["Team"])
+  
   """
   The ID of the user as a collaborator.
   """
@@ -27822,14 +31706,17 @@ type ProjectV2Connection {
   A list of edges.
   """
   edges: [ProjectV2Edge]
+  
   """
   A list of nodes.
   """
   nodes: [ProjectV2]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -27866,6 +31753,7 @@ type ProjectV2Edge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -27880,23 +31768,28 @@ type ProjectV2Field implements Node & ProjectV2FieldCommon {
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
+  
   """
   The field's type.
   """
   dataType: ProjectV2FieldType!
+  
   """
   Identifies the primary key from the database.
   """
   databaseId: Int
   id: ID!
+  
   """
   The project field's name.
   """
   name: String!
+  
   """
   The project that contains this field.
   """
   project: ProjectV2!
+  
   """
   Identifies the date and time when the object was last updated.
   """
@@ -27911,23 +31804,28 @@ interface ProjectV2FieldCommon {
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
+  
   """
   The field's type.
   """
   dataType: ProjectV2FieldType!
+  
   """
   Identifies the primary key from the database.
   """
   databaseId: Int
   id: ID!
+  
   """
   The project field's name.
   """
   name: String!
+  
   """
   The project that contains this field.
   """
   project: ProjectV2!
+  
   """
   Identifies the date and time when the object was last updated.
   """
@@ -27949,14 +31847,17 @@ type ProjectV2FieldConfigurationConnection {
   A list of edges.
   """
   edges: [ProjectV2FieldConfigurationEdge]
+  
   """
   A list of nodes.
   """
   nodes: [ProjectV2FieldConfiguration]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -27971,6 +31872,7 @@ type ProjectV2FieldConfigurationEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -27985,14 +31887,17 @@ type ProjectV2FieldConnection {
   A list of edges.
   """
   edges: [ProjectV2FieldEdge]
+  
   """
   A list of nodes.
   """
   nodes: [ProjectV2Field]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -28007,6 +31912,7 @@ type ProjectV2FieldEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -28021,6 +31927,7 @@ input ProjectV2FieldOrder {
   The ordering direction.
   """
   direction: OrderDirection!
+  
   """
   The field to order the project v2 fields by.
   """
@@ -28115,18 +32022,22 @@ input ProjectV2FieldValue {
   The ISO 8601 date to set on the field.
   """
   date: Date
+  
   """
   The id of the iteration to set on the field.
   """
   iterationId: String
+  
   """
   The number to set on the field.
   """
   number: Float
+  
   """
   The id of the single select option to set on the field.
   """
   singleSelectOptionId: String
+  
   """
   The text to set on the field.
   """
@@ -28151,18 +32062,22 @@ type ProjectV2Item implements Node {
   The content of the referenced draft issue, issue, or pull request
   """
   content: ProjectV2ItemContent
+  
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
+  
   """
   The actor who created the item.
   """
   creator: Actor
+  
   """
   Identifies the primary key from the database.
   """
   databaseId: Int
+  
   """
   The field value of the first project field which matches the 'name' argument that is set on the item.
   """
@@ -28172,6 +32087,7 @@ type ProjectV2Item implements Node {
     """
     name: String!
   ): ProjectV2ItemFieldValue
+  
   """
   The field values that are set on the item.
   """
@@ -28180,36 +32096,44 @@ type ProjectV2Item implements Node {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for project v2 item field values returned from the connection
     """
     orderBy: ProjectV2ItemFieldValueOrder = { field: POSITION, direction: ASC }
   ): ProjectV2ItemFieldValueConnection!
   id: ID!
+  
   """
   Whether the item is archived.
   """
   isArchived: Boolean!
+  
   """
   The project that contains this item.
   """
   project: ProjectV2!
+  
   """
   The type of the item.
   """
   type: ProjectV2ItemType!
+  
   """
   Identifies the date and time when the object was last updated.
   """
@@ -28224,14 +32148,17 @@ type ProjectV2ItemConnection {
   A list of edges.
   """
   edges: [ProjectV2ItemEdge]
+  
   """
   A list of nodes.
   """
   nodes: [ProjectV2Item]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -28251,6 +32178,7 @@ type ProjectV2ItemEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -28265,27 +32193,33 @@ type ProjectV2ItemFieldDateValue implements Node & ProjectV2ItemFieldValueCommon
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
+  
   """
   The actor who created the item.
   """
   creator: Actor
+  
   """
   Identifies the primary key from the database.
   """
   databaseId: Int
+  
   """
   Date value for the field
   """
   date: Date
+  
   """
   The project field that contains this value.
   """
   field: ProjectV2FieldConfiguration!
   id: ID!
+  
   """
   The project item that contains this value.
   """
   item: ProjectV2Item!
+  
   """
   Identifies the date and time when the object was last updated.
   """
@@ -28300,43 +32234,53 @@ type ProjectV2ItemFieldIterationValue implements Node & ProjectV2ItemFieldValueC
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
+  
   """
   The actor who created the item.
   """
   creator: Actor
+  
   """
   Identifies the primary key from the database.
   """
   databaseId: Int
+  
   """
   The duration of the iteration in days.
   """
   duration: Int!
+  
   """
   The project field that contains this value.
   """
   field: ProjectV2FieldConfiguration!
   id: ID!
+  
   """
   The project item that contains this value.
   """
   item: ProjectV2Item!
+  
   """
   The ID of the iteration.
   """
   iterationId: String!
+  
   """
   The start date of the iteration.
   """
   startDate: Date!
+  
   """
   The title of the iteration.
   """
   title: String!
+  
   """
   The title of the iteration, with HTML.
   """
   titleHTML: String!
+  
   """
   Identifies the date and time when the object was last updated.
   """
@@ -28351,6 +32295,7 @@ type ProjectV2ItemFieldLabelValue {
   The field that contains this value.
   """
   field: ProjectV2FieldConfiguration!
+  
   """
   Labels value of a field
   """
@@ -28359,14 +32304,17 @@ type ProjectV2ItemFieldLabelValue {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
@@ -28382,6 +32330,7 @@ type ProjectV2ItemFieldMilestoneValue {
   The field that contains this value.
   """
   field: ProjectV2FieldConfiguration!
+  
   """
   Milestone value of a field
   """
@@ -28396,27 +32345,33 @@ type ProjectV2ItemFieldNumberValue implements Node & ProjectV2ItemFieldValueComm
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
+  
   """
   The actor who created the item.
   """
   creator: Actor
+  
   """
   Identifies the primary key from the database.
   """
   databaseId: Int
+  
   """
   The project field that contains this value.
   """
   field: ProjectV2FieldConfiguration!
   id: ID!
+  
   """
   The project item that contains this value.
   """
   item: ProjectV2Item!
+  
   """
   Number as a float(8)
   """
   number: Float
+  
   """
   Identifies the date and time when the object was last updated.
   """
@@ -28431,6 +32386,7 @@ type ProjectV2ItemFieldPullRequestValue {
   The field that contains this value.
   """
   field: ProjectV2FieldConfiguration!
+  
   """
   The pull requests for this field
   """
@@ -28439,18 +32395,22 @@ type ProjectV2ItemFieldPullRequestValue {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for pull requests.
     """
@@ -28466,6 +32426,7 @@ type ProjectV2ItemFieldRepositoryValue {
   The field that contains this value.
   """
   field: ProjectV2FieldConfiguration!
+  
   """
   The repository for this field.
   """
@@ -28480,6 +32441,7 @@ type ProjectV2ItemFieldReviewerValue {
   The field that contains this value.
   """
   field: ProjectV2FieldConfiguration!
+  
   """
   The reviewers for this field.
   """
@@ -28488,14 +32450,17 @@ type ProjectV2ItemFieldReviewerValue {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
@@ -28511,47 +32476,58 @@ type ProjectV2ItemFieldSingleSelectValue implements Node & ProjectV2ItemFieldVal
   The color applied to the selected single-select option.
   """
   color: ProjectV2SingleSelectFieldOptionColor!
+  
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
+  
   """
   The actor who created the item.
   """
   creator: Actor
+  
   """
   Identifies the primary key from the database.
   """
   databaseId: Int
+  
   """
   A plain-text description of the selected single-select option, such as what the option means.
   """
   description: String
+  
   """
   The description of the selected single-select option, including HTML tags.
   """
   descriptionHTML: String
+  
   """
   The project field that contains this value.
   """
   field: ProjectV2FieldConfiguration!
   id: ID!
+  
   """
   The project item that contains this value.
   """
   item: ProjectV2Item!
+  
   """
   The name of the selected single select option.
   """
   name: String
+  
   """
   The html name of the selected single select option.
   """
   nameHTML: String
+  
   """
   The id of the selected single select option.
   """
   optionId: String
+  
   """
   Identifies the date and time when the object was last updated.
   """
@@ -28566,27 +32542,33 @@ type ProjectV2ItemFieldTextValue implements Node & ProjectV2ItemFieldValueCommon
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
+  
   """
   The actor who created the item.
   """
   creator: Actor
+  
   """
   Identifies the primary key from the database.
   """
   databaseId: Int
+  
   """
   The project field that contains this value.
   """
   field: ProjectV2FieldConfiguration!
   id: ID!
+  
   """
   The project item that contains this value.
   """
   item: ProjectV2Item!
+  
   """
   Text value of a field
   """
   text: String
+  
   """
   Identifies the date and time when the object was last updated.
   """
@@ -28601,6 +32583,7 @@ type ProjectV2ItemFieldUserValue {
   The field that contains this value.
   """
   field: ProjectV2FieldConfiguration!
+  
   """
   The users for this field
   """
@@ -28609,14 +32592,17 @@ type ProjectV2ItemFieldUserValue {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
@@ -28647,23 +32633,28 @@ interface ProjectV2ItemFieldValueCommon {
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
+  
   """
   The actor who created the item.
   """
   creator: Actor
+  
   """
   Identifies the primary key from the database.
   """
   databaseId: Int
+  
   """
   The project field that contains this value.
   """
   field: ProjectV2FieldConfiguration!
   id: ID!
+  
   """
   The project item that contains this value.
   """
   item: ProjectV2Item!
+  
   """
   Identifies the date and time when the object was last updated.
   """
@@ -28678,14 +32669,17 @@ type ProjectV2ItemFieldValueConnection {
   A list of edges.
   """
   edges: [ProjectV2ItemFieldValueEdge]
+  
   """
   A list of nodes.
   """
   nodes: [ProjectV2ItemFieldValue]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -28700,6 +32694,7 @@ type ProjectV2ItemFieldValueEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -28714,6 +32709,7 @@ input ProjectV2ItemFieldValueOrder {
   The ordering direction.
   """
   direction: OrderDirection!
+  
   """
   The field to order the project v2 item field values by.
   """
@@ -28738,6 +32734,7 @@ input ProjectV2ItemOrder {
   The ordering direction.
   """
   direction: OrderDirection!
+  
   """
   The field to order the project v2 items by.
   """
@@ -28784,27 +32781,33 @@ type ProjectV2IterationField implements Node & ProjectV2FieldCommon {
   Iteration configuration settings
   """
   configuration: ProjectV2IterationFieldConfiguration!
+  
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
+  
   """
   The field's type.
   """
   dataType: ProjectV2FieldType!
+  
   """
   Identifies the primary key from the database.
   """
   databaseId: Int
   id: ID!
+  
   """
   The project field's name.
   """
   name: String!
+  
   """
   The project that contains this field.
   """
   project: ProjectV2!
+  
   """
   Identifies the date and time when the object was last updated.
   """
@@ -28819,14 +32822,17 @@ type ProjectV2IterationFieldConfiguration {
   The iteration's completed iterations
   """
   completedIterations: [ProjectV2IterationFieldIteration!]!
+  
   """
   The iteration's duration in days
   """
   duration: Int!
+  
   """
   The iteration's iterations
   """
   iterations: [ProjectV2IterationFieldIteration!]!
+  
   """
   The iteration's start day of the week
   """
@@ -28841,18 +32847,22 @@ type ProjectV2IterationFieldIteration {
   The iteration's duration in days
   """
   duration: Int!
+  
   """
   The iteration's ID.
   """
   id: String!
+  
   """
   The iteration's start date
   """
   startDate: Date!
+  
   """
   The iteration's title.
   """
   title: String!
+  
   """
   The iteration's html title.
   """
@@ -28867,6 +32877,7 @@ input ProjectV2Order {
   The direction in which to order projects by the specified field.
   """
   direction: OrderDirection!
+  
   """
   The field in which to order projects by.
   """
@@ -28900,6 +32911,7 @@ Represents an owner of a project (beta).
 """
 interface ProjectV2Owner {
   id: ID!
+  
   """
   Find a project by number.
   """
@@ -28909,6 +32921,7 @@ interface ProjectV2Owner {
     """
     number: Int!
   ): ProjectV2
+  
   """
   A list of projects under the owner.
   """
@@ -28917,22 +32930,27 @@ interface ProjectV2Owner {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     How to order the returned projects.
     """
     orderBy: ProjectV2Order = { field: NUMBER, direction: DESC }
+    
     """
     A project to search for under the the owner.
     """
@@ -28952,14 +32970,17 @@ interface ProjectV2Recent {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
@@ -28997,19 +33018,23 @@ type ProjectV2SingleSelectField implements Node & ProjectV2FieldCommon {
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
+  
   """
   The field's type.
   """
   dataType: ProjectV2FieldType!
+  
   """
   Identifies the primary key from the database.
   """
   databaseId: Int
   id: ID!
+  
   """
   The project field's name.
   """
   name: String!
+  
   """
   Options for the single select field
   """
@@ -29019,10 +33044,12 @@ type ProjectV2SingleSelectField implements Node & ProjectV2FieldCommon {
     """
     names: [String!]
   ): [ProjectV2SingleSelectFieldOption!]!
+  
   """
   The project that contains this field.
   """
   project: ProjectV2!
+  
   """
   Identifies the date and time when the object was last updated.
   """
@@ -29037,22 +33064,27 @@ type ProjectV2SingleSelectFieldOption {
   The option's display color.
   """
   color: ProjectV2SingleSelectFieldOptionColor!
+  
   """
   The option's plain-text description.
   """
   description: String!
+  
   """
   The option's description, possibly containing HTML.
   """
   descriptionHTML: String!
+  
   """
   The option's ID.
   """
   id: String!
+  
   """
   The option's name.
   """
   name: String!
+  
   """
   The option's html name.
   """
@@ -29105,10 +33137,12 @@ input ProjectV2SingleSelectFieldOptionInput {
   The display color of the option
   """
   color: ProjectV2SingleSelectFieldOptionColor!
+  
   """
   The description text of the option
   """
   description: String!
+  
   """
   The name of the option
   """
@@ -29123,6 +33157,7 @@ type ProjectV2SortBy {
   The direction of the sorting. Possible values are ASC and DESC.
   """
   direction: OrderDirection!
+  
   """
   The field by which items are sorted.
   """
@@ -29137,14 +33172,17 @@ type ProjectV2SortByConnection {
   A list of edges.
   """
   edges: [ProjectV2SortByEdge]
+  
   """
   A list of nodes.
   """
   nodes: [ProjectV2SortBy]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -29159,6 +33197,7 @@ type ProjectV2SortByEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -29173,6 +33212,7 @@ type ProjectV2SortByField {
   The direction of the sorting. Possible values are ASC and DESC.
   """
   direction: OrderDirection!
+  
   """
   The field by which items are sorted.
   """
@@ -29187,14 +33227,17 @@ type ProjectV2SortByFieldConnection {
   A list of edges.
   """
   edges: [ProjectV2SortByFieldEdge]
+  
   """
   A list of nodes.
   """
   nodes: [ProjectV2SortByField]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -29209,6 +33252,7 @@ type ProjectV2SortByFieldEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -29237,10 +33281,12 @@ type ProjectV2View implements Node {
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
+  
   """
   Identifies the primary key from the database.
   """
   databaseId: Int
+  
   """
   The view's visible fields.
   """
@@ -29249,27 +33295,33 @@ type ProjectV2View implements Node {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for the project v2 fields returned from the connection.
     """
     orderBy: ProjectV2FieldOrder = { field: POSITION, direction: ASC }
   ): ProjectV2FieldConfigurationConnection
+  
   """
   The project view's filter.
   """
   filter: String
+  
   """
   The view's group-by field.
   """
@@ -29278,18 +33330,22 @@ type ProjectV2View implements Node {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for the project v2 fields returned from the connection.
     """
@@ -29298,6 +33354,7 @@ type ProjectV2View implements Node {
     @deprecated(
       reason: "The `ProjectV2View#order_by` API is deprecated in favour of the more capable `ProjectV2View#group_by_field` API. Check out the `ProjectV2View#group_by_fields` API as an example for the more capable alternative. Removal on 2023-04-01 UTC."
     )
+  
   """
   The view's group-by field.
   """
@@ -29306,40 +33363,49 @@ type ProjectV2View implements Node {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for the project v2 fields returned from the connection.
     """
     orderBy: ProjectV2FieldOrder = { field: POSITION, direction: ASC }
   ): ProjectV2FieldConfigurationConnection
   id: ID!
+  
   """
   The project view's layout.
   """
   layout: ProjectV2ViewLayout!
+  
   """
   The project view's name.
   """
   name: String!
+  
   """
   The project view's number.
   """
   number: Int!
+  
   """
   The project that contains this view.
   """
   project: ProjectV2!
+  
   """
   The view's sort-by config.
   """
@@ -29348,14 +33414,17 @@ type ProjectV2View implements Node {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
@@ -29364,6 +33433,7 @@ type ProjectV2View implements Node {
     @deprecated(
       reason: "The `ProjectV2View#sort_by` API is deprecated in favour of the more capable `ProjectV2View#sort_by_fields` API. Check out the `ProjectV2View#sort_by_fields` API as an example for the more capable alternative. Removal on 2023-04-01 UTC."
     )
+  
   """
   The view's sort-by config.
   """
@@ -29372,23 +33442,28 @@ type ProjectV2View implements Node {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): ProjectV2SortByFieldConnection
+  
   """
   Identifies the date and time when the object was last updated.
   """
   updatedAt: DateTime!
+  
   """
   The view's vertical-group-by field.
   """
@@ -29397,18 +33472,22 @@ type ProjectV2View implements Node {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for the project v2 fields returned from the connection.
     """
@@ -29417,6 +33496,7 @@ type ProjectV2View implements Node {
     @deprecated(
       reason: "The `ProjectV2View#vertical_group_by` API is deprecated in favour of the more capable `ProjectV2View#vertical_group_by_fields` API. Check out the `ProjectV2View#vertical_group_by_fields` API as an example for the more capable alternative. Removal on 2023-04-01 UTC."
     )
+  
   """
   The view's vertical-group-by field.
   """
@@ -29425,23 +33505,28 @@ type ProjectV2View implements Node {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for the project v2 fields returned from the connection.
     """
     orderBy: ProjectV2FieldOrder = { field: POSITION, direction: ASC }
   ): ProjectV2FieldConfigurationConnection
+  
   """
   The view's visible fields.
   """
@@ -29450,18 +33535,22 @@ type ProjectV2View implements Node {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for the project v2 fields returned from the connection.
     """
@@ -29480,14 +33569,17 @@ type ProjectV2ViewConnection {
   A list of edges.
   """
   edges: [ProjectV2ViewEdge]
+  
   """
   A list of nodes.
   """
   nodes: [ProjectV2View]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -29502,6 +33594,7 @@ type ProjectV2ViewEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -29534,6 +33627,7 @@ input ProjectV2ViewOrder {
   The ordering direction.
   """
   direction: OrderDirection!
+  
   """
   The field to order the project v2 views by.
   """
@@ -29566,27 +33660,33 @@ type ProjectV2Workflow implements Node {
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
+  
   """
   Identifies the primary key from the database.
   """
   databaseId: Int
+  
   """
   The workflows' enabled state.
   """
   enabled: Boolean!
   id: ID!
+  
   """
   The workflows' name.
   """
   name: String!
+  
   """
   The workflows' number.
   """
   number: Int!
+  
   """
   The project that contains this workflow.
   """
   project: ProjectV2!
+  
   """
   Identifies the date and time when the object was last updated.
   """
@@ -29601,14 +33701,17 @@ type ProjectV2WorkflowConnection {
   A list of edges.
   """
   edges: [ProjectV2WorkflowEdge]
+  
   """
   A list of nodes.
   """
   nodes: [ProjectV2Workflow]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -29623,6 +33726,7 @@ type ProjectV2WorkflowEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -29637,6 +33741,7 @@ input ProjectV2WorkflowOrder {
   The ordering direction.
   """
   direction: OrderDirection!
+  
   """
   The field to order the project v2 workflows by.
   """
@@ -29673,24 +33778,29 @@ type PublicKey implements Node {
   The last time this authorization was used to perform an action. Values will be null for keys not owned by the user.
   """
   accessedAt: DateTime
+  
   """
   Identifies the date and time when the key was created. Keys created before
   March 5th, 2014 have inaccurate values. Values will be null for keys not owned by the user.
   """
   createdAt: DateTime
+  
   """
   The fingerprint for this PublicKey.
   """
   fingerprint: String!
   id: ID!
+  
   """
   Whether this PublicKey is read-only or not. Values will be null for keys not owned by the user.
   """
   isReadOnly: Boolean
+  
   """
   The public key string.
   """
   key: String!
+  
   """
   Identifies the date and time when the key was updated. Keys created before
   March 5th, 2014 may have inaccurate values. Values will be null for keys not
@@ -29707,14 +33817,17 @@ type PublicKeyConnection {
   A list of edges.
   """
   edges: [PublicKeyEdge]
+  
   """
   A list of nodes.
   """
   nodes: [PublicKey]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -29729,6 +33842,7 @@ type PublicKeyEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -29743,6 +33857,7 @@ input PublishSponsorsTierInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The ID of the draft tier to publish.
   """
@@ -29757,6 +33872,7 @@ type PublishSponsorsTierPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The tier that was published.
   """
@@ -29771,10 +33887,12 @@ type PullRequest implements Assignable & Closable & Comment & Labelable & Lockab
   Reason that the conversation was locked.
   """
   activeLockReason: LockReason
+  
   """
   The number of additions in this pull request.
   """
   additions: Int!
+  
   """
   A list of Users assigned to this object.
   """
@@ -29783,83 +33901,103 @@ type PullRequest implements Assignable & Closable & Comment & Labelable & Lockab
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): UserConnection!
+  
   """
   The actor who authored the comment.
   """
   author: Actor
+  
   """
   Author's association with the subject of the comment.
   """
   authorAssociation: CommentAuthorAssociation!
+  
   """
   Returns the auto-merge request object if one exists for this pull request.
   """
   autoMergeRequest: AutoMergeRequest
+  
   """
   Identifies the base Ref associated with the pull request.
   """
   baseRef: Ref
+  
   """
   Identifies the name of the base Ref associated with the pull request, even if the ref has been deleted.
   """
   baseRefName: String!
+  
   """
   Identifies the oid of the base ref associated with the pull request, even if the ref has been deleted.
   """
   baseRefOid: GitObjectID!
+  
   """
   The repository associated with this pull request's base Ref.
   """
   baseRepository: Repository
+  
   """
   The body as Markdown.
   """
   body: String!
+  
   """
   The body rendered to HTML.
   """
   bodyHTML: HTML!
+  
   """
   The body rendered to text.
   """
   bodyText: String!
+  
   """
   Whether or not the pull request is rebaseable.
   """
   canBeRebased: Boolean! @preview(toggledBy: "merge-info-preview")
+  
   """
   The number of changed files in this pull request.
   """
   changedFiles: Int!
+  
   """
   The HTTP path for the checks of this pull request.
   """
   checksResourcePath: URI!
+  
   """
   The HTTP URL for the checks of this pull request.
   """
   checksUrl: URI!
+  
   """
   `true` if the pull request is closed
   """
   closed: Boolean!
+  
   """
   Identifies the date and time when the object was closed.
   """
   closedAt: DateTime
+  
   """
   List of issues that were may be closed by this pull request
   """
@@ -29868,27 +34006,33 @@ type PullRequest implements Assignable & Closable & Comment & Labelable & Lockab
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for issues returned from the connection
     """
     orderBy: IssueOrder
+    
     """
     Return only manually linked Issues
     """
     userLinkedOnly: Boolean = false
   ): IssueConnection
+  
   """
   A list of comments associated with the pull request.
   """
@@ -29897,23 +34041,28 @@ type PullRequest implements Assignable & Closable & Comment & Labelable & Lockab
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for issue comments returned from the connection.
     """
     orderBy: IssueCommentOrder
   ): IssueCommentConnection!
+  
   """
   A list of commits present in this pull request's head branch not present in the base branch.
   """
@@ -29922,39 +34071,48 @@ type PullRequest implements Assignable & Closable & Comment & Labelable & Lockab
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): PullRequestCommitConnection!
+  
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
+  
   """
   Check if this comment was created via an email reply.
   """
   createdViaEmail: Boolean!
+  
   """
   Identifies the primary key from the database.
   """
   databaseId: Int
+  
   """
   The number of deletions in this pull request.
   """
   deletions: Int!
+  
   """
   The actor who edited this pull request's body.
   """
   editor: Actor
+  
   """
   Lists the files changed within this pull request.
   """
@@ -29963,39 +34121,48 @@ type PullRequest implements Assignable & Closable & Comment & Labelable & Lockab
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): PullRequestChangedFileConnection
+  
   """
   Identifies the head Ref associated with the pull request.
   """
   headRef: Ref
+  
   """
   Identifies the name of the head Ref associated with the pull request, even if the ref has been deleted.
   """
   headRefName: String!
+  
   """
   Identifies the oid of the head ref associated with the pull request, even if the ref has been deleted.
   """
   headRefOid: GitObjectID!
+  
   """
   The repository associated with this pull request's head Ref.
   """
   headRepository: Repository
+  
   """
   The owner of the repository associated with this pull request's head Ref.
   """
   headRepositoryOwner: RepositoryOwner
+  
   """
   The hovercard information for this issue
   """
@@ -30006,22 +34173,27 @@ type PullRequest implements Assignable & Closable & Comment & Labelable & Lockab
     includeNotificationContexts: Boolean = true
   ): Hovercard!
   id: ID!
+  
   """
   Check if this comment was edited and includes an edit with the creation data
   """
   includesCreatedEdit: Boolean!
+  
   """
   The head and base repositories are different.
   """
   isCrossRepository: Boolean!
+  
   """
   Identifies if the pull request is a draft.
   """
   isDraft: Boolean!
+  
   """
   Is this pull request read by the viewer
   """
   isReadByViewer: Boolean
+  
   """
   A list of labels associated with the object.
   """
@@ -30030,27 +34202,33 @@ type PullRequest implements Assignable & Closable & Comment & Labelable & Lockab
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for labels returned from the connection.
     """
     orderBy: LabelOrder = { field: CREATED_AT, direction: ASC }
   ): LabelConnection
+  
   """
   The moment the editor made the last edit
   """
   lastEditedAt: DateTime
+  
   """
   A list of latest reviews per user associated with the pull request.
   """
@@ -30059,23 +34237,28 @@ type PullRequest implements Assignable & Closable & Comment & Labelable & Lockab
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Only return reviews from user who have write access to the repository
     """
     writersOnly: Boolean = false
   ): PullRequestReviewConnection
+  
   """
   A list of latest reviews per user associated with the pull request that are not also pending review.
   """
@@ -30084,63 +34267,78 @@ type PullRequest implements Assignable & Closable & Comment & Labelable & Lockab
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): PullRequestReviewConnection
+  
   """
   `true` if the pull request is locked
   """
   locked: Boolean!
+  
   """
   Indicates whether maintainers can modify the pull request.
   """
   maintainerCanModify: Boolean!
+  
   """
   The commit that was created when this pull request was merged.
   """
   mergeCommit: Commit
+  
   """
   The merge queue entry of the pull request in the base branch's merge queue
   """
   mergeQueueEntry: MergeQueueEntry
+  
   """
   Detailed information about the current pull request merge state status.
   """
   mergeStateStatus: MergeStateStatus! @preview(toggledBy: "merge-info-preview")
+  
   """
   Whether or not the pull request can be merged based on the existence of merge conflicts.
   """
   mergeable: MergeableState!
+  
   """
   Whether or not the pull request was merged.
   """
   merged: Boolean!
+  
   """
   The date and time that the pull request was merged.
   """
   mergedAt: DateTime
+  
   """
   The actor who merged the pull request.
   """
   mergedBy: Actor
+  
   """
   Identifies the milestone associated with the pull request.
   """
   milestone: Milestone
+  
   """
   Identifies the pull request number.
   """
   number: Int!
+  
   """
   A list of Users that are participating in the Pull Request conversation.
   """
@@ -30149,23 +34347,28 @@ type PullRequest implements Assignable & Closable & Comment & Labelable & Lockab
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): UserConnection!
+  
   """
   The permalink to the pull request.
   """
   permalink: URI!
+  
   """
   The commit that GitHub automatically generated to test if this pull request
   could be merged. This field will not return a value if the pull request is
@@ -30173,6 +34376,7 @@ type PullRequest implements Assignable & Closable & Comment & Labelable & Lockab
   `mergeable` field for more details on the mergeability of the pull request.
   """
   potentialMergeCommit: Commit
+  
   """
   List of project cards associated with this pull request.
   """
@@ -30181,23 +34385,28 @@ type PullRequest implements Assignable & Closable & Comment & Labelable & Lockab
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     A list of archived states to filter the cards by
     """
     archivedStates: [ProjectCardArchivedState] = [ARCHIVED, NOT_ARCHIVED]
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): ProjectCardConnection!
+  
   """
   List of project items associated with this pull request.
   """
@@ -30206,23 +34415,28 @@ type PullRequest implements Assignable & Closable & Comment & Labelable & Lockab
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Include archived items.
     """
     includeArchived: Boolean = true
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): ProjectV2ItemConnection!
+  
   """
   Find a project by number.
   """
@@ -30232,6 +34446,7 @@ type PullRequest implements Assignable & Closable & Comment & Labelable & Lockab
     """
     number: Int!
   ): ProjectV2
+  
   """
   A list of projects under the owner.
   """
@@ -30240,35 +34455,43 @@ type PullRequest implements Assignable & Closable & Comment & Labelable & Lockab
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     How to order the returned projects.
     """
     orderBy: ProjectV2Order = { field: NUMBER, direction: DESC }
+    
     """
     A project to search for under the the owner.
     """
     query: String
   ): ProjectV2Connection!
+  
   """
   Identifies when the comment was published at.
   """
   publishedAt: DateTime
+  
   """
   A list of reactions grouped by content left on the subject.
   """
   reactionGroups: [ReactionGroup!]
+  
   """
   A list of Reactions left on the Issue.
   """
@@ -30277,47 +34500,58 @@ type PullRequest implements Assignable & Closable & Comment & Labelable & Lockab
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Allows filtering Reactions by emoji.
     """
     content: ReactionContent
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Allows specifying the order in which reactions are returned.
     """
     orderBy: ReactionOrder
   ): ReactionConnection!
+  
   """
   The repository associated with this node.
   """
   repository: Repository!
+  
   """
   The HTTP path for this pull request.
   """
   resourcePath: URI!
+  
   """
   The HTTP path for reverting this pull request.
   """
   revertResourcePath: URI!
+  
   """
   The HTTP URL for reverting this pull request.
   """
   revertUrl: URI!
+  
   """
   The current status of this pull request with respect to code review.
   """
   reviewDecision: PullRequestReviewDecision
+  
   """
   A list of review requests associated with the pull request.
   """
@@ -30326,19 +34560,23 @@ type PullRequest implements Assignable & Closable & Comment & Labelable & Lockab
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): ReviewRequestConnection
+  
   """
   The list of all review threads for this pull request.
   """
@@ -30347,19 +34585,23 @@ type PullRequest implements Assignable & Closable & Comment & Labelable & Lockab
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): PullRequestReviewThreadConnection!
+  
   """
   A list of reviews associated with the pull request.
   """
@@ -30368,35 +34610,43 @@ type PullRequest implements Assignable & Closable & Comment & Labelable & Lockab
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Filter by author of the review.
     """
     author: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     A list of states to filter the reviews.
     """
     states: [PullRequestReviewState!]
   ): PullRequestReviewConnection
+  
   """
   Identifies the state of the pull request.
   """
   state: PullRequestState!
+  
   """
   A list of reviewer suggestions based on commit history and past review comments.
   """
   suggestedReviewers: [SuggestedReviewer]!
+  
   """
   A list of events, comments, commits, etc. associated with the pull request.
   """
@@ -30405,18 +34655,22 @@ type PullRequest implements Assignable & Closable & Comment & Labelable & Lockab
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Allows filtering timeline events by a `since` timestamp.
     """
@@ -30425,6 +34679,7 @@ type PullRequest implements Assignable & Closable & Comment & Labelable & Lockab
     @deprecated(
       reason: "`timeline` will be removed Use PullRequest.timelineItems instead. Removal on 2020-10-01 UTC."
     )
+  
   """
   A list of events, comments, commits, etc. associated with the pull request.
   """
@@ -30433,51 +34688,63 @@ type PullRequest implements Assignable & Closable & Comment & Labelable & Lockab
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Filter timeline items by type.
     """
     itemTypes: [PullRequestTimelineItemsItemType!]
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Filter timeline items by a `since` timestamp.
     """
     since: DateTime
+    
     """
     Skips the first _n_ elements in the list.
     """
     skip: Int
   ): PullRequestTimelineItemsConnection!
+  
   """
   Identifies the pull request title.
   """
   title: String!
+  
   """
   Identifies the pull request title rendered to HTML.
   """
   titleHTML: HTML!
+  
   """
   Returns a count of how many comments this pull request has received.
   """
   totalCommentsCount: Int
+  
   """
   Identifies the date and time when the object was last updated.
   """
   updatedAt: DateTime!
+  
   """
   The HTTP URL for this pull request.
   """
   url: URI!
+  
   """
   A list of edits to this content.
   """
@@ -30486,84 +34753,104 @@ type PullRequest implements Assignable & Closable & Comment & Labelable & Lockab
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): UserContentEditConnection
+  
   """
   Whether or not the viewer can apply suggestion.
   """
   viewerCanApplySuggestion: Boolean!
+  
   """
   Indicates if the object can be closed by the viewer.
   """
   viewerCanClose: Boolean!
+  
   """
   Check if the viewer can restore the deleted head ref.
   """
   viewerCanDeleteHeadRef: Boolean!
+  
   """
   Whether or not the viewer can disable auto-merge
   """
   viewerCanDisableAutoMerge: Boolean!
+  
   """
   Can the viewer edit files within this pull request.
   """
   viewerCanEditFiles: Boolean!
+  
   """
   Whether or not the viewer can enable auto-merge
   """
   viewerCanEnableAutoMerge: Boolean!
+  
   """
   Indicates whether the viewer can bypass branch protections and merge the pull request immediately
   """
   viewerCanMergeAsAdmin: Boolean!
+  
   """
   Can user react to this subject
   """
   viewerCanReact: Boolean!
+  
   """
   Indicates if the object can be reopened by the viewer.
   """
   viewerCanReopen: Boolean!
+  
   """
   Check if the viewer is able to change their subscription status for the repository.
   """
   viewerCanSubscribe: Boolean!
+  
   """
   Check if the current viewer can update this object.
   """
   viewerCanUpdate: Boolean!
+  
   """
   Whether or not the viewer can update the head ref of this PR, by merging or rebasing the base ref.
   If the head ref is up to date or unable to be updated by this user, this will return false.
   """
   viewerCanUpdateBranch: Boolean!
+  
   """
   Reasons why the current viewer can not update this comment.
   """
   viewerCannotUpdateReasons: [CommentCannotUpdateReason!]!
+  
   """
   Did the viewer author this comment.
   """
   viewerDidAuthor: Boolean!
+  
   """
   The latest review given from the viewer.
   """
   viewerLatestReview: PullRequestReview
+  
   """
   The person who has requested the viewer for review on this pull request.
   """
   viewerLatestReviewRequest: ReviewRequest
+  
   """
   The merge body text for the viewer and method.
   """
@@ -30573,6 +34860,7 @@ type PullRequest implements Assignable & Closable & Comment & Labelable & Lockab
     """
     mergeType: PullRequestMergeMethod
   ): String!
+  
   """
   The merge headline text for the viewer and method.
   """
@@ -30582,6 +34870,7 @@ type PullRequest implements Assignable & Closable & Comment & Labelable & Lockab
     """
     mergeType: PullRequestMergeMethod
   ): String!
+  
   """
   Identifies if the viewer is watching, not watching, or ignoring the subscribable entity.
   """
@@ -30610,18 +34899,22 @@ type PullRequestChangedFile {
   The number of additions to the file.
   """
   additions: Int!
+  
   """
   How the file was changed in this PullRequest
   """
   changeType: PatchStatus!
+  
   """
   The number of deletions to the file.
   """
   deletions: Int!
+  
   """
   The path of the file.
   """
   path: String!
+  
   """
   The state of the file for the viewer.
   """
@@ -30636,14 +34929,17 @@ type PullRequestChangedFileConnection {
   A list of edges.
   """
   edges: [PullRequestChangedFileEdge]
+  
   """
   A list of nodes.
   """
   nodes: [PullRequestChangedFile]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -30658,6 +34954,7 @@ type PullRequestChangedFileEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -30673,14 +34970,17 @@ type PullRequestCommit implements Node & UniformResourceLocatable {
   """
   commit: Commit!
   id: ID!
+  
   """
   The pull request this commit belongs to
   """
   pullRequest: PullRequest!
+  
   """
   The HTTP path for this pull request commit
   """
   resourcePath: URI!
+  
   """
   The HTTP URL for this pull request commit
   """
@@ -30699,36 +34999,44 @@ type PullRequestCommitCommentThread implements Node & RepositoryNode {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): CommitCommentConnection!
+  
   """
   The commit the comments were made on.
   """
   commit: Commit!
   id: ID!
+  
   """
   The file the comments were made on.
   """
   path: String
+  
   """
   The position in the diff for the commit that the comment was made on.
   """
   position: Int
+  
   """
   The pull request this commit comment thread belongs to
   """
   pullRequest: PullRequest!
+  
   """
   The repository associated with this node.
   """
@@ -30743,14 +35051,17 @@ type PullRequestCommitConnection {
   A list of edges.
   """
   edges: [PullRequestCommitEdge]
+  
   """
   A list of nodes.
   """
   nodes: [PullRequestCommit]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -30765,6 +35076,7 @@ type PullRequestCommitEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -30779,14 +35091,17 @@ type PullRequestConnection {
   A list of edges.
   """
   edges: [PullRequestEdge]
+  
   """
   A list of nodes.
   """
   nodes: [PullRequest]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -30805,23 +35120,28 @@ type PullRequestContributionsByRepository {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for contributions returned from the connection.
     """
     orderBy: ContributionOrder = { direction: DESC }
   ): CreatedPullRequestContributionConnection!
+  
   """
   The repository in which the pull requests were opened.
   """
@@ -30836,6 +35156,7 @@ type PullRequestEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -30868,6 +35189,7 @@ input PullRequestOrder {
   The direction in which to order pull requests by the specified field.
   """
   direction: OrderDirection!
+  
   """
   The field in which to order pull requests by.
   """
@@ -30896,18 +35218,22 @@ type PullRequestParameters {
   New, reviewable commits pushed will dismiss previous pull request review approvals.
   """
   dismissStaleReviewsOnPush: Boolean!
+  
   """
   Require an approving review in pull requests that modify files that have a designated code owner.
   """
   requireCodeOwnerReview: Boolean!
+  
   """
   Whether the most recent reviewable push must be approved by someone other than the person who pushed it.
   """
   requireLastPushApproval: Boolean!
+  
   """
   The number of approving reviews that are required before a pull request can be merged.
   """
   requiredApprovingReviewCount: Int!
+  
   """
   All conversations on code must be resolved before a pull request can be merged.
   """
@@ -30922,18 +35248,22 @@ input PullRequestParametersInput {
   New, reviewable commits pushed will dismiss previous pull request review approvals.
   """
   dismissStaleReviewsOnPush: Boolean!
+  
   """
   Require an approving review in pull requests that modify files that have a designated code owner.
   """
   requireCodeOwnerReview: Boolean!
+  
   """
   Whether the most recent reviewable push must be approved by someone other than the person who pushed it.
   """
   requireLastPushApproval: Boolean!
+  
   """
   The number of approving reviews that are required before a pull request can be merged.
   """
   requiredApprovingReviewCount: Int!
+  
   """
   All conversations on code must be resolved before a pull request can be merged.
   """
@@ -30948,26 +35278,32 @@ type PullRequestReview implements Comment & Deletable & Node & Reactable & Repos
   The actor who authored the comment.
   """
   author: Actor
+  
   """
   Author's association with the subject of the comment.
   """
   authorAssociation: CommentAuthorAssociation!
+  
   """
   Indicates whether the author of this review has push access to the repository.
   """
   authorCanPushToRepository: Boolean!
+  
   """
   Identifies the pull request review body.
   """
   body: String!
+  
   """
   The body rendered to HTML.
   """
   bodyHTML: HTML!
+  
   """
   The body of this review rendered as plain text.
   """
   bodyText: String!
+  
   """
   A list of review comments for the current pull request review.
   """
@@ -30976,48 +35312,59 @@ type PullRequestReview implements Comment & Deletable & Node & Reactable & Repos
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): PullRequestReviewCommentConnection!
+  
   """
   Identifies the commit associated with this pull request review.
   """
   commit: Commit
+  
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
+  
   """
   Check if this comment was created via an email reply.
   """
   createdViaEmail: Boolean!
+  
   """
   Identifies the primary key from the database.
   """
   databaseId: Int
+  
   """
   The actor who edited the comment.
   """
   editor: Actor
   id: ID!
+  
   """
   Check if this comment was edited and includes an edit with the creation data
   """
   includesCreatedEdit: Boolean!
+  
   """
   The moment the editor made the last edit
   """
   lastEditedAt: DateTime
+  
   """
   A list of teams that this review was made on behalf of.
   """
@@ -31026,31 +35373,38 @@ type PullRequestReview implements Comment & Deletable & Node & Reactable & Repos
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): TeamConnection!
+  
   """
   Identifies when the comment was published at.
   """
   publishedAt: DateTime
+  
   """
   Identifies the pull request associated with this pull request review.
   """
   pullRequest: PullRequest!
+  
   """
   A list of reactions grouped by content left on the subject.
   """
   reactionGroups: [ReactionGroup!]
+  
   """
   A list of Reactions left on the Issue.
   """
@@ -31059,51 +35413,63 @@ type PullRequestReview implements Comment & Deletable & Node & Reactable & Repos
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Allows filtering Reactions by emoji.
     """
     content: ReactionContent
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Allows specifying the order in which reactions are returned.
     """
     orderBy: ReactionOrder
   ): ReactionConnection!
+  
   """
   The repository associated with this node.
   """
   repository: Repository!
+  
   """
   The HTTP path permalink for this PullRequestReview.
   """
   resourcePath: URI!
+  
   """
   Identifies the current state of the pull request review.
   """
   state: PullRequestReviewState!
+  
   """
   Identifies when the Pull Request Review was submitted
   """
   submittedAt: DateTime
+  
   """
   Identifies the date and time when the object was last updated.
   """
   updatedAt: DateTime!
+  
   """
   The HTTP URL permalink for this PullRequestReview.
   """
   url: URI!
+  
   """
   A list of edits to this content.
   """
@@ -31112,35 +35478,43 @@ type PullRequestReview implements Comment & Deletable & Node & Reactable & Repos
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): UserContentEditConnection
+  
   """
   Check if the current viewer can delete this object.
   """
   viewerCanDelete: Boolean!
+  
   """
   Can user react to this subject
   """
   viewerCanReact: Boolean!
+  
   """
   Check if the current viewer can update this object.
   """
   viewerCanUpdate: Boolean!
+  
   """
   Reasons why the current viewer can not update this comment.
   """
   viewerCannotUpdateReasons: [CommentCannotUpdateReason!]!
+  
   """
   Did the viewer author this comment.
   """
@@ -31155,81 +35529,100 @@ type PullRequestReviewComment implements Comment & Deletable & Minimizable & Nod
   The actor who authored the comment.
   """
   author: Actor
+  
   """
   Author's association with the subject of the comment.
   """
   authorAssociation: CommentAuthorAssociation!
+  
   """
   The comment body of this review comment.
   """
   body: String!
+  
   """
   The body rendered to HTML.
   """
   bodyHTML: HTML!
+  
   """
   The comment body of this review comment rendered as plain text.
   """
   bodyText: String!
+  
   """
   Identifies the commit associated with the comment.
   """
   commit: Commit
+  
   """
   Identifies when the comment was created.
   """
   createdAt: DateTime!
+  
   """
   Check if this comment was created via an email reply.
   """
   createdViaEmail: Boolean!
+  
   """
   Identifies the primary key from the database.
   """
   databaseId: Int
+  
   """
   The diff hunk to which the comment applies.
   """
   diffHunk: String!
+  
   """
   Identifies when the comment was created in a draft state.
   """
   draftedAt: DateTime!
+  
   """
   The actor who edited the comment.
   """
   editor: Actor
   id: ID!
+  
   """
   Check if this comment was edited and includes an edit with the creation data
   """
   includesCreatedEdit: Boolean!
+  
   """
   Returns whether or not a comment has been minimized.
   """
   isMinimized: Boolean!
+  
   """
   The moment the editor made the last edit
   """
   lastEditedAt: DateTime
+  
   """
   The end line number on the file to which the comment applies
   """
   line: Int
+  
   """
   Returns why the comment was minimized. One of `abuse`, `off-topic`,
   `outdated`, `resolved`, `duplicate` and `spam`. Note that the case and
   formatting of these values differs from the inputs to the `MinimizeComment` mutation.
   """
   minimizedReason: String
+  
   """
   Identifies the original commit associated with the comment.
   """
   originalCommit: Commit
+  
   """
   The end line number on the file to which the comment applied when it was first created
   """
   originalLine: Int
+  
   """
   The original line index in the diff to which the comment applies.
   """
@@ -31237,18 +35630,22 @@ type PullRequestReviewComment implements Comment & Deletable & Minimizable & Nod
     @deprecated(
       reason: "We are phasing out diff-relative positioning for PR comments Removal on 2023-10-01 UTC."
     )
+  
   """
   The start line number on the file to which the comment applied when it was first created
   """
   originalStartLine: Int
+  
   """
   Identifies when the comment body is outdated
   """
   outdated: Boolean!
+  
   """
   The path to which the comment applies.
   """
   path: String!
+  
   """
   The line index in the diff to which the comment applies.
   """
@@ -31256,22 +35653,27 @@ type PullRequestReviewComment implements Comment & Deletable & Minimizable & Nod
     @deprecated(
       reason: "We are phasing out diff-relative positioning for PR comments Use the `line` and `startLine` fields instead, which are file line numbers instead of diff line numbers Removal on 2023-10-01 UTC."
     )
+  
   """
   Identifies when the comment was published at.
   """
   publishedAt: DateTime
+  
   """
   The pull request associated with this review comment.
   """
   pullRequest: PullRequest!
+  
   """
   The pull request review associated with this review comment.
   """
   pullRequestReview: PullRequestReview
+  
   """
   A list of reactions grouped by content left on the subject.
   """
   reactionGroups: [ReactionGroup!]
+  
   """
   A list of Reactions left on the Issue.
   """
@@ -31280,59 +35682,73 @@ type PullRequestReviewComment implements Comment & Deletable & Minimizable & Nod
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Allows filtering Reactions by emoji.
     """
     content: ReactionContent
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Allows specifying the order in which reactions are returned.
     """
     orderBy: ReactionOrder
   ): ReactionConnection!
+  
   """
   The comment this is a reply to.
   """
   replyTo: PullRequestReviewComment
+  
   """
   The repository associated with this node.
   """
   repository: Repository!
+  
   """
   The HTTP path permalink for this review comment.
   """
   resourcePath: URI!
+  
   """
   The start line number on the file to which the comment applies
   """
   startLine: Int
+  
   """
   Identifies the state of the comment.
   """
   state: PullRequestReviewCommentState!
+  
   """
   The level at which the comments in the corresponding thread are targeted, can be a diff line or a file
   """
   subjectType: PullRequestReviewThreadSubjectType!
+  
   """
   Identifies when the comment was last updated.
   """
   updatedAt: DateTime!
+  
   """
   The HTTP URL permalink for this review comment.
   """
   url: URI!
+  
   """
   A list of edits to this content.
   """
@@ -31341,39 +35757,48 @@ type PullRequestReviewComment implements Comment & Deletable & Minimizable & Nod
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): UserContentEditConnection
+  
   """
   Check if the current viewer can delete this object.
   """
   viewerCanDelete: Boolean!
+  
   """
   Check if the current viewer can minimize this object.
   """
   viewerCanMinimize: Boolean!
+  
   """
   Can user react to this subject
   """
   viewerCanReact: Boolean!
+  
   """
   Check if the current viewer can update this object.
   """
   viewerCanUpdate: Boolean!
+  
   """
   Reasons why the current viewer can not update this comment.
   """
   viewerCannotUpdateReasons: [CommentCannotUpdateReason!]!
+  
   """
   Did the viewer author this comment.
   """
@@ -31388,14 +35813,17 @@ type PullRequestReviewCommentConnection {
   A list of edges.
   """
   edges: [PullRequestReviewCommentEdge]
+  
   """
   A list of nodes.
   """
   nodes: [PullRequestReviewComment]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -31410,6 +35838,7 @@ type PullRequestReviewCommentEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -31438,14 +35867,17 @@ type PullRequestReviewConnection {
   A list of edges.
   """
   edges: [PullRequestReviewEdge]
+  
   """
   A list of nodes.
   """
   nodes: [PullRequestReview]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -31464,23 +35896,28 @@ type PullRequestReviewContributionsByRepository {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for contributions returned from the connection.
     """
     orderBy: ContributionOrder = { direction: DESC }
   ): CreatedPullRequestReviewContributionConnection!
+  
   """
   The repository in which the pull request reviews were made.
   """
@@ -31513,6 +35950,7 @@ type PullRequestReviewEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -31579,88 +36017,109 @@ type PullRequestReviewThread implements Node {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Skips the first _n_ elements in the list.
     """
     skip: Int
   ): PullRequestReviewCommentConnection!
+  
   """
   The side of the diff on which this thread was placed.
   """
   diffSide: DiffSide!
   id: ID!
+  
   """
   Whether or not the thread has been collapsed (resolved)
   """
   isCollapsed: Boolean!
+  
   """
   Indicates whether this thread was outdated by newer changes.
   """
   isOutdated: Boolean!
+  
   """
   Whether this thread has been resolved
   """
   isResolved: Boolean!
+  
   """
   The line in the file to which this thread refers
   """
   line: Int
+  
   """
   The original line in the file to which this thread refers.
   """
   originalLine: Int
+  
   """
   The original start line in the file to which this thread refers (multi-line only).
   """
   originalStartLine: Int
+  
   """
   Identifies the file path of this thread.
   """
   path: String!
+  
   """
   Identifies the pull request associated with this thread.
   """
   pullRequest: PullRequest!
+  
   """
   Identifies the repository associated with this thread.
   """
   repository: Repository!
+  
   """
   The user who resolved this thread
   """
   resolvedBy: User
+  
   """
   The side of the diff that the first line of the thread starts on (multi-line only)
   """
   startDiffSide: DiffSide
+  
   """
   The start line in the file to which this thread refers (multi-line only)
   """
   startLine: Int
+  
   """
   The level at which the comments in the corresponding thread are targeted, can be a diff line or a file
   """
   subjectType: PullRequestReviewThreadSubjectType!
+  
   """
   Indicates whether the current viewer can reply to this thread.
   """
   viewerCanReply: Boolean!
+  
   """
   Whether or not the viewer can resolve this thread
   """
   viewerCanResolve: Boolean!
+  
   """
   Whether or not the viewer can unresolve this thread
   """
@@ -31675,14 +36134,17 @@ type PullRequestReviewThreadConnection {
   A list of edges.
   """
   edges: [PullRequestReviewThreadEdge]
+  
   """
   A list of nodes.
   """
   nodes: [PullRequestReviewThread]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -31697,6 +36159,7 @@ type PullRequestReviewThreadEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -31725,10 +36188,12 @@ type PullRequestRevisionMarker {
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
+  
   """
   The last commit the viewer has seen.
   """
   lastSeenCommit: Commit!
+  
   """
   The pull request to which the marker belongs.
   """
@@ -31761,10 +36226,12 @@ type PullRequestTemplate {
   The body of the template
   """
   body: String
+  
   """
   The filename of the template
   """
   filename: String
+  
   """
   The repository the template belongs to
   """
@@ -31783,80 +36250,99 @@ type PullRequestThread implements Node {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Skips the first _n_ elements in the list.
     """
     skip: Int
   ): PullRequestReviewCommentConnection!
+  
   """
   The side of the diff on which this thread was placed.
   """
   diffSide: DiffSide!
   id: ID!
+  
   """
   Whether or not the thread has been collapsed (resolved)
   """
   isCollapsed: Boolean!
+  
   """
   Indicates whether this thread was outdated by newer changes.
   """
   isOutdated: Boolean!
+  
   """
   Whether this thread has been resolved
   """
   isResolved: Boolean!
+  
   """
   The line in the file to which this thread refers
   """
   line: Int
+  
   """
   Identifies the file path of this thread.
   """
   path: String!
+  
   """
   Identifies the pull request associated with this thread.
   """
   pullRequest: PullRequest!
+  
   """
   Identifies the repository associated with this thread.
   """
   repository: Repository!
+  
   """
   The user who resolved this thread
   """
   resolvedBy: User
+  
   """
   The side of the diff that the first line of the thread starts on (multi-line only)
   """
   startDiffSide: DiffSide
+  
   """
   The line of the first file diff in the thread.
   """
   startLine: Int
+  
   """
   The level at which the comments in the corresponding thread are targeted, can be a diff line or a file
   """
   subjectType: PullRequestReviewThreadSubjectType!
+  
   """
   Indicates whether the current viewer can reply to this thread.
   """
   viewerCanReply: Boolean!
+  
   """
   Whether or not the viewer can resolve this thread
   """
   viewerCanResolve: Boolean!
+  
   """
   Whether or not the viewer can unresolve this thread
   """
@@ -31871,14 +36357,17 @@ type PullRequestTimelineConnection {
   A list of edges.
   """
   edges: [PullRequestTimelineItemEdge]
+  
   """
   A list of nodes.
   """
   nodes: [PullRequestTimelineItem]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -31930,6 +36419,7 @@ type PullRequestTimelineItemEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -32006,26 +36496,32 @@ type PullRequestTimelineItemsConnection {
   A list of edges.
   """
   edges: [PullRequestTimelineItemsEdge]
+  
   """
   Identifies the count of items after applying `before` and `after` filters.
   """
   filteredCount: Int!
+  
   """
   A list of nodes.
   """
   nodes: [PullRequestTimelineItems]
+  
   """
   Identifies the count of items after applying `before`/`after` filters and `first`/`last`/`skip` slicing.
   """
   pageCount: Int!
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
   totalCount: Int!
+  
   """
   Identifies the date and time when the timeline was last updated.
   """
@@ -32040,6 +36536,7 @@ type PullRequestTimelineItemsEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -32303,22 +36800,27 @@ A Git push.
 """
 type Push implements Node {
   id: ID!
+  
   """
   The SHA after the push
   """
   nextSha: GitObjectID
+  
   """
   The permalink for this push.
   """
   permalink: URI!
+  
   """
   The SHA before the push
   """
   previousSha: GitObjectID
+  
   """
   The actor who pushed
   """
   pusher: Actor!
+  
   """
   The repository that was pushed to
   """
@@ -32333,6 +36835,7 @@ type PushAllowance implements Node {
   The actor that can push.
   """
   actor: PushAllowanceActor
+  
   """
   Identifies the branch protection rule associated with the allowed user, team, or app.
   """
@@ -32353,14 +36856,17 @@ type PushAllowanceConnection {
   A list of edges.
   """
   edges: [PushAllowanceEdge]
+  
   """
   A list of nodes.
   """
   nodes: [PushAllowance]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -32375,6 +36881,7 @@ type PushAllowanceEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -32394,10 +36901,12 @@ type Query {
     """
     key: String!
   ): CodeOfConduct
+  
   """
   Look up a code of conduct by its key
   """
   codesOfConduct: [CodeOfConduct]
+  
   """
   Look up an enterprise by URL slug.
   """
@@ -32406,11 +36915,13 @@ type Query {
     The enterprise invitation token.
     """
     invitationToken: String
+    
     """
     The enterprise URL slug.
     """
     slug: String!
   ): Enterprise
+  
   """
   Look up a pending enterprise administrator invitation by invitee, enterprise and role.
   """
@@ -32419,15 +36930,18 @@ type Query {
     The slug of the enterprise the user was invited to join.
     """
     enterpriseSlug: String!
+    
     """
     The role for the business member invitation.
     """
     role: EnterpriseAdministratorRole!
+    
     """
     The login of the user invited to join the business.
     """
     userLogin: String!
   ): EnterpriseAdministratorInvitation
+  
   """
   Look up a pending enterprise administrator invitation by invitation token.
   """
@@ -32437,6 +36951,7 @@ type Query {
     """
     invitationToken: String!
   ): EnterpriseAdministratorInvitation
+  
   """
   Look up an open source license by its key
   """
@@ -32446,10 +36961,12 @@ type Query {
     """
     key: String!
   ): License
+  
   """
   Return a list of known open source licenses
   """
   licenses: [License]!
+  
   """
   Get alphabetically sorted list of Marketplace categories
   """
@@ -32458,15 +36975,18 @@ type Query {
     Exclude categories with no listings.
     """
     excludeEmpty: Boolean
+    
     """
     Returns top level categories only, excluding any subcategories.
     """
     excludeSubcategories: Boolean
+    
     """
     Return only the specified categories.
     """
     includeCategories: [String!]
   ): [MarketplaceCategory!]!
+  
   """
   Look up a Marketplace category by its slug.
   """
@@ -32475,11 +36995,13 @@ type Query {
     The URL slug of the category.
     """
     slug: String!
+    
     """
     Also check topic aliases for the category slug
     """
     useTopicAliases: Boolean
   ): MarketplaceCategory
+  
   """
   Look up a single Marketplace listing
   """
@@ -32489,6 +37011,7 @@ type Query {
     """
     slug: String!
   ): MarketplaceListing
+  
   """
   Look up Marketplace listings
   """
@@ -32497,61 +37020,75 @@ type Query {
     Select listings that can be administered by the specified user.
     """
     adminId: ID
+    
     """
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Select listings visible to the viewer even if they are not approved. If omitted or
     false, only approved listings will be returned.
     """
     allStates: Boolean
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Select only listings with the given category.
     """
     categorySlug: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Select listings for products owned by the specified organization.
     """
     organizationId: ID
+    
     """
     Select only listings where the primary category matches the given category slug.
     """
     primaryCategoryOnly: Boolean = false
+    
     """
     Select the listings with these slugs, if they are visible to the viewer.
     """
     slugs: [String]
+    
     """
     Also check topic aliases for the category slug
     """
     useTopicAliases: Boolean
+    
     """
     Select listings to which user has admin access. If omitted, listings visible to the
     viewer are returned.
     """
     viewerCanAdmin: Boolean
+    
     """
     Select only listings that offer a free trial.
     """
     withFreeTrialsOnly: Boolean = false
   ): MarketplaceListingConnection!
+  
   """
   Return information about the GitHub instance
   """
   meta: GitHubMetadata!
+  
   """
   Fetches an object given its ID.
   """
@@ -32561,6 +37098,7 @@ type Query {
     """
     id: ID!
   ): Node
+  
   """
   Lookup nodes by a list of IDs.
   """
@@ -32570,6 +37108,7 @@ type Query {
     """
     ids: [ID!]!
   ): [Node]!
+  
   """
   Lookup a organization by login.
   """
@@ -32579,6 +37118,7 @@ type Query {
     """
     login: String!
   ): Organization
+  
   """
   The client's rate limit information.
   """
@@ -32588,11 +37128,13 @@ type Query {
     """
     dryRun: Boolean = false
   ): RateLimit
+  
   """
   Workaround for re-exposing the root query object. (Refer to
   https://github.com/facebook/relay/issues/112 for more information.)
   """
   relay: Query!
+  
   """
   Lookup a given repository by the owner and repository name.
   """
@@ -32601,15 +37143,18 @@ type Query {
     Follow repository renames. If disabled, a repository referenced by its old name will return an error.
     """
     followRenames: Boolean = true
+    
     """
     The name of the repository
     """
     name: String!
+    
     """
     The login field of a user or organization
     """
     owner: String!
   ): Repository
+  
   """
   Lookup a repository owner (ie. either a User or an Organization) by login.
   """
@@ -32619,6 +37164,7 @@ type Query {
     """
     login: String!
   ): RepositoryOwner
+  
   """
   Lookup resource by a URL.
   """
@@ -32628,6 +37174,7 @@ type Query {
     """
     url: URI!
   ): UniformResourceLocatable
+  
   """
   Perform a search across resources, returning a maximum of 1,000 results.
   """
@@ -32636,27 +37183,33 @@ type Query {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     The search string to look for.
     """
     query: String!
+    
     """
     The types of search items to search within.
     """
     type: SearchType!
   ): SearchResultItemConnection!
+  
   """
   GitHub Security Advisories
   """
@@ -32665,39 +37218,48 @@ type Query {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     A list of classifications to filter advisories by.
     """
     classifications: [SecurityAdvisoryClassification!]
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Filter advisories by identifier, e.g. GHSA or CVE.
     """
     identifier: SecurityAdvisoryIdentifierFilter
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for the returned topics.
     """
     orderBy: SecurityAdvisoryOrder = { field: UPDATED_AT, direction: DESC }
+    
     """
     Filter advisories to those published since a time in the past.
     """
     publishedSince: DateTime
+    
     """
     Filter advisories to those updated since a time in the past.
     """
     updatedSince: DateTime
   ): SecurityAdvisoryConnection!
+  
   """
   Fetch a Security Advisory by its GHSA ID
   """
@@ -32707,6 +37269,7 @@ type Query {
     """
     ghsaId: String!
   ): SecurityAdvisory
+  
   """
   Software Vulnerabilities documented by GitHub Security Advisories
   """
@@ -32715,39 +37278,48 @@ type Query {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     A list of advisory classifications to filter vulnerabilities by.
     """
     classifications: [SecurityAdvisoryClassification!]
+    
     """
     An ecosystem to filter vulnerabilities by.
     """
     ecosystem: SecurityAdvisoryEcosystem
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for the returned topics.
     """
     orderBy: SecurityVulnerabilityOrder = { field: UPDATED_AT, direction: DESC }
+    
     """
     A package name to filter vulnerabilities by.
     """
     package: String
+    
     """
     A list of severities to filter vulnerabilities by.
     """
     severities: [SecurityAdvisorySeverity!]
   ): SecurityVulnerabilityConnection!
+  
   """
   Users and organizations who can be sponsored via GitHub Sponsors.
   """
@@ -32756,10 +37328,12 @@ type Query {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Optional filter for which dependencies should be checked for sponsorable
     owners. Only sponsorable owners of dependencies in this ecosystem will be
@@ -32770,20 +37344,24 @@ type Query {
     **Reason:** The type is switching from SecurityAdvisoryEcosystem to DependencyGraphEcosystem.
     """
     dependencyEcosystem: SecurityAdvisoryEcosystem
+    
     """
     Optional filter for which dependencies should be checked for sponsorable
     owners. Only sponsorable owners of dependencies in this ecosystem will be
     included. Used when onlyDependencies = true.
     """
     ecosystem: DependencyGraphEcosystem
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Whether only sponsorables who own the viewer's dependencies will be
     returned. Must be authenticated to use. Can check an organization instead
@@ -32791,10 +37369,12 @@ type Query {
     orgLoginForDependencies.
     """
     onlyDependencies: Boolean = false
+    
     """
     Ordering options for users and organizations returned from the connection.
     """
     orderBy: SponsorableOrder = { field: LOGIN, direction: ASC }
+    
     """
     Optional organization username for whose dependencies should be checked.
     Used when onlyDependencies = true. Omit to check your own dependencies. If
@@ -32803,6 +37383,7 @@ type Query {
     """
     orgLoginForDependencies: String
   ): SponsorableItemConnection!
+  
   """
   Look up a topic by name.
   """
@@ -32812,6 +37393,7 @@ type Query {
     """
     name: String!
   ): Topic
+  
   """
   Lookup a user by login.
   """
@@ -32821,6 +37403,7 @@ type Query {
     """
     login: String!
   ): User
+  
   """
   The currently authenticated user.
   """
@@ -32835,22 +37418,27 @@ type RateLimit {
   The point cost for the current query counting against the rate limit.
   """
   cost: Int!
+  
   """
   The maximum number of points the client is permitted to consume in a 60 minute window.
   """
   limit: Int!
+  
   """
   The maximum number of nodes this query may return
   """
   nodeCount: Int!
+  
   """
   The number of points remaining in the current rate limit window.
   """
   remaining: Int!
+  
   """
   The time at which the current rate limit window resets in UTC epoch seconds.
   """
   resetAt: DateTime!
+  
   """
   The number of points used in the current rate limit window.
   """
@@ -32866,10 +37454,12 @@ interface Reactable {
   """
   databaseId: Int
   id: ID!
+  
   """
   A list of reactions grouped by content left on the subject.
   """
   reactionGroups: [ReactionGroup!]
+  
   """
   A list of Reactions left on the Issue.
   """
@@ -32878,27 +37468,33 @@ interface Reactable {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Allows filtering Reactions by emoji.
     """
     content: ReactionContent
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Allows specifying the order in which reactions are returned.
     """
     orderBy: ReactionOrder
   ): ReactionConnection!
+  
   """
   Can user react to this subject
   """
@@ -32913,14 +37509,17 @@ type ReactingUserConnection {
   A list of edges.
   """
   edges: [ReactingUserEdge]
+  
   """
   A list of nodes.
   """
   nodes: [User]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -32936,6 +37535,7 @@ type ReactingUserEdge {
   """
   cursor: String!
   node: User!
+  
   """
   The moment when the user made the reaction.
   """
@@ -32950,19 +37550,23 @@ type Reaction implements Node {
   Identifies the emoji reaction.
   """
   content: ReactionContent!
+  
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
+  
   """
   Identifies the primary key from the database.
   """
   databaseId: Int
   id: ID!
+  
   """
   The reactable piece of content
   """
   reactable: Reactable!
+  
   """
   Identifies the user who created this reaction.
   """
@@ -32977,18 +37581,22 @@ type ReactionConnection {
   A list of edges.
   """
   edges: [ReactionEdge]
+  
   """
   A list of nodes.
   """
   nodes: [Reaction]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
   totalCount: Int!
+  
   """
   Whether or not the authenticated user has left a reaction on the subject.
   """
@@ -33041,6 +37649,7 @@ type ReactionEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -33055,10 +37664,12 @@ type ReactionGroup {
   Identifies the emoji reaction.
   """
   content: ReactionContent!
+  
   """
   Identifies when the reaction was created.
   """
   createdAt: DateTime
+  
   """
   Reactors to the reaction subject with the emotion represented by this reaction group.
   """
@@ -33067,23 +37678,28 @@ type ReactionGroup {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): ReactorConnection!
+  
   """
   The subject that was reacted to.
   """
   subject: Reactable!
+  
   """
   Users who have reacted to the reaction subject with the emotion represented by this reaction group
   """
@@ -33092,14 +37708,17 @@ type ReactionGroup {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
@@ -33108,6 +37727,7 @@ type ReactionGroup {
     @deprecated(
       reason: "Reactors can now be mannequins, bots, and organizations. Use the `reactors` field instead. Removal on 2021-10-01 UTC."
     )
+  
   """
   Whether or not the authenticated user has left a reaction on the subject.
   """
@@ -33122,6 +37742,7 @@ input ReactionOrder {
   The direction in which to order reactions by the specified field.
   """
   direction: OrderDirection!
+  
   """
   The field in which to order reactions by.
   """
@@ -33151,14 +37772,17 @@ type ReactorConnection {
   A list of edges.
   """
   edges: [ReactorEdge]
+  
   """
   A list of nodes.
   """
   nodes: [Reactor]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -33173,10 +37797,12 @@ type ReactorEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The author of the reaction.
   """
   node: Reactor!
+  
   """
   The moment when the user made the reaction.
   """
@@ -33191,19 +37817,23 @@ type ReadyForReviewEvent implements Node & UniformResourceLocatable {
   Identifies the actor who performed the event.
   """
   actor: Actor
+  
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
   id: ID!
+  
   """
   PullRequest referenced by event.
   """
   pullRequest: PullRequest!
+  
   """
   The HTTP path for this ready for review event.
   """
   resourcePath: URI!
+  
   """
   The HTTP URL for this ready for review event.
   """
@@ -33222,43 +37852,53 @@ type Ref implements Node {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     The base ref name to filter the pull requests by.
     """
     baseRefName: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     The head ref name to filter the pull requests by.
     """
     headRefName: String
+    
     """
     A list of label names to filter the pull requests by.
     """
     labels: [String!]
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for pull requests returned from the connection.
     """
     orderBy: IssueOrder
+    
     """
     A list of states to filter the pull requests by.
     """
     states: [PullRequestState!]
   ): PullRequestConnection!
+  
   """
   Branch protection rules for this ref
   """
   branchProtectionRule: BranchProtectionRule
+  
   """
   Compares the current ref as a base ref to another head ref, if the comparison can be made.
   """
@@ -33269,22 +37909,27 @@ type Ref implements Node {
     headRef: String!
   ): Comparison
   id: ID!
+  
   """
   The ref name.
   """
   name: String!
+  
   """
   The ref's prefix, such as `refs/heads/` or `refs/tags/`.
   """
   prefix: String!
+  
   """
   Branch protection rules that are viewable by non-admins
   """
   refUpdateRule: RefUpdateRule
+  
   """
   The repository the ref belongs to.
   """
   repository: Repository!
+  
   """
   The object the ref points to. Returns null when object does not exist.
   """
@@ -33299,14 +37944,17 @@ type RefConnection {
   A list of edges.
   """
   edges: [RefEdge]
+  
   """
   A list of nodes.
   """
   nodes: [Ref]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -33321,6 +37969,7 @@ type RefEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -33335,6 +37984,7 @@ type RefNameConditionTarget {
   Array of ref names or patterns to exclude. The condition will not pass if any of these patterns match.
   """
   exclude: [String!]!
+  
   """
   Array of ref names or patterns to include. One of these patterns must match
   for the condition to pass. Also accepts `~DEFAULT_BRANCH` to include the
@@ -33351,6 +38001,7 @@ input RefNameConditionTargetInput {
   Array of ref names or patterns to exclude. The condition will not pass if any of these patterns match.
   """
   exclude: [String!]!
+  
   """
   Array of ref names or patterns to include. One of these patterns must match
   for the condition to pass. Also accepts `~DEFAULT_BRANCH` to include the
@@ -33367,6 +38018,7 @@ input RefOrder {
   The direction in which to order refs by the specified field.
   """
   direction: OrderDirection!
+  
   """
   The field in which to order refs by.
   """
@@ -33395,14 +38047,17 @@ input RefUpdate @preview(toggledBy: "update-refs-preview") {
   The value this ref should be updated to.
   """
   afterOid: GitObjectID!
+  
   """
   The value this ref needs to point to before the update.
   """
   beforeOid: GitObjectID
+  
   """
   Force a non fast-forward update.
   """
   force: Boolean = false
+  
   """
   The fully qualified name of the ref to be update. For example `refs/heads/branch-name`
   """
@@ -33417,46 +38072,57 @@ type RefUpdateRule {
   Can this branch be deleted.
   """
   allowsDeletions: Boolean!
+  
   """
   Are force pushes allowed on this branch.
   """
   allowsForcePushes: Boolean!
+  
   """
   Can matching branches be created.
   """
   blocksCreations: Boolean!
+  
   """
   Identifies the protection rule pattern.
   """
   pattern: String!
+  
   """
   Number of approving reviews required to update matching branches.
   """
   requiredApprovingReviewCount: Int
+  
   """
   List of required status check contexts that must pass for commits to be accepted to matching branches.
   """
   requiredStatusCheckContexts: [String]
+  
   """
   Are reviews from code owners required to update matching branches.
   """
   requiresCodeOwnerReviews: Boolean!
+  
   """
   Are conversations required to be resolved before merging.
   """
   requiresConversationResolution: Boolean!
+  
   """
   Are merge commits prohibited from being pushed to this branch.
   """
   requiresLinearHistory: Boolean!
+  
   """
   Are commits required to be signed.
   """
   requiresSignatures: Boolean!
+  
   """
   Is the viewer allowed to dismiss reviews.
   """
   viewerAllowedToDismissReviews: Boolean!
+  
   """
   Can the viewer push to the branch
   """
@@ -33471,27 +38137,33 @@ type ReferencedEvent implements Node {
   Identifies the actor who performed the event.
   """
   actor: Actor
+  
   """
   Identifies the commit associated with the 'referenced' event.
   """
   commit: Commit
+  
   """
   Identifies the repository associated with the 'referenced' event.
   """
   commitRepository: Repository!
+  
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
   id: ID!
+  
   """
   Reference originated in a different repository.
   """
   isCrossRepository: Boolean!
+  
   """
   Checks if the commit message itself references the subject. Can be false in the case of a commit comment reference.
   """
   isDirectReference: Boolean!
+  
   """
   Object referenced by event.
   """
@@ -33511,6 +38183,7 @@ input RegenerateEnterpriseIdentityProviderRecoveryCodesInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The ID of the enterprise on which to set an identity provider.
   """
@@ -33525,6 +38198,7 @@ type RegenerateEnterpriseIdentityProviderRecoveryCodesPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The identity provider for the enterprise.
   """
@@ -33539,6 +38213,7 @@ input RegenerateVerifiableDomainTokenInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The ID of the verifiable domain to regenerate the verification token of.
   """
@@ -33553,6 +38228,7 @@ type RegenerateVerifiableDomainTokenPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The verification token that was generated.
   """
@@ -33567,14 +38243,17 @@ input RejectDeploymentsInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   Optional comment for rejecting deployments
   """
   comment: String = ""
+  
   """
   The ids of environments to reject deployments
   """
   environmentIds: [ID!]!
+  
   """
   The node ID of the workflow run containing the pending deployments.
   """
@@ -33589,6 +38268,7 @@ type RejectDeploymentsPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The affected deployments.
   """
@@ -33603,35 +38283,43 @@ type Release implements Node & Reactable & UniformResourceLocatable {
   The author of the release
   """
   author: User
+  
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
+  
   """
   Identifies the primary key from the database.
   """
   databaseId: Int
+  
   """
   The description of the release.
   """
   description: String
+  
   """
   The description of this release rendered to HTML.
   """
   descriptionHTML: HTML
   id: ID!
+  
   """
   Whether or not the release is a draft
   """
   isDraft: Boolean!
+  
   """
   Whether or not the release is the latest releast
   """
   isLatest: Boolean!
+  
   """
   Whether or not the release is a prerelease
   """
   isPrerelease: Boolean!
+  
   """
   A list of users mentioned in the release description
   """
@@ -33640,31 +38328,38 @@ type Release implements Node & Reactable & UniformResourceLocatable {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): UserConnection
+  
   """
   The title of the release.
   """
   name: String
+  
   """
   Identifies the date and time when the release was created.
   """
   publishedAt: DateTime
+  
   """
   A list of reactions grouped by content left on the subject.
   """
   reactionGroups: [ReactionGroup!]
+  
   """
   A list of Reactions left on the Issue.
   """
@@ -33673,27 +38368,33 @@ type Release implements Node & Reactable & UniformResourceLocatable {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Allows filtering Reactions by emoji.
     """
     content: ReactionContent
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Allows specifying the order in which reactions are returned.
     """
     orderBy: ReactionOrder
   ): ReactionConnection!
+  
   """
   List of releases assets which are dependent on this release.
   """
@@ -33702,31 +38403,38 @@ type Release implements Node & Reactable & UniformResourceLocatable {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     A list of names to filter the assets by.
     """
     name: String
   ): ReleaseAssetConnection!
+  
   """
   The repository that the release belongs to.
   """
   repository: Repository!
+  
   """
   The HTTP path for this issue
   """
   resourcePath: URI!
+  
   """
   A description of the release, rendered to HTML without any links in it.
   """
@@ -33736,26 +38444,32 @@ type Release implements Node & Reactable & UniformResourceLocatable {
     """
     limit: Int = 200
   ): HTML
+  
   """
   The Git tag the release points to
   """
   tag: Ref
+  
   """
   The tag commit for this release.
   """
   tagCommit: Commit
+  
   """
   The name of the release's Git tag
   """
   tagName: String!
+  
   """
   Identifies the date and time when the object was last updated.
   """
   updatedAt: DateTime!
+  
   """
   The HTTP URL for this issue
   """
   url: URI!
+  
   """
   Can user react to this subject
   """
@@ -33770,39 +38484,48 @@ type ReleaseAsset implements Node {
   The asset's content-type
   """
   contentType: String!
+  
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
+  
   """
   The number of times this asset was downloaded
   """
   downloadCount: Int!
+  
   """
   Identifies the URL where you can download the release asset via the browser.
   """
   downloadUrl: URI!
   id: ID!
+  
   """
   Identifies the title of the release asset.
   """
   name: String!
+  
   """
   Release that the asset is associated with
   """
   release: Release
+  
   """
   The size (in bytes) of the asset
   """
   size: Int!
+  
   """
   Identifies the date and time when the object was last updated.
   """
   updatedAt: DateTime!
+  
   """
   The user that performed the upload
   """
   uploadedBy: User!
+  
   """
   Identifies the URL of the release asset.
   """
@@ -33817,14 +38540,17 @@ type ReleaseAssetConnection {
   A list of edges.
   """
   edges: [ReleaseAssetEdge]
+  
   """
   A list of nodes.
   """
   nodes: [ReleaseAsset]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -33839,6 +38565,7 @@ type ReleaseAssetEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -33853,14 +38580,17 @@ type ReleaseConnection {
   A list of edges.
   """
   edges: [ReleaseEdge]
+  
   """
   A list of nodes.
   """
   nodes: [Release]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -33875,6 +38605,7 @@ type ReleaseEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -33889,6 +38620,7 @@ input ReleaseOrder {
   The direction in which to order releases by the specified field.
   """
   direction: OrderDirection!
+  
   """
   The field in which to order releases by.
   """
@@ -33921,10 +38653,12 @@ input RemoveAssigneesFromAssignableInput {
       concreteTypes: ["Issue", "PullRequest"]
       abstractType: "Assignable"
     )
+  
   """
   The id of users to remove as assignees.
   """
   assigneeIds: [ID!]! @possibleTypes(concreteTypes: ["User"])
+  
   """
   A unique identifier for the client performing the mutation.
   """
@@ -33939,6 +38673,7 @@ type RemoveAssigneesFromAssignablePayload {
   The item that was unassigned.
   """
   assignable: Assignable
+  
   """
   A unique identifier for the client performing the mutation.
   """
@@ -33953,10 +38688,12 @@ input RemoveEnterpriseAdminInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The Enterprise ID from which to remove the administrator.
   """
   enterpriseId: ID! @possibleTypes(concreteTypes: ["Enterprise"])
+  
   """
   The login of the user to remove as an administrator.
   """
@@ -33971,18 +38708,22 @@ type RemoveEnterpriseAdminPayload {
   The user who was removed as an administrator.
   """
   admin: User
+  
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The updated enterprise.
   """
   enterprise: Enterprise
+  
   """
   A message confirming the result of removing an administrator.
   """
   message: String
+  
   """
   The viewer performing the mutation.
   """
@@ -33997,6 +38738,7 @@ input RemoveEnterpriseIdentityProviderInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The ID of the enterprise from which to remove the identity provider.
   """
@@ -34011,6 +38753,7 @@ type RemoveEnterpriseIdentityProviderPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The identity provider that was removed from the enterprise.
   """
@@ -34025,10 +38768,12 @@ input RemoveEnterpriseMemberInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The ID of the enterprise from which the user should be removed.
   """
   enterpriseId: ID! @possibleTypes(concreteTypes: ["Enterprise"])
+  
   """
   The ID of the user to remove from the enterprise.
   """
@@ -34043,14 +38788,17 @@ type RemoveEnterpriseMemberPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The updated enterprise.
   """
   enterprise: Enterprise
+  
   """
   The user that was removed from the enterprise.
   """
   user: User
+  
   """
   The viewer performing the mutation.
   """
@@ -34065,10 +38813,12 @@ input RemoveEnterpriseOrganizationInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The ID of the enterprise from which the organization should be removed.
   """
   enterpriseId: ID! @possibleTypes(concreteTypes: ["Enterprise"])
+  
   """
   The ID of the organization to remove from the enterprise.
   """
@@ -34083,14 +38833,17 @@ type RemoveEnterpriseOrganizationPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The updated enterprise.
   """
   enterprise: Enterprise
+  
   """
   The organization that was removed from the enterprise.
   """
   organization: Organization
+  
   """
   The viewer performing the mutation.
   """
@@ -34105,10 +38858,12 @@ input RemoveEnterpriseSupportEntitlementInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The ID of the Enterprise which the admin belongs to.
   """
   enterpriseId: ID! @possibleTypes(concreteTypes: ["Enterprise"])
+  
   """
   The login of a member who will lose the support entitlement.
   """
@@ -34123,6 +38878,7 @@ type RemoveEnterpriseSupportEntitlementPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   A message confirming the result of removing the support entitlement.
   """
@@ -34137,10 +38893,12 @@ input RemoveLabelsFromLabelableInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The ids of labels to remove.
   """
   labelIds: [ID!]! @possibleTypes(concreteTypes: ["Label"])
+  
   """
   The id of the Labelable to remove labels from.
   """
@@ -34159,6 +38917,7 @@ type RemoveLabelsFromLabelablePayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The Labelable the labels were removed from.
   """
@@ -34173,10 +38932,12 @@ input RemoveOutsideCollaboratorInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The ID of the organization to remove the outside collaborator from.
   """
   organizationId: ID! @possibleTypes(concreteTypes: ["Organization"])
+  
   """
   The ID of the outside collaborator to remove.
   """
@@ -34191,6 +38952,7 @@ type RemoveOutsideCollaboratorPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The user that was removed as an outside collaborator.
   """
@@ -34205,10 +38967,12 @@ input RemoveReactionInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The name of the emoji reaction to remove.
   """
   content: ReactionContent!
+  
   """
   The Node ID of the subject to modify.
   """
@@ -34239,14 +39003,17 @@ type RemoveReactionPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The reaction object.
   """
   reaction: Reaction
+  
   """
   The reaction groups for the subject.
   """
   reactionGroups: [ReactionGroup!]
+  
   """
   The reactable subject.
   """
@@ -34261,6 +39028,7 @@ input RemoveStarInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The Starrable ID to unstar.
   """
@@ -34279,6 +39047,7 @@ type RemoveStarPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The starrable.
   """
@@ -34293,6 +39062,7 @@ input RemoveUpvoteInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The Node ID of the discussion or comment to remove upvote.
   """
@@ -34311,6 +39081,7 @@ type RemoveUpvotePayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The votable subject.
   """
@@ -34325,27 +39096,33 @@ type RemovedFromMergeQueueEvent implements Node {
   Identifies the actor who performed the event.
   """
   actor: Actor
+  
   """
   Identifies the before commit SHA for the 'removed_from_merge_queue' event.
   """
   beforeCommit: Commit
+  
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
+  
   """
   The user who removed this Pull Request from the merge queue
   """
   enqueuer: User
   id: ID!
+  
   """
   The merge queue where this pull request was removed from.
   """
   mergeQueue: MergeQueue
+  
   """
   PullRequest referenced by event.
   """
   pullRequest: PullRequest
+  
   """
   The reason this pull request was removed from the queue.
   """
@@ -34360,19 +39137,23 @@ type RemovedFromProjectEvent implements Node {
   Identifies the actor who performed the event.
   """
   actor: Actor
+  
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
+  
   """
   Identifies the primary key from the database.
   """
   databaseId: Int
   id: ID!
+  
   """
   Project referenced by event.
   """
   project: Project @preview(toggledBy: "starfox-preview")
+  
   """
   Column name referenced by this project event.
   """
@@ -34387,19 +39168,23 @@ type RenamedTitleEvent implements Node {
   Identifies the actor who performed the event.
   """
   actor: Actor
+  
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
+  
   """
   Identifies the current title of the issue or pull request.
   """
   currentTitle: String!
   id: ID!
+  
   """
   Identifies the previous title of the issue or pull request.
   """
   previousTitle: String!
+  
   """
   Subject that was renamed.
   """
@@ -34419,6 +39204,7 @@ input ReopenDiscussionInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   ID of the discussion to be reopened.
   """
@@ -34433,6 +39219,7 @@ type ReopenDiscussionPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The discussion that was reopened.
   """
@@ -34447,6 +39234,7 @@ input ReopenIssueInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   ID of the issue to be opened.
   """
@@ -34461,6 +39249,7 @@ type ReopenIssuePayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The issue that was opened.
   """
@@ -34475,6 +39264,7 @@ input ReopenPullRequestInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   ID of the pull request to be reopened.
   """
@@ -34489,6 +39279,7 @@ type ReopenPullRequestPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The pull request that was reopened.
   """
@@ -34503,15 +39294,18 @@ type ReopenedEvent implements Node {
   Identifies the actor who performed the event.
   """
   actor: Actor
+  
   """
   Object that was reopened.
   """
   closable: Closable!
+  
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
   id: ID!
+  
   """
   The reason the issue state was changed to open.
   """
@@ -34526,87 +39320,108 @@ type RepoAccessAuditEntry implements AuditEntry & Node & OrganizationAuditEntryD
   The action name
   """
   action: String!
+  
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
+  
   """
   The IP address of the actor
   """
   actorIp: String
+  
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
+  
   """
   The username of the user who initiated the action
   """
   actorLogin: String
+  
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
+  
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
+  
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
   id: ID!
+  
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
+  
   """
   The Organization associated with the Audit Entry.
   """
   organization: Organization
+  
   """
   The name of the Organization.
   """
   organizationName: String
+  
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
+  
   """
   The HTTP URL for the organization
   """
   organizationUrl: URI
+  
   """
   The repository associated with the action
   """
   repository: Repository
+  
   """
   The name of the repository
   """
   repositoryName: String
+  
   """
   The HTTP path for the repository
   """
   repositoryResourcePath: URI
+  
   """
   The HTTP URL for the repository
   """
   repositoryUrl: URI
+  
   """
   The user affected by the action
   """
   user: User
+  
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
+  
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
+  
   """
   The HTTP URL for the user.
   """
   userUrl: URI
+  
   """
   The visibility of the repository
   """
@@ -34639,87 +39454,108 @@ type RepoAddMemberAuditEntry implements AuditEntry & Node & OrganizationAuditEnt
   The action name
   """
   action: String!
+  
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
+  
   """
   The IP address of the actor
   """
   actorIp: String
+  
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
+  
   """
   The username of the user who initiated the action
   """
   actorLogin: String
+  
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
+  
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
+  
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
   id: ID!
+  
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
+  
   """
   The Organization associated with the Audit Entry.
   """
   organization: Organization
+  
   """
   The name of the Organization.
   """
   organizationName: String
+  
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
+  
   """
   The HTTP URL for the organization
   """
   organizationUrl: URI
+  
   """
   The repository associated with the action
   """
   repository: Repository
+  
   """
   The name of the repository
   """
   repositoryName: String
+  
   """
   The HTTP path for the repository
   """
   repositoryResourcePath: URI
+  
   """
   The HTTP URL for the repository
   """
   repositoryUrl: URI
+  
   """
   The user affected by the action
   """
   user: User
+  
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
+  
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
+  
   """
   The HTTP URL for the user.
   """
   userUrl: URI
+  
   """
   The visibility of the repository
   """
@@ -34752,91 +39588,113 @@ type RepoAddTopicAuditEntry implements AuditEntry & Node & OrganizationAuditEntr
   The action name
   """
   action: String!
+  
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
+  
   """
   The IP address of the actor
   """
   actorIp: String
+  
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
+  
   """
   The username of the user who initiated the action
   """
   actorLogin: String
+  
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
+  
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
+  
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
   id: ID!
+  
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
+  
   """
   The Organization associated with the Audit Entry.
   """
   organization: Organization
+  
   """
   The name of the Organization.
   """
   organizationName: String
+  
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
+  
   """
   The HTTP URL for the organization
   """
   organizationUrl: URI
+  
   """
   The repository associated with the action
   """
   repository: Repository
+  
   """
   The name of the repository
   """
   repositoryName: String
+  
   """
   The HTTP path for the repository
   """
   repositoryResourcePath: URI
+  
   """
   The HTTP URL for the repository
   """
   repositoryUrl: URI
+  
   """
   The name of the topic added to the repository
   """
   topic: Topic
+  
   """
   The name of the topic added to the repository
   """
   topicName: String
+  
   """
   The user affected by the action
   """
   user: User
+  
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
+  
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
+  
   """
   The HTTP URL for the user.
   """
@@ -34851,87 +39709,108 @@ type RepoArchivedAuditEntry implements AuditEntry & Node & OrganizationAuditEntr
   The action name
   """
   action: String!
+  
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
+  
   """
   The IP address of the actor
   """
   actorIp: String
+  
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
+  
   """
   The username of the user who initiated the action
   """
   actorLogin: String
+  
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
+  
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
+  
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
   id: ID!
+  
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
+  
   """
   The Organization associated with the Audit Entry.
   """
   organization: Organization
+  
   """
   The name of the Organization.
   """
   organizationName: String
+  
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
+  
   """
   The HTTP URL for the organization
   """
   organizationUrl: URI
+  
   """
   The repository associated with the action
   """
   repository: Repository
+  
   """
   The name of the repository
   """
   repositoryName: String
+  
   """
   The HTTP path for the repository
   """
   repositoryResourcePath: URI
+  
   """
   The HTTP URL for the repository
   """
   repositoryUrl: URI
+  
   """
   The user affected by the action
   """
   user: User
+  
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
+  
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
+  
   """
   The HTTP URL for the user.
   """
   userUrl: URI
+  
   """
   The visibility of the repository
   """
@@ -34964,91 +39843,113 @@ type RepoChangeMergeSettingAuditEntry implements AuditEntry & Node & Organizatio
   The action name
   """
   action: String!
+  
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
+  
   """
   The IP address of the actor
   """
   actorIp: String
+  
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
+  
   """
   The username of the user who initiated the action
   """
   actorLogin: String
+  
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
+  
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
+  
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
   id: ID!
+  
   """
   Whether the change was to enable (true) or disable (false) the merge type
   """
   isEnabled: Boolean
+  
   """
   The merge method affected by the change
   """
   mergeType: RepoChangeMergeSettingAuditEntryMergeType
+  
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
+  
   """
   The Organization associated with the Audit Entry.
   """
   organization: Organization
+  
   """
   The name of the Organization.
   """
   organizationName: String
+  
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
+  
   """
   The HTTP URL for the organization
   """
   organizationUrl: URI
+  
   """
   The repository associated with the action
   """
   repository: Repository
+  
   """
   The name of the repository
   """
   repositoryName: String
+  
   """
   The HTTP path for the repository
   """
   repositoryResourcePath: URI
+  
   """
   The HTTP URL for the repository
   """
   repositoryUrl: URI
+  
   """
   The user affected by the action
   """
   user: User
+  
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
+  
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
+  
   """
   The HTTP URL for the user.
   """
@@ -35081,83 +39982,103 @@ type RepoConfigDisableAnonymousGitAccessAuditEntry implements AuditEntry & Node 
   The action name
   """
   action: String!
+  
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
+  
   """
   The IP address of the actor
   """
   actorIp: String
+  
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
+  
   """
   The username of the user who initiated the action
   """
   actorLogin: String
+  
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
+  
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
+  
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
   id: ID!
+  
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
+  
   """
   The Organization associated with the Audit Entry.
   """
   organization: Organization
+  
   """
   The name of the Organization.
   """
   organizationName: String
+  
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
+  
   """
   The HTTP URL for the organization
   """
   organizationUrl: URI
+  
   """
   The repository associated with the action
   """
   repository: Repository
+  
   """
   The name of the repository
   """
   repositoryName: String
+  
   """
   The HTTP path for the repository
   """
   repositoryResourcePath: URI
+  
   """
   The HTTP URL for the repository
   """
   repositoryUrl: URI
+  
   """
   The user affected by the action
   """
   user: User
+  
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
+  
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
+  
   """
   The HTTP URL for the user.
   """
@@ -35172,83 +40093,103 @@ type RepoConfigDisableCollaboratorsOnlyAuditEntry implements AuditEntry & Node &
   The action name
   """
   action: String!
+  
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
+  
   """
   The IP address of the actor
   """
   actorIp: String
+  
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
+  
   """
   The username of the user who initiated the action
   """
   actorLogin: String
+  
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
+  
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
+  
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
   id: ID!
+  
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
+  
   """
   The Organization associated with the Audit Entry.
   """
   organization: Organization
+  
   """
   The name of the Organization.
   """
   organizationName: String
+  
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
+  
   """
   The HTTP URL for the organization
   """
   organizationUrl: URI
+  
   """
   The repository associated with the action
   """
   repository: Repository
+  
   """
   The name of the repository
   """
   repositoryName: String
+  
   """
   The HTTP path for the repository
   """
   repositoryResourcePath: URI
+  
   """
   The HTTP URL for the repository
   """
   repositoryUrl: URI
+  
   """
   The user affected by the action
   """
   user: User
+  
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
+  
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
+  
   """
   The HTTP URL for the user.
   """
@@ -35263,83 +40204,103 @@ type RepoConfigDisableContributorsOnlyAuditEntry implements AuditEntry & Node & 
   The action name
   """
   action: String!
+  
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
+  
   """
   The IP address of the actor
   """
   actorIp: String
+  
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
+  
   """
   The username of the user who initiated the action
   """
   actorLogin: String
+  
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
+  
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
+  
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
   id: ID!
+  
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
+  
   """
   The Organization associated with the Audit Entry.
   """
   organization: Organization
+  
   """
   The name of the Organization.
   """
   organizationName: String
+  
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
+  
   """
   The HTTP URL for the organization
   """
   organizationUrl: URI
+  
   """
   The repository associated with the action
   """
   repository: Repository
+  
   """
   The name of the repository
   """
   repositoryName: String
+  
   """
   The HTTP path for the repository
   """
   repositoryResourcePath: URI
+  
   """
   The HTTP URL for the repository
   """
   repositoryUrl: URI
+  
   """
   The user affected by the action
   """
   user: User
+  
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
+  
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
+  
   """
   The HTTP URL for the user.
   """
@@ -35354,83 +40315,103 @@ type RepoConfigDisableSockpuppetDisallowedAuditEntry implements AuditEntry & Nod
   The action name
   """
   action: String!
+  
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
+  
   """
   The IP address of the actor
   """
   actorIp: String
+  
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
+  
   """
   The username of the user who initiated the action
   """
   actorLogin: String
+  
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
+  
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
+  
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
   id: ID!
+  
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
+  
   """
   The Organization associated with the Audit Entry.
   """
   organization: Organization
+  
   """
   The name of the Organization.
   """
   organizationName: String
+  
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
+  
   """
   The HTTP URL for the organization
   """
   organizationUrl: URI
+  
   """
   The repository associated with the action
   """
   repository: Repository
+  
   """
   The name of the repository
   """
   repositoryName: String
+  
   """
   The HTTP path for the repository
   """
   repositoryResourcePath: URI
+  
   """
   The HTTP URL for the repository
   """
   repositoryUrl: URI
+  
   """
   The user affected by the action
   """
   user: User
+  
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
+  
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
+  
   """
   The HTTP URL for the user.
   """
@@ -35445,83 +40426,103 @@ type RepoConfigEnableAnonymousGitAccessAuditEntry implements AuditEntry & Node &
   The action name
   """
   action: String!
+  
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
+  
   """
   The IP address of the actor
   """
   actorIp: String
+  
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
+  
   """
   The username of the user who initiated the action
   """
   actorLogin: String
+  
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
+  
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
+  
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
   id: ID!
+  
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
+  
   """
   The Organization associated with the Audit Entry.
   """
   organization: Organization
+  
   """
   The name of the Organization.
   """
   organizationName: String
+  
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
+  
   """
   The HTTP URL for the organization
   """
   organizationUrl: URI
+  
   """
   The repository associated with the action
   """
   repository: Repository
+  
   """
   The name of the repository
   """
   repositoryName: String
+  
   """
   The HTTP path for the repository
   """
   repositoryResourcePath: URI
+  
   """
   The HTTP URL for the repository
   """
   repositoryUrl: URI
+  
   """
   The user affected by the action
   """
   user: User
+  
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
+  
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
+  
   """
   The HTTP URL for the user.
   """
@@ -35536,83 +40537,103 @@ type RepoConfigEnableCollaboratorsOnlyAuditEntry implements AuditEntry & Node & 
   The action name
   """
   action: String!
+  
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
+  
   """
   The IP address of the actor
   """
   actorIp: String
+  
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
+  
   """
   The username of the user who initiated the action
   """
   actorLogin: String
+  
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
+  
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
+  
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
   id: ID!
+  
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
+  
   """
   The Organization associated with the Audit Entry.
   """
   organization: Organization
+  
   """
   The name of the Organization.
   """
   organizationName: String
+  
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
+  
   """
   The HTTP URL for the organization
   """
   organizationUrl: URI
+  
   """
   The repository associated with the action
   """
   repository: Repository
+  
   """
   The name of the repository
   """
   repositoryName: String
+  
   """
   The HTTP path for the repository
   """
   repositoryResourcePath: URI
+  
   """
   The HTTP URL for the repository
   """
   repositoryUrl: URI
+  
   """
   The user affected by the action
   """
   user: User
+  
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
+  
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
+  
   """
   The HTTP URL for the user.
   """
@@ -35627,83 +40648,103 @@ type RepoConfigEnableContributorsOnlyAuditEntry implements AuditEntry & Node & O
   The action name
   """
   action: String!
+  
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
+  
   """
   The IP address of the actor
   """
   actorIp: String
+  
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
+  
   """
   The username of the user who initiated the action
   """
   actorLogin: String
+  
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
+  
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
+  
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
   id: ID!
+  
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
+  
   """
   The Organization associated with the Audit Entry.
   """
   organization: Organization
+  
   """
   The name of the Organization.
   """
   organizationName: String
+  
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
+  
   """
   The HTTP URL for the organization
   """
   organizationUrl: URI
+  
   """
   The repository associated with the action
   """
   repository: Repository
+  
   """
   The name of the repository
   """
   repositoryName: String
+  
   """
   The HTTP path for the repository
   """
   repositoryResourcePath: URI
+  
   """
   The HTTP URL for the repository
   """
   repositoryUrl: URI
+  
   """
   The user affected by the action
   """
   user: User
+  
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
+  
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
+  
   """
   The HTTP URL for the user.
   """
@@ -35718,83 +40759,103 @@ type RepoConfigEnableSockpuppetDisallowedAuditEntry implements AuditEntry & Node
   The action name
   """
   action: String!
+  
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
+  
   """
   The IP address of the actor
   """
   actorIp: String
+  
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
+  
   """
   The username of the user who initiated the action
   """
   actorLogin: String
+  
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
+  
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
+  
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
   id: ID!
+  
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
+  
   """
   The Organization associated with the Audit Entry.
   """
   organization: Organization
+  
   """
   The name of the Organization.
   """
   organizationName: String
+  
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
+  
   """
   The HTTP URL for the organization
   """
   organizationUrl: URI
+  
   """
   The repository associated with the action
   """
   repository: Repository
+  
   """
   The name of the repository
   """
   repositoryName: String
+  
   """
   The HTTP path for the repository
   """
   repositoryResourcePath: URI
+  
   """
   The HTTP URL for the repository
   """
   repositoryUrl: URI
+  
   """
   The user affected by the action
   """
   user: User
+  
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
+  
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
+  
   """
   The HTTP URL for the user.
   """
@@ -35809,83 +40870,103 @@ type RepoConfigLockAnonymousGitAccessAuditEntry implements AuditEntry & Node & O
   The action name
   """
   action: String!
+  
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
+  
   """
   The IP address of the actor
   """
   actorIp: String
+  
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
+  
   """
   The username of the user who initiated the action
   """
   actorLogin: String
+  
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
+  
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
+  
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
   id: ID!
+  
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
+  
   """
   The Organization associated with the Audit Entry.
   """
   organization: Organization
+  
   """
   The name of the Organization.
   """
   organizationName: String
+  
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
+  
   """
   The HTTP URL for the organization
   """
   organizationUrl: URI
+  
   """
   The repository associated with the action
   """
   repository: Repository
+  
   """
   The name of the repository
   """
   repositoryName: String
+  
   """
   The HTTP path for the repository
   """
   repositoryResourcePath: URI
+  
   """
   The HTTP URL for the repository
   """
   repositoryUrl: URI
+  
   """
   The user affected by the action
   """
   user: User
+  
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
+  
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
+  
   """
   The HTTP URL for the user.
   """
@@ -35900,83 +40981,103 @@ type RepoConfigUnlockAnonymousGitAccessAuditEntry implements AuditEntry & Node &
   The action name
   """
   action: String!
+  
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
+  
   """
   The IP address of the actor
   """
   actorIp: String
+  
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
+  
   """
   The username of the user who initiated the action
   """
   actorLogin: String
+  
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
+  
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
+  
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
   id: ID!
+  
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
+  
   """
   The Organization associated with the Audit Entry.
   """
   organization: Organization
+  
   """
   The name of the Organization.
   """
   organizationName: String
+  
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
+  
   """
   The HTTP URL for the organization
   """
   organizationUrl: URI
+  
   """
   The repository associated with the action
   """
   repository: Repository
+  
   """
   The name of the repository
   """
   repositoryName: String
+  
   """
   The HTTP path for the repository
   """
   repositoryResourcePath: URI
+  
   """
   The HTTP URL for the repository
   """
   repositoryUrl: URI
+  
   """
   The user affected by the action
   """
   user: User
+  
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
+  
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
+  
   """
   The HTTP URL for the user.
   """
@@ -35991,95 +41092,118 @@ type RepoCreateAuditEntry implements AuditEntry & Node & OrganizationAuditEntryD
   The action name
   """
   action: String!
+  
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
+  
   """
   The IP address of the actor
   """
   actorIp: String
+  
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
+  
   """
   The username of the user who initiated the action
   """
   actorLogin: String
+  
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
+  
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
+  
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
+  
   """
   The name of the parent repository for this forked repository.
   """
   forkParentName: String
+  
   """
   The name of the root repository for this network.
   """
   forkSourceName: String
   id: ID!
+  
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
+  
   """
   The Organization associated with the Audit Entry.
   """
   organization: Organization
+  
   """
   The name of the Organization.
   """
   organizationName: String
+  
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
+  
   """
   The HTTP URL for the organization
   """
   organizationUrl: URI
+  
   """
   The repository associated with the action
   """
   repository: Repository
+  
   """
   The name of the repository
   """
   repositoryName: String
+  
   """
   The HTTP path for the repository
   """
   repositoryResourcePath: URI
+  
   """
   The HTTP URL for the repository
   """
   repositoryUrl: URI
+  
   """
   The user affected by the action
   """
   user: User
+  
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
+  
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
+  
   """
   The HTTP URL for the user.
   """
   userUrl: URI
+  
   """
   The visibility of the repository
   """
@@ -36112,87 +41236,108 @@ type RepoDestroyAuditEntry implements AuditEntry & Node & OrganizationAuditEntry
   The action name
   """
   action: String!
+  
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
+  
   """
   The IP address of the actor
   """
   actorIp: String
+  
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
+  
   """
   The username of the user who initiated the action
   """
   actorLogin: String
+  
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
+  
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
+  
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
   id: ID!
+  
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
+  
   """
   The Organization associated with the Audit Entry.
   """
   organization: Organization
+  
   """
   The name of the Organization.
   """
   organizationName: String
+  
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
+  
   """
   The HTTP URL for the organization
   """
   organizationUrl: URI
+  
   """
   The repository associated with the action
   """
   repository: Repository
+  
   """
   The name of the repository
   """
   repositoryName: String
+  
   """
   The HTTP path for the repository
   """
   repositoryResourcePath: URI
+  
   """
   The HTTP URL for the repository
   """
   repositoryUrl: URI
+  
   """
   The user affected by the action
   """
   user: User
+  
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
+  
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
+  
   """
   The HTTP URL for the user.
   """
   userUrl: URI
+  
   """
   The visibility of the repository
   """
@@ -36225,87 +41370,108 @@ type RepoRemoveMemberAuditEntry implements AuditEntry & Node & OrganizationAudit
   The action name
   """
   action: String!
+  
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
+  
   """
   The IP address of the actor
   """
   actorIp: String
+  
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
+  
   """
   The username of the user who initiated the action
   """
   actorLogin: String
+  
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
+  
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
+  
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
   id: ID!
+  
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
+  
   """
   The Organization associated with the Audit Entry.
   """
   organization: Organization
+  
   """
   The name of the Organization.
   """
   organizationName: String
+  
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
+  
   """
   The HTTP URL for the organization
   """
   organizationUrl: URI
+  
   """
   The repository associated with the action
   """
   repository: Repository
+  
   """
   The name of the repository
   """
   repositoryName: String
+  
   """
   The HTTP path for the repository
   """
   repositoryResourcePath: URI
+  
   """
   The HTTP URL for the repository
   """
   repositoryUrl: URI
+  
   """
   The user affected by the action
   """
   user: User
+  
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
+  
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
+  
   """
   The HTTP URL for the user.
   """
   userUrl: URI
+  
   """
   The visibility of the repository
   """
@@ -36338,91 +41504,113 @@ type RepoRemoveTopicAuditEntry implements AuditEntry & Node & OrganizationAuditE
   The action name
   """
   action: String!
+  
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
+  
   """
   The IP address of the actor
   """
   actorIp: String
+  
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
+  
   """
   The username of the user who initiated the action
   """
   actorLogin: String
+  
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
+  
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
+  
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
   id: ID!
+  
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
+  
   """
   The Organization associated with the Audit Entry.
   """
   organization: Organization
+  
   """
   The name of the Organization.
   """
   organizationName: String
+  
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
+  
   """
   The HTTP URL for the organization
   """
   organizationUrl: URI
+  
   """
   The repository associated with the action
   """
   repository: Repository
+  
   """
   The name of the repository
   """
   repositoryName: String
+  
   """
   The HTTP path for the repository
   """
   repositoryResourcePath: URI
+  
   """
   The HTTP URL for the repository
   """
   repositoryUrl: URI
+  
   """
   The name of the topic added to the repository
   """
   topic: Topic
+  
   """
   The name of the topic added to the repository
   """
   topicName: String
+  
   """
   The user affected by the action
   """
   user: User
+  
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
+  
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
+  
   """
   The HTTP URL for the user.
   """
@@ -36468,10 +41656,12 @@ type Repository implements Node & PackageOwner & ProjectOwner & ProjectV2Recent 
   always be updated even if it is not required to be up to date before merging.
   """
   allowUpdateBranch: Boolean!
+  
   """
   Identifies the date and time when the repository was archived.
   """
   archivedAt: DateTime
+  
   """
   A list of users that can be assigned to issues in this repository.
   """
@@ -36480,27 +41670,33 @@ type Repository implements Node & PackageOwner & ProjectOwner & ProjectV2Recent 
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Filters users with query on user name and login.
     """
     query: String
   ): UserConnection!
+  
   """
   Whether or not Auto-merge can be enabled on pull requests in this repository.
   """
   autoMergeAllowed: Boolean!
+  
   """
   A list of branch protection rules for this repository.
   """
@@ -36509,23 +41705,28 @@ type Repository implements Node & PackageOwner & ProjectOwner & ProjectV2Recent 
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): BranchProtectionRuleConnection!
+  
   """
   Returns the code of conduct for this repository
   """
   codeOfConduct: CodeOfConduct
+  
   """
   Information extracted from the repository's `CODEOWNERS` file.
   """
@@ -36535,6 +41736,7 @@ type Repository implements Node & PackageOwner & ProjectOwner & ProjectV2Recent 
     """
     refName: String
   ): RepositoryCodeowners
+  
   """
   A list of collaborators associated with the repository.
   """
@@ -36543,31 +41745,38 @@ type Repository implements Node & PackageOwner & ProjectOwner & ProjectV2Recent 
     Collaborators affiliation level with a repository.
     """
     affiliation: CollaboratorAffiliation
+    
     """
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     The login of one specific collaborator.
     """
     login: String
+    
     """
     Filters users with query on user name and login
     """
     query: String
   ): RepositoryCollaboratorConnection
+  
   """
   A list of commit comments associated with the repository.
   """
@@ -36576,43 +41785,53 @@ type Repository implements Node & PackageOwner & ProjectOwner & ProjectV2Recent 
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): CommitCommentConnection!
+  
   """
   Returns a list of contact links associated to the repository
   """
   contactLinks: [RepositoryContactLink!]
+  
   """
   Returns the contributing guidelines for this repository.
   """
   contributingGuidelines: ContributingGuidelines
+  
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
+  
   """
   Identifies the primary key from the database.
   """
   databaseId: Int
+  
   """
   The Ref associated with the repository's default branch.
   """
   defaultBranchRef: Ref
+  
   """
   Whether or not branches are automatically deleted when merged in this repository.
   """
   deleteBranchOnMerge: Boolean!
+  
   """
   A list of dependency manifests contained in the repository
   """
@@ -36621,31 +41840,38 @@ type Repository implements Node & PackageOwner & ProjectOwner & ProjectV2Recent 
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Cursor to paginate dependencies
     """
     dependenciesAfter: String
+    
     """
     Number of dependencies to fetch
     """
     dependenciesFirst: Int
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Flag to scope to only manifests with dependencies
     """
     withDependencies: Boolean
   ): DependencyGraphManifestConnection @preview(toggledBy: "hawkgirl-preview")
+  
   """
   A list of deploy keys that are on this repository.
   """
@@ -36654,19 +41880,23 @@ type Repository implements Node & PackageOwner & ProjectOwner & ProjectV2Recent 
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): DeployKeyConnection!
+  
   """
   Deployments associated with the repository
   """
@@ -36675,35 +41905,43 @@ type Repository implements Node & PackageOwner & ProjectOwner & ProjectV2Recent 
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Environments to list deployments for
     """
     environments: [String!]
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for deployments returned from the connection.
     """
     orderBy: DeploymentOrder = { field: CREATED_AT, direction: ASC }
   ): DeploymentConnection!
+  
   """
   The description of the repository.
   """
   description: String
+  
   """
   The description of the repository rendered to HTML.
   """
   descriptionHTML: HTML!
+  
   """
   Returns a single discussion from the current repository by number.
   """
@@ -36713,6 +41951,7 @@ type Repository implements Node & PackageOwner & ProjectOwner & ProjectV2Recent 
     """
     number: Int!
   ): Discussion
+  
   """
   A list of discussion categories that are available in the repository.
   """
@@ -36721,23 +41960,28 @@ type Repository implements Node & PackageOwner & ProjectOwner & ProjectV2Recent 
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Filter by categories that are assignable by the viewer.
     """
     filterByAssignable: Boolean = false
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): DiscussionCategoryConnection!
+  
   """
   A discussion category by slug.
   """
@@ -36747,6 +41991,7 @@ type Repository implements Node & PackageOwner & ProjectOwner & ProjectV2Recent 
     """
     slug: String!
   ): DiscussionCategory
+  
   """
   A list of discussions that have been opened in the repository.
   """
@@ -36755,39 +42000,48 @@ type Repository implements Node & PackageOwner & ProjectOwner & ProjectV2Recent 
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Only show answered or unanswered discussions
     """
     answered: Boolean = null
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Only include discussions that belong to the category with this ID.
     """
     categoryId: ID = null
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for discussions returned from the connection.
     """
     orderBy: DiscussionOrder = { field: UPDATED_AT, direction: DESC }
+    
     """
     A list of states to filter the discussions by.
     """
     states: [DiscussionState!] = []
   ): DiscussionConnection!
+  
   """
   The number of kilobytes this repository occupies on disk.
   """
   diskUsage: Int
+  
   """
   Returns a single active environment from the current repository by name.
   """
@@ -36797,6 +42051,7 @@ type Repository implements Node & PackageOwner & ProjectOwner & ProjectV2Recent 
     """
     name: String!
   ): Environment
+  
   """
   A list of environments that are in this repository.
   """
@@ -36805,31 +42060,38 @@ type Repository implements Node & PackageOwner & ProjectOwner & ProjectV2Recent 
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for the environments
     """
     orderBy: Environments = { field: NAME, direction: ASC }
   ): EnvironmentConnection!
+  
   """
   Returns how many forks there are of this repository in the whole network.
   """
   forkCount: Int!
+  
   """
   Whether this repository allows forks.
   """
   forkingAllowed: Boolean!
+  
   """
   A list of direct forked repositories.
   """
@@ -36840,126 +42102,156 @@ type Repository implements Node & PackageOwner & ProjectOwner & ProjectV2Recent 
     current viewer owns.
     """
     affiliations: [RepositoryAffiliation]
+    
     """
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     If non-null, filters repositories according to whether they have issues enabled
     """
     hasIssuesEnabled: Boolean
+    
     """
     If non-null, filters repositories according to whether they have been locked
     """
     isLocked: Boolean
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for repositories returned from the connection
     """
     orderBy: RepositoryOrder
+    
     """
     Array of owner's affiliation options for repositories returned from the
     connection. For example, OWNER will include only repositories that the
     organization or user being viewed owns.
     """
     ownerAffiliations: [RepositoryAffiliation] = [OWNER, COLLABORATOR]
+    
     """
     If non-null, filters repositories according to privacy
     """
     privacy: RepositoryPrivacy
   ): RepositoryConnection!
+  
   """
   The funding links for this repository
   """
   fundingLinks: [FundingLink!]!
+  
   """
   Indicates if the repository has the Discussions feature enabled.
   """
   hasDiscussionsEnabled: Boolean!
+  
   """
   Indicates if the repository has issues feature enabled.
   """
   hasIssuesEnabled: Boolean!
+  
   """
   Indicates if the repository has the Projects feature enabled.
   """
   hasProjectsEnabled: Boolean!
+  
   """
   Whether vulnerability alerts are enabled for the repository.
   """
   hasVulnerabilityAlertsEnabled: Boolean!
+  
   """
   Indicates if the repository has wiki feature enabled.
   """
   hasWikiEnabled: Boolean!
+  
   """
   The repository's URL.
   """
   homepageUrl: URI
   id: ID!
+  
   """
   The interaction ability settings for this repository.
   """
   interactionAbility: RepositoryInteractionAbility
+  
   """
   Indicates if the repository is unmaintained.
   """
   isArchived: Boolean!
+  
   """
   Returns true if blank issue creation is allowed
   """
   isBlankIssuesEnabled: Boolean!
+  
   """
   Returns whether or not this repository disabled.
   """
   isDisabled: Boolean!
+  
   """
   Returns whether or not this repository is empty.
   """
   isEmpty: Boolean!
+  
   """
   Identifies if the repository is a fork.
   """
   isFork: Boolean!
+  
   """
   Indicates if a repository is either owned by an organization, or is a private fork of an organization repository.
   """
   isInOrganization: Boolean!
+  
   """
   Indicates if the repository has been locked or not.
   """
   isLocked: Boolean!
+  
   """
   Identifies if the repository is a mirror.
   """
   isMirror: Boolean!
+  
   """
   Identifies if the repository is private or internal.
   """
   isPrivate: Boolean!
+  
   """
   Returns true if this repository has a security policy
   """
   isSecurityPolicyEnabled: Boolean
+  
   """
   Identifies if the repository is a template that can be used to generate new repositories.
   """
   isTemplate: Boolean!
+  
   """
   Is this repository a user configuration repository?
   """
   isUserConfigurationRepository: Boolean!
+  
   """
   Returns a single issue from the current repository by number.
   """
@@ -36969,6 +42261,7 @@ type Repository implements Node & PackageOwner & ProjectOwner & ProjectV2Recent 
     """
     number: Int!
   ): Issue
+  
   """
   Returns a single issue-like object from the current repository by number.
   """
@@ -36978,10 +42271,12 @@ type Repository implements Node & PackageOwner & ProjectOwner & ProjectV2Recent 
     """
     number: Int!
   ): IssueOrPullRequest
+  
   """
   Returns a list of issue templates associated to the repository
   """
   issueTemplates: [IssueTemplate!]
+  
   """
   A list of issues that have been opened in the repository.
   """
@@ -36990,35 +42285,43 @@ type Repository implements Node & PackageOwner & ProjectOwner & ProjectV2Recent 
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Filtering options for issues returned from the connection.
     """
     filterBy: IssueFilters
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     A list of label names to filter the pull requests by.
     """
     labels: [String!]
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for issues returned from the connection.
     """
     orderBy: IssueOrder
+    
     """
     A list of states to filter the issues by.
     """
     states: [IssueState!]
   ): IssueConnection!
+  
   """
   Returns a single label by name
   """
@@ -37028,6 +42331,7 @@ type Repository implements Node & PackageOwner & ProjectOwner & ProjectV2Recent 
     """
     name: String!
   ): Label
+  
   """
   A list of labels associated with the repository.
   """
@@ -37036,27 +42340,33 @@ type Repository implements Node & PackageOwner & ProjectOwner & ProjectV2Recent 
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for labels returned from the connection.
     """
     orderBy: LabelOrder = { field: CREATED_AT, direction: ASC }
+    
     """
     If provided, searches labels by name and description.
     """
     query: String
   ): LabelConnection
+  
   """
   A list containing a breakdown of the language composition of the repository.
   """
@@ -37065,35 +42375,43 @@ type Repository implements Node & PackageOwner & ProjectOwner & ProjectV2Recent 
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Order for connection
     """
     orderBy: LanguageOrder
   ): LanguageConnection
+  
   """
   Get the latest release for the repository if one exists.
   """
   latestRelease: Release
+  
   """
   The license associated with the repository
   """
   licenseInfo: License
+  
   """
   The reason the repository has been locked.
   """
   lockReason: RepositoryLockReason
+  
   """
   A list of Users that can be mentioned in the context of the repository.
   """
@@ -37102,35 +42420,43 @@ type Repository implements Node & PackageOwner & ProjectOwner & ProjectV2Recent 
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Filters users with query on user name and login
     """
     query: String
   ): UserConnection!
+  
   """
   Whether or not PRs are merged with a merge commit on this repository.
   """
   mergeCommitAllowed: Boolean!
+  
   """
   How the default commit message will be generated when merging a pull request.
   """
   mergeCommitMessage: MergeCommitMessage!
+  
   """
   How the default commit title will be generated when merging a pull request.
   """
   mergeCommitTitle: MergeCommitTitle!
+  
   """
   The merge queue for a specified branch, otherwise the default branch if not provided.
   """
@@ -37140,6 +42466,7 @@ type Repository implements Node & PackageOwner & ProjectOwner & ProjectV2Recent 
     """
     branch: String
   ): MergeQueue
+  
   """
   Returns a single milestone from the current repository by number.
   """
@@ -37149,6 +42476,7 @@ type Repository implements Node & PackageOwner & ProjectOwner & ProjectV2Recent 
     """
     number: Int!
   ): Milestone
+  
   """
   A list of milestones associated with the repository.
   """
@@ -37157,43 +42485,53 @@ type Repository implements Node & PackageOwner & ProjectOwner & ProjectV2Recent 
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for milestones.
     """
     orderBy: MilestoneOrder
+    
     """
     Filters milestones with a query on the title
     """
     query: String
+    
     """
     Filter by the state of the milestones.
     """
     states: [MilestoneState!]
   ): MilestoneConnection
+  
   """
   The repository's original mirror URL.
   """
   mirrorUrl: URI
+  
   """
   The name of the repository.
   """
   name: String!
+  
   """
   The repository's name with owner.
   """
   nameWithOwner: String!
+  
   """
   A Git object in the repository
   """
@@ -37202,19 +42540,23 @@ type Repository implements Node & PackageOwner & ProjectOwner & ProjectV2Recent 
     A Git revision expression suitable for rev-parse
     """
     expression: String
+    
     """
     The Git object ID
     """
     oid: GitObjectID
   ): GitObject
+  
   """
   The image used to represent this repository in Open Graph data.
   """
   openGraphImageUrl: URI!
+  
   """
   The User owner of the repository.
   """
   owner: RepositoryOwner!
+  
   """
   A list of packages under the owner.
   """
@@ -37223,39 +42565,48 @@ type Repository implements Node & PackageOwner & ProjectOwner & ProjectV2Recent 
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Find packages by their names.
     """
     names: [String]
+    
     """
     Ordering of the returned packages.
     """
     orderBy: PackageOrder = { field: CREATED_AT, direction: DESC }
+    
     """
     Filter registry package by type.
     """
     packageType: PackageType
+    
     """
     Find packages in a repository by ID.
     """
     repositoryId: ID
   ): PackageConnection!
+  
   """
   The repository parent, if this is a fork.
   """
   parent: Repository
+  
   """
   A list of discussions that have been pinned in this repository.
   """
@@ -37264,19 +42615,23 @@ type Repository implements Node & PackageOwner & ProjectOwner & ProjectV2Recent 
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): PinnedDiscussionConnection!
+  
   """
   A list of pinned issues for this repository.
   """
@@ -37285,23 +42640,28 @@ type Repository implements Node & PackageOwner & ProjectOwner & ProjectV2Recent 
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): PinnedIssueConnection
+  
   """
   The primary language of the repository's code.
   """
   primaryLanguage: Language
+  
   """
   Find project by number.
   """
@@ -37311,6 +42671,7 @@ type Repository implements Node & PackageOwner & ProjectOwner & ProjectV2Recent 
     """
     number: Int!
   ): Project
+  
   """
   Finds and returns the Project according to the provided Project number.
   """
@@ -37320,6 +42681,7 @@ type Repository implements Node & PackageOwner & ProjectOwner & ProjectV2Recent 
     """
     number: Int!
   ): ProjectV2
+  
   """
   A list of projects under the owner.
   """
@@ -37328,39 +42690,48 @@ type Repository implements Node & PackageOwner & ProjectOwner & ProjectV2Recent 
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for projects returned from the connection
     """
     orderBy: ProjectOrder
+    
     """
     Query to search projects by, currently only searching by name.
     """
     search: String
+    
     """
     A list of states to filter the projects by.
     """
     states: [ProjectState!]
   ): ProjectConnection!
+  
   """
   The HTTP path listing the repository's projects
   """
   projectsResourcePath: URI!
+  
   """
   The HTTP URL listing the repository's projects
   """
   projectsUrl: URI!
+  
   """
   List of projects linked to this repository.
   """
@@ -37369,27 +42740,33 @@ type Repository implements Node & PackageOwner & ProjectOwner & ProjectV2Recent 
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     How to order the returned projects.
     """
     orderBy: ProjectV2Order = { field: NUMBER, direction: DESC }
+    
     """
     A project to search for linked to the repo.
     """
     query: String
   ): ProjectV2Connection!
+  
   """
   Returns a single pull request from the current repository by number.
   """
@@ -37399,10 +42776,12 @@ type Repository implements Node & PackageOwner & ProjectOwner & ProjectV2Recent 
     """
     number: Int!
   ): PullRequest
+  
   """
   Returns a list of pull request templates associated to the repository
   """
   pullRequestTemplates: [PullRequestTemplate!]
+  
   """
   A list of pull requests that have been opened in the repository.
   """
@@ -37411,47 +42790,58 @@ type Repository implements Node & PackageOwner & ProjectOwner & ProjectV2Recent 
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     The base ref name to filter the pull requests by.
     """
     baseRefName: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     The head ref name to filter the pull requests by.
     """
     headRefName: String
+    
     """
     A list of label names to filter the pull requests by.
     """
     labels: [String!]
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for pull requests returned from the connection.
     """
     orderBy: IssueOrder
+    
     """
     A list of states to filter the pull requests by.
     """
     states: [PullRequestState!]
   ): PullRequestConnection!
+  
   """
   Identifies the date and time when the repository was last pushed to.
   """
   pushedAt: DateTime
+  
   """
   Whether or not rebase-merging is enabled on this repository.
   """
   rebaseMergeAllowed: Boolean!
+  
   """
   Recent projects that this user has modified in the context of the owner.
   """
@@ -37460,19 +42850,23 @@ type Repository implements Node & PackageOwner & ProjectOwner & ProjectV2Recent 
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): ProjectV2Connection!
+  
   """
   Fetch a given ref from the repository
   """
@@ -37483,6 +42877,7 @@ type Repository implements Node & PackageOwner & ProjectOwner & ProjectV2Recent 
     """
     qualifiedName: String!
   ): Ref
+  
   """
   Fetch a list of refs from the repository
   """
@@ -37491,35 +42886,43 @@ type Repository implements Node & PackageOwner & ProjectOwner & ProjectV2Recent 
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     DEPRECATED: use orderBy. The ordering direction.
     """
     direction: OrderDirection
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for refs returned from the connection.
     """
     orderBy: RefOrder
+    
     """
     Filters refs with query on name
     """
     query: String
+    
     """
     A ref name prefix like `refs/heads/`, `refs/tags/`, etc.
     """
     refPrefix: String!
   ): RefConnection
+  
   """
   Lookup a single release given various criteria.
   """
@@ -37529,6 +42932,7 @@ type Repository implements Node & PackageOwner & ProjectOwner & ProjectV2Recent 
     """
     tagName: String!
   ): Release
+  
   """
   List of releases which are dependent on this repository.
   """
@@ -37537,23 +42941,28 @@ type Repository implements Node & PackageOwner & ProjectOwner & ProjectV2Recent 
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Order for connection
     """
     orderBy: ReleaseOrder
   ): ReleaseConnection!
+  
   """
   A list of applied repository-topic associations for this repository.
   """
@@ -37562,23 +42971,28 @@ type Repository implements Node & PackageOwner & ProjectOwner & ProjectV2Recent 
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): RepositoryTopicConnection!
+  
   """
   The HTTP path for this repository
   """
   resourcePath: URI!
+  
   """
   Returns a single ruleset from the current repository by ID.
   """
@@ -37587,11 +43001,13 @@ type Repository implements Node & PackageOwner & ProjectOwner & ProjectV2Recent 
     The ID of the ruleset to be returned.
     """
     databaseId: Int!
+    
     """
     Include rulesets configured at higher levels that apply to this repository
     """
     includeParents: Boolean = true
   ): RepositoryRuleset
+  
   """
   A list of rulesets for this repository.
   """
@@ -37600,27 +43016,33 @@ type Repository implements Node & PackageOwner & ProjectOwner & ProjectV2Recent 
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Return rulesets configured at higher levels that apply to this repository
     """
     includeParents: Boolean = true
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): RepositoryRulesetConnection
+  
   """
   The security policy URL.
   """
   securityPolicyUrl: URI
+  
   """
   A description of the repository, rendered to HTML without any links in it.
   """
@@ -37630,18 +43052,22 @@ type Repository implements Node & PackageOwner & ProjectOwner & ProjectV2Recent 
     """
     limit: Int = 200
   ): HTML!
+  
   """
   Whether or not squash-merging is enabled on this repository.
   """
   squashMergeAllowed: Boolean!
+  
   """
   How the default commit message will be generated when squash merging a pull request.
   """
   squashMergeCommitMessage: SquashMergeCommitMessage!
+  
   """
   How the default commit title will be generated when squash merging a pull request.
   """
   squashMergeCommitTitle: SquashMergeCommitTitle!
+  
   """
   Whether a squash merge commit can use the pull request title as default.
   """
@@ -37649,14 +43075,17 @@ type Repository implements Node & PackageOwner & ProjectOwner & ProjectV2Recent 
     @deprecated(
       reason: "`squashPrTitleUsedAsDefault` will be removed. Use `Repository.squashMergeCommitTitle` instead. Removal on 2023-04-01 UTC."
     )
+  
   """
   The SSH URL to clone this repository
   """
   sshUrl: GitSSHRemote!
+  
   """
   Returns a count of how many stargazers there are on this object
   """
   stargazerCount: Int!
+  
   """
   A list of users who have starred this starrable.
   """
@@ -37665,23 +43094,28 @@ type Repository implements Node & PackageOwner & ProjectOwner & ProjectV2Recent 
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Order for connection
     """
     orderBy: StarOrder
   ): StargazerConnection!
+  
   """
   Returns a list of all submodules in this repository parsed from the
   .gitmodules file as of the default branch's HEAD commit.
@@ -37691,83 +43125,103 @@ type Repository implements Node & PackageOwner & ProjectOwner & ProjectV2Recent 
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): SubmoduleConnection!
+  
   """
   Temporary authentication token for cloning this repository.
   """
   tempCloneToken: String
+  
   """
   The repository from which this repository was generated, if any.
   """
   templateRepository: Repository
+  
   """
   Identifies the date and time when the object was last updated.
   """
   updatedAt: DateTime!
+  
   """
   The HTTP URL for this repository
   """
   url: URI!
+  
   """
   Whether this repository has a custom image to use with Open Graph as opposed to being represented by the owner's avatar.
   """
   usesCustomOpenGraphImage: Boolean!
+  
   """
   Indicates whether the viewer has admin permissions on this repository.
   """
   viewerCanAdminister: Boolean!
+  
   """
   Can the current viewer create new projects on this owner.
   """
   viewerCanCreateProjects: Boolean!
+  
   """
   Check if the viewer is able to change their subscription status for the repository.
   """
   viewerCanSubscribe: Boolean!
+  
   """
   Indicates whether the viewer can update the topics of this repository.
   """
   viewerCanUpdateTopics: Boolean!
+  
   """
   The last commit email for the viewer.
   """
   viewerDefaultCommitEmail: String
+  
   """
   The last used merge method by the viewer or the default for the repository.
   """
   viewerDefaultMergeMethod: PullRequestMergeMethod!
+  
   """
   Returns a boolean indicating whether the viewing user has starred this starrable.
   """
   viewerHasStarred: Boolean!
+  
   """
   The users permission level on the repository. Will return null if authenticated as an GitHub App.
   """
   viewerPermission: RepositoryPermission
+  
   """
   A list of emails this viewer can commit with.
   """
   viewerPossibleCommitEmails: [String!]
+  
   """
   Identifies if the viewer is watching, not watching, or ignoring the subscribable entity.
   """
   viewerSubscription: SubscriptionState
+  
   """
   Indicates the repository's visibility level.
   """
   visibility: RepositoryVisibility!
+  
   """
   Returns a single vulnerability alert from the current repository by number.
   """
@@ -37777,6 +43231,7 @@ type Repository implements Node & PackageOwner & ProjectOwner & ProjectV2Recent 
     """
     number: Int!
   ): RepositoryVulnerabilityAlert
+  
   """
   A list of vulnerability alerts that are on this repository.
   """
@@ -37785,27 +43240,33 @@ type Repository implements Node & PackageOwner & ProjectOwner & ProjectV2Recent 
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Filter by the scope of the alert's dependency
     """
     dependencyScopes: [RepositoryVulnerabilityAlertDependencyScope!]
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Filter by the state of the alert
     """
     states: [RepositoryVulnerabilityAlertState!]
   ): RepositoryVulnerabilityAlertConnection
+  
   """
   A list of users watching the repository.
   """
@@ -37814,19 +43275,23 @@ type Repository implements Node & PackageOwner & ProjectOwner & ProjectV2Recent 
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): UserConnection!
+  
   """
   Whether contributors are required to sign off on web-based commits in this repository.
   """
@@ -37860,14 +43325,17 @@ interface RepositoryAuditEntryData {
   The repository associated with the action
   """
   repository: Repository
+  
   """
   The name of the repository
   """
   repositoryName: String
+  
   """
   The HTTP path for the repository
   """
   repositoryResourcePath: URI
+  
   """
   The HTTP URL for the repository
   """
@@ -37892,26 +43360,32 @@ type RepositoryCodeownersError {
   The column number where the error occurs.
   """
   column: Int!
+  
   """
   A short string describing the type of error.
   """
   kind: String!
+  
   """
   The line number where the error occurs.
   """
   line: Int!
+  
   """
   A complete description of the error, combining information from other fields.
   """
   message: String!
+  
   """
   The path to the file when the error occurs.
   """
   path: String!
+  
   """
   The content of the line where the error occurs.
   """
   source: String!
+  
   """
   A suggestion of how to fix the error.
   """
@@ -37926,14 +43400,17 @@ type RepositoryCollaboratorConnection {
   A list of edges.
   """
   edges: [RepositoryCollaboratorEdge]
+  
   """
   A list of nodes.
   """
   nodes: [User]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -37949,10 +43426,12 @@ type RepositoryCollaboratorEdge {
   """
   cursor: String!
   node: User!
+  
   """
   The permission the user has on the repository.
   """
   permission: RepositoryPermission!
+  
   """
   A list of sources for the user's access to the repository.
   """
@@ -37967,18 +43446,22 @@ type RepositoryConnection {
   A list of edges.
   """
   edges: [RepositoryEdge]
+  
   """
   A list of nodes.
   """
   nodes: [Repository]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
   totalCount: Int!
+  
   """
   The total size in kilobytes of all repositories in the connection.
   """
@@ -37993,10 +43476,12 @@ type RepositoryContactLink {
   The contact link purpose.
   """
   about: String!
+  
   """
   The contact link name.
   """
   name: String!
+  
   """
   The contact link URL.
   """
@@ -38041,31 +43526,38 @@ interface RepositoryDiscussionAuthor {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Filter discussions to only those that have been answered or not. Defaults to
     including both answered and unanswered discussions.
     """
     answered: Boolean = null
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for discussions returned from the connection.
     """
     orderBy: DiscussionOrder = { field: CREATED_AT, direction: DESC }
+    
     """
     Filter discussions to only those in a specific repository.
     """
     repositoryId: ID
+    
     """
     A list of states to filter the discussions by.
     """
@@ -38085,22 +43577,27 @@ interface RepositoryDiscussionCommentAuthor {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Filter discussion comments to only those that were marked as the answer
     """
     onlyAnswers: Boolean = false
+    
     """
     Filter discussion comments to only those in a specific repository.
     """
@@ -38116,6 +43613,7 @@ type RepositoryEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -38150,106 +43648,132 @@ interface RepositoryInfo {
   Identifies the date and time when the repository was archived.
   """
   archivedAt: DateTime
+  
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
+  
   """
   The description of the repository.
   """
   description: String
+  
   """
   The description of the repository rendered to HTML.
   """
   descriptionHTML: HTML!
+  
   """
   Returns how many forks there are of this repository in the whole network.
   """
   forkCount: Int!
+  
   """
   Indicates if the repository has the Discussions feature enabled.
   """
   hasDiscussionsEnabled: Boolean!
+  
   """
   Indicates if the repository has issues feature enabled.
   """
   hasIssuesEnabled: Boolean!
+  
   """
   Indicates if the repository has the Projects feature enabled.
   """
   hasProjectsEnabled: Boolean!
+  
   """
   Indicates if the repository has wiki feature enabled.
   """
   hasWikiEnabled: Boolean!
+  
   """
   The repository's URL.
   """
   homepageUrl: URI
+  
   """
   Indicates if the repository is unmaintained.
   """
   isArchived: Boolean!
+  
   """
   Identifies if the repository is a fork.
   """
   isFork: Boolean!
+  
   """
   Indicates if a repository is either owned by an organization, or is a private fork of an organization repository.
   """
   isInOrganization: Boolean!
+  
   """
   Indicates if the repository has been locked or not.
   """
   isLocked: Boolean!
+  
   """
   Identifies if the repository is a mirror.
   """
   isMirror: Boolean!
+  
   """
   Identifies if the repository is private or internal.
   """
   isPrivate: Boolean!
+  
   """
   Identifies if the repository is a template that can be used to generate new repositories.
   """
   isTemplate: Boolean!
+  
   """
   The license associated with the repository
   """
   licenseInfo: License
+  
   """
   The reason the repository has been locked.
   """
   lockReason: RepositoryLockReason
+  
   """
   The repository's original mirror URL.
   """
   mirrorUrl: URI
+  
   """
   The name of the repository.
   """
   name: String!
+  
   """
   The repository's name with owner.
   """
   nameWithOwner: String!
+  
   """
   The image used to represent this repository in Open Graph data.
   """
   openGraphImageUrl: URI!
+  
   """
   The User owner of the repository.
   """
   owner: RepositoryOwner!
+  
   """
   Identifies the date and time when the repository was last pushed to.
   """
   pushedAt: DateTime
+  
   """
   The HTTP path for this repository
   """
   resourcePath: URI!
+  
   """
   A description of the repository, rendered to HTML without any links in it.
   """
@@ -38259,18 +43783,22 @@ interface RepositoryInfo {
     """
     limit: Int = 200
   ): HTML!
+  
   """
   Identifies the date and time when the object was last updated.
   """
   updatedAt: DateTime!
+  
   """
   The HTTP URL for this repository
   """
   url: URI!
+  
   """
   Whether this repository has a custom image to use with Open Graph as opposed to being represented by the owner's avatar.
   """
   usesCustomOpenGraphImage: Boolean!
+  
   """
   Indicates the repository's visibility level.
   """
@@ -38285,10 +43813,12 @@ type RepositoryInteractionAbility {
   The time the currently active limit expires.
   """
   expiresAt: DateTime
+  
   """
   The current limit that is enabled on this object.
   """
   limit: RepositoryInteractionLimit!
+  
   """
   The origin of the currently active interaction limit.
   """
@@ -38370,22 +43900,27 @@ type RepositoryInvitation implements Node {
   """
   email: String
   id: ID!
+  
   """
   The user who received the invitation.
   """
   invitee: User
+  
   """
   The user who created the invitation.
   """
   inviter: User!
+  
   """
   The permalink for this repository invitation.
   """
   permalink: URI!
+  
   """
   The permission granted on this repository by this invitation.
   """
   permission: RepositoryPermission!
+  
   """
   The Repository the user is invited to.
   """
@@ -38400,14 +43935,17 @@ type RepositoryInvitationConnection {
   A list of edges.
   """
   edges: [RepositoryInvitationEdge]
+  
   """
   A list of nodes.
   """
   nodes: [RepositoryInvitation]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -38422,6 +43960,7 @@ type RepositoryInvitationEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -38436,6 +43975,7 @@ input RepositoryInvitationOrder {
   The ordering direction.
   """
   direction: OrderDirection!
+  
   """
   The field to order repository invitations by.
   """
@@ -38486,39 +44026,48 @@ type RepositoryMigration implements Migration & Node {
   The migration flag to continue on error.
   """
   continueOnError: Boolean!
+  
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
+  
   """
   Identifies the primary key from the database.
   """
   databaseId: String
+  
   """
   The reason the migration failed.
   """
   failureReason: String
   id: ID!
+  
   """
   The URL for the migration log (expires 1 day after migration completes).
   """
   migrationLogUrl: URI
+  
   """
   The migration source.
   """
   migrationSource: MigrationSource!
+  
   """
   The target repository name.
   """
   repositoryName: String!
+  
   """
   The migration source URL, for example `https://github.com` or `https://monalisa.ghe.com`.
   """
   sourceUrl: URI!
+  
   """
   The migration state.
   """
   state: MigrationState!
+  
   """
   The number of warnings encountered for this migration. To review the warnings,
   check the [Migration Log](https://docs.github.com/en/migrations/using-github-enterprise-importer/completing-your-migration-with-github-enterprise-importer/accessing-your-migration-logs-for-github-enterprise-importer).
@@ -38534,14 +44083,17 @@ type RepositoryMigrationConnection {
   A list of edges.
   """
   edges: [RepositoryMigrationEdge]
+  
   """
   A list of nodes.
   """
   nodes: [RepositoryMigration]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -38556,6 +44108,7 @@ type RepositoryMigrationEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -38570,6 +44123,7 @@ input RepositoryMigrationOrder {
   The ordering direction.
   """
   direction: RepositoryMigrationOrderDirection!
+  
   """
   The field to order repository migrations by.
   """
@@ -38608,11 +44162,13 @@ type RepositoryNameConditionTarget {
   Array of repository names or patterns to exclude. The condition will not pass if any of these patterns match.
   """
   exclude: [String!]!
+  
   """
   Array of repository names or patterns to include. One of these patterns must
   match for the condition to pass. Also accepts `~ALL` to include all repositories.
   """
   include: [String!]!
+  
   """
   Target changes that match these patterns will be prevented except by those with bypass permissions.
   """
@@ -38627,11 +44183,13 @@ input RepositoryNameConditionTargetInput {
   Array of repository names or patterns to exclude. The condition will not pass if any of these patterns match.
   """
   exclude: [String!]!
+  
   """
   Array of repository names or patterns to include. One of these patterns must
   match for the condition to pass. Also accepts `~ALL` to include all repositories.
   """
   include: [String!]!
+  
   """
   Target changes that match these patterns will be prevented except by those with bypass permissions.
   """
@@ -38656,6 +44214,7 @@ input RepositoryOrder {
   The ordering direction.
   """
   direction: OrderDirection!
+  
   """
   The field to order repositories by.
   """
@@ -38702,10 +44261,12 @@ interface RepositoryOwner {
     size: Int
   ): URI!
   id: ID!
+  
   """
   The username used to login.
   """
   login: String!
+  
   """
   A list of repositories that the user owns.
   """
@@ -38716,53 +44277,65 @@ interface RepositoryOwner {
     current viewer owns.
     """
     affiliations: [RepositoryAffiliation]
+    
     """
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     If non-null, filters repositories according to whether they have issues enabled
     """
     hasIssuesEnabled: Boolean
+    
     """
     If non-null, filters repositories according to whether they are archived and not maintained
     """
     isArchived: Boolean
+    
     """
     If non-null, filters repositories according to whether they are forks of another repository
     """
     isFork: Boolean
+    
     """
     If non-null, filters repositories according to whether they have been locked
     """
     isLocked: Boolean
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for repositories returned from the connection
     """
     orderBy: RepositoryOrder
+    
     """
     Array of owner's affiliation options for repositories returned from the
     connection. For example, OWNER will include only repositories that the
     organization or user being viewed owns.
     """
     ownerAffiliations: [RepositoryAffiliation] = [OWNER, COLLABORATOR]
+    
     """
     If non-null, filters repositories according to privacy
     """
     privacy: RepositoryPrivacy
   ): RepositoryConnection!
+  
   """
   Find Repository.
   """
@@ -38771,15 +44344,18 @@ interface RepositoryOwner {
     Follow repository renames. If disabled, a repository referenced by its old name will return an error.
     """
     followRenames: Boolean = true
+    
     """
     Name of Repository to find.
     """
     name: String!
   ): Repository
+  
   """
   The HTTP URL for the owner.
   """
   resourcePath: URI!
+  
   """
   The HTTP URL for the owner.
   """
@@ -38832,14 +44408,17 @@ A repository rule.
 """
 type RepositoryRule implements Node {
   id: ID!
+  
   """
   The parameters for this rule.
   """
   parameters: RuleParameters
+  
   """
   The repository ruleset associated with this rule configuration
   """
   repositoryRuleset: RepositoryRuleset
+  
   """
   The type of rule.
   """
@@ -38854,10 +44433,12 @@ type RepositoryRuleConditions {
   Configuration for the ref_name condition
   """
   refName: RefNameConditionTarget
+  
   """
   Configuration for the repository_id condition
   """
   repositoryId: RepositoryIdConditionTarget
+  
   """
   Configuration for the repository_name condition
   """
@@ -38872,10 +44453,12 @@ input RepositoryRuleConditionsInput {
   Configuration for the ref_name condition
   """
   refName: RefNameConditionTargetInput
+  
   """
   Configuration for the repository_id condition
   """
   repositoryId: RepositoryIdConditionTargetInput
+  
   """
   Configuration for the repository_name condition
   """
@@ -38890,14 +44473,17 @@ type RepositoryRuleConnection {
   A list of edges.
   """
   edges: [RepositoryRuleEdge]
+  
   """
   A list of nodes.
   """
   nodes: [RepositoryRule]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -38912,6 +44498,7 @@ type RepositoryRuleEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -38926,10 +44513,12 @@ input RepositoryRuleInput {
   Optional ID of this rule when updating
   """
   id: ID @possibleTypes(concreteTypes: ["RepositoryRule"])
+  
   """
   The parameters for the rule.
   """
   parameters: RuleParametersInput
+  
   """
   The type of rule to create.
   """
@@ -39013,40 +44602,49 @@ type RepositoryRuleset implements Node {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): RepositoryRulesetBypassActorConnection
+  
   """
   The set of conditions that must evaluate to true for this ruleset to apply
   """
   conditions: RepositoryRuleConditions!
+  
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
+  
   """
   Identifies the primary key from the database.
   """
   databaseId: Int
+  
   """
   The enforcement level of this ruleset
   """
   enforcement: RuleEnforcement!
   id: ID!
+  
   """
   Name of the ruleset.
   """
   name: String!
+  
   """
   List of rules.
   """
@@ -39055,31 +44653,38 @@ type RepositoryRuleset implements Node {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     The type of rule.
     """
     type: RepositoryRuleType
   ): RepositoryRuleConnection
+  
   """
   Source of ruleset.
   """
   source: RuleSource!
+  
   """
   Target of the ruleset.
   """
   target: RepositoryRulesetTarget
+  
   """
   Identifies the date and time when the object was last updated.
   """
@@ -39094,23 +44699,28 @@ type RepositoryRulesetBypassActor implements Node {
   The actor that can bypass rules.
   """
   actor: BypassActor
+  
   """
   The mode for the bypass actor
   """
   bypassMode: RepositoryRulesetBypassActorBypassMode
   id: ID!
+  
   """
   This actor represents the ability for an organization admin to bypass
   """
   organizationAdmin: Boolean!
+  
   """
   If the actor is a repository role, the repository role's ID that can bypass
   """
   repositoryRoleDatabaseId: Int
+  
   """
   If the actor is a repository role, the repository role's name that can bypass
   """
   repositoryRoleName: String
+  
   """
   Identifies the ruleset associated with the allowed actor
   """
@@ -39139,14 +44749,17 @@ type RepositoryRulesetBypassActorConnection {
   A list of edges.
   """
   edges: [RepositoryRulesetBypassActorEdge]
+  
   """
   A list of nodes.
   """
   nodes: [RepositoryRulesetBypassActor]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -39161,6 +44774,7 @@ type RepositoryRulesetBypassActorEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -39176,14 +44790,17 @@ input RepositoryRulesetBypassActorInput {
   For Team and Integration bypasses, the Team or Integration ID
   """
   actorId: ID
+  
   """
   The bypass mode for this actor.
   """
   bypassMode: RepositoryRulesetBypassActorBypassMode!
+  
   """
   For org admin bupasses, true
   """
   organizationAdmin: Boolean
+  
   """
   For role bypasses, the role database ID
   """
@@ -39198,14 +44815,17 @@ type RepositoryRulesetConnection {
   A list of edges.
   """
   edges: [RepositoryRulesetEdge]
+  
   """
   A list of nodes.
   """
   nodes: [RepositoryRuleset]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -39220,6 +44840,7 @@ type RepositoryRulesetEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -39245,14 +44866,17 @@ A repository-topic connects a repository to a topic.
 """
 type RepositoryTopic implements Node & UniformResourceLocatable {
   id: ID!
+  
   """
   The HTTP path for this repository-topic.
   """
   resourcePath: URI!
+  
   """
   The topic.
   """
   topic: Topic!
+  
   """
   The HTTP URL for this repository-topic.
   """
@@ -39267,14 +44891,17 @@ type RepositoryTopicConnection {
   A list of edges.
   """
   edges: [RepositoryTopicEdge]
+  
   """
   A list of nodes.
   """
   nodes: [RepositoryTopic]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -39289,6 +44916,7 @@ type RepositoryTopicEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -39321,79 +44949,98 @@ type RepositoryVisibilityChangeDisableAuditEntry implements AuditEntry & Enterpr
   The action name
   """
   action: String!
+  
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
+  
   """
   The IP address of the actor
   """
   actorIp: String
+  
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
+  
   """
   The username of the user who initiated the action
   """
   actorLogin: String
+  
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
+  
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
+  
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
+  
   """
   The HTTP path for this enterprise.
   """
   enterpriseResourcePath: URI
+  
   """
   The slug of the enterprise.
   """
   enterpriseSlug: String
+  
   """
   The HTTP URL for this enterprise.
   """
   enterpriseUrl: URI
   id: ID!
+  
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
+  
   """
   The Organization associated with the Audit Entry.
   """
   organization: Organization
+  
   """
   The name of the Organization.
   """
   organizationName: String
+  
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
+  
   """
   The HTTP URL for the organization
   """
   organizationUrl: URI
+  
   """
   The user affected by the action
   """
   user: User
+  
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
+  
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
+  
   """
   The HTTP URL for the user.
   """
@@ -39408,79 +45055,98 @@ type RepositoryVisibilityChangeEnableAuditEntry implements AuditEntry & Enterpri
   The action name
   """
   action: String!
+  
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
+  
   """
   The IP address of the actor
   """
   actorIp: String
+  
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
+  
   """
   The username of the user who initiated the action
   """
   actorLogin: String
+  
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
+  
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
+  
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
+  
   """
   The HTTP path for this enterprise.
   """
   enterpriseResourcePath: URI
+  
   """
   The slug of the enterprise.
   """
   enterpriseSlug: String
+  
   """
   The HTTP URL for this enterprise.
   """
   enterpriseUrl: URI
   id: ID!
+  
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
+  
   """
   The Organization associated with the Audit Entry.
   """
   organization: Organization
+  
   """
   The name of the Organization.
   """
   organizationName: String
+  
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
+  
   """
   The HTTP URL for the organization
   """
   organizationUrl: URI
+  
   """
   The user affected by the action
   """
   user: User
+  
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
+  
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
+  
   """
   The HTTP URL for the user.
   """
@@ -39495,67 +45161,83 @@ type RepositoryVulnerabilityAlert implements Node & RepositoryNode {
   When was the alert auto-dismissed?
   """
   autoDismissedAt: DateTime
+  
   """
   When was the alert created?
   """
   createdAt: DateTime!
+  
   """
   The associated Dependabot update
   """
   dependabotUpdate: DependabotUpdate
+  
   """
   The scope of an alert's dependency
   """
   dependencyScope: RepositoryVulnerabilityAlertDependencyScope
+  
   """
   Comment explaining the reason the alert was dismissed
   """
   dismissComment: String
+  
   """
   The reason the alert was dismissed
   """
   dismissReason: String
+  
   """
   When was the alert dismissed?
   """
   dismissedAt: DateTime
+  
   """
   The user who dismissed the alert
   """
   dismisser: User
+  
   """
   When was the alert fixed?
   """
   fixedAt: DateTime
   id: ID!
+  
   """
   Identifies the alert number.
   """
   number: Int!
+  
   """
   The associated repository
   """
   repository: Repository!
+  
   """
   The associated security advisory
   """
   securityAdvisory: SecurityAdvisory
+  
   """
   The associated security vulnerability
   """
   securityVulnerability: SecurityVulnerability
+  
   """
   Identifies the state of the alert.
   """
   state: RepositoryVulnerabilityAlertState!
+  
   """
   The vulnerable manifest filename
   """
   vulnerableManifestFilename: String!
+  
   """
   The vulnerable manifest path
   """
   vulnerableManifestPath: String!
+  
   """
   The vulnerable requirements
   """
@@ -39570,14 +45252,17 @@ type RepositoryVulnerabilityAlertConnection {
   A list of edges.
   """
   edges: [RepositoryVulnerabilityAlertEdge]
+  
   """
   A list of nodes.
   """
   nodes: [RepositoryVulnerabilityAlert]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -39606,6 +45291,7 @@ type RepositoryVulnerabilityAlertEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -39642,18 +45328,22 @@ input RequestReviewsInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The Node ID of the pull request to modify.
   """
   pullRequestId: ID! @possibleTypes(concreteTypes: ["PullRequest"])
+  
   """
   The Node IDs of the team to request.
   """
   teamIds: [ID!] @possibleTypes(concreteTypes: ["Team"])
+  
   """
   Add users to the set rather than replace.
   """
   union: Boolean = false
+  
   """
   The Node IDs of the user to request.
   """
@@ -39668,14 +45358,17 @@ type RequestReviewsPayload {
   Identifies the actor who performed the event.
   """
   actor: Actor
+  
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The pull request that is getting requests.
   """
   pullRequest: PullRequest
+  
   """
   The edge from the pull request to the requested reviewers.
   """
@@ -39721,14 +45414,17 @@ type RequestedReviewerConnection {
   A list of edges.
   """
   edges: [RequestedReviewerEdge]
+  
   """
   A list of nodes.
   """
   nodes: [RequestedReviewer]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -39743,6 +45439,7 @@ type RequestedReviewerEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -39761,6 +45458,7 @@ interface RequirableByPullRequest {
     The id of the pull request this is required for
     """
     pullRequestId: ID
+    
     """
     The number of the pull request this is required for
     """
@@ -39796,6 +45494,7 @@ type RequiredStatusCheckDescription {
   The App that must provide this status in order for it to be accepted.
   """
   app: App
+  
   """
   The name of this status.
   """
@@ -39812,6 +45511,7 @@ input RequiredStatusCheckInput {
   use "any" to allow any app to set the status.
   """
   appId: ID
+  
   """
   Status check context that must pass for commits to be accepted to the matching branch.
   """
@@ -39829,6 +45529,7 @@ type RequiredStatusChecksParameters {
   Status checks that are required.
   """
   requiredStatusChecks: [StatusCheckConfiguration!]!
+  
   """
   Whether pull requests targeting a matching branch must be tested with the
   latest code. This setting will not take effect unless at least one status
@@ -39848,6 +45549,7 @@ input RequiredStatusChecksParametersInput {
   Status checks that are required.
   """
   requiredStatusChecks: [StatusCheckConfigurationInput!]!
+  
   """
   Whether pull requests targeting a matching branch must be tested with the
   latest code. This setting will not take effect unless at least one status
@@ -39864,10 +45566,12 @@ input RerequestCheckSuiteInput {
   The Node ID of the check suite.
   """
   checkSuiteId: ID! @possibleTypes(concreteTypes: ["CheckSuite"])
+  
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The Node ID of the repository.
   """
@@ -39882,6 +45586,7 @@ type RerequestCheckSuitePayload {
   The requested check suite.
   """
   checkSuite: CheckSuite
+  
   """
   A unique identifier for the client performing the mutation.
   """
@@ -39896,6 +45601,7 @@ input ResolveReviewThreadInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The ID of the thread to resolve
   """
@@ -39910,6 +45616,7 @@ type ResolveReviewThreadPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The thread to resolve.
   """
@@ -39926,18 +45633,22 @@ type RestrictedContribution implements Contribution {
   longer access.
   """
   isRestricted: Boolean!
+  
   """
   When this contribution was made.
   """
   occurredAt: DateTime!
+  
   """
   The HTTP path for this contribution.
   """
   resourcePath: URI!
+  
   """
   The HTTP URL for this contribution.
   """
   url: URI!
+  
   """
   The user who made this contribution.
   """
@@ -39952,6 +45663,7 @@ input RetireSponsorsTierInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The ID of the published tier to retire.
   """
@@ -39966,6 +45678,7 @@ type RetireSponsorsTierPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The tier that was retired.
   """
@@ -39980,18 +45693,22 @@ input RevertPullRequestInput {
   The description of the revert pull request.
   """
   body: String
+  
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   Indicates whether the revert pull request should be a draft.
   """
   draft: Boolean = false
+  
   """
   The ID of the pull request to revert.
   """
   pullRequestId: ID! @possibleTypes(concreteTypes: ["PullRequest"])
+  
   """
   The title of the revert pull request.
   """
@@ -40006,10 +45723,12 @@ type RevertPullRequestPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The pull request that was reverted.
   """
   pullRequest: PullRequest
+  
   """
   The new pull request that reverts the input pull request.
   """
@@ -40024,6 +45743,7 @@ type ReviewDismissalAllowance implements Node {
   The actor that can dismiss.
   """
   actor: ReviewDismissalAllowanceActor
+  
   """
   Identifies the branch protection rule associated with the allowed user, team, or app.
   """
@@ -40044,14 +45764,17 @@ type ReviewDismissalAllowanceConnection {
   A list of edges.
   """
   edges: [ReviewDismissalAllowanceEdge]
+  
   """
   A list of nodes.
   """
   nodes: [ReviewDismissalAllowance]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -40066,6 +45789,7 @@ type ReviewDismissalAllowanceEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -40080,43 +45804,53 @@ type ReviewDismissedEvent implements Node & UniformResourceLocatable {
   Identifies the actor who performed the event.
   """
   actor: Actor
+  
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
+  
   """
   Identifies the primary key from the database.
   """
   databaseId: Int
+  
   """
   Identifies the optional message associated with the 'review_dismissed' event.
   """
   dismissalMessage: String
+  
   """
   Identifies the optional message associated with the event, rendered to HTML.
   """
   dismissalMessageHTML: String
   id: ID!
+  
   """
   Identifies the previous state of the review with the 'review_dismissed' event.
   """
   previousReviewState: PullRequestReviewState!
+  
   """
   PullRequest referenced by event.
   """
   pullRequest: PullRequest!
+  
   """
   Identifies the commit which caused the review to become stale.
   """
   pullRequestCommit: PullRequestCommit
+  
   """
   The HTTP path for this review dismissed event.
   """
   resourcePath: URI!
+  
   """
   Identifies the review associated with the 'review_dismissed' event.
   """
   review: PullRequestReview
+  
   """
   The HTTP URL for this review dismissed event.
   """
@@ -40131,15 +45865,18 @@ type ReviewRequest implements Node {
   Whether this request was created for a code owner
   """
   asCodeOwner: Boolean!
+  
   """
   Identifies the primary key from the database.
   """
   databaseId: Int
   id: ID!
+  
   """
   Identifies the pull request associated with this review request.
   """
   pullRequest: PullRequest!
+  
   """
   The reviewer that is requested.
   """
@@ -40154,14 +45891,17 @@ type ReviewRequestConnection {
   A list of edges.
   """
   edges: [ReviewRequestEdge]
+  
   """
   A list of nodes.
   """
   nodes: [ReviewRequest]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -40176,6 +45916,7 @@ type ReviewRequestEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -40190,15 +45931,18 @@ type ReviewRequestRemovedEvent implements Node {
   Identifies the actor who performed the event.
   """
   actor: Actor
+  
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
   id: ID!
+  
   """
   PullRequest referenced by event.
   """
   pullRequest: PullRequest!
+  
   """
   Identifies the reviewer whose review request was removed.
   """
@@ -40213,15 +45957,18 @@ type ReviewRequestedEvent implements Node {
   Identifies the actor who performed the event.
   """
   actor: Actor
+  
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
   id: ID!
+  
   """
   PullRequest referenced by event.
   """
   pullRequest: PullRequest!
+  
   """
   Identifies the reviewer whose review was requested.
   """
@@ -40237,10 +45984,12 @@ type ReviewStatusHovercardContext implements HovercardContext {
   A string describing this context
   """
   message: String!
+  
   """
   An octicon to accompany this context
   """
   octicon: String!
+  
   """
   The current status of the pull request with respect to code review.
   """
@@ -40255,10 +46004,12 @@ input RevokeEnterpriseOrganizationsMigratorRoleInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The ID of the enterprise to which all organizations managed by it will be granted the migrator role.
   """
   enterpriseId: ID! @possibleTypes(concreteTypes: ["Enterprise"])
+  
   """
   The login of the user to revoke the migrator role
   """
@@ -40273,6 +46024,7 @@ type RevokeEnterpriseOrganizationsMigratorRolePayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The organizations that had the migrator role revoked for the given user.
   """
@@ -40281,14 +46033,17 @@ type RevokeEnterpriseOrganizationsMigratorRolePayload {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
@@ -40304,14 +46059,17 @@ input RevokeMigratorRoleInput {
   The user login or Team slug to revoke the migrator role from.
   """
   actor: String!
+  
   """
   Specifies the type of the actor, can be either USER or TEAM.
   """
   actorType: ActorType!
+  
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The ID of the organization that the user/team belongs to.
   """
@@ -40326,6 +46084,7 @@ type RevokeMigratorRolePayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   Did the operation succeed?
   """
@@ -40390,34 +46149,42 @@ input RuleParametersInput {
   Parameters used for the `branch_name_pattern` rule type
   """
   branchNamePattern: BranchNamePatternParametersInput
+  
   """
   Parameters used for the `commit_author_email_pattern` rule type
   """
   commitAuthorEmailPattern: CommitAuthorEmailPatternParametersInput
+  
   """
   Parameters used for the `commit_message_pattern` rule type
   """
   commitMessagePattern: CommitMessagePatternParametersInput
+  
   """
   Parameters used for the `committer_email_pattern` rule type
   """
   committerEmailPattern: CommitterEmailPatternParametersInput
+  
   """
   Parameters used for the `pull_request` rule type
   """
   pullRequest: PullRequestParametersInput
+  
   """
   Parameters used for the `required_deployments` rule type
   """
   requiredDeployments: RequiredDeploymentsParametersInput
+  
   """
   Parameters used for the `required_status_checks` rule type
   """
   requiredStatusChecks: RequiredStatusChecksParametersInput
+  
   """
   Parameters used for the `tag_name_pattern` rule type
   """
   tagNamePattern: TagNamePatternParametersInput
+  
   """
   Parameters used for the `update` rule type
   """
@@ -40481,19 +46248,23 @@ type SavedReply implements Node {
   The body of the saved reply.
   """
   body: String!
+  
   """
   The saved reply body rendered to HTML.
   """
   bodyHTML: HTML!
+  
   """
   Identifies the primary key from the database.
   """
   databaseId: Int
   id: ID!
+  
   """
   The title of the saved reply.
   """
   title: String!
+  
   """
   The user that saved this reply.
   """
@@ -40508,14 +46279,17 @@ type SavedReplyConnection {
   A list of edges.
   """
   edges: [SavedReplyEdge]
+  
   """
   A list of nodes.
   """
   nodes: [SavedReply]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -40530,6 +46304,7 @@ type SavedReplyEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -40544,6 +46319,7 @@ input SavedReplyOrder {
   The ordering direction.
   """
   direction: OrderDirection!
+  
   """
   The field to order saved replies by.
   """
@@ -40584,40 +46360,48 @@ type SearchResultItemConnection {
   across all types.
   """
   codeCount: Int!
+  
   """
   The total number of discussions that matched the search query. Regardless of
   the total number of matches, a maximum of 1,000 results will be available
   across all types.
   """
   discussionCount: Int!
+  
   """
   A list of edges.
   """
   edges: [SearchResultItemEdge]
+  
   """
   The total number of issues that matched the search query. Regardless of the
   total number of matches, a maximum of 1,000 results will be available across all types.
   """
   issueCount: Int!
+  
   """
   A list of nodes.
   """
   nodes: [SearchResultItem]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   The total number of repositories that matched the search query. Regardless of
   the total number of matches, a maximum of 1,000 results will be available
   across all types.
   """
   repositoryCount: Int!
+  
   """
   The total number of users that matched the search query. Regardless of the
   total number of matches, a maximum of 1,000 results will be available across all types.
   """
   userCount: Int!
+  
   """
   The total number of wiki pages that matched the search query. Regardless of
   the total number of matches, a maximum of 1,000 results will be available
@@ -40634,10 +46418,12 @@ type SearchResultItemEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
   node: SearchResultItem
+  
   """
   Text matches on the result found.
   """
@@ -40674,10 +46460,12 @@ type SecurityAdvisory implements Node {
   The classification of the advisory
   """
   classification: SecurityAdvisoryClassification!
+  
   """
   The CVSS associated with this advisory
   """
   cvss: CVSS!
+  
   """
   CWEs associated with this Advisory
   """
@@ -40686,68 +46474,84 @@ type SecurityAdvisory implements Node {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): CWEConnection!
+  
   """
   Identifies the primary key from the database.
   """
   databaseId: Int
+  
   """
   This is a long plaintext description of the advisory
   """
   description: String!
+  
   """
   The GitHub Security Advisory ID
   """
   ghsaId: String!
   id: ID!
+  
   """
   A list of identifiers for this advisory
   """
   identifiers: [SecurityAdvisoryIdentifier!]!
+  
   """
   The permalink for the advisory's dependabot alerts page
   """
   notificationsPermalink: URI
+  
   """
   The organization that originated the advisory
   """
   origin: String!
+  
   """
   The permalink for the advisory
   """
   permalink: URI
+  
   """
   When the advisory was published
   """
   publishedAt: DateTime!
+  
   """
   A list of references for this advisory
   """
   references: [SecurityAdvisoryReference!]!
+  
   """
   The severity of the advisory
   """
   severity: SecurityAdvisorySeverity!
+  
   """
   A short plaintext summary of the advisory
   """
   summary: String!
+  
   """
   When the advisory was last updated
   """
   updatedAt: DateTime!
+  
   """
   Vulnerabilities associated with this Advisory
   """
@@ -40756,39 +46560,48 @@ type SecurityAdvisory implements Node {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     A list of advisory classifications to filter vulnerabilities by.
     """
     classifications: [SecurityAdvisoryClassification!]
+    
     """
     An ecosystem to filter vulnerabilities by.
     """
     ecosystem: SecurityAdvisoryEcosystem
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for the returned topics.
     """
     orderBy: SecurityVulnerabilityOrder = { field: UPDATED_AT, direction: DESC }
+    
     """
     A package name to filter vulnerabilities by.
     """
     package: String
+    
     """
     A list of severities to filter vulnerabilities by.
     """
     severities: [SecurityAdvisorySeverity!]
   ): SecurityVulnerabilityConnection!
+  
   """
   When the advisory was withdrawn, if it has been withdrawn
   """
@@ -40817,14 +46630,17 @@ type SecurityAdvisoryConnection {
   A list of edges.
   """
   edges: [SecurityAdvisoryEdge]
+  
   """
   A list of nodes.
   """
   nodes: [SecurityAdvisory]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -40893,6 +46709,7 @@ type SecurityAdvisoryEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -40907,6 +46724,7 @@ type SecurityAdvisoryIdentifier {
   The identifier type, e.g. GHSA, CVE
   """
   type: String!
+  
   """
   The identifier
   """
@@ -40921,6 +46739,7 @@ input SecurityAdvisoryIdentifierFilter {
   The identifier type.
   """
   type: SecurityAdvisoryIdentifierType!
+  
   """
   The identifier string. Supports exact or partial matching.
   """
@@ -40949,6 +46768,7 @@ input SecurityAdvisoryOrder {
   The ordering direction.
   """
   direction: OrderDirection!
+  
   """
   The field to order security advisories by.
   """
@@ -40977,6 +46797,7 @@ type SecurityAdvisoryPackage {
   The ecosystem the package belongs to, e.g. RUBYGEMS, NPM
   """
   ecosystem: SecurityAdvisoryEcosystem!
+  
   """
   The package name
   """
@@ -41033,22 +46854,27 @@ type SecurityVulnerability {
   The Advisory associated with this Vulnerability
   """
   advisory: SecurityAdvisory!
+  
   """
   The first version containing a fix for the vulnerability
   """
   firstPatchedVersion: SecurityAdvisoryPackageVersion
+  
   """
   A description of the vulnerable package
   """
   package: SecurityAdvisoryPackage!
+  
   """
   The severity of the vulnerability within this package
   """
   severity: SecurityAdvisorySeverity!
+  
   """
   When the vulnerability was last updated
   """
   updatedAt: DateTime!
+  
   """
   A string that describes the vulnerable package versions.
   This string follows a basic syntax with a few forms.
@@ -41069,14 +46895,17 @@ type SecurityVulnerabilityConnection {
   A list of edges.
   """
   edges: [SecurityVulnerabilityEdge]
+  
   """
   A list of nodes.
   """
   nodes: [SecurityVulnerability]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -41091,6 +46920,7 @@ type SecurityVulnerabilityEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -41105,6 +46935,7 @@ input SecurityVulnerabilityOrder {
   The ordering direction.
   """
   direction: OrderDirection!
+  
   """
   The field to order security vulnerabilities by.
   """
@@ -41129,26 +46960,32 @@ input SetEnterpriseIdentityProviderInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The digest algorithm used to sign SAML requests for the identity provider.
   """
   digestMethod: SamlDigestAlgorithm!
+  
   """
   The ID of the enterprise on which to set an identity provider.
   """
   enterpriseId: ID! @possibleTypes(concreteTypes: ["Enterprise"])
+  
   """
   The x509 certificate used by the identity provider to sign assertions and responses.
   """
   idpCertificate: String!
+  
   """
   The Issuer Entity ID for the SAML identity provider
   """
   issuer: String
+  
   """
   The signature algorithm used to sign SAML requests for the identity provider.
   """
   signatureMethod: SamlSignatureAlgorithm!
+  
   """
   The URL endpoint for the identity provider's SAML SSO.
   """
@@ -41163,6 +47000,7 @@ type SetEnterpriseIdentityProviderPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The identity provider for the enterprise.
   """
@@ -41177,14 +47015,17 @@ input SetOrganizationInteractionLimitInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   When this limit should expire.
   """
   expiry: RepositoryInteractionLimitExpiry
+  
   """
   The limit to set.
   """
   limit: RepositoryInteractionLimit!
+  
   """
   The ID of the organization to set a limit for.
   """
@@ -41199,6 +47040,7 @@ type SetOrganizationInteractionLimitPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The organization that the interaction limit was set for.
   """
@@ -41213,14 +47055,17 @@ input SetRepositoryInteractionLimitInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   When this limit should expire.
   """
   expiry: RepositoryInteractionLimitExpiry
+  
   """
   The limit to set.
   """
   limit: RepositoryInteractionLimit!
+  
   """
   The ID of the repository to set a limit for.
   """
@@ -41235,6 +47080,7 @@ type SetRepositoryInteractionLimitPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The repository that the interaction limit was set for.
   """
@@ -41249,14 +47095,17 @@ input SetUserInteractionLimitInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   When this limit should expire.
   """
   expiry: RepositoryInteractionLimitExpiry
+  
   """
   The limit to set.
   """
   limit: RepositoryInteractionLimit!
+  
   """
   The ID of the user to set a limit for.
   """
@@ -41271,6 +47120,7 @@ type SetUserInteractionLimitPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The user that the interaction limit was set for.
   """
@@ -41285,27 +47135,33 @@ type SmimeSignature implements GitSignature {
   Email used to sign this object.
   """
   email: String!
+  
   """
   True if the signature is valid and verified by GitHub.
   """
   isValid: Boolean!
+  
   """
   Payload for GPG signing object. Raw ODB object without the signature header.
   """
   payload: String!
+  
   """
   ASCII-armored signature header from object.
   """
   signature: String!
+  
   """
   GitHub user corresponding to the email signing this commit.
   """
   signer: User
+  
   """
   The state of this signature. `VALID` if signature is valid and verified by
   GitHub, otherwise represents reason why signature is considered invalid.
   """
   state: GitSignatureState!
+  
   """
   True if the signature was made with GitHub's signing key.
   """
@@ -41320,10 +47176,12 @@ type SocialAccount {
   Name of the social media account as it appears on the profile.
   """
   displayName: String!
+  
   """
   Software or company that hosts the social media account.
   """
   provider: SocialAccountProvider!
+  
   """
   URL of the social media account.
   """
@@ -41338,14 +47196,17 @@ type SocialAccountConnection {
   A list of edges.
   """
   edges: [SocialAccountEdge]
+  
   """
   A list of nodes.
   """
   nodes: [SocialAccount]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -41360,6 +47221,7 @@ type SocialAccountEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -41425,14 +47287,17 @@ type SponsorConnection {
   A list of edges.
   """
   edges: [SponsorEdge]
+  
   """
   A list of nodes.
   """
   nodes: [Sponsor]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -41447,6 +47312,7 @@ type SponsorEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -41461,6 +47327,7 @@ input SponsorOrder {
   The ordering direction.
   """
   direction: OrderDirection!
+  
   """
   The field to order sponsor entities by.
   """
@@ -41489,10 +47356,12 @@ interface Sponsorable {
   The estimated next GitHub Sponsors payout for this user/organization in cents (USD).
   """
   estimatedNextSponsorsPayoutInCents: Int!
+  
   """
   True if this user/organization has a GitHub Sponsors listing.
   """
   hasSponsorsListing: Boolean!
+  
   """
   Whether the given account is sponsoring this user/organization.
   """
@@ -41502,14 +47371,17 @@ interface Sponsorable {
     """
     accountLogin: String!
   ): Boolean!
+  
   """
   True if the viewer is sponsored by this user/organization.
   """
   isSponsoringViewer: Boolean!
+  
   """
   The estimated monthly GitHub Sponsors income for this user/organization in cents (USD).
   """
   monthlyEstimatedSponsorsIncomeInCents: Int!
+  
   """
   List of users and organizations this entity is sponsoring.
   """
@@ -41518,23 +47390,28 @@ interface Sponsorable {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for the users and organizations returned from the connection.
     """
     orderBy: SponsorOrder = { field: RELEVANCE, direction: DESC }
   ): SponsorConnection!
+  
   """
   List of sponsors for this user or organization.
   """
@@ -41543,28 +47420,34 @@ interface Sponsorable {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for sponsors returned from the connection.
     """
     orderBy: SponsorOrder = { field: RELEVANCE, direction: DESC }
+    
     """
     If given, will filter for sponsors at the given tier. Will only return
     sponsors whose tier the viewer is permitted to see.
     """
     tierId: ID
   ): SponsorConnection!
+  
   """
   Events involving this sponsorable, such as new sponsorships.
   """
@@ -41573,55 +47456,67 @@ interface Sponsorable {
     Filter activities to only the specified actions.
     """
     actions: [SponsorsActivityAction!] = []
+    
     """
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Whether to include those events where this sponsorable acted as the sponsor.
     Defaults to only including events where this sponsorable was the recipient
     of a sponsorship.
     """
     includeAsSponsor: Boolean = false
+    
     """
     Whether or not to include private activities in the result set. Defaults to including public and private activities.
     """
     includePrivate: Boolean = true
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for activity returned from the connection.
     """
     orderBy: SponsorsActivityOrder = { field: TIMESTAMP, direction: DESC }
+    
     """
     Filter activities returned to only those that occurred in the most recent
     specified time period. Set to ALL to avoid filtering by when the activity
     occurred. Will be ignored if `since` or `until` is given.
     """
     period: SponsorsActivityPeriod = MONTH
+    
     """
     Filter activities to those that occurred on or after this time.
     """
     since: DateTime
+    
     """
     Filter activities to those that occurred before this time.
     """
     until: DateTime
   ): SponsorsActivityConnection!
+  
   """
   The GitHub Sponsors listing for this user or organization.
   """
   sponsorsListing: SponsorsListing
+  
   """
   The sponsorship from the viewer to this user/organization; that is, the sponsorship where you're the sponsor.
   """
@@ -41632,6 +47527,7 @@ interface Sponsorable {
     """
     activeOnly: Boolean = true
   ): Sponsorship
+  
   """
   The sponsorship from this user/organization to the viewer; that is, the sponsorship you're receiving.
   """
@@ -41642,6 +47538,7 @@ interface Sponsorable {
     """
     activeOnly: Boolean = true
   ): Sponsorship
+  
   """
   List of sponsorship updates sent from this sponsorable to sponsors.
   """
@@ -41650,23 +47547,28 @@ interface Sponsorable {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for sponsorship updates returned from the connection.
     """
     orderBy: SponsorshipNewsletterOrder = { field: CREATED_AT, direction: DESC }
   ): SponsorshipNewsletterConnection!
+  
   """
   The sponsorships where this user or organization is the maintainer receiving the funds.
   """
@@ -41676,32 +47578,39 @@ interface Sponsorable {
     sponsorships this maintainer has ever received.
     """
     activeOnly: Boolean = true
+    
     """
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Whether or not to include private sponsorships in the result set
     """
     includePrivate: Boolean = false
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for sponsorships returned from this connection. If left
     blank, the sponsorships will be ordered based on relevancy to the viewer.
     """
     orderBy: SponsorshipOrder
   ): SponsorshipConnection!
+  
   """
   The sponsorships where this user or organization is the funder.
   """
@@ -41710,34 +47619,41 @@ interface Sponsorable {
     Whether to include only sponsorships that are active right now, versus all sponsorships this sponsor has ever made.
     """
     activeOnly: Boolean = true
+    
     """
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Filter sponsorships returned to those for the specified maintainers. That
     is, the recipient of the sponsorship is a user or organization with one of
     the given logins.
     """
     maintainerLogins: [String!]
+    
     """
     Ordering options for sponsorships returned from this connection. If left
     blank, the sponsorships will be ordered based on relevancy to the viewer.
     """
     orderBy: SponsorshipOrder
   ): SponsorshipConnection!
+  
   """
   The amount in United States cents (e.g., 500 = $5.00 USD) that this entity has
   spent on GitHub to fund sponsorships. Only returns a value when viewed by the
@@ -41748,19 +47664,23 @@ interface Sponsorable {
     Filter payments to those that occurred on or after this time.
     """
     since: DateTime
+    
     """
     Filter payments to those made to the users or organizations with the specified usernames.
     """
     sponsorableLogins: [String!] = []
+    
     """
     Filter payments to those that occurred before this time.
     """
     until: DateTime
   ): Int
+  
   """
   Whether or not the viewer is able to sponsor this user/organization.
   """
   viewerCanSponsor: Boolean!
+  
   """
   True if the viewer is sponsoring this user/organization.
   """
@@ -41780,14 +47700,17 @@ type SponsorableItemConnection {
   A list of edges.
   """
   edges: [SponsorableItemEdge]
+  
   """
   A list of nodes.
   """
   nodes: [SponsorableItem]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -41802,6 +47725,7 @@ type SponsorableItemEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -41816,6 +47740,7 @@ input SponsorableOrder {
   The ordering direction.
   """
   direction: OrderDirection!
+  
   """
   The field to order sponsorable entities by.
   """
@@ -41840,31 +47765,38 @@ type SponsorsActivity implements Node {
   What action this activity indicates took place.
   """
   action: SponsorsActivityAction!
+  
   """
   The sponsor's current privacy level.
   """
   currentPrivacyLevel: SponsorshipPrivacy
   id: ID!
+  
   """
   The tier that the sponsorship used to use, for tier change events.
   """
   previousSponsorsTier: SponsorsTier
+  
   """
   The user or organization who triggered this activity and was/is sponsoring the sponsorable.
   """
   sponsor: Sponsor
+  
   """
   The user or organization that is being sponsored, the maintainer.
   """
   sponsorable: Sponsorable!
+  
   """
   The associated sponsorship tier.
   """
   sponsorsTier: SponsorsTier
+  
   """
   The timestamp of this event.
   """
   timestamp: DateTime
+  
   """
   Was this sponsorship made alongside other sponsorships at the same time from the same sponsor?
   """
@@ -41909,14 +47841,17 @@ type SponsorsActivityConnection {
   A list of edges.
   """
   edges: [SponsorsActivityEdge]
+  
   """
   A list of nodes.
   """
   nodes: [SponsorsActivity]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -41931,6 +47866,7 @@ type SponsorsActivityEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -41945,6 +47881,7 @@ input SponsorsActivityOrder {
   The ordering direction.
   """
   direction: OrderDirection!
+  
   """
   The field to order activity by.
   """
@@ -42981,19 +48918,23 @@ type SponsorsGoal {
   A description of the goal from the maintainer.
   """
   description: String
+  
   """
   What the objective of this goal is.
   """
   kind: SponsorsGoalKind!
+  
   """
   The percentage representing how complete this goal is, between 0-100.
   """
   percentComplete: Int!
+  
   """
   What the goal amount is. Represents an amount in USD for monthly sponsorship
   amount goals. Represents a count of unique sponsors for total sponsors count goals.
   """
   targetValue: Int!
+  
   """
   A brief summary of the kind and target value of this goal.
   """
@@ -43022,36 +48963,43 @@ type SponsorsListing implements Node {
   The current goal the maintainer is trying to reach with GitHub Sponsors, if any.
   """
   activeGoal: SponsorsGoal
+  
   """
   The Stripe Connect account currently in use for payouts for this Sponsors
   listing, if any. Will only return a value when queried by the maintainer
   themselves, or by an admin of the sponsorable organization.
   """
   activeStripeConnectAccount: StripeConnectAccount
+  
   """
   The name of the country or region with the maintainer's bank account or fiscal
   host. Will only return a value when queried by the maintainer themselves, or
   by an admin of the sponsorable organization.
   """
   billingCountryOrRegion: String
+  
   """
   The email address used by GitHub to contact the sponsorable about their GitHub
   Sponsors profile. Will only return a value when queried by the maintainer
   themselves, or by an admin of the sponsorable organization.
   """
   contactEmailAddress: String
+  
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
+  
   """
   The HTTP path for the Sponsors dashboard for this Sponsors listing.
   """
   dashboardResourcePath: URI!
+  
   """
   The HTTP URL for the Sponsors dashboard for this Sponsors listing.
   """
   dashboardUrl: URI!
+  
   """
   The records featured on the GitHub Sponsors profile.
   """
@@ -43064,54 +49012,66 @@ type SponsorsListing implements Node {
       USER
     ]
   ): [SponsorsListingFeaturedItem!]!
+  
   """
   The fiscal host used for payments, if any. Will only return a value when
   queried by the maintainer themselves, or by an admin of the sponsorable organization.
   """
   fiscalHost: Organization
+  
   """
   The full description of the listing.
   """
   fullDescription: String!
+  
   """
   The full description of the listing rendered to HTML.
   """
   fullDescriptionHTML: HTML!
   id: ID!
+  
   """
   Whether this listing is publicly visible.
   """
   isPublic: Boolean!
+  
   """
   The listing's full name.
   """
   name: String!
+  
   """
   A future date on which this listing is eligible to receive a payout.
   """
   nextPayoutDate: Date
+  
   """
   The name of the country or region where the maintainer resides. Will only
   return a value when queried by the maintainer themselves, or by an admin of
   the sponsorable organization.
   """
   residenceCountryOrRegion: String
+  
   """
   The HTTP path for this Sponsors listing.
   """
   resourcePath: URI!
+  
   """
   The short description of the listing.
   """
   shortDescription: String!
+  
   """
   The short name of the listing.
   """
   slug: String!
+  
   """
   The entity this listing represents who can be sponsored on GitHub Sponsors.
   """
   sponsorable: Sponsorable!
+  
   """
   The tiers for this GitHub Sponsors profile.
   """
@@ -43120,14 +49080,17 @@ type SponsorsListing implements Node {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Whether to include tiers that aren't published. Only admins of the Sponsors
     listing can see draft tiers. Only admins of the Sponsors listing and viewers
@@ -43136,16 +49099,19 @@ type SponsorsListing implements Node {
     can see the GitHub Sponsors profile.
     """
     includeUnpublished: Boolean = false
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for Sponsors tiers returned from the connection.
     """
     orderBy: SponsorsTierOrder = { field: MONTHLY_PRICE_IN_CENTS, direction: ASC
     }
   ): SponsorsTierConnection
+  
   """
   The HTTP URL for this Sponsors listing.
   """
@@ -43165,26 +49131,31 @@ type SponsorsListingFeaturedItem implements Node {
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
+  
   """
   Will either be a description from the sponsorable maintainer about why they
   featured this item, or the item's description itself, such as a user's bio
   from their GitHub profile page.
   """
   description: String
+  
   """
   The record that is featured on the GitHub Sponsors profile.
   """
   featureable: SponsorsListingFeatureableItem!
   id: ID!
+  
   """
   The position of this featured item on the GitHub Sponsors profile with a lower
   position indicating higher precedence. Starts at 1.
   """
   position: Int!
+  
   """
   The GitHub Sponsors profile that features this record.
   """
   sponsorsListing: SponsorsListing!
+  
   """
   Identifies the date and time when the object was last updated.
   """
@@ -43213,50 +49184,61 @@ type SponsorsTier implements Node {
   SponsorsTier information only visible to users that can administer the associated Sponsors listing.
   """
   adminInfo: SponsorsTierAdminInfo
+  
   """
   Get a different tier for this tier's maintainer that is at the same frequency
   as this tier but with an equal or lesser cost. Returns the published tier with
   the monthly price closest to this tier's without going over.
   """
   closestLesserValueTier: SponsorsTier
+  
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
+  
   """
   The description of the tier.
   """
   description: String!
+  
   """
   The tier description rendered to HTML
   """
   descriptionHTML: HTML!
   id: ID!
+  
   """
   Whether this tier was chosen at checkout time by the sponsor rather than
   defined ahead of time by the maintainer who manages the Sponsors listing.
   """
   isCustomAmount: Boolean!
+  
   """
   Whether this tier is only for use with one-time sponsorships.
   """
   isOneTime: Boolean!
+  
   """
   How much this tier costs per month in cents.
   """
   monthlyPriceInCents: Int!
+  
   """
   How much this tier costs per month in USD.
   """
   monthlyPriceInDollars: Int!
+  
   """
   The name of the tier.
   """
   name: String!
+  
   """
   The sponsors listing that this tier belongs to.
   """
   sponsorsListing: SponsorsListing!
+  
   """
   Identifies the date and time when the object was last updated.
   """
@@ -43275,6 +49257,7 @@ type SponsorsTierAdminInfo {
   GitHub Sponsors profile.
   """
   isDraft: Boolean!
+  
   """
   Indicates whether this tier is published to the associated GitHub Sponsors
   profile. Published tiers are visible to anyone who can see the GitHub Sponsors
@@ -43282,6 +49265,7 @@ type SponsorsTierAdminInfo {
   profile is publicly visible.
   """
   isPublished: Boolean!
+  
   """
   Indicates whether this tier has been retired from the associated GitHub
   Sponsors profile. Retired tiers are no longer shown on the GitHub Sponsors
@@ -43289,6 +49273,7 @@ type SponsorsTierAdminInfo {
   still use retired tiers if the sponsor selected the tier before it was retired.
   """
   isRetired: Boolean!
+  
   """
   The sponsorships using this tier.
   """
@@ -43297,23 +49282,28 @@ type SponsorsTierAdminInfo {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Whether or not to return private sponsorships using this tier. Defaults to
     only returning public sponsorships on this tier.
     """
     includePrivate: Boolean = false
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for sponsorships returned from this connection. If left
     blank, the sponsorships will be ordered based on relevancy to the viewer.
@@ -43330,14 +49320,17 @@ type SponsorsTierConnection {
   A list of edges.
   """
   edges: [SponsorsTierEdge]
+  
   """
   A list of nodes.
   """
   nodes: [SponsorsTier]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -43352,6 +49345,7 @@ type SponsorsTierEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -43366,6 +49360,7 @@ input SponsorsTierOrder {
   The ordering direction.
   """
   direction: OrderDirection!
+  
   """
   The field to order tiers by.
   """
@@ -43395,20 +49390,24 @@ type Sponsorship implements Node {
   """
   createdAt: DateTime!
   id: ID!
+  
   """
   Whether the sponsorship is active. False implies the sponsor is a past sponsor
   of the maintainer, while true implies they are a current sponsor.
   """
   isActive: Boolean!
+  
   """
   Whether this sponsorship represents a one-time payment versus a recurring sponsorship.
   """
   isOneTimePayment: Boolean!
+  
   """
   Whether the sponsor has chosen to receive sponsorship update emails sent from
   the sponsorable. Only returns a non-null value when the viewer has permission to know this.
   """
   isSponsorOptedIntoEmail: Boolean
+  
   """
   The entity that is being sponsored
   """
@@ -43416,10 +49415,12 @@ type Sponsorship implements Node {
     @deprecated(
       reason: "`Sponsorship.maintainer` will be removed. Use `Sponsorship.sponsorable` instead. Removal on 2020-04-01 UTC."
     )
+  
   """
   The privacy level for this sponsorship.
   """
   privacyLevel: SponsorshipPrivacy!
+  
   """
   The user that is sponsoring. Returns null if the sponsorship is private or if sponsor is not a user.
   """
@@ -43427,18 +49428,22 @@ type Sponsorship implements Node {
     @deprecated(
       reason: "`Sponsorship.sponsor` will be removed. Use `Sponsorship.sponsorEntity` instead. Removal on 2020-10-01 UTC."
     )
+  
   """
   The user or organization that is sponsoring, if you have permission to view them.
   """
   sponsorEntity: Sponsor
+  
   """
   The entity that is being sponsored
   """
   sponsorable: Sponsorable!
+  
   """
   The associated sponsorship tier
   """
   tier: SponsorsTier
+  
   """
   Identifies the date and time when the current tier was chosen for this sponsorship.
   """
@@ -43453,23 +49458,28 @@ type SponsorshipConnection {
   A list of edges.
   """
   edges: [SponsorshipEdge]
+  
   """
   A list of nodes.
   """
   nodes: [Sponsorship]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
   totalCount: Int!
+  
   """
   The total amount in cents of all recurring sponsorships in the connection
   whose amount you can view. Does not include one-time sponsorships.
   """
   totalRecurringMonthlyPriceInCents: Int!
+  
   """
   The total amount in USD of all recurring sponsorships in the connection whose
   amount you can view. Does not include one-time sponsorships.
@@ -43485,6 +49495,7 @@ type SponsorshipEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -43499,27 +49510,33 @@ type SponsorshipNewsletter implements Node {
   The author of the newsletter.
   """
   author: User
+  
   """
   The contents of the newsletter, the message the sponsorable wanted to give.
   """
   body: String!
+  
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
   id: ID!
+  
   """
   Indicates if the newsletter has been made available to sponsors.
   """
   isPublished: Boolean!
+  
   """
   The user or organization this newsletter is from.
   """
   sponsorable: Sponsorable!
+  
   """
   The subject of the newsletter, what it's about.
   """
   subject: String!
+  
   """
   Identifies the date and time when the object was last updated.
   """
@@ -43534,14 +49551,17 @@ type SponsorshipNewsletterConnection {
   A list of edges.
   """
   edges: [SponsorshipNewsletterEdge]
+  
   """
   A list of nodes.
   """
   nodes: [SponsorshipNewsletter]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -43556,6 +49576,7 @@ type SponsorshipNewsletterEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -43570,6 +49591,7 @@ input SponsorshipNewsletterOrder {
   The ordering direction.
   """
   direction: OrderDirection!
+  
   """
   The field to order sponsorship newsletters by.
   """
@@ -43594,6 +49616,7 @@ input SponsorshipOrder {
   The ordering direction.
   """
   direction: OrderDirection!
+  
   """
   The field to order sponsorship by.
   """
@@ -43664,31 +49687,38 @@ type SshSignature implements GitSignature {
   Email used to sign this object.
   """
   email: String!
+  
   """
   True if the signature is valid and verified by GitHub.
   """
   isValid: Boolean!
+  
   """
   Hex-encoded fingerprint of the key that signed this object.
   """
   keyFingerprint: String
+  
   """
   Payload for GPG signing object. Raw ODB object without the signature header.
   """
   payload: String!
+  
   """
   ASCII-armored signature header from object.
   """
   signature: String!
+  
   """
   GitHub user corresponding to the email signing this commit.
   """
   signer: User
+  
   """
   The state of this signature. `VALID` if signature is valid and verified by
   GitHub, otherwise represents reason why signature is considered invalid.
   """
   state: GitSignatureState!
+  
   """
   True if the signature was made with GitHub's signing key.
   """
@@ -43703,6 +49733,7 @@ input StarOrder {
   The direction in which to order nodes.
   """
   direction: OrderDirection!
+  
   """
   The field in which to order nodes by.
   """
@@ -43727,14 +49758,17 @@ type StargazerConnection {
   A list of edges.
   """
   edges: [StargazerEdge]
+  
   """
   A list of nodes.
   """
   nodes: [User]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -43750,6 +49784,7 @@ type StargazerEdge {
   """
   cursor: String!
   node: User!
+  
   """
   Identifies when the item was starred.
   """
@@ -43761,10 +49796,12 @@ Things that can be starred.
 """
 interface Starrable {
   id: ID!
+  
   """
   Returns a count of how many stargazers there are on this object
   """
   stargazerCount: Int!
+  
   """
   A list of users who have starred this starrable.
   """
@@ -43773,23 +49810,28 @@ interface Starrable {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Order for connection
     """
     orderBy: StarOrder
   ): StargazerConnection!
+  
   """
   Returns a boolean indicating whether the viewing user has starred this starrable.
   """
@@ -43804,18 +49846,22 @@ type StarredRepositoryConnection {
   A list of edges.
   """
   edges: [StarredRepositoryEdge]
+  
   """
   Is the list of stars for this user truncated? This is true for users that have many stars.
   """
   isOverLimit: Boolean!
+  
   """
   A list of nodes.
   """
   nodes: [Repository]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -43831,6 +49877,7 @@ type StarredRepositoryEdge {
   """
   cursor: String!
   node: Repository!
+  
   """
   Identifies when the item was starred.
   """
@@ -43845,18 +49892,22 @@ input StartOrganizationMigrationInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The migration source access token.
   """
   sourceAccessToken: String!
+  
   """
   The URL of the organization to migrate.
   """
   sourceOrgUrl: URI!
+  
   """
   The ID of the enterprise the target organization belongs to.
   """
   targetEnterpriseId: ID! @possibleTypes(concreteTypes: ["Enterprise"])
+  
   """
   The name of the target organization.
   """
@@ -43871,6 +49922,7 @@ type StartOrganizationMigrationPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The new organization migration.
   """
@@ -43885,50 +49937,62 @@ input StartRepositoryMigrationInput {
   The migration source access token.
   """
   accessToken: String
+  
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   Whether to continue the migration on error. Defaults to `true`.
   """
   continueOnError: Boolean
+  
   """
   The signed URL to access the user-uploaded git archive.
   """
   gitArchiveUrl: String
+  
   """
   The GitHub personal access token of the user importing to the target repository.
   """
   githubPat: String
+  
   """
   Whether to lock the source repository.
   """
   lockSource: Boolean
+  
   """
   The signed URL to access the user-uploaded metadata archive.
   """
   metadataArchiveUrl: String
+  
   """
   The ID of the organization that will own the imported repository.
   """
   ownerId: ID! @possibleTypes(concreteTypes: ["Organization"])
+  
   """
   The name of the imported repository.
   """
   repositoryName: String!
+  
   """
   Whether to skip migrating releases for the repository.
   """
   skipReleases: Boolean
+  
   """
   The ID of the migration source.
   """
   sourceId: ID! @possibleTypes(concreteTypes: ["MigrationSource"])
+  
   """
   The URL of the source repository.
   """
   sourceRepositoryUrl: URI
+  
   """
   The visibility of the imported repository.
   """
@@ -43943,6 +50007,7 @@ type StartRepositoryMigrationPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The new repository migration.
   """
@@ -43961,23 +50026,28 @@ type Status implements Node {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): StatusCheckRollupContextConnection!
+  
   """
   The commit this status is attached to.
   """
   commit: Commit
+  
   """
   Looks up an individual status context by context name.
   """
@@ -43987,11 +50057,13 @@ type Status implements Node {
     """
     name: String!
   ): StatusContext
+  
   """
   The individual status contexts for this commit.
   """
   contexts: [StatusContext!]!
   id: ID!
+  
   """
   The combined commit status.
   """
@@ -44006,6 +50078,7 @@ type StatusCheckConfiguration {
   The status check context name that must be present on the commit.
   """
   context: String!
+  
   """
   The optional integration ID that this status check must originate from.
   """
@@ -44020,6 +50093,7 @@ input StatusCheckConfigurationInput {
   The status check context name that must be present on the commit.
   """
   context: String!
+  
   """
   The optional integration ID that this status check must originate from.
   """
@@ -44034,6 +50108,7 @@ type StatusCheckRollup implements Node {
   The commit the status and check runs are attached to.
   """
   commit: Commit
+  
   """
   A list of status contexts and check runs for this commit.
   """
@@ -44042,20 +50117,24 @@ type StatusCheckRollup implements Node {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): StatusCheckRollupContextConnection!
   id: ID!
+  
   """
   The combined status for the commit.
   """
@@ -44075,30 +50154,37 @@ type StatusCheckRollupContextConnection {
   The number of check runs in this rollup.
   """
   checkRunCount: Int!
+  
   """
   Counts of check runs by state.
   """
   checkRunCountsByState: [CheckRunStateCount!]
+  
   """
   A list of edges.
   """
   edges: [StatusCheckRollupContextEdge]
+  
   """
   A list of nodes.
   """
   nodes: [StatusCheckRollupContext]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   The number of status contexts in this rollup.
   """
   statusContextCount: Int!
+  
   """
   Counts of status contexts by state.
   """
   statusContextCountsByState: [StatusContextStateCount!]
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -44113,6 +50199,7 @@ type StatusCheckRollupContextEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -44132,27 +50219,33 @@ type StatusContext implements Node & RequirableByPullRequest {
     """
     size: Int = 40
   ): URI
+  
   """
   This commit this status context is attached to.
   """
   commit: Commit
+  
   """
   The name of this status context.
   """
   context: String!
+  
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
+  
   """
   The actor who created this status context.
   """
   creator: Actor
+  
   """
   The description for this status context.
   """
   description: String
   id: ID!
+  
   """
   Whether this is required to pass before merging for a specific pull request.
   """
@@ -44161,15 +50254,18 @@ type StatusContext implements Node & RequirableByPullRequest {
     The id of the pull request this is required for
     """
     pullRequestId: ID
+    
     """
     The number of the pull request this is required for
     """
     pullRequestNumber: Int
   ): Boolean!
+  
   """
   The state of this status context.
   """
   state: StatusState!
+  
   """
   The URL for this status context.
   """
@@ -44184,6 +50280,7 @@ type StatusContextStateCount {
   The number of statuses with this state.
   """
   count: Int!
+  
   """
   The state of a status context.
   """
@@ -44224,6 +50321,7 @@ type StripeConnectAccount {
   The account number used to identify this Stripe Connect account.
   """
   accountId: String!
+  
   """
   The name of the country or region of an external account, such as a bank
   account, tied to the Stripe Connect account. Will only return a value when
@@ -44231,20 +50329,24 @@ type StripeConnectAccount {
   themselves, or by an admin of the sponsorable organization.
   """
   billingCountryOrRegion: String
+  
   """
   The name of the country or region of the Stripe Connect account. Will only
   return a value when queried by the maintainer of the associated GitHub
   Sponsors profile themselves, or by an admin of the sponsorable organization.
   """
   countryOrRegion: String
+  
   """
   Whether this Stripe Connect account is currently in use for the associated GitHub Sponsors profile.
   """
   isActive: Boolean!
+  
   """
   The GitHub Sponsors profile associated with this Stripe Connect account.
   """
   sponsorsListing: SponsorsListing!
+  
   """
   The URL to access this Stripe Connect account on Stripe's website.
   """
@@ -44259,18 +50361,22 @@ input SubmitPullRequestReviewInput {
   The text field to set on the Pull Request Review.
   """
   body: String
+  
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The event to send to the Pull Request Review.
   """
   event: PullRequestReviewEvent!
+  
   """
   The Pull Request ID to submit any pending reviews.
   """
   pullRequestId: ID @possibleTypes(concreteTypes: ["PullRequest"])
+  
   """
   The Pull Request Review ID to submit.
   """
@@ -44285,6 +50391,7 @@ type SubmitPullRequestReviewPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The submitted pull request review.
   """
@@ -44299,26 +50406,32 @@ type Submodule {
   The branch of the upstream submodule for tracking updates
   """
   branch: String
+  
   """
   The git URL of the submodule repository
   """
   gitUrl: URI!
+  
   """
   The name of the submodule in .gitmodules
   """
   name: String!
+  
   """
   The name of the submodule in .gitmodules (Base64-encoded)
   """
   nameRaw: Base64String!
+  
   """
   The path in the superproject that this submodule is located in
   """
   path: String!
+  
   """
   The path in the superproject that this submodule is located in (Base64-encoded)
   """
   pathRaw: Base64String!
+  
   """
   The commit revision of the subproject repository being tracked by the submodule
   """
@@ -44333,14 +50446,17 @@ type SubmoduleConnection {
   A list of edges.
   """
   edges: [SubmoduleEdge]
+  
   """
   A list of nodes.
   """
   nodes: [Submodule]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -44355,6 +50471,7 @@ type SubmoduleEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -44366,10 +50483,12 @@ Entities that can be subscribed to for web and email notifications.
 """
 interface Subscribable {
   id: ID!
+  
   """
   Check if the viewer is able to change their subscription status for the repository.
   """
   viewerCanSubscribe: Boolean!
+  
   """
   Identifies if the viewer is watching, not watching, or ignoring the subscribable entity.
   """
@@ -44381,10 +50500,12 @@ Entities that can be subscribed to for web and email notifications.
 """
 interface SubscribableThread {
   id: ID!
+  
   """
   Identifies the viewer's thread subscription form action.
   """
   viewerThreadSubscriptionFormAction: ThreadSubscriptionFormAction
+  
   """
   Identifies the viewer's thread subscription status.
   """
@@ -44399,11 +50520,13 @@ type SubscribedEvent implements Node {
   Identifies the actor who performed the event.
   """
   actor: Actor
+  
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
   id: ID!
+  
   """
   Object referenced by event.
   """
@@ -44436,10 +50559,12 @@ type SuggestedReviewer {
   Is this suggestion based on past commits?
   """
   isAuthor: Boolean!
+  
   """
   Is this suggestion based on past review comments?
   """
   isCommenter: Boolean!
+  
   """
   Identifies the user suggested to review the pull request.
   """
@@ -44454,35 +50579,43 @@ type Tag implements GitObject & Node {
   An abbreviated version of the Git object ID
   """
   abbreviatedOid: String!
+  
   """
   The HTTP path for this Git object
   """
   commitResourcePath: URI!
+  
   """
   The HTTP URL for this Git object
   """
   commitUrl: URI!
   id: ID!
+  
   """
   The Git tag message.
   """
   message: String
+  
   """
   The Git tag name.
   """
   name: String!
+  
   """
   The Git object ID
   """
   oid: GitObjectID!
+  
   """
   The Repository the Git object belongs to
   """
   repository: Repository!
+  
   """
   Details about the tag author.
   """
   tagger: GitActor
+  
   """
   The Git object the tag points to.
   """
@@ -44497,14 +50630,17 @@ type TagNamePatternParameters {
   How this rule will appear to users.
   """
   name: String
+  
   """
   If true, the rule will fail if the pattern matches.
   """
   negate: Boolean!
+  
   """
   The operator to use for matching.
   """
   operator: String!
+  
   """
   The pattern to match with.
   """
@@ -44519,14 +50655,17 @@ input TagNamePatternParametersInput {
   How this rule will appear to users.
   """
   name: String
+  
   """
   If true, the rule will fail if the pattern matches.
   """
   negate: Boolean
+  
   """
   The operator to use for matching.
   """
   operator: String!
+  
   """
   The pattern to match with.
   """
@@ -44545,19 +50684,23 @@ type Team implements MemberStatusable & Node & Subscribable {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): TeamConnection!
+  
   """
   A URL pointing to the team's avatar.
   """
@@ -44567,6 +50710,7 @@ type Team implements MemberStatusable & Node & Subscribable {
     """
     size: Int = 400
   ): URI
+  
   """
   List of child teams belonging to this team
   """
@@ -44575,47 +50719,58 @@ type Team implements MemberStatusable & Node & Subscribable {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Whether to list immediate child teams or all descendant child teams.
     """
     immediateOnly: Boolean = true
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Order for connection
     """
     orderBy: TeamOrder
+    
     """
     User logins to filter by
     """
     userLogins: [String!]
   ): TeamConnection!
+  
   """
   The slug corresponding to the organization and team.
   """
   combinedSlug: String!
+  
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
+  
   """
   Identifies the primary key from the database.
   """
   databaseId: Int
+  
   """
   The description of the team.
   """
   description: String
+  
   """
   Find a team discussion by its number.
   """
@@ -44625,6 +50780,7 @@ type Team implements MemberStatusable & Node & Subscribable {
     """
     number: Int!
   ): TeamDiscussion
+  
   """
   A list of team discussions.
   """
@@ -44633,44 +50789,54 @@ type Team implements MemberStatusable & Node & Subscribable {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     If provided, filters discussions according to whether or not they are pinned.
     """
     isPinned: Boolean
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Order for connection
     """
     orderBy: TeamDiscussionOrder
   ): TeamDiscussionConnection!
+  
   """
   The HTTP path for team discussions
   """
   discussionsResourcePath: URI!
+  
   """
   The HTTP URL for team discussions
   """
   discussionsUrl: URI!
+  
   """
   The HTTP path for editing this team
   """
   editTeamResourcePath: URI!
+  
   """
   The HTTP URL for editing this team
   """
   editTeamUrl: URI!
   id: ID!
+  
   """
   A list of pending invitations for users to this team
   """
@@ -44679,19 +50845,23 @@ type Team implements MemberStatusable & Node & Subscribable {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): OrganizationInvitationConnection
+  
   """
   Get the status messages members of this entity have set that are either public or visible only to the organization.
   """
@@ -44700,23 +50870,28 @@ type Team implements MemberStatusable & Node & Subscribable {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for user statuses returned from the connection.
     """
     orderBy: UserStatusOrder = { field: UPDATED_AT, direction: DESC }
   ): UserStatusConnection!
+  
   """
   A list of users who are members of this team.
   """
@@ -44725,71 +50900,88 @@ type Team implements MemberStatusable & Node & Subscribable {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Filter by membership type
     """
     membership: TeamMembershipType = ALL
+    
     """
     Order for the connection.
     """
     orderBy: TeamMemberOrder
+    
     """
     The search string to look for.
     """
     query: String
+    
     """
     Filter by team member role
     """
     role: TeamMemberRole
   ): TeamMemberConnection!
+  
   """
   The HTTP path for the team' members
   """
   membersResourcePath: URI!
+  
   """
   The HTTP URL for the team' members
   """
   membersUrl: URI!
+  
   """
   The name of the team.
   """
   name: String!
+  
   """
   The HTTP path creating a new team
   """
   newTeamResourcePath: URI!
+  
   """
   The HTTP URL creating a new team
   """
   newTeamUrl: URI!
+  
   """
   The notification setting that the team has set.
   """
   notificationSetting: TeamNotificationSetting!
+  
   """
   The organization that owns this team.
   """
   organization: Organization!
+  
   """
   The parent team of the team.
   """
   parentTeam: Team
+  
   """
   The level of privacy the team has.
   """
   privacy: TeamPrivacy!
+  
   """
   Finds and returns the project according to the provided project number.
   """
@@ -44799,6 +50991,7 @@ type Team implements MemberStatusable & Node & Subscribable {
     """
     number: Int!
   ): ProjectV2
+  
   """
   List of projects this team has collaborator access to.
   """
@@ -44807,31 +51000,38 @@ type Team implements MemberStatusable & Node & Subscribable {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Filtering options for projects returned from this connection
     """
     filterBy: ProjectV2Filters = {}
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     How to order the returned projects.
     """
     orderBy: ProjectV2Order = { field: NUMBER, direction: DESC }
+    
     """
     The query to search projects by.
     """
     query: String = ""
   ): ProjectV2Connection!
+  
   """
   A list of repositories this team has access to.
   """
@@ -44840,87 +51040,107 @@ type Team implements MemberStatusable & Node & Subscribable {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Order for the connection.
     """
     orderBy: TeamRepositoryOrder
+    
     """
     The search string to look for. Repositories will be returned where the name contains your search string.
     """
     query: String
   ): TeamRepositoryConnection!
+  
   """
   The HTTP path for this team's repositories
   """
   repositoriesResourcePath: URI!
+  
   """
   The HTTP URL for this team's repositories
   """
   repositoriesUrl: URI!
+  
   """
   The HTTP path for this team
   """
   resourcePath: URI!
+  
   """
   What algorithm is used for review assignment for this team
   """
   reviewRequestDelegationAlgorithm: TeamReviewAssignmentAlgorithm
     @preview(toggledBy: "stone-crop-preview")
+  
   """
   True if review assignment is enabled for this team
   """
   reviewRequestDelegationEnabled: Boolean!
     @preview(toggledBy: "stone-crop-preview")
+  
   """
   How many team members are required for review assignment for this team
   """
   reviewRequestDelegationMemberCount: Int
     @preview(toggledBy: "stone-crop-preview")
+  
   """
   When assigning team members via delegation, whether the entire team should be notified as well.
   """
   reviewRequestDelegationNotifyTeam: Boolean!
     @preview(toggledBy: "stone-crop-preview")
+  
   """
   The slug corresponding to the team.
   """
   slug: String!
+  
   """
   The HTTP path for this team's teams
   """
   teamsResourcePath: URI!
+  
   """
   The HTTP URL for this team's teams
   """
   teamsUrl: URI!
+  
   """
   Identifies the date and time when the object was last updated.
   """
   updatedAt: DateTime!
+  
   """
   The HTTP URL for this team
   """
   url: URI!
+  
   """
   Team is adminable by the viewer.
   """
   viewerCanAdminister: Boolean!
+  
   """
   Check if the viewer is able to change their subscription status for the repository.
   """
   viewerCanSubscribe: Boolean!
+  
   """
   Identifies if the viewer is watching, not watching, or ignoring the subscribable entity.
   """
@@ -44935,87 +51155,108 @@ type TeamAddMemberAuditEntry implements AuditEntry & Node & OrganizationAuditEnt
   The action name
   """
   action: String!
+  
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
+  
   """
   The IP address of the actor
   """
   actorIp: String
+  
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
+  
   """
   The username of the user who initiated the action
   """
   actorLogin: String
+  
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
+  
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
+  
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
   id: ID!
+  
   """
   Whether the team was mapped to an LDAP Group.
   """
   isLdapMapped: Boolean
+  
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
+  
   """
   The Organization associated with the Audit Entry.
   """
   organization: Organization
+  
   """
   The name of the Organization.
   """
   organizationName: String
+  
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
+  
   """
   The HTTP URL for the organization
   """
   organizationUrl: URI
+  
   """
   The team associated with the action
   """
   team: Team
+  
   """
   The name of the team
   """
   teamName: String
+  
   """
   The HTTP path for this team
   """
   teamResourcePath: URI
+  
   """
   The HTTP URL for this team
   """
   teamUrl: URI
+  
   """
   The user affected by the action
   """
   user: User
+  
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
+  
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
+  
   """
   The HTTP URL for the user.
   """
@@ -45030,103 +51271,128 @@ type TeamAddRepositoryAuditEntry implements AuditEntry & Node & OrganizationAudi
   The action name
   """
   action: String!
+  
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
+  
   """
   The IP address of the actor
   """
   actorIp: String
+  
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
+  
   """
   The username of the user who initiated the action
   """
   actorLogin: String
+  
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
+  
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
+  
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
   id: ID!
+  
   """
   Whether the team was mapped to an LDAP Group.
   """
   isLdapMapped: Boolean
+  
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
+  
   """
   The Organization associated with the Audit Entry.
   """
   organization: Organization
+  
   """
   The name of the Organization.
   """
   organizationName: String
+  
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
+  
   """
   The HTTP URL for the organization
   """
   organizationUrl: URI
+  
   """
   The repository associated with the action
   """
   repository: Repository
+  
   """
   The name of the repository
   """
   repositoryName: String
+  
   """
   The HTTP path for the repository
   """
   repositoryResourcePath: URI
+  
   """
   The HTTP URL for the repository
   """
   repositoryUrl: URI
+  
   """
   The team associated with the action
   """
   team: Team
+  
   """
   The name of the team
   """
   teamName: String
+  
   """
   The HTTP path for this team
   """
   teamResourcePath: URI
+  
   """
   The HTTP URL for this team
   """
   teamUrl: URI
+  
   """
   The user affected by the action
   """
   user: User
+  
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
+  
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
+  
   """
   The HTTP URL for the user.
   """
@@ -45141,14 +51407,17 @@ interface TeamAuditEntryData {
   The team associated with the action
   """
   team: Team
+  
   """
   The name of the team
   """
   teamName: String
+  
   """
   The HTTP path for this team
   """
   teamResourcePath: URI
+  
   """
   The HTTP URL for this team
   """
@@ -45163,119 +51432,148 @@ type TeamChangeParentTeamAuditEntry implements AuditEntry & Node & OrganizationA
   The action name
   """
   action: String!
+  
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
+  
   """
   The IP address of the actor
   """
   actorIp: String
+  
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
+  
   """
   The username of the user who initiated the action
   """
   actorLogin: String
+  
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
+  
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
+  
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
   id: ID!
+  
   """
   Whether the team was mapped to an LDAP Group.
   """
   isLdapMapped: Boolean
+  
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
+  
   """
   The Organization associated with the Audit Entry.
   """
   organization: Organization
+  
   """
   The name of the Organization.
   """
   organizationName: String
+  
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
+  
   """
   The HTTP URL for the organization
   """
   organizationUrl: URI
+  
   """
   The new parent team.
   """
   parentTeam: Team
+  
   """
   The name of the new parent team
   """
   parentTeamName: String
+  
   """
   The name of the former parent team
   """
   parentTeamNameWas: String
+  
   """
   The HTTP path for the parent team
   """
   parentTeamResourcePath: URI
+  
   """
   The HTTP URL for the parent team
   """
   parentTeamUrl: URI
+  
   """
   The former parent team.
   """
   parentTeamWas: Team
+  
   """
   The HTTP path for the previous parent team
   """
   parentTeamWasResourcePath: URI
+  
   """
   The HTTP URL for the previous parent team
   """
   parentTeamWasUrl: URI
+  
   """
   The team associated with the action
   """
   team: Team
+  
   """
   The name of the team
   """
   teamName: String
+  
   """
   The HTTP path for this team
   """
   teamResourcePath: URI
+  
   """
   The HTTP URL for this team
   """
   teamUrl: URI
+  
   """
   The user affected by the action
   """
   user: User
+  
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
+  
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
+  
   """
   The HTTP URL for the user.
   """
@@ -45290,14 +51588,17 @@ type TeamConnection {
   A list of edges.
   """
   edges: [TeamEdge]
+  
   """
   A list of nodes.
   """
   nodes: [Team]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -45312,6 +51613,7 @@ type TeamDiscussion implements Comment & Deletable & Node & Reactable & Subscrib
   The actor who authored the comment.
   """
   author: Actor
+  
   """
   Author's association with the discussion's team.
   """
@@ -45319,18 +51621,22 @@ type TeamDiscussion implements Comment & Deletable & Node & Reactable & Subscrib
     @deprecated(
       reason: "The Team Discussions feature is deprecated in favor of Organization Discussions. Follow the guide at https://github.blog/changelog/2023-02-08-sunset-notice-team-discussions/ to find a suitable replacement. Removal on 2024-07-01 UTC."
     )
+  
   """
   The body as Markdown.
   """
   body: String!
+  
   """
   The body rendered to HTML.
   """
   bodyHTML: HTML!
+  
   """
   The body rendered to text.
   """
   bodyText: String!
+  
   """
   Identifies the discussion body hash.
   """
@@ -45338,6 +51644,7 @@ type TeamDiscussion implements Comment & Deletable & Node & Reactable & Subscrib
     @deprecated(
       reason: "The Team Discussions feature is deprecated in favor of Organization Discussions. Follow the guide at https://github.blog/changelog/2023-02-08-sunset-notice-team-discussions/ to find a suitable replacement. Removal on 2024-07-01 UTC."
     )
+  
   """
   A list of comments on this discussion.
   """
@@ -45346,22 +51653,27 @@ type TeamDiscussion implements Comment & Deletable & Node & Reactable & Subscrib
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     When provided, filters the connection such that results begin with the comment with this number.
     """
     fromComment: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Order for connection
     """
@@ -45370,6 +51682,7 @@ type TeamDiscussion implements Comment & Deletable & Node & Reactable & Subscrib
     @deprecated(
       reason: "The Team Discussions feature is deprecated in favor of Organization Discussions. Follow the guide at https://github.blog/changelog/2023-02-08-sunset-notice-team-discussions/ to find a suitable replacement. Removal on 2024-07-01 UTC."
     )
+  
   """
   The HTTP path for discussion comments
   """
@@ -45377,6 +51690,7 @@ type TeamDiscussion implements Comment & Deletable & Node & Reactable & Subscrib
     @deprecated(
       reason: "The Team Discussions feature is deprecated in favor of Organization Discussions. Follow the guide at https://github.blog/changelog/2023-02-08-sunset-notice-team-discussions/ to find a suitable replacement. Removal on 2024-07-01 UTC."
     )
+  
   """
   The HTTP URL for discussion comments
   """
@@ -45384,27 +51698,33 @@ type TeamDiscussion implements Comment & Deletable & Node & Reactable & Subscrib
     @deprecated(
       reason: "The Team Discussions feature is deprecated in favor of Organization Discussions. Follow the guide at https://github.blog/changelog/2023-02-08-sunset-notice-team-discussions/ to find a suitable replacement. Removal on 2024-07-01 UTC."
     )
+  
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
+  
   """
   Check if this comment was created via an email reply.
   """
   createdViaEmail: Boolean!
+  
   """
   Identifies the primary key from the database.
   """
   databaseId: Int
+  
   """
   The actor who edited the comment.
   """
   editor: Actor
   id: ID!
+  
   """
   Check if this comment was edited and includes an edit with the creation data
   """
   includesCreatedEdit: Boolean!
+  
   """
   Whether or not the discussion is pinned.
   """
@@ -45412,6 +51732,7 @@ type TeamDiscussion implements Comment & Deletable & Node & Reactable & Subscrib
     @deprecated(
       reason: "The Team Discussions feature is deprecated in favor of Organization Discussions. Follow the guide at https://github.blog/changelog/2023-02-08-sunset-notice-team-discussions/ to find a suitable replacement. Removal on 2024-07-01 UTC."
     )
+  
   """
   Whether or not the discussion is only visible to team members and org admins.
   """
@@ -45419,10 +51740,12 @@ type TeamDiscussion implements Comment & Deletable & Node & Reactable & Subscrib
     @deprecated(
       reason: "The Team Discussions feature is deprecated in favor of Organization Discussions. Follow the guide at https://github.blog/changelog/2023-02-08-sunset-notice-team-discussions/ to find a suitable replacement. Removal on 2024-07-01 UTC."
     )
+  
   """
   The moment the editor made the last edit
   """
   lastEditedAt: DateTime
+  
   """
   Identifies the discussion within its team.
   """
@@ -45430,14 +51753,17 @@ type TeamDiscussion implements Comment & Deletable & Node & Reactable & Subscrib
     @deprecated(
       reason: "The Team Discussions feature is deprecated in favor of Organization Discussions. Follow the guide at https://github.blog/changelog/2023-02-08-sunset-notice-team-discussions/ to find a suitable replacement. Removal on 2024-07-01 UTC."
     )
+  
   """
   Identifies when the comment was published at.
   """
   publishedAt: DateTime
+  
   """
   A list of reactions grouped by content left on the subject.
   """
   reactionGroups: [ReactionGroup!]
+  
   """
   A list of Reactions left on the Issue.
   """
@@ -45446,27 +51772,33 @@ type TeamDiscussion implements Comment & Deletable & Node & Reactable & Subscrib
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Allows filtering Reactions by emoji.
     """
     content: ReactionContent
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Allows specifying the order in which reactions are returned.
     """
     orderBy: ReactionOrder
   ): ReactionConnection!
+  
   """
   The HTTP path for this discussion
   """
@@ -45474,6 +51806,7 @@ type TeamDiscussion implements Comment & Deletable & Node & Reactable & Subscrib
     @deprecated(
       reason: "The Team Discussions feature is deprecated in favor of Organization Discussions. Follow the guide at https://github.blog/changelog/2023-02-08-sunset-notice-team-discussions/ to find a suitable replacement. Removal on 2024-07-01 UTC."
     )
+  
   """
   The team that defines the context of this discussion.
   """
@@ -45481,6 +51814,7 @@ type TeamDiscussion implements Comment & Deletable & Node & Reactable & Subscrib
     @deprecated(
       reason: "The Team Discussions feature is deprecated in favor of Organization Discussions. Follow the guide at https://github.blog/changelog/2023-02-08-sunset-notice-team-discussions/ to find a suitable replacement. Removal on 2024-07-01 UTC."
     )
+  
   """
   The title of the discussion
   """
@@ -45488,10 +51822,12 @@ type TeamDiscussion implements Comment & Deletable & Node & Reactable & Subscrib
     @deprecated(
       reason: "The Team Discussions feature is deprecated in favor of Organization Discussions. Follow the guide at https://github.blog/changelog/2023-02-08-sunset-notice-team-discussions/ to find a suitable replacement. Removal on 2024-07-01 UTC."
     )
+  
   """
   Identifies the date and time when the object was last updated.
   """
   updatedAt: DateTime!
+  
   """
   The HTTP URL for this discussion
   """
@@ -45499,6 +51835,7 @@ type TeamDiscussion implements Comment & Deletable & Node & Reactable & Subscrib
     @deprecated(
       reason: "The Team Discussions feature is deprecated in favor of Organization Discussions. Follow the guide at https://github.blog/changelog/2023-02-08-sunset-notice-team-discussions/ to find a suitable replacement. Removal on 2024-07-01 UTC."
     )
+  
   """
   A list of edits to this content.
   """
@@ -45507,23 +51844,28 @@ type TeamDiscussion implements Comment & Deletable & Node & Reactable & Subscrib
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): UserContentEditConnection
+  
   """
   Check if the current viewer can delete this object.
   """
   viewerCanDelete: Boolean!
+  
   """
   Whether or not the current viewer can pin this discussion.
   """
@@ -45531,26 +51873,32 @@ type TeamDiscussion implements Comment & Deletable & Node & Reactable & Subscrib
     @deprecated(
       reason: "The Team Discussions feature is deprecated in favor of Organization Discussions. Follow the guide at https://github.blog/changelog/2023-02-08-sunset-notice-team-discussions/ to find a suitable replacement. Removal on 2024-07-01 UTC."
     )
+  
   """
   Can user react to this subject
   """
   viewerCanReact: Boolean!
+  
   """
   Check if the viewer is able to change their subscription status for the repository.
   """
   viewerCanSubscribe: Boolean!
+  
   """
   Check if the current viewer can update this object.
   """
   viewerCanUpdate: Boolean!
+  
   """
   Reasons why the current viewer can not update this comment.
   """
   viewerCannotUpdateReasons: [CommentCannotUpdateReason!]!
+  
   """
   Did the viewer author this comment.
   """
   viewerDidAuthor: Boolean!
+  
   """
   Identifies if the viewer is watching, not watching, or ignoring the subscribable entity.
   """
@@ -45565,6 +51913,7 @@ type TeamDiscussionComment implements Comment & Deletable & Node & Reactable & U
   The actor who authored the comment.
   """
   author: Actor
+  
   """
   Author's association with the comment's team.
   """
@@ -45572,18 +51921,22 @@ type TeamDiscussionComment implements Comment & Deletable & Node & Reactable & U
     @deprecated(
       reason: "The Team Discussions feature is deprecated in favor of Organization Discussions. Follow the guide at https://github.blog/changelog/2023-02-08-sunset-notice-team-discussions/ to find a suitable replacement. Removal on 2024-07-01 UTC."
     )
+  
   """
   The body as Markdown.
   """
   body: String!
+  
   """
   The body rendered to HTML.
   """
   bodyHTML: HTML!
+  
   """
   The body rendered to text.
   """
   bodyText: String!
+  
   """
   The current version of the body content.
   """
@@ -45591,18 +51944,22 @@ type TeamDiscussionComment implements Comment & Deletable & Node & Reactable & U
     @deprecated(
       reason: "The Team Discussions feature is deprecated in favor of Organization Discussions. Follow the guide at https://github.blog/changelog/2023-02-08-sunset-notice-team-discussions/ to find a suitable replacement. Removal on 2024-07-01 UTC."
     )
+  
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
+  
   """
   Check if this comment was created via an email reply.
   """
   createdViaEmail: Boolean!
+  
   """
   Identifies the primary key from the database.
   """
   databaseId: Int
+  
   """
   The discussion this comment is about.
   """
@@ -45610,19 +51967,23 @@ type TeamDiscussionComment implements Comment & Deletable & Node & Reactable & U
     @deprecated(
       reason: "The Team Discussions feature is deprecated in favor of Organization Discussions. Follow the guide at https://github.blog/changelog/2023-02-08-sunset-notice-team-discussions/ to find a suitable replacement. Removal on 2024-07-01 UTC."
     )
+  
   """
   The actor who edited the comment.
   """
   editor: Actor
   id: ID!
+  
   """
   Check if this comment was edited and includes an edit with the creation data
   """
   includesCreatedEdit: Boolean!
+  
   """
   The moment the editor made the last edit
   """
   lastEditedAt: DateTime
+  
   """
   Identifies the comment number.
   """
@@ -45630,14 +51991,17 @@ type TeamDiscussionComment implements Comment & Deletable & Node & Reactable & U
     @deprecated(
       reason: "The Team Discussions feature is deprecated in favor of Organization Discussions. Follow the guide at https://github.blog/changelog/2023-02-08-sunset-notice-team-discussions/ to find a suitable replacement. Removal on 2024-07-01 UTC."
     )
+  
   """
   Identifies when the comment was published at.
   """
   publishedAt: DateTime
+  
   """
   A list of reactions grouped by content left on the subject.
   """
   reactionGroups: [ReactionGroup!]
+  
   """
   A list of Reactions left on the Issue.
   """
@@ -45646,27 +52010,33 @@ type TeamDiscussionComment implements Comment & Deletable & Node & Reactable & U
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Allows filtering Reactions by emoji.
     """
     content: ReactionContent
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Allows specifying the order in which reactions are returned.
     """
     orderBy: ReactionOrder
   ): ReactionConnection!
+  
   """
   The HTTP path for this comment
   """
@@ -45674,10 +52044,12 @@ type TeamDiscussionComment implements Comment & Deletable & Node & Reactable & U
     @deprecated(
       reason: "The Team Discussions feature is deprecated in favor of Organization Discussions. Follow the guide at https://github.blog/changelog/2023-02-08-sunset-notice-team-discussions/ to find a suitable replacement. Removal on 2024-07-01 UTC."
     )
+  
   """
   Identifies the date and time when the object was last updated.
   """
   updatedAt: DateTime!
+  
   """
   The HTTP URL for this comment
   """
@@ -45685,6 +52057,7 @@ type TeamDiscussionComment implements Comment & Deletable & Node & Reactable & U
     @deprecated(
       reason: "The Team Discussions feature is deprecated in favor of Organization Discussions. Follow the guide at https://github.blog/changelog/2023-02-08-sunset-notice-team-discussions/ to find a suitable replacement. Removal on 2024-07-01 UTC."
     )
+  
   """
   A list of edits to this content.
   """
@@ -45693,35 +52066,43 @@ type TeamDiscussionComment implements Comment & Deletable & Node & Reactable & U
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): UserContentEditConnection
+  
   """
   Check if the current viewer can delete this object.
   """
   viewerCanDelete: Boolean!
+  
   """
   Can user react to this subject
   """
   viewerCanReact: Boolean!
+  
   """
   Check if the current viewer can update this object.
   """
   viewerCanUpdate: Boolean!
+  
   """
   Reasons why the current viewer can not update this comment.
   """
   viewerCannotUpdateReasons: [CommentCannotUpdateReason!]!
+  
   """
   Did the viewer author this comment.
   """
@@ -45736,14 +52117,17 @@ type TeamDiscussionCommentConnection {
   A list of edges.
   """
   edges: [TeamDiscussionCommentEdge]
+  
   """
   A list of nodes.
   """
   nodes: [TeamDiscussionComment]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -45758,6 +52142,7 @@ type TeamDiscussionCommentEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -45772,6 +52157,7 @@ input TeamDiscussionCommentOrder {
   The direction in which to order nodes.
   """
   direction: OrderDirection!
+  
   """
   The field by which to order nodes.
   """
@@ -45796,14 +52182,17 @@ type TeamDiscussionConnection {
   A list of edges.
   """
   edges: [TeamDiscussionEdge]
+  
   """
   A list of nodes.
   """
   nodes: [TeamDiscussion]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -45818,6 +52207,7 @@ type TeamDiscussionEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -45832,6 +52222,7 @@ input TeamDiscussionOrder {
   The direction in which to order nodes.
   """
   direction: OrderDirection!
+  
   """
   The field by which to order nodes.
   """
@@ -45856,6 +52247,7 @@ type TeamEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -45870,14 +52262,17 @@ type TeamMemberConnection {
   A list of edges.
   """
   edges: [TeamMemberEdge]
+  
   """
   A list of nodes.
   """
   nodes: [User]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -45892,15 +52287,18 @@ type TeamMemberEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The HTTP path to the organization's member access page.
   """
   memberAccessResourcePath: URI!
+  
   """
   The HTTP URL to the organization's member access page.
   """
   memberAccessUrl: URI!
   node: User!
+  
   """
   The role the member has on the team.
   """
@@ -45915,6 +52313,7 @@ input TeamMemberOrder {
   The ordering direction.
   """
   direction: OrderDirection!
+  
   """
   The field to order team members by.
   """
@@ -45989,6 +52388,7 @@ input TeamOrder {
   The direction in which to order nodes.
   """
   direction: OrderDirection!
+  
   """
   The field in which to order nodes by.
   """
@@ -46027,87 +52427,108 @@ type TeamRemoveMemberAuditEntry implements AuditEntry & Node & OrganizationAudit
   The action name
   """
   action: String!
+  
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
+  
   """
   The IP address of the actor
   """
   actorIp: String
+  
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
+  
   """
   The username of the user who initiated the action
   """
   actorLogin: String
+  
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
+  
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
+  
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
   id: ID!
+  
   """
   Whether the team was mapped to an LDAP Group.
   """
   isLdapMapped: Boolean
+  
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
+  
   """
   The Organization associated with the Audit Entry.
   """
   organization: Organization
+  
   """
   The name of the Organization.
   """
   organizationName: String
+  
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
+  
   """
   The HTTP URL for the organization
   """
   organizationUrl: URI
+  
   """
   The team associated with the action
   """
   team: Team
+  
   """
   The name of the team
   """
   teamName: String
+  
   """
   The HTTP path for this team
   """
   teamResourcePath: URI
+  
   """
   The HTTP URL for this team
   """
   teamUrl: URI
+  
   """
   The user affected by the action
   """
   user: User
+  
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
+  
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
+  
   """
   The HTTP URL for the user.
   """
@@ -46122,103 +52543,128 @@ type TeamRemoveRepositoryAuditEntry implements AuditEntry & Node & OrganizationA
   The action name
   """
   action: String!
+  
   """
   The user who initiated the action
   """
   actor: AuditEntryActor
+  
   """
   The IP address of the actor
   """
   actorIp: String
+  
   """
   A readable representation of the actor's location
   """
   actorLocation: ActorLocation
+  
   """
   The username of the user who initiated the action
   """
   actorLogin: String
+  
   """
   The HTTP path for the actor.
   """
   actorResourcePath: URI
+  
   """
   The HTTP URL for the actor.
   """
   actorUrl: URI
+  
   """
   The time the action was initiated
   """
   createdAt: PreciseDateTime!
   id: ID!
+  
   """
   Whether the team was mapped to an LDAP Group.
   """
   isLdapMapped: Boolean
+  
   """
   The corresponding operation type for the action
   """
   operationType: OperationType
+  
   """
   The Organization associated with the Audit Entry.
   """
   organization: Organization
+  
   """
   The name of the Organization.
   """
   organizationName: String
+  
   """
   The HTTP path for the organization
   """
   organizationResourcePath: URI
+  
   """
   The HTTP URL for the organization
   """
   organizationUrl: URI
+  
   """
   The repository associated with the action
   """
   repository: Repository
+  
   """
   The name of the repository
   """
   repositoryName: String
+  
   """
   The HTTP path for the repository
   """
   repositoryResourcePath: URI
+  
   """
   The HTTP URL for the repository
   """
   repositoryUrl: URI
+  
   """
   The team associated with the action
   """
   team: Team
+  
   """
   The name of the team
   """
   teamName: String
+  
   """
   The HTTP path for this team
   """
   teamResourcePath: URI
+  
   """
   The HTTP URL for this team
   """
   teamUrl: URI
+  
   """
   The user affected by the action
   """
   user: User
+  
   """
   For actions involving two users, the actor is the initiator and the user is the affected user.
   """
   userLogin: String
+  
   """
   The HTTP path for the user.
   """
   userResourcePath: URI
+  
   """
   The HTTP URL for the user.
   """
@@ -46233,14 +52679,17 @@ type TeamRepositoryConnection {
   A list of edges.
   """
   edges: [TeamRepositoryEdge]
+  
   """
   A list of nodes.
   """
   nodes: [Repository]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -46256,6 +52705,7 @@ type TeamRepositoryEdge {
   """
   cursor: String!
   node: Repository!
+  
   """
   The permission level the team has on the repository
   """
@@ -46270,6 +52720,7 @@ input TeamRepositoryOrder {
   The ordering direction.
   """
   direction: OrderDirection!
+  
   """
   The field to order repositories by.
   """
@@ -46342,10 +52793,12 @@ type TextMatch {
   The specific text fragment within the property matched on.
   """
   fragment: String!
+  
   """
   Highlights within the matched fragment.
   """
   highlights: [TextMatchHighlight!]!
+  
   """
   The property matched on.
   """
@@ -46360,10 +52813,12 @@ type TextMatchHighlight {
   The indice in the fragment where the matched text begins.
   """
   beginIndice: Int!
+  
   """
   The indice in the fragment where the matched text ends.
   """
   endIndice: Int!
+  
   """
   The text matched.
   """
@@ -46435,10 +52890,12 @@ A topic aggregates entities that are related to a subject.
 """
 type Topic implements Node & Starrable {
   id: ID!
+  
   """
   The topic's name.
   """
   name: String!
+  
   """
   A list of related topics, including aliases of this topic, sorted with the most relevant
   first. Returns up to 10 Topics.
@@ -46449,6 +52906,7 @@ type Topic implements Node & Starrable {
     """
     first: Int = 3
   ): [Topic!]!
+  
   """
   A list of repositories.
   """
@@ -46459,53 +52917,65 @@ type Topic implements Node & Starrable {
     current viewer owns.
     """
     affiliations: [RepositoryAffiliation]
+    
     """
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     If non-null, filters repositories according to whether they have issues enabled
     """
     hasIssuesEnabled: Boolean
+    
     """
     If non-null, filters repositories according to whether they have been locked
     """
     isLocked: Boolean
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for repositories returned from the connection
     """
     orderBy: RepositoryOrder
+    
     """
     Array of owner's affiliation options for repositories returned from the
     connection. For example, OWNER will include only repositories that the
     organization or user being viewed owns.
     """
     ownerAffiliations: [RepositoryAffiliation] = [OWNER, COLLABORATOR]
+    
     """
     If non-null, filters repositories according to privacy
     """
     privacy: RepositoryPrivacy
+    
     """
     If true, only repositories whose owner can be sponsored via GitHub Sponsors will be returned.
     """
     sponsorableOnly: Boolean = false
   ): RepositoryConnection!
+  
   """
   Returns a count of how many stargazers there are on this object
   """
   stargazerCount: Int!
+  
   """
   A list of users who have starred this starrable.
   """
@@ -46514,23 +52984,28 @@ type Topic implements Node & Starrable {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Order for connection
     """
     orderBy: StarOrder
   ): StargazerConnection!
+  
   """
   Returns a boolean indicating whether the viewing user has starred this starrable.
   """
@@ -46545,6 +53020,7 @@ interface TopicAuditEntryData {
   The name of the topic added to the repository
   """
   topic: Topic
+  
   """
   The name of the topic added to the repository
   """
@@ -46595,10 +53071,12 @@ input TransferEnterpriseOrganizationInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The ID of the enterprise where the organization should be transferred.
   """
   destinationEnterpriseId: ID! @possibleTypes(concreteTypes: ["Enterprise"])
+  
   """
   The ID of the organization to transfer.
   """
@@ -46613,6 +53091,7 @@ type TransferEnterpriseOrganizationPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The organization for which a transfer was initiated.
   """
@@ -46627,14 +53106,17 @@ input TransferIssueInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   Whether to create labels if they don't exist in the target repository (matched by name)
   """
   createLabelsIfMissing: Boolean = false
+  
   """
   The Node ID of the issue to be transferred
   """
   issueId: ID! @possibleTypes(concreteTypes: ["Issue"])
+  
   """
   The Node ID of the repository the issue should be transferred to
   """
@@ -46649,6 +53131,7 @@ type TransferIssuePayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The issue that was transferred
   """
@@ -46663,15 +53146,18 @@ type TransferredEvent implements Node {
   Identifies the actor who performed the event.
   """
   actor: Actor
+  
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
+  
   """
   The repository this came from
   """
   fromRepository: Repository
   id: ID!
+  
   """
   Identifies the issue associated with the event.
   """
@@ -46686,23 +53172,28 @@ type Tree implements GitObject & Node {
   An abbreviated version of the Git object ID
   """
   abbreviatedOid: String!
+  
   """
   The HTTP path for this Git object
   """
   commitResourcePath: URI!
+  
   """
   The HTTP URL for this Git object
   """
   commitUrl: URI!
+  
   """
   A list of tree entries.
   """
   entries: [TreeEntry!]
   id: ID!
+  
   """
   The Git object ID
   """
   oid: GitObjectID!
+  
   """
   The Repository the Git object belongs to
   """
@@ -46717,58 +53208,72 @@ type TreeEntry {
   The extension of the file
   """
   extension: String
+  
   """
   Whether or not this tree entry is generated
   """
   isGenerated: Boolean!
+  
   """
   The programming language this file is written in.
   """
   language: Language
+  
   """
   Number of lines in the file.
   """
   lineCount: Int
+  
   """
   Entry file mode.
   """
   mode: Int!
+  
   """
   Entry file name.
   """
   name: String!
+  
   """
   Entry file name. (Base64-encoded)
   """
   nameRaw: Base64String!
+  
   """
   Entry file object.
   """
   object: GitObject
+  
   """
   Entry file Git object ID.
   """
   oid: GitObjectID!
+  
   """
   The full path of the file.
   """
   path: String
+  
   """
   The full path of the file. (Base64-encoded)
   """
   pathRaw: Base64String
+  
   """
   The Repository the tree entry belongs to
   """
   repository: Repository!
+  
   """
   Entry byte size
   """
   size: Int!
+  
   """
   If the TreeEntry is for a directory occupied by a submodule project, this returns the corresponding submodule
   """
   submodule: Submodule
+  
   """
   Entry file type.
   """
@@ -46788,10 +53293,12 @@ input UnarchiveProjectV2ItemInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The ID of the ProjectV2Item to unarchive.
   """
   itemId: ID! @possibleTypes(concreteTypes: ["ProjectV2Item"])
+  
   """
   The ID of the Project to archive the item from.
   """
@@ -46806,6 +53313,7 @@ type UnarchiveProjectV2ItemPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The item unarchived from the project.
   """
@@ -46820,6 +53328,7 @@ input UnarchiveRepositoryInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The ID of the repository to unarchive.
   """
@@ -46834,6 +53343,7 @@ type UnarchiveRepositoryPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The repository that was unarchived.
   """
@@ -46848,19 +53358,23 @@ type UnassignedEvent implements Node {
   Identifies the actor who performed the event.
   """
   actor: Actor
+  
   """
   Identifies the assignable associated with the event.
   """
   assignable: Assignable!
+  
   """
   Identifies the user or mannequin that was unassigned.
   """
   assignee: Assignee
+  
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
   id: ID!
+  
   """
   Identifies the subject (user) who was unassigned.
   """
@@ -46878,6 +53392,7 @@ input UnfollowOrganizationInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   ID of the organization to unfollow.
   """
@@ -46892,6 +53407,7 @@ type UnfollowOrganizationPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The organization that was unfollowed.
   """
@@ -46906,6 +53422,7 @@ input UnfollowUserInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   ID of the user to unfollow.
   """
@@ -46920,6 +53437,7 @@ type UnfollowUserPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The user that was unfollowed.
   """
@@ -46934,6 +53452,7 @@ interface UniformResourceLocatable {
   The HTML path to this resource.
   """
   resourcePath: URI!
+  
   """
   The URL to this resource.
   """
@@ -46948,27 +53467,33 @@ type UnknownSignature implements GitSignature {
   Email used to sign this object.
   """
   email: String!
+  
   """
   True if the signature is valid and verified by GitHub.
   """
   isValid: Boolean!
+  
   """
   Payload for GPG signing object. Raw ODB object without the signature header.
   """
   payload: String!
+  
   """
   ASCII-armored signature header from object.
   """
   signature: String!
+  
   """
   GitHub user corresponding to the email signing this commit.
   """
   signer: User
+  
   """
   The state of this signature. `VALID` if signature is valid and verified by
   GitHub, otherwise represents reason why signature is considered invalid.
   """
   state: GitSignatureState!
+  
   """
   True if the signature was made with GitHub's signing key.
   """
@@ -46983,15 +53508,18 @@ type UnlabeledEvent implements Node {
   Identifies the actor who performed the event.
   """
   actor: Actor
+  
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
   id: ID!
+  
   """
   Identifies the label associated with the 'unlabeled' event.
   """
   label: Label!
+  
   """
   Identifies the `Labelable` associated with the event.
   """
@@ -47006,10 +53534,12 @@ input UnlinkProjectV2FromRepositoryInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The ID of the project to unlink from the repository.
   """
   projectId: ID! @possibleTypes(concreteTypes: ["ProjectV2"])
+  
   """
   The ID of the repository to unlink from the project.
   """
@@ -47024,6 +53554,7 @@ type UnlinkProjectV2FromRepositoryPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The repository the project is no longer linked to.
   """
@@ -47038,10 +53569,12 @@ input UnlinkProjectV2FromTeamInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The ID of the project to unlink from the team.
   """
   projectId: ID! @possibleTypes(concreteTypes: ["ProjectV2"])
+  
   """
   The ID of the team to unlink from the project.
   """
@@ -47056,6 +53589,7 @@ type UnlinkProjectV2FromTeamPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The team the project is unlinked from
   """
@@ -47070,10 +53604,12 @@ input UnlinkRepositoryFromProjectInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The ID of the Project linked to the Repository.
   """
   projectId: ID! @possibleTypes(concreteTypes: ["Project"])
+  
   """
   The ID of the Repository linked to the Project.
   """
@@ -47088,10 +53624,12 @@ type UnlinkRepositoryFromProjectPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The linked Project.
   """
   project: Project
+  
   """
   The linked Repository.
   """
@@ -47106,6 +53644,7 @@ input UnlockLockableInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   ID of the item to be unlocked.
   """
@@ -47124,10 +53663,12 @@ type UnlockLockablePayload {
   Identifies the actor who performed the event.
   """
   actor: Actor
+  
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The item that was unlocked.
   """
@@ -47142,11 +53683,13 @@ type UnlockedEvent implements Node {
   Identifies the actor who performed the event.
   """
   actor: Actor
+  
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
   id: ID!
+  
   """
   Object that was unlocked.
   """
@@ -47161,6 +53704,7 @@ input UnmarkDiscussionCommentAsAnswerInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The Node ID of the discussion comment to unmark as an answer.
   """
@@ -47175,6 +53719,7 @@ type UnmarkDiscussionCommentAsAnswerPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The discussion that includes the comment.
   """
@@ -47189,10 +53734,12 @@ input UnmarkFileAsViewedInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The path of the file to mark as unviewed
   """
   path: String!
+  
   """
   The Node ID of the pull request.
   """
@@ -47207,6 +53754,7 @@ type UnmarkFileAsViewedPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The updated pull request.
   """
@@ -47225,10 +53773,12 @@ input UnmarkIssueAsDuplicateInput {
       concreteTypes: ["Issue", "PullRequest"]
       abstractType: "IssueOrPullRequest"
     )
+  
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   ID of the issue or pull request currently marked as a duplicate.
   """
@@ -47247,6 +53797,7 @@ type UnmarkIssueAsDuplicatePayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The issue or pull request that was marked as a duplicate.
   """
@@ -47261,6 +53812,7 @@ input UnmarkProjectV2AsTemplateInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The ID of the Project to unmark as a template.
   """
@@ -47275,6 +53827,7 @@ type UnmarkProjectV2AsTemplatePayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The project.
   """
@@ -47289,19 +53842,23 @@ type UnmarkedAsDuplicateEvent implements Node {
   Identifies the actor who performed the event.
   """
   actor: Actor
+  
   """
   The authoritative issue or pull request which has been duplicated by another.
   """
   canonical: IssueOrPullRequest
+  
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
+  
   """
   The issue or pull request which has been marked as a duplicate of another.
   """
   duplicate: IssueOrPullRequest
   id: ID!
+  
   """
   Canonical and duplicate belong to different repositories.
   """
@@ -47316,6 +53873,7 @@ input UnminimizeCommentInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The Node ID of the subject to modify.
   """
@@ -47340,6 +53898,7 @@ type UnminimizeCommentPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The comment that was unminimized.
   """
@@ -47354,6 +53913,7 @@ input UnpinIssueInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The ID of the issue to be unpinned
   """
@@ -47368,6 +53928,7 @@ type UnpinIssuePayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The issue that was unpinned
   """
@@ -47382,11 +53943,13 @@ type UnpinnedEvent implements Node {
   Identifies the actor who performed the event.
   """
   actor: Actor
+  
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
   id: ID!
+  
   """
   Identifies the issue associated with the event.
   """
@@ -47401,6 +53964,7 @@ input UnresolveReviewThreadInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The ID of the thread to unresolve
   """
@@ -47415,6 +53979,7 @@ type UnresolveReviewThreadPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The thread to resolve.
   """
@@ -47429,11 +53994,13 @@ type UnsubscribedEvent implements Node {
   Identifies the actor who performed the event.
   """
   actor: Actor
+  
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
   id: ID!
+  
   """
   Object referenced by event.
   """
@@ -47468,116 +54035,144 @@ input UpdateBranchProtectionRuleInput {
   Can this branch be deleted.
   """
   allowsDeletions: Boolean
+  
   """
   Are force pushes allowed on this branch.
   """
   allowsForcePushes: Boolean
+  
   """
   Is branch creation a protected operation.
   """
   blocksCreations: Boolean
+  
   """
   The global relay id of the branch protection rule to be updated.
   """
   branchProtectionRuleId: ID!
     @possibleTypes(concreteTypes: ["BranchProtectionRule"])
+  
   """
   A list of User, Team, or App IDs allowed to bypass force push targeting matching branches.
   """
   bypassForcePushActorIds: [ID!]
+  
   """
   A list of User, Team, or App IDs allowed to bypass pull requests targeting matching branches.
   """
   bypassPullRequestActorIds: [ID!]
+  
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   Will new commits pushed to matching branches dismiss pull request review approvals.
   """
   dismissesStaleReviews: Boolean
+  
   """
   Can admins overwrite branch protection.
   """
   isAdminEnforced: Boolean
+  
   """
   Whether users can pull changes from upstream when the branch is locked. Set to
   `true` to allow fork syncing. Set to `false` to prevent fork syncing.
   """
   lockAllowsFetchAndMerge: Boolean
+  
   """
   Whether to set the branch as read-only. If this is true, users will not be able to push to the branch.
   """
   lockBranch: Boolean
+  
   """
   The glob-like pattern used to determine matching branches.
   """
   pattern: String
+  
   """
   A list of User, Team, or App IDs allowed to push to matching branches.
   """
   pushActorIds: [ID!]
+  
   """
   Whether the most recent push must be approved by someone other than the person who pushed it
   """
   requireLastPushApproval: Boolean
+  
   """
   Number of approving reviews required to update matching branches.
   """
   requiredApprovingReviewCount: Int
+  
   """
   The list of required deployment environments
   """
   requiredDeploymentEnvironments: [String!]
+  
   """
   List of required status check contexts that must pass for commits to be accepted to matching branches.
   """
   requiredStatusCheckContexts: [String!]
+  
   """
   The list of required status checks
   """
   requiredStatusChecks: [RequiredStatusCheckInput!]
+  
   """
   Are approving reviews required to update matching branches.
   """
   requiresApprovingReviews: Boolean
+  
   """
   Are reviews from code owners required to update matching branches.
   """
   requiresCodeOwnerReviews: Boolean
+  
   """
   Are commits required to be signed.
   """
   requiresCommitSignatures: Boolean
+  
   """
   Are conversations required to be resolved before merging.
   """
   requiresConversationResolution: Boolean
+  
   """
   Are successful deployments required before merging.
   """
   requiresDeployments: Boolean
+  
   """
   Are merge commits prohibited from being pushed to this branch.
   """
   requiresLinearHistory: Boolean
+  
   """
   Are status checks required to update matching branches.
   """
   requiresStatusChecks: Boolean
+  
   """
   Are branches required to be up to date before merging.
   """
   requiresStrictStatusChecks: Boolean
+  
   """
   Is pushing to matching branches restricted.
   """
   restrictsPushes: Boolean
+  
   """
   Is dismissal of pull request reviews restricted.
   """
   restrictsReviewDismissals: Boolean
+  
   """
   A list of User, Team, or App IDs allowed to dismiss reviews on pull requests targeting matching branches.
   """
@@ -47592,6 +54187,7 @@ type UpdateBranchProtectionRulePayload {
   The newly created BranchProtectionRule.
   """
   branchProtectionRule: BranchProtectionRule
+  
   """
   A unique identifier for the client performing the mutation.
   """
@@ -47606,46 +54202,57 @@ input UpdateCheckRunInput {
   Possible further actions the integrator can perform, which a user may trigger.
   """
   actions: [CheckRunAction!]
+  
   """
   The node of the check.
   """
   checkRunId: ID! @possibleTypes(concreteTypes: ["CheckRun"])
+  
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The time that the check run finished.
   """
   completedAt: DateTime
+  
   """
   The final conclusion of the check.
   """
   conclusion: CheckConclusionState
+  
   """
   The URL of the integrator's site that has the full details of the check.
   """
   detailsUrl: URI
+  
   """
   A reference for the run on the integrator's system.
   """
   externalId: String
+  
   """
   The name of the check.
   """
   name: String
+  
   """
   Descriptive details about the run.
   """
   output: CheckRunOutput
+  
   """
   The node ID of the repository.
   """
   repositoryId: ID! @possibleTypes(concreteTypes: ["Repository"])
+  
   """
   The time that the check run began.
   """
   startedAt: DateTime
+  
   """
   The current status.
   """
@@ -47660,6 +54267,7 @@ type UpdateCheckRunPayload {
   The updated check run.
   """
   checkRun: CheckRun
+  
   """
   A unique identifier for the client performing the mutation.
   """
@@ -47674,10 +54282,12 @@ input UpdateCheckSuitePreferencesInput {
   The check suite preferences to modify.
   """
   autoTriggerPreferences: [CheckSuiteAutoTriggerPreference!]!
+  
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The Node ID of the repository.
   """
@@ -47692,6 +54302,7 @@ type UpdateCheckSuitePreferencesPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The updated repository.
   """
@@ -47706,10 +54317,12 @@ input UpdateDiscussionCommentInput {
   The new contents of the comment body.
   """
   body: String!
+  
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The Node ID of the discussion comment to update.
   """
@@ -47724,6 +54337,7 @@ type UpdateDiscussionCommentPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The modified discussion comment.
   """
@@ -47738,18 +54352,22 @@ input UpdateDiscussionInput {
   The new contents of the discussion body.
   """
   body: String
+  
   """
   The Node ID of a discussion category within the same repository to change this discussion to.
   """
   categoryId: ID @possibleTypes(concreteTypes: ["DiscussionCategory"])
+  
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The Node ID of the discussion to update.
   """
   discussionId: ID! @possibleTypes(concreteTypes: ["Discussion"])
+  
   """
   The new discussion title.
   """
@@ -47764,6 +54382,7 @@ type UpdateDiscussionPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The modified discussion.
   """
@@ -47778,14 +54397,17 @@ input UpdateEnterpriseAdministratorRoleInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The ID of the Enterprise which the admin belongs to.
   """
   enterpriseId: ID! @possibleTypes(concreteTypes: ["Enterprise"])
+  
   """
   The login of a administrator whose role is being changed.
   """
   login: String!
+  
   """
   The new role for the Enterprise administrator.
   """
@@ -47800,6 +54422,7 @@ type UpdateEnterpriseAdministratorRolePayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   A message confirming the result of changing the administrator's role.
   """
@@ -47814,14 +54437,17 @@ input UpdateEnterpriseAllowPrivateRepositoryForkingSettingInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The ID of the enterprise on which to set the allow private repository forking setting.
   """
   enterpriseId: ID! @possibleTypes(concreteTypes: ["Enterprise"])
+  
   """
   The value for the allow private repository forking policy on the enterprise.
   """
   policyValue: EnterpriseAllowPrivateRepositoryForkingPolicyValue
+  
   """
   The value for the allow private repository forking setting on the enterprise.
   """
@@ -47836,10 +54462,12 @@ type UpdateEnterpriseAllowPrivateRepositoryForkingSettingPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The enterprise with the updated allow private repository forking setting.
   """
   enterprise: Enterprise
+  
   """
   A message confirming the result of updating the allow private repository forking setting.
   """
@@ -47854,10 +54482,12 @@ input UpdateEnterpriseDefaultRepositoryPermissionSettingInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The ID of the enterprise on which to set the base repository permission setting.
   """
   enterpriseId: ID! @possibleTypes(concreteTypes: ["Enterprise"])
+  
   """
   The value for the base repository permission setting on the enterprise.
   """
@@ -47872,10 +54502,12 @@ type UpdateEnterpriseDefaultRepositoryPermissionSettingPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The enterprise with the updated base repository permission setting.
   """
   enterprise: Enterprise
+  
   """
   A message confirming the result of updating the base repository permission setting.
   """
@@ -47890,10 +54522,12 @@ input UpdateEnterpriseMembersCanChangeRepositoryVisibilitySettingInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The ID of the enterprise on which to set the members can change repository visibility setting.
   """
   enterpriseId: ID! @possibleTypes(concreteTypes: ["Enterprise"])
+  
   """
   The value for the members can change repository visibility setting on the enterprise.
   """
@@ -47908,10 +54542,12 @@ type UpdateEnterpriseMembersCanChangeRepositoryVisibilitySettingPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The enterprise with the updated members can change repository visibility setting.
   """
   enterprise: Enterprise
+  
   """
   A message confirming the result of updating the members can change repository visibility setting.
   """
@@ -47926,26 +54562,32 @@ input UpdateEnterpriseMembersCanCreateRepositoriesSettingInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The ID of the enterprise on which to set the members can create repositories setting.
   """
   enterpriseId: ID! @possibleTypes(concreteTypes: ["Enterprise"])
+  
   """
   Allow members to create internal repositories. Defaults to current value.
   """
   membersCanCreateInternalRepositories: Boolean
+  
   """
   Allow members to create private repositories. Defaults to current value.
   """
   membersCanCreatePrivateRepositories: Boolean
+  
   """
   Allow members to create public repositories. Defaults to current value.
   """
   membersCanCreatePublicRepositories: Boolean
+  
   """
   When false, allow member organizations to set their own repository creation member privileges.
   """
   membersCanCreateRepositoriesPolicyEnabled: Boolean
+  
   """
   Value for the members can create repositories setting on the enterprise. This
   or the granular public/private/internal allowed fields (but not both) must be provided.
@@ -47961,10 +54603,12 @@ type UpdateEnterpriseMembersCanCreateRepositoriesSettingPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The enterprise with the updated members can create repositories setting.
   """
   enterprise: Enterprise
+  
   """
   A message confirming the result of updating the members can create repositories setting.
   """
@@ -47979,10 +54623,12 @@ input UpdateEnterpriseMembersCanDeleteIssuesSettingInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The ID of the enterprise on which to set the members can delete issues setting.
   """
   enterpriseId: ID! @possibleTypes(concreteTypes: ["Enterprise"])
+  
   """
   The value for the members can delete issues setting on the enterprise.
   """
@@ -47997,10 +54643,12 @@ type UpdateEnterpriseMembersCanDeleteIssuesSettingPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The enterprise with the updated members can delete issues setting.
   """
   enterprise: Enterprise
+  
   """
   A message confirming the result of updating the members can delete issues setting.
   """
@@ -48015,10 +54663,12 @@ input UpdateEnterpriseMembersCanDeleteRepositoriesSettingInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The ID of the enterprise on which to set the members can delete repositories setting.
   """
   enterpriseId: ID! @possibleTypes(concreteTypes: ["Enterprise"])
+  
   """
   The value for the members can delete repositories setting on the enterprise.
   """
@@ -48033,10 +54683,12 @@ type UpdateEnterpriseMembersCanDeleteRepositoriesSettingPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The enterprise with the updated members can delete repositories setting.
   """
   enterprise: Enterprise
+  
   """
   A message confirming the result of updating the members can delete repositories setting.
   """
@@ -48051,10 +54703,12 @@ input UpdateEnterpriseMembersCanInviteCollaboratorsSettingInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The ID of the enterprise on which to set the members can invite collaborators setting.
   """
   enterpriseId: ID! @possibleTypes(concreteTypes: ["Enterprise"])
+  
   """
   The value for the members can invite collaborators setting on the enterprise.
   """
@@ -48069,10 +54723,12 @@ type UpdateEnterpriseMembersCanInviteCollaboratorsSettingPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The enterprise with the updated members can invite collaborators setting.
   """
   enterprise: Enterprise
+  
   """
   A message confirming the result of updating the members can invite collaborators setting.
   """
@@ -48087,10 +54743,12 @@ input UpdateEnterpriseMembersCanMakePurchasesSettingInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The ID of the enterprise on which to set the members can make purchases setting.
   """
   enterpriseId: ID! @possibleTypes(concreteTypes: ["Enterprise"])
+  
   """
   The value for the members can make purchases setting on the enterprise.
   """
@@ -48105,10 +54763,12 @@ type UpdateEnterpriseMembersCanMakePurchasesSettingPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The enterprise with the updated members can make purchases setting.
   """
   enterprise: Enterprise
+  
   """
   A message confirming the result of updating the members can make purchases setting.
   """
@@ -48123,10 +54783,12 @@ input UpdateEnterpriseMembersCanUpdateProtectedBranchesSettingInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The ID of the enterprise on which to set the members can update protected branches setting.
   """
   enterpriseId: ID! @possibleTypes(concreteTypes: ["Enterprise"])
+  
   """
   The value for the members can update protected branches setting on the enterprise.
   """
@@ -48141,10 +54803,12 @@ type UpdateEnterpriseMembersCanUpdateProtectedBranchesSettingPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The enterprise with the updated members can update protected branches setting.
   """
   enterprise: Enterprise
+  
   """
   A message confirming the result of updating the members can update protected branches setting.
   """
@@ -48159,10 +54823,12 @@ input UpdateEnterpriseMembersCanViewDependencyInsightsSettingInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The ID of the enterprise on which to set the members can view dependency insights setting.
   """
   enterpriseId: ID! @possibleTypes(concreteTypes: ["Enterprise"])
+  
   """
   The value for the members can view dependency insights setting on the enterprise.
   """
@@ -48177,10 +54843,12 @@ type UpdateEnterpriseMembersCanViewDependencyInsightsSettingPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The enterprise with the updated members can view dependency insights setting.
   """
   enterprise: Enterprise
+  
   """
   A message confirming the result of updating the members can view dependency insights setting.
   """
@@ -48195,10 +54863,12 @@ input UpdateEnterpriseOrganizationProjectsSettingInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The ID of the enterprise on which to set the organization projects setting.
   """
   enterpriseId: ID! @possibleTypes(concreteTypes: ["Enterprise"])
+  
   """
   The value for the organization projects setting on the enterprise.
   """
@@ -48213,10 +54883,12 @@ type UpdateEnterpriseOrganizationProjectsSettingPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The enterprise with the updated organization projects setting.
   """
   enterprise: Enterprise
+  
   """
   A message confirming the result of updating the organization projects setting.
   """
@@ -48231,14 +54903,17 @@ input UpdateEnterpriseOwnerOrganizationRoleInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The ID of the Enterprise which the owner belongs to.
   """
   enterpriseId: ID! @possibleTypes(concreteTypes: ["Enterprise"])
+  
   """
   The ID of the organization for membership change.
   """
   organizationId: ID! @possibleTypes(concreteTypes: ["Organization"])
+  
   """
   The role to assume in the organization.
   """
@@ -48253,6 +54928,7 @@ type UpdateEnterpriseOwnerOrganizationRolePayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   A message confirming the result of changing the owner's organization role.
   """
@@ -48267,22 +54943,27 @@ input UpdateEnterpriseProfileInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The description of the enterprise.
   """
   description: String
+  
   """
   The Enterprise ID to update.
   """
   enterpriseId: ID! @possibleTypes(concreteTypes: ["Enterprise"])
+  
   """
   The location of the enterprise.
   """
   location: String
+  
   """
   The name of the enterprise.
   """
   name: String
+  
   """
   The URL of the enterprise's website.
   """
@@ -48297,6 +54978,7 @@ type UpdateEnterpriseProfilePayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The updated enterprise.
   """
@@ -48311,10 +54993,12 @@ input UpdateEnterpriseRepositoryProjectsSettingInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The ID of the enterprise on which to set the repository projects setting.
   """
   enterpriseId: ID! @possibleTypes(concreteTypes: ["Enterprise"])
+  
   """
   The value for the repository projects setting on the enterprise.
   """
@@ -48329,10 +55013,12 @@ type UpdateEnterpriseRepositoryProjectsSettingPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The enterprise with the updated repository projects setting.
   """
   enterprise: Enterprise
+  
   """
   A message confirming the result of updating the repository projects setting.
   """
@@ -48347,10 +55033,12 @@ input UpdateEnterpriseTeamDiscussionsSettingInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The ID of the enterprise on which to set the team discussions setting.
   """
   enterpriseId: ID! @possibleTypes(concreteTypes: ["Enterprise"])
+  
   """
   The value for the team discussions setting on the enterprise.
   """
@@ -48365,10 +55053,12 @@ type UpdateEnterpriseTeamDiscussionsSettingPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The enterprise with the updated team discussions setting.
   """
   enterprise: Enterprise
+  
   """
   A message confirming the result of updating the team discussions setting.
   """
@@ -48383,10 +55073,12 @@ input UpdateEnterpriseTwoFactorAuthenticationRequiredSettingInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The ID of the enterprise on which to set the two factor authentication required setting.
   """
   enterpriseId: ID! @possibleTypes(concreteTypes: ["Enterprise"])
+  
   """
   The value for the two factor authentication required setting on the enterprise.
   """
@@ -48401,10 +55093,12 @@ type UpdateEnterpriseTwoFactorAuthenticationRequiredSettingPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The enterprise with the updated two factor authentication required setting.
   """
   enterprise: Enterprise
+  
   """
   A message confirming the result of updating the two factor authentication required setting.
   """
@@ -48419,14 +55113,17 @@ input UpdateEnvironmentInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The node ID of the environment.
   """
   environmentId: ID! @possibleTypes(concreteTypes: ["Environment"])
+  
   """
   The ids of users or teams that can approve deployments to this environment
   """
   reviewers: [ID!]
+  
   """
   The wait timer in minutes.
   """
@@ -48441,6 +55138,7 @@ type UpdateEnvironmentPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The updated environment.
   """
@@ -48455,6 +55153,7 @@ input UpdateIpAllowListEnabledSettingInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The ID of the owner on which to set the IP allow list enabled setting.
   """
@@ -48463,6 +55162,7 @@ input UpdateIpAllowListEnabledSettingInput {
       concreteTypes: ["App", "Enterprise", "Organization"]
       abstractType: "IpAllowListOwner"
     )
+  
   """
   The value for the IP allow list enabled setting.
   """
@@ -48477,6 +55177,7 @@ type UpdateIpAllowListEnabledSettingPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The IP allow list owner on which the setting was updated.
   """
@@ -48491,18 +55192,22 @@ input UpdateIpAllowListEntryInput {
   An IP address or range of addresses in CIDR notation.
   """
   allowListValue: String!
+  
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The ID of the IP allow list entry to update.
   """
   ipAllowListEntryId: ID! @possibleTypes(concreteTypes: ["IpAllowListEntry"])
+  
   """
   Whether the IP allow list entry is active when an IP allow list is enabled.
   """
   isActive: Boolean!
+  
   """
   An optional name for the IP allow list entry.
   """
@@ -48517,6 +55222,7 @@ type UpdateIpAllowListEntryPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The IP allow list entry that was updated.
   """
@@ -48531,6 +55237,7 @@ input UpdateIpAllowListForInstalledAppsEnabledSettingInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The ID of the owner.
   """
@@ -48539,6 +55246,7 @@ input UpdateIpAllowListForInstalledAppsEnabledSettingInput {
       concreteTypes: ["App", "Enterprise", "Organization"]
       abstractType: "IpAllowListOwner"
     )
+  
   """
   The value for the IP allow list configuration for installed GitHub Apps setting.
   """
@@ -48553,6 +55261,7 @@ type UpdateIpAllowListForInstalledAppsEnabledSettingPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The IP allow list owner on which the setting was updated.
   """
@@ -48567,10 +55276,12 @@ input UpdateIssueCommentInput {
   The updated text of the comment.
   """
   body: String!
+  
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The ID of the IssueComment to modify.
   """
@@ -48585,6 +55296,7 @@ type UpdateIssueCommentPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The updated comment.
   """
@@ -48599,34 +55311,42 @@ input UpdateIssueInput {
   An array of Node IDs of users for this issue.
   """
   assigneeIds: [ID!] @possibleTypes(concreteTypes: ["User"])
+  
   """
   The body for the issue description.
   """
   body: String
+  
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The ID of the Issue to modify.
   """
   id: ID! @possibleTypes(concreteTypes: ["Issue"])
+  
   """
   An array of Node IDs of labels for this issue.
   """
   labelIds: [ID!] @possibleTypes(concreteTypes: ["Label"])
+  
   """
   The Node ID of the milestone for this issue.
   """
   milestoneId: ID @possibleTypes(concreteTypes: ["Milestone"])
+  
   """
   An array of Node IDs for projects associated with this issue.
   """
   projectIds: [ID!]
+  
   """
   The desired issue state.
   """
   state: IssueState
+  
   """
   The title for the issue.
   """
@@ -48641,10 +55361,12 @@ type UpdateIssuePayload {
   Identifies the actor who performed the event.
   """
   actor: Actor
+  
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The issue.
   """
@@ -48659,18 +55381,22 @@ input UpdateLabelInput @preview(toggledBy: "bane-preview") {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   A 6 character hex code, without the leading #, identifying the updated color of the label.
   """
   color: String
+  
   """
   A brief description of the label, such as its purpose.
   """
   description: String
+  
   """
   The Node ID of the label to be updated.
   """
   id: ID! @possibleTypes(concreteTypes: ["Label"])
+  
   """
   The updated name of the label.
   """
@@ -48685,6 +55411,7 @@ type UpdateLabelPayload @preview(toggledBy: "bane-preview") {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The updated label.
   """
@@ -48699,6 +55426,7 @@ input UpdateNotificationRestrictionSettingInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The ID of the owner on which to set the restrict notifications setting.
   """
@@ -48707,6 +55435,7 @@ input UpdateNotificationRestrictionSettingInput {
       concreteTypes: ["Enterprise", "Organization"]
       abstractType: "VerifiableDomainOwner"
     )
+  
   """
   The value for the restrict notifications setting.
   """
@@ -48721,6 +55450,7 @@ type UpdateNotificationRestrictionSettingPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The owner on which the setting was updated.
   """
@@ -48735,10 +55465,12 @@ input UpdateOrganizationAllowPrivateRepositoryForkingSettingInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   Enable forking of private repositories in the organization?
   """
   forkingEnabled: Boolean!
+  
   """
   The ID of the organization on which to set the allow private repository forking setting.
   """
@@ -48753,10 +55485,12 @@ type UpdateOrganizationAllowPrivateRepositoryForkingSettingPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   A message confirming the result of updating the allow private repository forking setting.
   """
   message: String
+  
   """
   The organization with the updated allow private repository forking setting.
   """
@@ -48771,10 +55505,12 @@ input UpdateOrganizationWebCommitSignoffSettingInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The ID of the organization on which to set the web commit signoff setting.
   """
   organizationId: ID! @possibleTypes(concreteTypes: ["Organization"])
+  
   """
   Enable signoff on web-based commits for repositories in the organization?
   """
@@ -48789,10 +55525,12 @@ type UpdateOrganizationWebCommitSignoffSettingPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   A message confirming the result of updating the web commit signoff setting.
   """
   message: String
+  
   """
   The organization with the updated web commit signoff setting.
   """
@@ -48827,14 +55565,17 @@ input UpdateProjectCardInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   Whether or not the ProjectCard should be archived
   """
   isArchived: Boolean
+  
   """
   The note of ProjectCard.
   """
   note: String
+  
   """
   The ProjectCard ID to update.
   """
@@ -48849,6 +55590,7 @@ type UpdateProjectCardPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The updated ProjectCard.
   """
@@ -48863,10 +55605,12 @@ input UpdateProjectColumnInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The name of project column.
   """
   name: String!
+  
   """
   The ProjectColumn ID to update.
   """
@@ -48881,6 +55625,7 @@ type UpdateProjectColumnPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The updated project column.
   """
@@ -48895,22 +55640,27 @@ input UpdateProjectInput {
   The description of project.
   """
   body: String
+  
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The name of project.
   """
   name: String
+  
   """
   The Project ID to update.
   """
   projectId: ID! @possibleTypes(concreteTypes: ["Project"])
+  
   """
   Whether the project is public or not.
   """
   public: Boolean
+  
   """
   Whether the project is open or closed.
   """
@@ -48925,6 +55675,7 @@ type UpdateProjectPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The updated project.
   """
@@ -48939,10 +55690,12 @@ input UpdateProjectV2CollaboratorsInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The collaborators to update.
   """
   collaborators: [ProjectV2Collaborator!]!
+  
   """
   The ID of the project to update the collaborators for.
   """
@@ -48957,6 +55710,7 @@ type UpdateProjectV2CollaboratorsPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The collaborators granted a role
   """
@@ -48965,14 +55719,17 @@ type UpdateProjectV2CollaboratorsPayload {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
@@ -48988,18 +55745,22 @@ input UpdateProjectV2DraftIssueInput {
   The IDs of the assignees of the draft issue.
   """
   assigneeIds: [ID!] @possibleTypes(concreteTypes: ["User"])
+  
   """
   The body of the draft issue.
   """
   body: String
+  
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The ID of the draft issue to update.
   """
   draftIssueId: ID! @possibleTypes(concreteTypes: ["DraftIssue"])
+  
   """
   The title of the draft issue.
   """
@@ -49014,6 +55775,7 @@ type UpdateProjectV2DraftIssuePayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The draft issue updated in the project.
   """
@@ -49028,26 +55790,32 @@ input UpdateProjectV2Input {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   Set the project to closed or open.
   """
   closed: Boolean
+  
   """
   The ID of the Project to update.
   """
   projectId: ID! @possibleTypes(concreteTypes: ["ProjectV2"])
+  
   """
   Set the project to public or private.
   """
   public: Boolean
+  
   """
   Set the readme description of the project.
   """
   readme: String
+  
   """
   Set the short description of the project.
   """
   shortDescription: String
+  
   """
   Set the title of the project.
   """
@@ -49062,6 +55830,7 @@ input UpdateProjectV2ItemFieldValueInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The ID of the field to be updated.
   """
@@ -49074,14 +55843,17 @@ input UpdateProjectV2ItemFieldValueInput {
       ]
       abstractType: "ProjectV2FieldConfiguration"
     )
+  
   """
   The ID of the item to be updated.
   """
   itemId: ID! @possibleTypes(concreteTypes: ["ProjectV2Item"])
+  
   """
   The ID of the Project.
   """
   projectId: ID! @possibleTypes(concreteTypes: ["ProjectV2"])
+  
   """
   The value which will be set on the field.
   """
@@ -49096,6 +55868,7 @@ type UpdateProjectV2ItemFieldValuePayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The updated item.
   """
@@ -49110,14 +55883,17 @@ input UpdateProjectV2ItemPositionInput {
   The ID of the item to position this item after. If omitted or set to null the item will be moved to top.
   """
   afterId: ID @possibleTypes(concreteTypes: ["ProjectV2Item"])
+  
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The ID of the item to be moved.
   """
   itemId: ID! @possibleTypes(concreteTypes: ["ProjectV2Item"])
+  
   """
   The ID of the Project.
   """
@@ -49132,6 +55908,7 @@ type UpdateProjectV2ItemPositionPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The items in the new order
   """
@@ -49140,14 +55917,17 @@ type UpdateProjectV2ItemPositionPayload {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
@@ -49163,6 +55943,7 @@ type UpdateProjectV2Payload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The updated Project.
   """
@@ -49177,14 +55958,17 @@ input UpdatePullRequestBranchInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The head ref oid for the upstream branch.
   """
   expectedHeadOid: GitObjectID
+  
   """
   The Node ID of the pull request.
   """
   pullRequestId: ID! @possibleTypes(concreteTypes: ["PullRequest"])
+  
   """
   The update branch method to use. If omitted, defaults to 'MERGE'
   """
@@ -49199,6 +55983,7 @@ type UpdatePullRequestBranchPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The updated pull request.
   """
@@ -49213,43 +55998,53 @@ input UpdatePullRequestInput {
   An array of Node IDs of users for this pull request.
   """
   assigneeIds: [ID!] @possibleTypes(concreteTypes: ["User"])
+  
   """
   The name of the branch you want your changes pulled into. This should be an existing branch
   on the current repository.
   """
   baseRefName: String
+  
   """
   The contents of the pull request.
   """
   body: String
+  
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   An array of Node IDs of labels for this pull request.
   """
   labelIds: [ID!] @possibleTypes(concreteTypes: ["Label"])
+  
   """
   Indicates whether maintainers can modify the pull request.
   """
   maintainerCanModify: Boolean
+  
   """
   The Node ID of the milestone for this pull request.
   """
   milestoneId: ID @possibleTypes(concreteTypes: ["Milestone"])
+  
   """
   An array of Node IDs for projects associated with this pull request.
   """
   projectIds: [ID!]
+  
   """
   The Node ID of the pull request.
   """
   pullRequestId: ID! @possibleTypes(concreteTypes: ["PullRequest"])
+  
   """
   The target state of the pull request.
   """
   state: PullRequestUpdateState
+  
   """
   The title of the pull request.
   """
@@ -49264,10 +56059,12 @@ type UpdatePullRequestPayload {
   Identifies the actor who performed the event.
   """
   actor: Actor
+  
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The updated pull request.
   """
@@ -49282,10 +56079,12 @@ input UpdatePullRequestReviewCommentInput {
   The text of the comment.
   """
   body: String!
+  
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The Node ID of the comment to modify.
   """
@@ -49301,6 +56100,7 @@ type UpdatePullRequestReviewCommentPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The updated comment.
   """
@@ -49315,10 +56115,12 @@ input UpdatePullRequestReviewInput {
   The contents of the pull request review body.
   """
   body: String!
+  
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The Node ID of the pull request review to modify.
   """
@@ -49333,6 +56135,7 @@ type UpdatePullRequestReviewPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The updated pull request review.
   """
@@ -49347,14 +56150,17 @@ input UpdateRefInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   Permit updates of branch Refs that are not fast-forwards?
   """
   force: Boolean = false
+  
   """
   The GitObjectID that the Ref shall be updated to target.
   """
   oid: GitObjectID!
+  
   """
   The Node ID of the Ref to be updated.
   """
@@ -49369,6 +56175,7 @@ type UpdateRefPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The updated Ref.
   """
@@ -49383,10 +56190,12 @@ input UpdateRefsInput @preview(toggledBy: "update-refs-preview") {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   A list of ref updates.
   """
   refUpdates: [RefUpdate!]!
+  
   """
   The Node ID of the repository.
   """
@@ -49411,38 +56220,47 @@ input UpdateRepositoryInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   A new description for the repository. Pass an empty string to erase the existing description.
   """
   description: String
+  
   """
   Indicates if the repository should have the discussions feature enabled.
   """
   hasDiscussionsEnabled: Boolean
+  
   """
   Indicates if the repository should have the issues feature enabled.
   """
   hasIssuesEnabled: Boolean
+  
   """
   Indicates if the repository should have the project boards feature enabled.
   """
   hasProjectsEnabled: Boolean
+  
   """
   Indicates if the repository should have the wiki feature enabled.
   """
   hasWikiEnabled: Boolean
+  
   """
   The URL for a web page about this repository. Pass an empty string to erase the existing URL.
   """
   homepageUrl: URI
+  
   """
   The new name of the repository.
   """
   name: String
+  
   """
   The ID of the repository to update.
   """
   repositoryId: ID! @possibleTypes(concreteTypes: ["Repository"])
+  
   """
   Whether this repository should be marked as a template such that anyone who
   can access it can create new repositories with the same files and directory structure.
@@ -49458,6 +56276,7 @@ type UpdateRepositoryPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The updated repository.
   """
@@ -49472,30 +56291,37 @@ input UpdateRepositoryRulesetInput {
   A list of actors that are allowed to bypass rules in this ruleset.
   """
   bypassActors: [RepositoryRulesetBypassActorInput!]
+  
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The list of conditions for this ruleset
   """
   conditions: RepositoryRuleConditionsInput
+  
   """
   The enforcement level for this ruleset
   """
   enforcement: RuleEnforcement
+  
   """
   The name of the ruleset.
   """
   name: String
+  
   """
   The global relay id of the repository ruleset to be updated.
   """
   repositoryRulesetId: ID! @possibleTypes(concreteTypes: ["RepositoryRuleset"])
+  
   """
   The list of rules for this ruleset
   """
   rules: [RepositoryRuleInput!]
+  
   """
   The target of the ruleset.
   """
@@ -49510,6 +56336,7 @@ type UpdateRepositoryRulesetPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The newly created Ruleset.
   """
@@ -49524,10 +56351,12 @@ input UpdateRepositoryWebCommitSignoffSettingInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The ID of the repository to update.
   """
   repositoryId: ID! @possibleTypes(concreteTypes: ["Repository"])
+  
   """
   Indicates if the repository should require signoff on web-based commits.
   """
@@ -49542,10 +56371,12 @@ type UpdateRepositoryWebCommitSignoffSettingPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   A message confirming the result of updating the web commit signoff setting.
   """
   message: String
+  
   """
   The updated repository.
   """
@@ -49560,15 +56391,18 @@ input UpdateSponsorshipPreferencesInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   Specify whether others should be able to see that the sponsor is sponsoring
   the sponsorable. Public visibility still does not reveal which tier is used.
   """
   privacyLevel: SponsorshipPrivacy = PUBLIC
+  
   """
   Whether the sponsor should receive email updates from the sponsorable.
   """
   receiveEmails: Boolean = true
+  
   """
   The ID of the user or organization who is acting as the sponsor, paying for
   the sponsorship. Required if sponsorLogin is not given.
@@ -49578,11 +56412,13 @@ input UpdateSponsorshipPreferencesInput {
       concreteTypes: ["Organization", "User"]
       abstractType: "Sponsor"
     )
+  
   """
   The username of the user or organization who is acting as the sponsor, paying
   for the sponsorship. Required if sponsorId is not given.
   """
   sponsorLogin: String
+  
   """
   The ID of the user or organization who is receiving the sponsorship. Required if sponsorableLogin is not given.
   """
@@ -49591,6 +56427,7 @@ input UpdateSponsorshipPreferencesInput {
       concreteTypes: ["Organization", "User"]
       abstractType: "Sponsorable"
     )
+  
   """
   The username of the user or organization who is receiving the sponsorship. Required if sponsorableId is not given.
   """
@@ -49605,6 +56442,7 @@ type UpdateSponsorshipPreferencesPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The sponsorship that was updated.
   """
@@ -49619,10 +56457,12 @@ input UpdateSubscriptionInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The new state of the subscription.
   """
   state: SubscriptionState!
+  
   """
   The Node ID of the subscribable object to modify.
   """
@@ -49649,6 +56489,7 @@ type UpdateSubscriptionPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The input subscribable entity.
   """
@@ -49663,14 +56504,17 @@ input UpdateTeamDiscussionCommentInput {
   The updated text of the comment.
   """
   body: String!
+  
   """
   The current version of the body content.
   """
   bodyVersion: String
+  
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The ID of the comment to modify.
   """
@@ -49685,6 +56529,7 @@ type UpdateTeamDiscussionCommentPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The updated comment.
   """
@@ -49699,23 +56544,28 @@ input UpdateTeamDiscussionInput {
   The updated text of the discussion.
   """
   body: String
+  
   """
   The current version of the body content. If provided, this update operation
   will be rejected if the given version does not match the latest version on the server.
   """
   bodyVersion: String
+  
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The Node ID of the discussion to modify.
   """
   id: ID! @possibleTypes(concreteTypes: ["TeamDiscussion"])
+  
   """
   If provided, sets the pinned state of the updated discussion.
   """
   pinned: Boolean
+  
   """
   The updated title of the discussion.
   """
@@ -49730,6 +56580,7 @@ type UpdateTeamDiscussionPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The updated discussion.
   """
@@ -49745,26 +56596,32 @@ input UpdateTeamReviewAssignmentInput
   The algorithm to use for review assignment
   """
   algorithm: TeamReviewAssignmentAlgorithm = ROUND_ROBIN
+  
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   Turn on or off review assignment
   """
   enabled: Boolean!
+  
   """
   An array of team member IDs to exclude
   """
   excludedTeamMemberIds: [ID!] @possibleTypes(concreteTypes: ["User"])
+  
   """
   The Node ID of the team to update review assignments of
   """
   id: ID! @possibleTypes(concreteTypes: ["Team"])
+  
   """
   Notify the entire team of the PR if it is delegated
   """
   notifyTeam: Boolean = true
+  
   """
   The number of team members to assign
   """
@@ -49779,6 +56636,7 @@ type UpdateTeamReviewAssignmentPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The team that was modified
   """
@@ -49793,14 +56651,17 @@ input UpdateTeamsRepositoryInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   Permission that should be granted to the teams.
   """
   permission: RepositoryPermission!
+  
   """
   Repository ID being granted access to.
   """
   repositoryId: ID! @possibleTypes(concreteTypes: ["Repository"])
+  
   """
   A list of teams being granted access. Limit: 10
   """
@@ -49815,10 +56676,12 @@ type UpdateTeamsRepositoryPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The repository that was updated.
   """
   repository: Repository
+  
   """
   The teams granted permission on the repository.
   """
@@ -49833,10 +56696,12 @@ input UpdateTopicsInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The Node ID of the repository.
   """
   repositoryId: ID! @possibleTypes(concreteTypes: ["Repository"])
+  
   """
   An array of topic names.
   """
@@ -49851,10 +56716,12 @@ type UpdateTopicsPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   Names of the provided topics that are not valid.
   """
   invalidTopicNames: [String!]
+  
   """
   The updated repository.
   """
@@ -49874,6 +56741,7 @@ type User implements Actor & Node & PackageOwner & ProfileOwner & ProjectOwner &
     """
     type: PinnableItemType
   ): Boolean!
+  
   """
   A URL pointing to the user's public avatar.
   """
@@ -49883,14 +56751,17 @@ type User implements Actor & Node & PackageOwner & ProfileOwner & ProjectOwner &
     """
     size: Int
   ): URI!
+  
   """
   The user's public profile bio.
   """
   bio: String
+  
   """
   The user's public profile bio as HTML.
   """
   bioHTML: HTML!
+  
   """
   Could this user receive email notifications, if the organization had notification restrictions enabled?
   """
@@ -49900,6 +56771,7 @@ type User implements Actor & Node & PackageOwner & ProfileOwner & ProjectOwner &
     """
     login: String!
   ): Boolean!
+  
   """
   A list of commit comments made by this user.
   """
@@ -49908,27 +56780,33 @@ type User implements Actor & Node & PackageOwner & ProfileOwner & ProjectOwner &
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): CommitCommentConnection!
+  
   """
   The user's public profile company.
   """
   company: String
+  
   """
   The user's public profile company as HTML.
   """
   companyHTML: HTML!
+  
   """
   The collection of contributions this user has made to different repositories.
   """
@@ -49937,10 +56815,12 @@ type User implements Actor & Node & PackageOwner & ProfileOwner & ProjectOwner &
     Only contributions made at this time or later will be counted. If omitted, defaults to a year ago.
     """
     from: DateTime
+    
     """
     The ID of the organization used to filter contributions.
     """
     organizationID: ID
+    
     """
     Only contributions made before and up to (including) this time will be
     counted. If omitted, defaults to the current time or one year from the
@@ -49948,18 +56828,22 @@ type User implements Actor & Node & PackageOwner & ProfileOwner & ProjectOwner &
     """
     to: DateTime
   ): ContributionsCollection!
+  
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
+  
   """
   Identifies the primary key from the database.
   """
   databaseId: Int
+  
   """
   The user's publicly visible profile email.
   """
   email: String!
+  
   """
   A list of enterprises that the user belongs to.
   """
@@ -49968,31 +56852,38 @@ type User implements Actor & Node & PackageOwner & ProfileOwner & ProjectOwner &
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Filter enterprises returned based on the user's membership type.
     """
     membershipType: EnterpriseMembershipType = ALL
+    
     """
     Ordering options for the User's enterprises.
     """
     orderBy: EnterpriseOrder = { field: NAME, direction: ASC }
   ): EnterpriseConnection
+  
   """
   The estimated next GitHub Sponsors payout for this user/organization in cents (USD).
   """
   estimatedNextSponsorsPayoutInCents: Int!
+  
   """
   A list of users the given user is followed by.
   """
@@ -50001,19 +56892,23 @@ type User implements Actor & Node & PackageOwner & ProfileOwner & ProjectOwner &
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): FollowerConnection!
+  
   """
   A list of users the given user is following.
   """
@@ -50022,19 +56917,23 @@ type User implements Actor & Node & PackageOwner & ProfileOwner & ProjectOwner &
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): FollowingConnection!
+  
   """
   Find gist by repo name.
   """
@@ -50044,6 +56943,7 @@ type User implements Actor & Node & PackageOwner & ProfileOwner & ProjectOwner &
     """
     name: String!
   ): Gist
+  
   """
   A list of gist comments made by this user.
   """
@@ -50052,19 +56952,23 @@ type User implements Actor & Node & PackageOwner & ProfileOwner & ProjectOwner &
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): GistCommentConnection!
+  
   """
   A list of the Gists the user has created.
   """
@@ -50073,31 +56977,38 @@ type User implements Actor & Node & PackageOwner & ProfileOwner & ProjectOwner &
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for gists returned from the connection
     """
     orderBy: GistOrder
+    
     """
     Filters Gists according to privacy.
     """
     privacy: GistPrivacy
   ): GistConnection!
+  
   """
   True if this user/organization has a GitHub Sponsors listing.
   """
   hasSponsorsListing: Boolean!
+  
   """
   The hovercard information for this user in a given context
   """
@@ -50108,42 +57019,52 @@ type User implements Actor & Node & PackageOwner & ProfileOwner & ProjectOwner &
     primarySubjectId: ID
   ): Hovercard!
   id: ID!
+  
   """
   The interaction ability settings for this user.
   """
   interactionAbility: RepositoryInteractionAbility
+  
   """
   Whether or not this user is a participant in the GitHub Security Bug Bounty.
   """
   isBountyHunter: Boolean!
+  
   """
   Whether or not this user is a participant in the GitHub Campus Experts Program.
   """
   isCampusExpert: Boolean!
+  
   """
   Whether or not this user is a GitHub Developer Program member.
   """
   isDeveloperProgramMember: Boolean!
+  
   """
   Whether or not this user is a GitHub employee.
   """
   isEmployee: Boolean!
+  
   """
   Whether or not this user is following the viewer. Inverse of viewerIsFollowing
   """
   isFollowingViewer: Boolean!
+  
   """
   Whether or not this user is a member of the GitHub Stars Program.
   """
   isGitHubStar: Boolean!
+  
   """
   Whether or not the user has marked themselves as for hire.
   """
   isHireable: Boolean!
+  
   """
   Whether or not this user is a site administrator.
   """
   isSiteAdmin: Boolean!
+  
   """
   Whether the given account is sponsoring this user/organization.
   """
@@ -50153,14 +57074,17 @@ type User implements Actor & Node & PackageOwner & ProfileOwner & ProjectOwner &
     """
     accountLogin: String!
   ): Boolean!
+  
   """
   True if the viewer is sponsored by this user/organization.
   """
   isSponsoringViewer: Boolean!
+  
   """
   Whether or not this user is the viewing user.
   """
   isViewer: Boolean!
+  
   """
   A list of issue comments made by this user.
   """
@@ -50169,23 +57093,28 @@ type User implements Actor & Node & PackageOwner & ProfileOwner & ProjectOwner &
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for issue comments returned from the connection.
     """
     orderBy: IssueCommentOrder
   ): IssueCommentConnection!
+  
   """
   A list of issues associated with this user.
   """
@@ -50194,56 +57123,69 @@ type User implements Actor & Node & PackageOwner & ProfileOwner & ProjectOwner &
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Filtering options for issues returned from the connection.
     """
     filterBy: IssueFilters
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     A list of label names to filter the pull requests by.
     """
     labels: [String!]
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for issues returned from the connection.
     """
     orderBy: IssueOrder
+    
     """
     A list of states to filter the issues by.
     """
     states: [IssueState!]
   ): IssueConnection!
+  
   """
   Showcases a selection of repositories and gists that the profile owner has
   either curated or that have been selected automatically based on popularity.
   """
   itemShowcase: ProfileItemShowcase!
+  
   """
   The user's public profile location.
   """
   location: String
+  
   """
   The username used to login.
   """
   login: String!
+  
   """
   The estimated monthly GitHub Sponsors income for this user/organization in cents (USD).
   """
   monthlyEstimatedSponsorsIncomeInCents: Int!
+  
   """
   The user's public profile name.
   """
   name: String
+  
   """
   Find an organization by its login that the user belongs to.
   """
@@ -50253,6 +57195,7 @@ type User implements Actor & Node & PackageOwner & ProfileOwner & ProjectOwner &
     """
     login: String!
   ): Organization
+  
   """
   Verified email addresses that match verified domains for a specified organization the user is a member of.
   """
@@ -50262,6 +57205,7 @@ type User implements Actor & Node & PackageOwner & ProfileOwner & ProjectOwner &
     """
     login: String!
   ): [String!]!
+  
   """
   A list of organizations the user belongs to.
   """
@@ -50270,23 +57214,28 @@ type User implements Actor & Node & PackageOwner & ProfileOwner & ProjectOwner &
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for the User's organizations.
     """
     orderBy: OrganizationOrder = null
   ): OrganizationConnection!
+  
   """
   A list of packages under the owner.
   """
@@ -50295,35 +57244,43 @@ type User implements Actor & Node & PackageOwner & ProfileOwner & ProjectOwner &
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Find packages by their names.
     """
     names: [String]
+    
     """
     Ordering of the returned packages.
     """
     orderBy: PackageOrder = { field: CREATED_AT, direction: DESC }
+    
     """
     Filter registry package by type.
     """
     packageType: PackageType
+    
     """
     Find packages in a repository by ID.
     """
     repositoryId: ID
   ): PackageConnection!
+  
   """
   A list of repositories and gists this profile owner can pin to their profile.
   """
@@ -50332,23 +57289,28 @@ type User implements Actor & Node & PackageOwner & ProfileOwner & ProjectOwner &
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Filter the types of pinnable items that are returned.
     """
     types: [PinnableItemType!]
   ): PinnableItemConnection!
+  
   """
   A list of repositories and gists this profile owner has pinned to their profile
   """
@@ -50357,27 +57319,33 @@ type User implements Actor & Node & PackageOwner & ProfileOwner & ProjectOwner &
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Filter the types of pinned items that are returned.
     """
     types: [PinnableItemType!]
   ): PinnableItemConnection!
+  
   """
   Returns how many more items this profile owner can pin to their profile.
   """
   pinnedItemsRemaining: Int!
+  
   """
   Find project by number.
   """
@@ -50387,6 +57355,7 @@ type User implements Actor & Node & PackageOwner & ProfileOwner & ProjectOwner &
     """
     number: Int!
   ): Project
+  
   """
   Find a project by number.
   """
@@ -50396,6 +57365,7 @@ type User implements Actor & Node & PackageOwner & ProfileOwner & ProjectOwner &
     """
     number: Int!
   ): ProjectV2
+  
   """
   A list of projects under the owner.
   """
@@ -50404,39 +57374,48 @@ type User implements Actor & Node & PackageOwner & ProfileOwner & ProjectOwner &
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for projects returned from the connection
     """
     orderBy: ProjectOrder
+    
     """
     Query to search projects by, currently only searching by name.
     """
     search: String
+    
     """
     A list of states to filter the projects by.
     """
     states: [ProjectState!]
   ): ProjectConnection!
+  
   """
   The HTTP path listing user's projects
   """
   projectsResourcePath: URI!
+  
   """
   The HTTP URL listing user's projects
   """
   projectsUrl: URI!
+  
   """
   A list of projects under the owner.
   """
@@ -50445,31 +57424,38 @@ type User implements Actor & Node & PackageOwner & ProfileOwner & ProjectOwner &
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     How to order the returned projects.
     """
     orderBy: ProjectV2Order = { field: NUMBER, direction: DESC }
+    
     """
     A project to search for under the the owner.
     """
     query: String
   ): ProjectV2Connection!
+  
   """
   The user's profile pronouns
   """
   pronouns: String
+  
   """
   A list of public keys associated with this user.
   """
@@ -50478,19 +57464,23 @@ type User implements Actor & Node & PackageOwner & ProfileOwner & ProjectOwner &
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): PublicKeyConnection!
+  
   """
   A list of pull requests associated with this user.
   """
@@ -50499,39 +57489,48 @@ type User implements Actor & Node & PackageOwner & ProfileOwner & ProjectOwner &
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     The base ref name to filter the pull requests by.
     """
     baseRefName: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     The head ref name to filter the pull requests by.
     """
     headRefName: String
+    
     """
     A list of label names to filter the pull requests by.
     """
     labels: [String!]
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for pull requests returned from the connection.
     """
     orderBy: IssueOrder
+    
     """
     A list of states to filter the pull requests by.
     """
     states: [PullRequestState!]
   ): PullRequestConnection!
+  
   """
   Recent projects that this user has modified in the context of the owner.
   """
@@ -50540,19 +57539,23 @@ type User implements Actor & Node & PackageOwner & ProfileOwner & ProjectOwner &
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): ProjectV2Connection!
+  
   """
   A list of repositories that the user owns.
   """
@@ -50563,53 +57566,65 @@ type User implements Actor & Node & PackageOwner & ProfileOwner & ProjectOwner &
     current viewer owns.
     """
     affiliations: [RepositoryAffiliation]
+    
     """
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     If non-null, filters repositories according to whether they have issues enabled
     """
     hasIssuesEnabled: Boolean
+    
     """
     If non-null, filters repositories according to whether they are archived and not maintained
     """
     isArchived: Boolean
+    
     """
     If non-null, filters repositories according to whether they are forks of another repository
     """
     isFork: Boolean
+    
     """
     If non-null, filters repositories according to whether they have been locked
     """
     isLocked: Boolean
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for repositories returned from the connection
     """
     orderBy: RepositoryOrder
+    
     """
     Array of owner's affiliation options for repositories returned from the
     connection. For example, OWNER will include only repositories that the
     organization or user being viewed owns.
     """
     ownerAffiliations: [RepositoryAffiliation] = [OWNER, COLLABORATOR]
+    
     """
     If non-null, filters repositories according to privacy
     """
     privacy: RepositoryPrivacy
   ): RepositoryConnection!
+  
   """
   A list of repositories that the user recently contributed to.
   """
@@ -50618,44 +57633,54 @@ type User implements Actor & Node & PackageOwner & ProfileOwner & ProjectOwner &
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     If non-null, include only the specified types of contributions. The
     GitHub.com UI uses [COMMIT, ISSUE, PULL_REQUEST, REPOSITORY]
     """
     contributionTypes: [RepositoryContributionType]
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     If non-null, filters repositories according to whether they have issues enabled
     """
     hasIssues: Boolean
+    
     """
     If true, include user repositories
     """
     includeUserRepositories: Boolean
+    
     """
     If non-null, filters repositories according to whether they have been locked
     """
     isLocked: Boolean
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for repositories returned from the connection
     """
     orderBy: RepositoryOrder
+    
     """
     If non-null, filters repositories according to privacy
     """
     privacy: RepositoryPrivacy
   ): RepositoryConnection!
+  
   """
   Find Repository.
   """
@@ -50664,11 +57689,13 @@ type User implements Actor & Node & PackageOwner & ProfileOwner & ProjectOwner &
     Follow repository renames. If disabled, a repository referenced by its old name will return an error.
     """
     followRenames: Boolean = true
+    
     """
     Name of Repository to find.
     """
     name: String!
   ): Repository
+  
   """
   Discussion comments this user has authored.
   """
@@ -50677,27 +57704,33 @@ type User implements Actor & Node & PackageOwner & ProfileOwner & ProjectOwner &
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Filter discussion comments to only those that were marked as the answer
     """
     onlyAnswers: Boolean = false
+    
     """
     Filter discussion comments to only those in a specific repository.
     """
     repositoryId: ID
   ): DiscussionCommentConnection!
+  
   """
   Discussions this user has started.
   """
@@ -50706,40 +57739,49 @@ type User implements Actor & Node & PackageOwner & ProfileOwner & ProjectOwner &
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Filter discussions to only those that have been answered or not. Defaults to
     including both answered and unanswered discussions.
     """
     answered: Boolean = null
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for discussions returned from the connection.
     """
     orderBy: DiscussionOrder = { field: CREATED_AT, direction: DESC }
+    
     """
     Filter discussions to only those in a specific repository.
     """
     repositoryId: ID
+    
     """
     A list of states to filter the discussions by.
     """
     states: [DiscussionState!] = []
   ): DiscussionConnection!
+  
   """
   The HTTP path for this user
   """
   resourcePath: URI!
+  
   """
   Replies this user has saved
   """
@@ -50748,23 +57790,28 @@ type User implements Actor & Node & PackageOwner & ProfileOwner & ProjectOwner &
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     The field to order saved replies by.
     """
     orderBy: SavedReplyOrder = { field: UPDATED_AT, direction: DESC }
   ): SavedReplyConnection
+  
   """
   The user's social media accounts, ordered as they appear on the user's profile.
   """
@@ -50773,19 +57820,23 @@ type User implements Actor & Node & PackageOwner & ProfileOwner & ProjectOwner &
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): SocialAccountConnection!
+  
   """
   List of users and organizations this entity is sponsoring.
   """
@@ -50794,23 +57845,28 @@ type User implements Actor & Node & PackageOwner & ProfileOwner & ProjectOwner &
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for the users and organizations returned from the connection.
     """
     orderBy: SponsorOrder = { field: RELEVANCE, direction: DESC }
   ): SponsorConnection!
+  
   """
   List of sponsors for this user or organization.
   """
@@ -50819,28 +57875,34 @@ type User implements Actor & Node & PackageOwner & ProfileOwner & ProjectOwner &
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for sponsors returned from the connection.
     """
     orderBy: SponsorOrder = { field: RELEVANCE, direction: DESC }
+    
     """
     If given, will filter for sponsors at the given tier. Will only return
     sponsors whose tier the viewer is permitted to see.
     """
     tierId: ID
   ): SponsorConnection!
+  
   """
   Events involving this sponsorable, such as new sponsorships.
   """
@@ -50849,55 +57911,67 @@ type User implements Actor & Node & PackageOwner & ProfileOwner & ProjectOwner &
     Filter activities to only the specified actions.
     """
     actions: [SponsorsActivityAction!] = []
+    
     """
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Whether to include those events where this sponsorable acted as the sponsor.
     Defaults to only including events where this sponsorable was the recipient
     of a sponsorship.
     """
     includeAsSponsor: Boolean = false
+    
     """
     Whether or not to include private activities in the result set. Defaults to including public and private activities.
     """
     includePrivate: Boolean = true
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for activity returned from the connection.
     """
     orderBy: SponsorsActivityOrder = { field: TIMESTAMP, direction: DESC }
+    
     """
     Filter activities returned to only those that occurred in the most recent
     specified time period. Set to ALL to avoid filtering by when the activity
     occurred. Will be ignored if `since` or `until` is given.
     """
     period: SponsorsActivityPeriod = MONTH
+    
     """
     Filter activities to those that occurred on or after this time.
     """
     since: DateTime
+    
     """
     Filter activities to those that occurred before this time.
     """
     until: DateTime
   ): SponsorsActivityConnection!
+  
   """
   The GitHub Sponsors listing for this user or organization.
   """
   sponsorsListing: SponsorsListing
+  
   """
   The sponsorship from the viewer to this user/organization; that is, the sponsorship where you're the sponsor.
   """
@@ -50908,6 +57982,7 @@ type User implements Actor & Node & PackageOwner & ProfileOwner & ProjectOwner &
     """
     activeOnly: Boolean = true
   ): Sponsorship
+  
   """
   The sponsorship from this user/organization to the viewer; that is, the sponsorship you're receiving.
   """
@@ -50918,6 +57993,7 @@ type User implements Actor & Node & PackageOwner & ProfileOwner & ProjectOwner &
     """
     activeOnly: Boolean = true
   ): Sponsorship
+  
   """
   List of sponsorship updates sent from this sponsorable to sponsors.
   """
@@ -50926,23 +58002,28 @@ type User implements Actor & Node & PackageOwner & ProfileOwner & ProjectOwner &
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for sponsorship updates returned from the connection.
     """
     orderBy: SponsorshipNewsletterOrder = { field: CREATED_AT, direction: DESC }
   ): SponsorshipNewsletterConnection!
+  
   """
   The sponsorships where this user or organization is the maintainer receiving the funds.
   """
@@ -50952,32 +58033,39 @@ type User implements Actor & Node & PackageOwner & ProfileOwner & ProjectOwner &
     sponsorships this maintainer has ever received.
     """
     activeOnly: Boolean = true
+    
     """
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Whether or not to include private sponsorships in the result set
     """
     includePrivate: Boolean = false
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for sponsorships returned from this connection. If left
     blank, the sponsorships will be ordered based on relevancy to the viewer.
     """
     orderBy: SponsorshipOrder
   ): SponsorshipConnection!
+  
   """
   The sponsorships where this user or organization is the funder.
   """
@@ -50986,34 +58074,41 @@ type User implements Actor & Node & PackageOwner & ProfileOwner & ProjectOwner &
     Whether to include only sponsorships that are active right now, versus all sponsorships this sponsor has ever made.
     """
     activeOnly: Boolean = true
+    
     """
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Filter sponsorships returned to those for the specified maintainers. That
     is, the recipient of the sponsorship is a user or organization with one of
     the given logins.
     """
     maintainerLogins: [String!]
+    
     """
     Ordering options for sponsorships returned from this connection. If left
     blank, the sponsorships will be ordered based on relevancy to the viewer.
     """
     orderBy: SponsorshipOrder
   ): SponsorshipConnection!
+  
   """
   Repositories the user has starred.
   """
@@ -51022,31 +58117,38 @@ type User implements Actor & Node & PackageOwner & ProfileOwner & ProjectOwner &
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Order for connection
     """
     orderBy: StarOrder
+    
     """
     Filters starred repositories to only return repositories owned by the viewer.
     """
     ownedByViewer: Boolean
   ): StarredRepositoryConnection!
+  
   """
   The user's description of what they're currently doing.
   """
   status: UserStatus
+  
   """
   Repositories the user has contributed to, ordered by contribution rank, plus repositories the user has created
   """
@@ -51055,27 +58157,33 @@ type User implements Actor & Node & PackageOwner & ProfileOwner & ProjectOwner &
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for repositories returned from the connection
     """
     orderBy: RepositoryOrder!
+    
     """
     How far back in time to fetch contributed repositories
     """
     since: DateTime
   ): RepositoryConnection!
+  
   """
   The amount in United States cents (e.g., 500 = $5.00 USD) that this entity has
   spent on GitHub to fund sponsorships. Only returns a value when viewed by the
@@ -51086,51 +58194,63 @@ type User implements Actor & Node & PackageOwner & ProfileOwner & ProjectOwner &
     Filter payments to those that occurred on or after this time.
     """
     since: DateTime
+    
     """
     Filter payments to those made to the users or organizations with the specified usernames.
     """
     sponsorableLogins: [String!] = []
+    
     """
     Filter payments to those that occurred before this time.
     """
     until: DateTime
   ): Int
+  
   """
   The user's Twitter username.
   """
   twitterUsername: String
+  
   """
   Identifies the date and time when the object was last updated.
   """
   updatedAt: DateTime!
+  
   """
   The HTTP URL for this user
   """
   url: URI!
+  
   """
   Can the viewer pin repositories and gists to the profile?
   """
   viewerCanChangePinnedItems: Boolean!
+  
   """
   Can the current viewer create new projects on this owner.
   """
   viewerCanCreateProjects: Boolean!
+  
   """
   Whether or not the viewer is able to follow the user.
   """
   viewerCanFollow: Boolean!
+  
   """
   Whether or not the viewer is able to sponsor this user/organization.
   """
   viewerCanSponsor: Boolean!
+  
   """
   Whether or not this user is followed by the viewer. Inverse of isFollowingViewer.
   """
   viewerIsFollowing: Boolean!
+  
   """
   True if the viewer is sponsoring this user/organization.
   """
   viewerIsSponsoring: Boolean!
+  
   """
   A list of repositories the given user is watching.
   """
@@ -51141,45 +58261,55 @@ type User implements Actor & Node & PackageOwner & ProfileOwner & ProjectOwner &
     viewer is an owner or collaborator, or member.
     """
     affiliations: [RepositoryAffiliation]
+    
     """
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     If non-null, filters repositories according to whether they have issues enabled
     """
     hasIssuesEnabled: Boolean
+    
     """
     If non-null, filters repositories according to whether they have been locked
     """
     isLocked: Boolean
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for repositories returned from the connection
     """
     orderBy: RepositoryOrder
+    
     """
     Array of owner's affiliation options for repositories returned from the
     connection. For example, OWNER will include only repositories that the
     organization or user being viewed owns.
     """
     ownerAffiliations: [RepositoryAffiliation] = [OWNER, COLLABORATOR]
+    
     """
     If non-null, filters repositories according to privacy
     """
     privacy: RepositoryPrivacy
   ): RepositoryConnection!
+  
   """
   A URL pointing to the user's public website/blog.
   """
@@ -51220,15 +58350,18 @@ type UserBlockedEvent implements Node {
   Identifies the actor who performed the event.
   """
   actor: Actor
+  
   """
   Number of days that the user was blocked for.
   """
   blockDuration: UserBlockDuration!
+  
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
   id: ID!
+  
   """
   The user who was blocked.
   """
@@ -51243,14 +58376,17 @@ type UserConnection {
   A list of edges.
   """
   edges: [UserEdge]
+  
   """
   A list of nodes.
   """
   nodes: [User]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -51265,27 +58401,33 @@ type UserContentEdit implements Node {
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
+  
   """
   Identifies the date and time when the object was deleted.
   """
   deletedAt: DateTime
+  
   """
   The actor who deleted this content
   """
   deletedBy: Actor
+  
   """
   A summary of the changes for this edit
   """
   diff: String
+  
   """
   When this content was edited
   """
   editedAt: DateTime!
+  
   """
   The actor who edited this content
   """
   editor: Actor
   id: ID!
+  
   """
   Identifies the date and time when the object was last updated.
   """
@@ -51300,14 +58442,17 @@ type UserContentEditConnection {
   A list of edges.
   """
   edges: [UserContentEditEdge]
+  
   """
   A list of nodes.
   """
   nodes: [UserContentEdit]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -51322,6 +58467,7 @@ type UserContentEditEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -51336,6 +58482,7 @@ type UserEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -51350,10 +58497,12 @@ type UserEmailMetadata {
   Boolean to identify primary emails
   """
   primary: Boolean
+  
   """
   Type of email
   """
   type: String
+  
   """
   Email id
   """
@@ -51368,35 +58517,43 @@ type UserStatus implements Node {
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
+  
   """
   An emoji summarizing the user's status.
   """
   emoji: String
+  
   """
   The status emoji as HTML.
   """
   emojiHTML: HTML
+  
   """
   If set, the status will not be shown after this date.
   """
   expiresAt: DateTime
   id: ID!
+  
   """
   Whether this status indicates the user is not fully available on GitHub.
   """
   indicatesLimitedAvailability: Boolean!
+  
   """
   A brief message describing what the user is doing.
   """
   message: String
+  
   """
   The organization whose members can see this status. If null, this status is publicly visible.
   """
   organization: Organization
+  
   """
   Identifies the date and time when the object was last updated.
   """
   updatedAt: DateTime!
+  
   """
   The user who has this status.
   """
@@ -51411,14 +58568,17 @@ type UserStatusConnection {
   A list of edges.
   """
   edges: [UserStatusEdge]
+  
   """
   A list of nodes.
   """
   nodes: [UserStatus]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -51433,6 +58593,7 @@ type UserStatusEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -51447,6 +58608,7 @@ input UserStatusOrder {
   The ordering direction.
   """
   direction: OrderDirection!
+  
   """
   The field to order user statuses by.
   """
@@ -51471,55 +58633,68 @@ type VerifiableDomain implements Node {
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
+  
   """
   Identifies the primary key from the database.
   """
   databaseId: Int
+  
   """
   The DNS host name that should be used for verification.
   """
   dnsHostName: URI
+  
   """
   The unicode encoded domain.
   """
   domain: URI!
+  
   """
   Whether a TXT record for verification with the expected host name was found.
   """
   hasFoundHostName: Boolean!
+  
   """
   Whether a TXT record for verification with the expected verification token was found.
   """
   hasFoundVerificationToken: Boolean!
   id: ID!
+  
   """
   Whether or not the domain is approved.
   """
   isApproved: Boolean!
+  
   """
   Whether this domain is required to exist for an organization or enterprise policy to be enforced.
   """
   isRequiredForPolicyEnforcement: Boolean!
+  
   """
   Whether or not the domain is verified.
   """
   isVerified: Boolean!
+  
   """
   The owner of the domain.
   """
   owner: VerifiableDomainOwner!
+  
   """
   The punycode encoded domain.
   """
   punycodeEncodedDomain: URI!
+  
   """
   The time that the current verification token will expire.
   """
   tokenExpirationTime: DateTime
+  
   """
   Identifies the date and time when the object was last updated.
   """
   updatedAt: DateTime!
+  
   """
   The current verification token for the domain.
   """
@@ -51534,14 +58709,17 @@ type VerifiableDomainConnection {
   A list of edges.
   """
   edges: [VerifiableDomainEdge]
+  
   """
   A list of nodes.
   """
   nodes: [VerifiableDomain]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -51556,6 +58734,7 @@ type VerifiableDomainEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -51570,6 +58749,7 @@ input VerifiableDomainOrder {
   The ordering direction.
   """
   direction: OrderDirection!
+  
   """
   The field to order verifiable domains by.
   """
@@ -51603,6 +58783,7 @@ input VerifyVerifiableDomainInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The ID of the verifiable domain to verify.
   """
@@ -51617,6 +58798,7 @@ type VerifyVerifiableDomainPayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  
   """
   The verifiable domain that was verified.
   """
@@ -51631,10 +58813,12 @@ type ViewerHovercardContext implements HovercardContext {
   A string describing this context
   """
   message: String!
+  
   """
   An octicon to accompany this context
   """
   octicon: String!
+  
   """
   Identifies the user who is related to this context.
   """
@@ -51649,10 +58833,12 @@ interface Votable {
   Number of upvotes that this subject has received.
   """
   upvoteCount: Int!
+  
   """
   Whether or not the current user can add or remove an upvote on this subject.
   """
   viewerCanUpvote: Boolean!
+  
   """
   Whether or not the current user has already upvoted this subject.
   """
@@ -51667,19 +58853,23 @@ type Workflow implements Node & UniformResourceLocatable {
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
+  
   """
   Identifies the primary key from the database.
   """
   databaseId: Int
   id: ID!
+  
   """
   The name of the workflow.
   """
   name: String!
+  
   """
   The HTTP path for this workflow
   """
   resourcePath: URI!
+  
   """
   The runs of the workflow.
   """
@@ -51688,31 +58878,38 @@ type Workflow implements Node & UniformResourceLocatable {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
+    
     """
     Ordering options for the connection
     """
     orderBy: WorkflowRunOrder = { field: CREATED_AT, direction: DESC }
   ): WorkflowRunConnection!
+  
   """
   The state of the workflow.
   """
   state: WorkflowState!
+  
   """
   Identifies the date and time when the object was last updated.
   """
   updatedAt: DateTime!
+  
   """
   The HTTP URL for this workflow
   """
@@ -51727,14 +58924,17 @@ type WorkflowRun implements Node & UniformResourceLocatable {
   The check suite this workflow run belongs to.
   """
   checkSuite: CheckSuite!
+  
   """
   Identifies the date and time when the object was created.
   """
   createdAt: DateTime!
+  
   """
   Identifies the primary key from the database.
   """
   databaseId: Int
+  
   """
   The log of deployment reviews
   """
@@ -51743,28 +58943,34 @@ type WorkflowRun implements Node & UniformResourceLocatable {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): DeploymentReviewConnection!
+  
   """
   The event that triggered the workflow run
   """
   event: String!
+  
   """
   The workflow file
   """
   file: WorkflowRunFile
   id: ID!
+  
   """
   The pending deployment requests of all check runs in this workflow run
   """
@@ -51773,35 +58979,43 @@ type WorkflowRun implements Node & UniformResourceLocatable {
     Returns the elements in the list that come after the specified cursor.
     """
     after: String
+    
     """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+    
     """
     Returns the last _n_ elements from the list.
     """
     last: Int
   ): DeploymentRequestConnection!
+  
   """
   The HTTP path for this workflow run
   """
   resourcePath: URI!
+  
   """
   A number that uniquely identifies this workflow run in its parent workflow.
   """
   runNumber: Int!
+  
   """
   Identifies the date and time when the object was last updated.
   """
   updatedAt: DateTime!
+  
   """
   The HTTP URL for this workflow run
   """
   url: URI!
+  
   """
   The workflow executed in this workflow run.
   """
@@ -51816,14 +59030,17 @@ type WorkflowRunConnection {
   A list of edges.
   """
   edges: [WorkflowRunEdge]
+  
   """
   A list of nodes.
   """
   nodes: [WorkflowRun]
+  
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   Identifies the total count of items in the connection.
   """
@@ -51838,6 +59055,7 @@ type WorkflowRunEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+  
   """
   The item at the end of the edge.
   """
@@ -51849,34 +59067,42 @@ An executed workflow file for a workflow run.
 """
 type WorkflowRunFile implements Node & UniformResourceLocatable {
   id: ID!
+  
   """
   The path of the workflow file relative to its repository.
   """
   path: String!
+  
   """
   The direct link to the file in the repository which stores the workflow file.
   """
   repositoryFileUrl: URI!
+  
   """
   The repository name and owner which stores the workflow file.
   """
   repositoryName: URI!
+  
   """
   The HTTP path for this workflow run file
   """
   resourcePath: URI!
+  
   """
   The parent workflow run execution for this file.
   """
   run: WorkflowRun!
+  
   """
   The HTTP URL for this workflow run file
   """
   url: URI!
+  
   """
   If the viewer has permissions to push to the repository which stores the workflow.
   """
   viewerCanPushRepository: Boolean!
+  
   """
   If the viewer has permissions to read the repository which stores the workflow.
   """
@@ -51891,6 +59117,7 @@ input WorkflowRunOrder {
   The direction in which to order workflow runs by the specified field.
   """
   direction: OrderDirection!
+  
   """
   The field by which to order workflows.
   """

--- a/cynic-parser/tests/snapshots/actual_schemas__github__snapshot.snap
+++ b/cynic-parser/tests/snapshots/actual_schemas__github__snapshot.snap
@@ -200,6 +200,7 @@ enum ActorType {
   Indicates a team actor.
   """
   TEAM
+
   """
   Indicates a user actor.
   """
@@ -2971,10 +2972,12 @@ enum CheckAnnotationLevel {
   An annotation indicating an inescapable error.
   """
   FAILURE
+
   """
   An annotation indicating some information.
   """
   NOTICE
+
   """
   An annotation indicating an ignorable error.
   """
@@ -3044,34 +3047,42 @@ enum CheckConclusionState {
   The check suite or run requires action.
   """
   ACTION_REQUIRED
+
   """
   The check suite or run has been cancelled.
   """
   CANCELLED
+
   """
   The check suite or run has failed.
   """
   FAILURE
+
   """
   The check suite or run was neutral.
   """
   NEUTRAL
+
   """
   The check suite or run was skipped.
   """
   SKIPPED
+
   """
   The check suite or run was marked stale by GitHub. Only GitHub can use this conclusion.
   """
   STALE
+
   """
   The check suite or run has failed at startup.
   """
   STARTUP_FAILURE
+
   """
   The check suite or run has succeeded.
   """
   SUCCESS
+
   """
   The check suite or run has timed out.
   """
@@ -3397,54 +3408,67 @@ enum CheckRunState {
   The check run requires action.
   """
   ACTION_REQUIRED
+
   """
   The check run has been cancelled.
   """
   CANCELLED
+
   """
   The check run has been completed.
   """
   COMPLETED
+
   """
   The check run has failed.
   """
   FAILURE
+
   """
   The check run is in progress.
   """
   IN_PROGRESS
+
   """
   The check run was neutral.
   """
   NEUTRAL
+
   """
   The check run is in pending state.
   """
   PENDING
+
   """
   The check run has been queued.
   """
   QUEUED
+
   """
   The check run was skipped.
   """
   SKIPPED
+
   """
   The check run was marked stale by GitHub. Only GitHub can use this conclusion.
   """
   STALE
+
   """
   The check run has failed at startup.
   """
   STARTUP_FAILURE
+
   """
   The check run has succeeded.
   """
   SUCCESS
+
   """
   The check run has timed out.
   """
   TIMED_OUT
+
   """
   The check run is in waiting state.
   """
@@ -3474,6 +3498,7 @@ enum CheckRunType {
   Every check run available.
   """
   ALL
+
   """
   The latest check run.
   """
@@ -3488,22 +3513,27 @@ enum CheckStatusState {
   The check suite or run has been completed.
   """
   COMPLETED
+
   """
   The check suite or run is in progress.
   """
   IN_PROGRESS
+
   """
   The check suite or run is in pending state.
   """
   PENDING
+
   """
   The check suite or run has been queued.
   """
   QUEUED
+
   """
   The check suite or run has been requested.
   """
   REQUESTED
+
   """
   The check suite or run is in waiting state.
   """
@@ -4242,10 +4272,12 @@ enum CollaboratorAffiliation {
   All collaborators the authenticated user can see.
   """
   ALL
+
   """
   All collaborators with permissions to an organization-owned subject, regardless of organization membership status.
   """
   DIRECT
+
   """
   All outside collaborators of an organization-owned subject.
   """
@@ -4356,30 +4388,37 @@ enum CommentAuthorAssociation {
   Author has been invited to collaborate on the repository.
   """
   COLLABORATOR
+
   """
   Author has previously committed to the repository.
   """
   CONTRIBUTOR
+
   """
   Author has not previously committed to GitHub.
   """
   FIRST_TIMER
+
   """
   Author has not previously committed to the repository.
   """
   FIRST_TIME_CONTRIBUTOR
+
   """
   Author is a placeholder for an unclaimed user.
   """
   MANNEQUIN
+
   """
   Author is a member of the organization that owns the repository.
   """
   MEMBER
+
   """
   Author has no association with the repository.
   """
   NONE
+
   """
   Author is the owner of the repository.
   """
@@ -4394,26 +4433,32 @@ enum CommentCannotUpdateReason {
   Unable to create comment because repository is archived.
   """
   ARCHIVED
+
   """
   You cannot update this comment
   """
   DENIED
+
   """
   You must be the author or have write access to this repository to update this comment.
   """
   INSUFFICIENT_ACCESS
+
   """
   Unable to create comment because issue is locked.
   """
   LOCKED
+
   """
   You must be logged in to update this comment.
   """
   LOGIN_REQUIRED
+
   """
   Repository is under maintenance.
   """
   MAINTENANCE
+
   """
   At least one email address must be verified to update this comment.
   """
@@ -5310,6 +5355,7 @@ enum CommitContributionOrderField {
   Order commit contributions by how many commits they represent.
   """
   COMMIT_COUNT
+
   """
   Order commit contributions by when they were made.
   """
@@ -5655,14 +5701,17 @@ enum ComparisonStatus {
   The head ref is ahead of the base ref.
   """
   AHEAD
+
   """
   The head ref is behind the base ref.
   """
   BEHIND
+
   """
   The head ref is both ahead and behind of the base ref, indicating git history has diverged.
   """
   DIVERGED
+
   """
   The head ref and base ref are identical.
   """
@@ -5861,18 +5910,22 @@ enum ContributionLevel {
   Lowest 25% of days of contributions.
   """
   FIRST_QUARTILE
+
   """
   Highest 25% of days of contributions. More contributions than the third quartile.
   """
   FOURTH_QUARTILE
+
   """
   No contributions occurred.
   """
   NONE
+
   """
   Second lowest 25% of days of contributions. More contributions than the first quartile.
   """
   SECOND_QUARTILE
+
   """
   Second highest 25% of days of contributions. More contributions than second quartile, less than the fourth quartile.
   """
@@ -8789,14 +8842,17 @@ enum DefaultRepositoryPermissionField {
   Can read, write, and administrate repos by default
   """
   ADMIN
+
   """
   No access
   """
   NONE
+
   """
   Can read repos by default
   """
   READ
+
   """
   Can read and write repos by default
   """
@@ -9705,42 +9761,52 @@ enum DependencyGraphEcosystem {
   GitHub Actions
   """
   ACTIONS
+
   """
   PHP packages hosted at packagist.org
   """
   COMPOSER
+
   """
   Go modules
   """
   GO
+
   """
   Java artifacts hosted at the Maven central repository
   """
   MAVEN
+
   """
   JavaScript packages hosted at npmjs.com
   """
   NPM
+
   """
   .NET packages hosted at the NuGet Gallery
   """
   NUGET
+
   """
   Python packages hosted at PyPI.org
   """
   PIP
+
   """
   Dart packages hosted at pub.dev
   """
   PUB
+
   """
   Ruby gems hosted at RubyGems.org
   """
   RUBYGEMS
+
   """
   Rust crates
   """
   RUST
+
   """
   Swift packages
   """
@@ -10251,6 +10317,7 @@ enum DeploymentProtectionRuleType {
   Required reviewers
   """
   REQUIRED_REVIEWERS
+
   """
   Wait timer
   """
@@ -10446,6 +10513,7 @@ enum DeploymentReviewState {
   The deployment was approved.
   """
   APPROVED
+
   """
   The deployment was rejected.
   """
@@ -10505,42 +10573,52 @@ enum DeploymentState {
   The pending deployment was not updated after 30 minutes.
   """
   ABANDONED
+
   """
   The deployment is currently active.
   """
   ACTIVE
+
   """
   An inactive transient deployment.
   """
   DESTROYED
+
   """
   The deployment experienced an error.
   """
   ERROR
+
   """
   The deployment has failed.
   """
   FAILURE
+
   """
   The deployment is inactive.
   """
   INACTIVE
+
   """
   The deployment is in progress.
   """
   IN_PROGRESS
+
   """
   The deployment is pending.
   """
   PENDING
+
   """
   The deployment has queued
   """
   QUEUED
+
   """
   The deployment was successful.
   """
   SUCCESS
+
   """
   The deployment is waiting.
   """
@@ -10646,30 +10724,37 @@ enum DeploymentStatusState {
   The deployment experienced an error.
   """
   ERROR
+
   """
   The deployment has failed.
   """
   FAILURE
+
   """
   The deployment is inactive.
   """
   INACTIVE
+
   """
   The deployment is in progress.
   """
   IN_PROGRESS
+
   """
   The deployment is pending.
   """
   PENDING
+
   """
   The deployment is queued
   """
   QUEUED
+
   """
   The deployment was successful.
   """
   SUCCESS
+
   """
   The deployment is waiting.
   """
@@ -10714,6 +10799,7 @@ enum DiffSide {
   The left side of the diff.
   """
   LEFT
+
   """
   The right side of the diff.
   """
@@ -11211,10 +11297,12 @@ enum DiscussionCloseReason {
   The discussion is a duplicate of another
   """
   DUPLICATE
+
   """
   The discussion is no longer relevant
   """
   OUTDATED
+
   """
   The discussion has been resolved
   """
@@ -11582,6 +11670,7 @@ enum DiscussionOrderField {
   Order discussions by creation time.
   """
   CREATED_AT
+
   """
   Order discussions by most recent modification time.
   """
@@ -11740,6 +11829,7 @@ enum DiscussionPollOptionOrderField {
   Order poll options by the order that the poll author specified when creating the poll.
   """
   AUTHORED_ORDER
+
   """
   Order poll options by the number of votes it has.
   """
@@ -11754,6 +11844,7 @@ enum DiscussionState {
   A discussion that has been closed
   """
   CLOSED
+
   """
   A discussion that is open
   """
@@ -11768,14 +11859,17 @@ enum DiscussionStateReason {
   The discussion is a duplicate of another
   """
   DUPLICATE
+
   """
   The discussion is no longer relevant
   """
   OUTDATED
+
   """
   The discussion was reopened
   """
   REOPENED
+
   """
   The discussion has been resolved
   """
@@ -11825,18 +11919,22 @@ enum DismissReason {
   A fix has already been started
   """
   FIX_STARTED
+
   """
   This alert is inaccurate or incorrect
   """
   INACCURATE
+
   """
   Vulnerable code is not actually used
   """
   NOT_USED
+
   """
   No bandwidth to fix this
   """
   NO_BANDWIDTH
+
   """
   Risk is tolerable to this project
   """
@@ -12502,6 +12600,7 @@ enum EnterpriseAdministratorRole {
   Represents a billing manager of the enterprise account.
   """
   BILLING_MANAGER
+
   """
   Represents an owner of the enterprise account.
   """
@@ -12516,22 +12615,27 @@ enum EnterpriseAllowPrivateRepositoryForkingPolicyValue {
   Members can fork a repository to an organization within this enterprise.
   """
   ENTERPRISE_ORGANIZATIONS
+
   """
   Members can fork a repository to their enterprise-managed user account or an organization inside this enterprise.
   """
   ENTERPRISE_ORGANIZATIONS_USER_ACCOUNTS
+
   """
   Members can fork a repository to their user account or an organization, either inside or outside of this enterprise.
   """
   EVERYWHERE
+
   """
   Members can fork a repository only within the same organization (intra-org).
   """
   SAME_ORGANIZATION
+
   """
   Members can fork a repository to their user account or within the same organization.
   """
   SAME_ORGANIZATION_USER_ACCOUNTS
+
   """
   Members can fork a repository to their user account.
   """
@@ -12646,18 +12750,22 @@ enum EnterpriseDefaultRepositoryPermissionSettingValue {
   Organization members will be able to clone, pull, push, and add new collaborators to all organization repositories.
   """
   ADMIN
+
   """
   Organization members will only be able to clone and pull public repositories.
   """
   NONE
+
   """
   Organizations in the enterprise choose base repository permissions for their members.
   """
   NO_POLICY
+
   """
   Organization members will be able to clone and pull all organization repositories.
   """
   READ
+
   """
   Organization members will be able to clone, pull, and push all organization repositories.
   """
@@ -12687,10 +12795,12 @@ enum EnterpriseEnabledDisabledSettingValue {
   The setting is disabled for organizations in the enterprise.
   """
   DISABLED
+
   """
   The setting is enabled for organizations in the enterprise.
   """
   ENABLED
+
   """
   There is no policy set for organizations in the enterprise.
   """
@@ -12705,6 +12815,7 @@ enum EnterpriseEnabledSettingValue {
   The setting is enabled for organizations in the enterprise.
   """
   ENABLED
+
   """
   There is no policy set for organizations in the enterprise.
   """
@@ -12907,6 +13018,7 @@ enum EnterpriseMemberOrderField {
   Order enterprise members by creation time
   """
   CREATED_AT
+
   """
   Order enterprise members by login
   """
@@ -12921,18 +13033,22 @@ enum EnterpriseMembersCanCreateRepositoriesSettingValue {
   Members will be able to create public and private repositories.
   """
   ALL
+
   """
   Members will not be able to create public or private repositories.
   """
   DISABLED
+
   """
   Organization administrators choose whether to allow members to create repositories.
   """
   NO_POLICY
+
   """
   Members will be able to create only private repositories.
   """
   PRIVATE
+
   """
   Members will be able to create only public repositories.
   """
@@ -12947,6 +13063,7 @@ enum EnterpriseMembersCanMakePurchasesSettingValue {
   The setting is disabled for organizations in the enterprise.
   """
   DISABLED
+
   """
   The setting is enabled for organizations in the enterprise.
   """
@@ -12961,14 +13078,17 @@ enum EnterpriseMembershipType {
   Returns all enterprises in which the user is an admin.
   """
   ADMIN
+
   """
   Returns all enterprises in which the user is a member, admin, or billing manager.
   """
   ALL
+
   """
   Returns all enterprises in which the user is a billing manager.
   """
   BILLING_MANAGER
+
   """
   Returns all enterprises in which the user is a member of an org that is owned by the enterprise.
   """
@@ -14464,10 +14584,12 @@ enum EnterpriseServerInstallationOrderField {
   Order Enterprise Server installations by creation time
   """
   CREATED_AT
+
   """
   Order Enterprise Server installations by customer name
   """
   CUSTOMER_NAME
+
   """
   Order Enterprise Server installations by host name
   """
@@ -14710,6 +14832,7 @@ enum EnterpriseServerUserAccountOrderField {
   Order user accounts by login
   """
   LOGIN
+
   """
   Order user accounts by creation time on the Enterprise Server installation
   """
@@ -14825,10 +14948,12 @@ enum EnterpriseServerUserAccountsUploadSyncState {
   The synchronization of the upload failed.
   """
   FAILURE
+
   """
   The synchronization of the upload is pending.
   """
   PENDING
+
   """
   The synchronization of the upload succeeded.
   """
@@ -14980,10 +15105,12 @@ enum EnterpriseUserAccountMembershipRole {
   The user is a member of an organization in the enterprise.
   """
   MEMBER
+
   """
   The user is an owner of an organization in the enterprise.
   """
   OWNER
+
   """
   The user is not an owner of the enterprise, and not a member or owner of any
   organizations in the enterprise; only for EMU-enabled enterprises.
@@ -14999,6 +15126,7 @@ enum EnterpriseUserDeployment {
   The user is part of a GitHub Enterprise Cloud deployment.
   """
   CLOUD
+
   """
   The user is part of a GitHub Enterprise Server deployment.
   """
@@ -15439,10 +15567,12 @@ enum FileViewedState {
   The file has new changes since last viewed.
   """
   DISMISSED
+
   """
   The file has not been marked as viewed.
   """
   UNVIEWED
+
   """
   The file has been marked as viewed.
   """
@@ -15582,42 +15712,52 @@ enum FundingPlatform {
   Community Bridge funding platform.
   """
   COMMUNITY_BRIDGE
+
   """
   Custom funding platform.
   """
   CUSTOM
+
   """
   GitHub funding platform.
   """
   GITHUB
+
   """
   IssueHunt funding platform.
   """
   ISSUEHUNT
+
   """
   Ko-fi funding platform.
   """
   KO_FI
+
   """
   LFX Crowdfunding funding platform.
   """
   LFX_CROWDFUNDING
+
   """
   Liberapay funding platform.
   """
   LIBERAPAY
+
   """
   Open Collective funding platform.
   """
   OPEN_COLLECTIVE
+
   """
   Otechie funding platform.
   """
   OTECHIE
+
   """
   Patreon funding platform.
   """
   PATREON
+
   """
   Tidelift funding platform.
   """
@@ -16101,10 +16241,12 @@ enum GistOrderField {
   Order gists by creation time
   """
   CREATED_AT
+
   """
   Order gists by push time
   """
   PUSHED_AT
+
   """
   Order gists by update time
   """
@@ -16119,10 +16261,12 @@ enum GistPrivacy {
   Gists that are public and secret
   """
   ALL
+
   """
   Public
   """
   PUBLIC
+
   """
   Secret
   """
@@ -16339,66 +16483,82 @@ enum GitSignatureState {
   The signing certificate or its chain could not be verified
   """
   BAD_CERT
+
   """
   Invalid email used for signing
   """
   BAD_EMAIL
+
   """
   Signing key expired
   """
   EXPIRED_KEY
+
   """
   Internal error - the GPG verification service misbehaved
   """
   GPGVERIFY_ERROR
+
   """
   Internal error - the GPG verification service is unavailable at the moment
   """
   GPGVERIFY_UNAVAILABLE
+
   """
   Invalid signature
   """
   INVALID
+
   """
   Malformed signature
   """
   MALFORMED_SIG
+
   """
   The usage flags for the key that signed this don't allow signing
   """
   NOT_SIGNING_KEY
+
   """
   Email used for signing not known to GitHub
   """
   NO_USER
+
   """
   Valid signature, though certificate revocation check failed
   """
   OCSP_ERROR
+
   """
   Valid signature, pending certificate revocation checking
   """
   OCSP_PENDING
+
   """
   One or more certificates in chain has been revoked
   """
   OCSP_REVOKED
+
   """
   Key used for signing not known to GitHub
   """
   UNKNOWN_KEY
+
   """
   Unknown signature type
   """
   UNKNOWN_SIG_TYPE
+
   """
   Unsigned
   """
   UNSIGNED
+
   """
   Email used for signing unverified on GitHub
   """
   UNVERIFIED_EMAIL
+
   """
   Valid signature and verified by GitHub
   """
@@ -16677,10 +16837,12 @@ enum IdentityProviderConfigurationState {
   Authentication with an identity provider is configured but not enforced.
   """
   CONFIGURED
+
   """
   Authentication with an identity provider is configured and enforced.
   """
   ENFORCED
+
   """
   Authentication with an identity provider is not configured.
   """
@@ -16790,6 +16952,7 @@ enum IpAllowListEnabledSettingValue {
   The setting is disabled for the owner.
   """
   DISABLED
+
   """
   The setting is enabled for the owner.
   """
@@ -16895,6 +17058,7 @@ enum IpAllowListEntryOrderField {
   Order IP allow list entries by the allow list value.
   """
   ALLOW_LIST_VALUE
+
   """
   Order IP allow list entries by creation time.
   """
@@ -16909,6 +17073,7 @@ enum IpAllowListForInstalledAppsEnabledSettingValue {
   The setting is disabled for the owner.
   """
   DISABLED
+
   """
   The setting is enabled for the owner.
   """
@@ -17592,6 +17757,7 @@ enum IssueClosedStateReason {
   An issue that has been closed as completed
   """
   COMPLETED
+
   """
   An issue that has been closed as not planned
   """
@@ -18035,10 +18201,12 @@ enum IssueOrderField {
   Order issues by comment count
   """
   COMMENTS
+
   """
   Order issues by creation time
   """
   CREATED_AT
+
   """
   Order issues by update time
   """
@@ -18053,6 +18221,7 @@ enum IssueState {
   An issue that has been closed
   """
   CLOSED
+
   """
   An issue that is still open
   """
@@ -18067,10 +18236,12 @@ enum IssueStateReason {
   An issue that has been closed as completed
   """
   COMPLETED
+
   """
   An issue that has been closed as not planned
   """
   NOT_PLANNED
+
   """
   An issue that has been reopened
   """
@@ -18323,122 +18494,152 @@ enum IssueTimelineItemsItemType {
   Represents a 'added_to_project' event on a given issue or pull request.
   """
   ADDED_TO_PROJECT_EVENT
+
   """
   Represents an 'assigned' event on any assignable object.
   """
   ASSIGNED_EVENT
+
   """
   Represents a 'closed' event on any `Closable`.
   """
   CLOSED_EVENT
+
   """
   Represents a 'comment_deleted' event on a given issue or pull request.
   """
   COMMENT_DELETED_EVENT
+
   """
   Represents a 'connected' event on a given issue or pull request.
   """
   CONNECTED_EVENT
+
   """
   Represents a 'converted_note_to_issue' event on a given issue or pull request.
   """
   CONVERTED_NOTE_TO_ISSUE_EVENT
+
   """
   Represents a 'converted_to_discussion' event on a given issue.
   """
   CONVERTED_TO_DISCUSSION_EVENT
+
   """
   Represents a mention made by one issue or pull request to another.
   """
   CROSS_REFERENCED_EVENT
+
   """
   Represents a 'demilestoned' event on a given issue or pull request.
   """
   DEMILESTONED_EVENT
+
   """
   Represents a 'disconnected' event on a given issue or pull request.
   """
   DISCONNECTED_EVENT
+
   """
   Represents a comment on an Issue.
   """
   ISSUE_COMMENT
+
   """
   Represents a 'labeled' event on a given issue or pull request.
   """
   LABELED_EVENT
+
   """
   Represents a 'locked' event on a given issue or pull request.
   """
   LOCKED_EVENT
+
   """
   Represents a 'marked_as_duplicate' event on a given issue or pull request.
   """
   MARKED_AS_DUPLICATE_EVENT
+
   """
   Represents a 'mentioned' event on a given issue or pull request.
   """
   MENTIONED_EVENT
+
   """
   Represents a 'milestoned' event on a given issue or pull request.
   """
   MILESTONED_EVENT
+
   """
   Represents a 'moved_columns_in_project' event on a given issue or pull request.
   """
   MOVED_COLUMNS_IN_PROJECT_EVENT
+
   """
   Represents a 'pinned' event on a given issue or pull request.
   """
   PINNED_EVENT
+
   """
   Represents a 'referenced' event on a given `ReferencedSubject`.
   """
   REFERENCED_EVENT
+
   """
   Represents a 'removed_from_project' event on a given issue or pull request.
   """
   REMOVED_FROM_PROJECT_EVENT
+
   """
   Represents a 'renamed' event on a given issue or pull request
   """
   RENAMED_TITLE_EVENT
+
   """
   Represents a 'reopened' event on any `Closable`.
   """
   REOPENED_EVENT
+
   """
   Represents a 'subscribed' event on a given `Subscribable`.
   """
   SUBSCRIBED_EVENT
+
   """
   Represents a 'transferred' event on a given issue or pull request.
   """
   TRANSFERRED_EVENT
+
   """
   Represents an 'unassigned' event on any assignable object.
   """
   UNASSIGNED_EVENT
+
   """
   Represents an 'unlabeled' event on a given issue or pull request.
   """
   UNLABELED_EVENT
+
   """
   Represents an 'unlocked' event on a given issue or pull request.
   """
   UNLOCKED_EVENT
+
   """
   Represents an 'unmarked_as_duplicate' event on a given issue or pull request.
   """
   UNMARKED_AS_DUPLICATE_EVENT
+
   """
   Represents an 'unpinned' event on a given issue or pull request.
   """
   UNPINNED_EVENT
+
   """
   Represents an 'unsubscribed' event on a given `Subscribable`.
   """
   UNSUBSCRIBED_EVENT
+
   """
   Represents a 'user_blocked' event on a given user.
   """
@@ -18686,6 +18887,7 @@ enum LabelOrderField {
   Order labels by creation time
   """
   CREATED_AT
+
   """
   Order labels by name
   """
@@ -19147,14 +19349,17 @@ enum LockReason {
   The issue or pull request was locked because the conversation was off-topic.
   """
   OFF_TOPIC
+
   """
   The issue or pull request was locked because the conversation was resolved.
   """
   RESOLVED
+
   """
   The issue or pull request was locked because the conversation was spam.
   """
   SPAM
+
   """
   The issue or pull request was locked because the conversation was too heated.
   """
@@ -19321,6 +19526,7 @@ enum MannequinOrderField {
   Order mannequins why when they were created.
   """
   CREATED_AT
+
   """
   Order mannequins alphabetically by their source login.
   """
@@ -20294,10 +20500,12 @@ enum MergeCommitMessage {
   Default to a blank commit message.
   """
   BLANK
+
   """
   Default to the pull request's body.
   """
   PR_BODY
+
   """
   Default to the pull request's title.
   """
@@ -20312,6 +20520,7 @@ enum MergeCommitTitle {
   Default to the classic title for a merge message (e.g., Merge pull request #123 from branch-name).
   """
   MERGE_MESSAGE
+
   """
   Default to the pull request's title.
   """
@@ -20584,18 +20793,22 @@ enum MergeQueueEntryState {
   The entry is currently waiting for checks to pass.
   """
   AWAITING_CHECKS
+
   """
   The entry is currently locked.
   """
   LOCKED
+
   """
   The entry is currently mergeable.
   """
   MERGEABLE
+
   """
   The entry is currently queued.
   """
   QUEUED
+
   """
   The entry is currently unmergeable.
   """
@@ -20610,6 +20823,7 @@ enum MergeQueueMergingStrategy {
   Entries only allowed to merge if they are passing.
   """
   ALLGREEN
+
   """
   Failing Entires are allowed to merge if they are with a passing entry.
   """
@@ -20624,32 +20838,39 @@ enum MergeStateStatus {
   The head ref is out of date.
   """
   BEHIND
+
   """
   The merge is blocked.
   """
   BLOCKED
+
   """
   Mergeable and passing commit status.
   """
   CLEAN
+
   """
   The merge commit cannot be cleanly created.
   """
   DIRTY
+
   """
   The merge is blocked due to the pull request being a draft.
   """
   DRAFT @deprecated(
     reason: "DRAFT state will be removed from this enum and `isDraft` should be used instead Use PullRequest.isDraft instead. Removal on 2021-01-01 UTC."
   )
+
   """
   Mergeable with passing commit status and pre-receive hooks.
   """
   HAS_HOOKS
+
   """
   The state cannot currently be determined.
   """
   UNKNOWN
+
   """
   Mergeable with non-passing commit status.
   """
@@ -20664,10 +20885,12 @@ enum MergeableState {
   The pull request cannot be merged due to merge conflicts.
   """
   CONFLICTING
+
   """
   The pull request can be merged.
   """
   MERGEABLE
+
   """
   The mergeability of the pull request is still being calculated.
   """
@@ -20807,10 +21030,12 @@ enum MigrationSourceType {
   An Azure DevOps migration source.
   """
   AZURE_DEVOPS
+
   """
   A Bitbucket Server migration source.
   """
   BITBUCKET_SERVER
+
   """
   A GitHub Migration API source.
   """
@@ -20825,26 +21050,32 @@ enum MigrationState {
   The migration has failed.
   """
   FAILED
+
   """
   The migration has invalid credentials.
   """
   FAILED_VALIDATION
+
   """
   The migration is in progress.
   """
   IN_PROGRESS
+
   """
   The migration has not started.
   """
   NOT_STARTED
+
   """
   The migration needs to have its credentials validated.
   """
   PENDING_VALIDATION
+
   """
   The migration has been queued.
   """
   QUEUED
+
   """
   The migration has succeeded.
   """
@@ -21100,14 +21331,17 @@ enum MilestoneOrderField {
   Order milestones by when they were created.
   """
   CREATED_AT
+
   """
   Order milestones by when they are due.
   """
   DUE_DATE
+
   """
   Order milestones by their number.
   """
   NUMBER
+
   """
   Order milestones by when they were last updated.
   """
@@ -21122,6 +21356,7 @@ enum MilestoneState {
   A milestone that has been closed.
   """
   CLOSED
+
   """
   A milestone that is still open.
   """
@@ -23674,6 +23909,7 @@ enum NotificationRestrictionSettingValue {
   The setting is disabled for the owner.
   """
   DISABLED
+
   """
   The setting is enabled for the owner.
   """
@@ -23907,10 +24143,12 @@ enum OauthApplicationCreateAuditEntryState {
   The OAuth application was active and allowed to have OAuth Accesses.
   """
   ACTIVE
+
   """
   The OAuth application was in the process of being deleted.
   """
   PENDING_DELETION
+
   """
   The OAuth application was suspended from generating OAuth Accesses due to abuse or security concerns.
   """
@@ -23925,26 +24163,32 @@ enum OperationType {
   An existing resource was accessed
   """
   ACCESS
+
   """
   A resource performed an authentication event
   """
   AUTHENTICATION
+
   """
   A new resource was created
   """
   CREATE
+
   """
   An existing resource was modified
   """
   MODIFY
+
   """
   An existing resource was removed
   """
   REMOVE
+
   """
   An existing resource was restored
   """
   RESTORE
+
   """
   An existing resource was transferred between multiple resources
   """
@@ -23959,6 +24203,7 @@ enum OrderDirection {
   Specifies an ascending order for a given `orderBy` argument.
   """
   ASC
+
   """
   Specifies a descending order for a given `orderBy` argument.
   """
@@ -24165,6 +24410,7 @@ enum OrgAddMemberAuditEntryPermission {
   Can read, clone, push, and add collaborators to repositories.
   """
   ADMIN
+
   """
   Can read and clone repositories.
   """
@@ -24568,18 +24814,22 @@ enum OrgCreateAuditEntryBillingPlan {
   Team Plan
   """
   BUSINESS
+
   """
   Enterprise Cloud Plan
   """
   BUSINESS_PLUS
+
   """
   Free Plan
   """
   FREE
+
   """
   Tiered Per Seat Plan
   """
   TIERED_PER_SEAT
+
   """
   Legacy Unlimited Plan
   """
@@ -26038,10 +26288,12 @@ enum OrgRemoveBillingManagerAuditEntryReason {
   SAML external identity missing
   """
   SAML_EXTERNAL_IDENTITY_MISSING
+
   """
   SAML SSO enforcement requires an external identity
   """
   SAML_SSO_ENFORCEMENT_REQUIRES_EXTERNAL_IDENTITY
+
   """
   The organization required 2FA of its billing managers and this user did not have 2FA enabled.
   """
@@ -26160,24 +26412,29 @@ enum OrgRemoveMemberAuditEntryMembershipType {
   and all of its repositories.
   """
   ADMIN
+
   """
   A billing manager is a user who manages the billing settings for the Organization, such as updating payment information.
   """
   BILLING_MANAGER
+
   """
   A direct member is a user that is a member of the Organization.
   """
   DIRECT_MEMBER
+
   """
   An outside collaborator is a person who isn't explicitly a member of the
   Organization, but who has Read, Write, or Admin permissions to one or more
   repositories in the organization.
   """
   OUTSIDE_COLLABORATOR
+
   """
   A suspended member.
   """
   SUSPENDED
+
   """
   An unaffiliated collaborator is a person who is not a member of the
   Organization and does not have access to any repositories in the Organization.
@@ -26193,18 +26450,22 @@ enum OrgRemoveMemberAuditEntryReason {
   SAML external identity missing
   """
   SAML_EXTERNAL_IDENTITY_MISSING
+
   """
   SAML SSO enforcement requires an external identity
   """
   SAML_SSO_ENFORCEMENT_REQUIRES_EXTERNAL_IDENTITY
+
   """
   User was removed from organization during account recovery
   """
   TWO_FACTOR_ACCOUNT_RECOVERY
+
   """
   The organization required 2FA of its billing managers and this user did not have 2FA enabled.
   """
   TWO_FACTOR_REQUIREMENT_NON_COMPLIANCE
+
   """
   User account has been deleted
   """
@@ -26320,12 +26581,14 @@ enum OrgRemoveOutsideCollaboratorAuditEntryMembershipType {
   A billing manager is a user who manages the billing settings for the Organization, such as updating payment information.
   """
   BILLING_MANAGER
+
   """
   An outside collaborator is a person who isn't explicitly a member of the
   Organization, but who has Read, Write, or Admin permissions to one or more
   repositories in the organization.
   """
   OUTSIDE_COLLABORATOR
+
   """
   An unaffiliated collaborator is a person who is not a member of the
   Organization and does not have access to any repositories in the organization.
@@ -26341,6 +26604,7 @@ enum OrgRemoveOutsideCollaboratorAuditEntryReason {
   SAML external identity missing
   """
   SAML_EXTERNAL_IDENTITY_MISSING
+
   """
   The organization required 2FA of its billing managers and this user did not have 2FA enabled.
   """
@@ -26775,14 +27039,17 @@ enum OrgUpdateDefaultRepositoryPermissionAuditEntryPermission {
   Can read, clone, push, and add collaborators to repositories.
   """
   ADMIN
+
   """
   No default permission value.
   """
   NONE
+
   """
   Can read and clone repositories.
   """
   READ
+
   """
   Can read, clone and push to repositories.
   """
@@ -26898,6 +27165,7 @@ enum OrgUpdateMemberAuditEntryPermission {
   Can read, clone, push, and add collaborators to repositories.
   """
   ADMIN
+
   """
   Can read and clone repositories.
   """
@@ -27013,30 +27281,37 @@ enum OrgUpdateMemberRepositoryCreationPermissionAuditEntryVisibility {
   All organization members are restricted from creating any repositories.
   """
   ALL
+
   """
   All organization members are restricted from creating internal repositories.
   """
   INTERNAL
+
   """
   All organization members are allowed to create any repositories.
   """
   NONE
+
   """
   All organization members are restricted from creating private repositories.
   """
   PRIVATE
+
   """
   All organization members are restricted from creating private or internal repositories.
   """
   PRIVATE_INTERNAL
+
   """
   All organization members are restricted from creating public repositories.
   """
   PUBLIC
+
   """
   All organization members are restricted from creating public or internal repositories.
   """
   PUBLIC_INTERNAL
+
   """
   All organization members are restricted from creating public or private repositories.
   """
@@ -28906,14 +29181,17 @@ enum OrganizationInvitationRole {
   The user is invited to be an admin of the organization.
   """
   ADMIN
+
   """
   The user is invited to be a billing manager of the organization.
   """
   BILLING_MANAGER
+
   """
   The user is invited to be a direct member of the organization.
   """
   DIRECT_MEMBER
+
   """
   The user's previous role will be reinstated.
   """
@@ -28928,10 +29206,12 @@ enum OrganizationInvitationSource {
   The invitation was created from the web interface or from API
   """
   MEMBER
+
   """
   The invitation was created from SCIM
   """
   SCIM
+
   """
   The invitation was sent before this feature was added
   """
@@ -28946,6 +29226,7 @@ enum OrganizationInvitationType {
   The invitation was to an email address.
   """
   EMAIL
+
   """
   The invitation was to an existing user.
   """
@@ -29010,6 +29291,7 @@ enum OrganizationMemberRole {
   The user is an administrator of the organization.
   """
   ADMIN
+
   """
   The user is a member of the organization.
   """
@@ -29024,14 +29306,17 @@ enum OrganizationMembersCanCreateRepositoriesSettingValue {
   Members will be able to create public and private repositories.
   """
   ALL
+
   """
   Members will not be able to create public or private repositories.
   """
   DISABLED
+
   """
   Members will be able to create only internal repositories.
   """
   INTERNAL
+
   """
   Members will be able to create only private repositories.
   """
@@ -29097,38 +29382,47 @@ enum OrganizationMigrationState {
   The Octoshift migration has failed.
   """
   FAILED
+
   """
   The Octoshift migration has invalid credentials.
   """
   FAILED_VALIDATION
+
   """
   The Octoshift migration is in progress.
   """
   IN_PROGRESS
+
   """
   The Octoshift migration has not started.
   """
   NOT_STARTED
+
   """
   The Octoshift migration needs to have its credentials validated.
   """
   PENDING_VALIDATION
+
   """
   The Octoshift migration is performing post repository migrations.
   """
   POST_REPO_MIGRATION
+
   """
   The Octoshift migration is performing pre repository migrations.
   """
   PRE_REPO_MIGRATION
+
   """
   The Octoshift migration has been queued.
   """
   QUEUED
+
   """
   The Octoshift org migration is performing repository migrations.
   """
   REPO_MIGRATION
+
   """
   The Octoshift migration has succeeded.
   """
@@ -29163,6 +29457,7 @@ enum OrganizationOrderField {
   Order organizations by creation time
   """
   CREATED_AT
+
   """
   Order organizations by login
   """
@@ -29610,34 +29905,40 @@ enum PackageType {
   A debian package.
   """
   DEBIAN
+
   """
   A docker image.
   """
   DOCKER @deprecated(
     reason: "DOCKER will be removed from this enum as this type will be migrated to only be used by the Packages REST API. Removal on 2021-06-21 UTC."
   )
+
   """
   A maven package.
   """
   MAVEN @deprecated(
     reason: "MAVEN will be removed from this enum as this type will be migrated to only be used by the Packages REST API. Removal on 2023-02-10 UTC."
   )
+
   """
   An npm package.
   """
   NPM @deprecated(
     reason: "NPM will be removed from this enum as this type will be migrated to only be used by the Packages REST API. Removal on 2022-11-21 UTC."
   )
+
   """
   A nuget package.
   """
   NUGET @deprecated(
     reason: "NUGET will be removed from this enum as this type will be migrated to only be used by the Packages REST API. Removal on 2022-11-21 UTC."
   )
+
   """
   A python package.
   """
   PYPI
+
   """
   A rubygems package.
   """
@@ -29830,22 +30131,27 @@ enum PatchStatus {
   The file was added. Git status 'A'.
   """
   ADDED
+
   """
   The file's type was changed. Git status 'T'.
   """
   CHANGED
+
   """
   The file was copied. Git status 'C'.
   """
   COPIED
+
   """
   The file was deleted. Git status 'D'.
   """
   DELETED
+
   """
   The file's contents were changed. Git status 'M'.
   """
   MODIFIED
+
   """
   The file was renamed. Git status 'R'.
   """
@@ -29960,30 +30266,37 @@ enum PinnableItemType {
   A gist.
   """
   GIST
+
   """
   An issue.
   """
   ISSUE
+
   """
   An organization.
   """
   ORGANIZATION
+
   """
   A project.
   """
   PROJECT
+
   """
   A pull request.
   """
   PULL_REQUEST
+
   """
   A repository.
   """
   REPOSITORY
+
   """
   A team.
   """
   TEAM
+
   """
   A user.
   """
@@ -30089,18 +30402,22 @@ enum PinnedDiscussionGradient {
   A gradient of blue to mint
   """
   BLUE_MINT
+
   """
   A gradient of blue to purple
   """
   BLUE_PURPLE
+
   """
   A gradient of pink to blue
   """
   PINK_BLUE
+
   """
   A gradient of purple to coral
   """
   PURPLE_CORAL
+
   """
   A gradient of red to orange
   """
@@ -30115,22 +30432,27 @@ enum PinnedDiscussionPattern {
   An upward-facing chevron pattern
   """
   CHEVRON_UP
+
   """
   A hollow dot pattern
   """
   DOT
+
   """
   A solid dot pattern
   """
   DOT_FILL
+
   """
   A heart pattern
   """
   HEART_FILL
+
   """
   A plus sign pattern
   """
   PLUS
+
   """
   A lightning bolt pattern
   """
@@ -30869,6 +31191,7 @@ enum ProjectCardArchivedState {
   A project card that is archived
   """
   ARCHIVED
+
   """
   A project card that is not archived
   """
@@ -30943,10 +31266,12 @@ enum ProjectCardState {
   The card has content only.
   """
   CONTENT_ONLY
+
   """
   The card has a note only.
   """
   NOTE_ONLY
+
   """
   The card is redacted.
   """
@@ -31097,10 +31422,12 @@ enum ProjectColumnPurpose {
   The column contains cards which are complete
   """
   DONE
+
   """
   The column contains cards which are currently being worked on
   """
   IN_PROGRESS
+
   """
   The column contains cards still to be worked on
   """
@@ -31170,10 +31497,12 @@ enum ProjectOrderField {
   Order projects by creation time
   """
   CREATED_AT
+
   """
   Order projects by name
   """
   NAME
+
   """
   Order projects by update time
   """
@@ -31300,6 +31629,7 @@ enum ProjectState {
   The project is closed.
   """
   CLOSED
+
   """
   The project is open.
   """
@@ -31314,14 +31644,17 @@ enum ProjectTemplate {
   Create a board with v2 triggers to automatically move cards across To do, In progress and Done columns.
   """
   AUTOMATED_KANBAN_V2
+
   """
   Create a board with triggers to automatically move cards across columns with review automation.
   """
   AUTOMATED_REVIEWS_KANBAN
+
   """
   Create a board with columns for To do, In progress and Done.
   """
   BASIC_KANBAN
+
   """
   Create a board to triage and prioritize bugs with To do, priority, and Done columns.
   """
@@ -31732,14 +32065,17 @@ enum ProjectV2CustomFieldType {
   Date
   """
   DATE
+
   """
   Number
   """
   NUMBER
+
   """
   Single Select
   """
   SINGLE_SELECT
+
   """
   Text
   """
@@ -31943,10 +32279,12 @@ enum ProjectV2FieldOrderField {
   Order project v2 fields by creation time
   """
   CREATED_AT
+
   """
   Order project v2 fields by name
   """
   NAME
+
   """
   Order project v2 fields by position
   """
@@ -31961,54 +32299,67 @@ enum ProjectV2FieldType {
   Assignees
   """
   ASSIGNEES
+
   """
   Date
   """
   DATE
+
   """
   Iteration
   """
   ITERATION
+
   """
   Labels
   """
   LABELS
+
   """
   Linked Pull Requests
   """
   LINKED_PULL_REQUESTS
+
   """
   Milestone
   """
   MILESTONE
+
   """
   Number
   """
   NUMBER
+
   """
   Repository
   """
   REPOSITORY
+
   """
   Reviewers
   """
   REVIEWERS
+
   """
   Single Select
   """
   SINGLE_SELECT
+
   """
   Text
   """
   TEXT
+
   """
   Title
   """
   TITLE
+
   """
   Tracked by
   """
   TRACKED_BY
+
   """
   Tracks
   """
@@ -32760,14 +33111,17 @@ enum ProjectV2ItemType {
   Draft Issue
   """
   DRAFT_ISSUE
+
   """
   Issue
   """
   ISSUE
+
   """
   Pull Request
   """
   PULL_REQUEST
+
   """
   Redacted Item
   """
@@ -32893,14 +33247,17 @@ enum ProjectV2OrderField {
   The project's date and time of creation
   """
   CREATED_AT
+
   """
   The project's number
   """
   NUMBER
+
   """
   The project's title
   """
   TITLE
+
   """
   The project's date and time of update
   """
@@ -32997,14 +33354,17 @@ enum ProjectV2Roles {
   The collaborator can view, edit, and maange the settings of the project
   """
   ADMIN
+
   """
   The collaborator has no direct access to the project
   """
   NONE
+
   """
   The collaborator can view the project
   """
   READER
+
   """
   The collaborator can view and edit the project
   """
@@ -33100,30 +33460,37 @@ enum ProjectV2SingleSelectFieldOptionColor {
   BLUE
   """
   BLUE
+
   """
   GRAY
   """
   GRAY
+
   """
   GREEN
   """
   GREEN
+
   """
   ORANGE
   """
   ORANGE
+
   """
   PINK
   """
   PINK
+
   """
   PURPLE
   """
   PURPLE
+
   """
   RED
   """
   RED
+
   """
   YELLOW
   """
@@ -33268,6 +33635,7 @@ enum ProjectV2State {
   A project v2 that has been closed
   """
   CLOSED
+
   """
   A project v2 that is still open
   """
@@ -33610,10 +33978,12 @@ enum ProjectV2ViewLayout {
   Board layout
   """
   BOARD_LAYOUT
+
   """
   Roadmap layout
   """
   ROADMAP_LAYOUT
+
   """
   Table layout
   """
@@ -33643,10 +34013,12 @@ enum ProjectV2ViewOrderField {
   Order project v2 views by creation time
   """
   CREATED_AT
+
   """
   Order project v2 views by name
   """
   NAME
+
   """
   Order project v2 views by position
   """
@@ -33757,14 +34129,17 @@ enum ProjectV2WorkflowsOrderField {
   The workflows' date and time of creation
   """
   CREATED_AT
+
   """
   The workflows' name
   """
   NAME
+
   """
   The workflows' number
   """
   NUMBER
+
   """
   The workflows' date and time of update
   """
@@ -34886,6 +35261,7 @@ enum PullRequestBranchUpdateMethod {
   Update branch via merge
   """
   MERGE
+
   """
   Update branch via rebase
   """
@@ -35172,10 +35548,12 @@ enum PullRequestMergeMethod {
   Add all commits from the head branch to the base branch with a merge commit.
   """
   MERGE
+
   """
   Add all commits from the head branch onto the base branch individually.
   """
   REBASE
+
   """
   Combine all commits from the head branch into a single commit in the base branch.
   """
@@ -35205,6 +35583,7 @@ enum PullRequestOrderField {
   Order pull_requests by creation time
   """
   CREATED_AT
+
   """
   Order pull_requests by update time
   """
@@ -35854,6 +36233,7 @@ enum PullRequestReviewCommentState {
   A comment that is part of a pending review
   """
   PENDING
+
   """
   A comment that is part of a submitted review
   """
@@ -35933,10 +36313,12 @@ enum PullRequestReviewDecision {
   The pull request has received an approving review.
   """
   APPROVED
+
   """
   Changes have been requested on the pull request.
   """
   CHANGES_REQUESTED
+
   """
   A review is required before the pull request can be merged.
   """
@@ -35966,14 +36348,17 @@ enum PullRequestReviewEvent {
   Submit feedback and approve merging these changes.
   """
   APPROVE
+
   """
   Submit general feedback without explicit approval.
   """
   COMMENT
+
   """
   Dismiss review so it now longer effects merging.
   """
   DISMISS
+
   """
   Submit feedback that must be addressed before merging.
   """
@@ -35988,18 +36373,22 @@ enum PullRequestReviewState {
   A review allowing the pull request to merge.
   """
   APPROVED
+
   """
   A review blocking the pull request from merging.
   """
   CHANGES_REQUESTED
+
   """
   An informational review.
   """
   COMMENTED
+
   """
   A review that has been dismissed.
   """
   DISMISSED
+
   """
   A review that has not yet been submitted.
   """
@@ -36175,6 +36564,7 @@ enum PullRequestReviewThreadSubjectType {
   A comment that has been made against the file of a pull request
   """
   FILE
+
   """
   A comment that has been made against the line of a pull request
   """
@@ -36209,10 +36599,12 @@ enum PullRequestState {
   A pull request that has been closed without being merged.
   """
   CLOSED
+
   """
   A pull request that has been closed by being merged.
   """
   MERGED
+
   """
   A pull request that is still open.
   """
@@ -36552,230 +36944,287 @@ enum PullRequestTimelineItemsItemType {
   Represents an 'added_to_merge_queue' event on a given pull request.
   """
   ADDED_TO_MERGE_QUEUE_EVENT
+
   """
   Represents a 'added_to_project' event on a given issue or pull request.
   """
   ADDED_TO_PROJECT_EVENT
+
   """
   Represents an 'assigned' event on any assignable object.
   """
   ASSIGNED_EVENT
+
   """
   Represents a 'automatic_base_change_failed' event on a given pull request.
   """
   AUTOMATIC_BASE_CHANGE_FAILED_EVENT
+
   """
   Represents a 'automatic_base_change_succeeded' event on a given pull request.
   """
   AUTOMATIC_BASE_CHANGE_SUCCEEDED_EVENT
+
   """
   Represents a 'auto_merge_disabled' event on a given pull request.
   """
   AUTO_MERGE_DISABLED_EVENT
+
   """
   Represents a 'auto_merge_enabled' event on a given pull request.
   """
   AUTO_MERGE_ENABLED_EVENT
+
   """
   Represents a 'auto_rebase_enabled' event on a given pull request.
   """
   AUTO_REBASE_ENABLED_EVENT
+
   """
   Represents a 'auto_squash_enabled' event on a given pull request.
   """
   AUTO_SQUASH_ENABLED_EVENT
+
   """
   Represents a 'base_ref_changed' event on a given issue or pull request.
   """
   BASE_REF_CHANGED_EVENT
+
   """
   Represents a 'base_ref_deleted' event on a given pull request.
   """
   BASE_REF_DELETED_EVENT
+
   """
   Represents a 'base_ref_force_pushed' event on a given pull request.
   """
   BASE_REF_FORCE_PUSHED_EVENT
+
   """
   Represents a 'closed' event on any `Closable`.
   """
   CLOSED_EVENT
+
   """
   Represents a 'comment_deleted' event on a given issue or pull request.
   """
   COMMENT_DELETED_EVENT
+
   """
   Represents a 'connected' event on a given issue or pull request.
   """
   CONNECTED_EVENT
+
   """
   Represents a 'converted_note_to_issue' event on a given issue or pull request.
   """
   CONVERTED_NOTE_TO_ISSUE_EVENT
+
   """
   Represents a 'converted_to_discussion' event on a given issue.
   """
   CONVERTED_TO_DISCUSSION_EVENT
+
   """
   Represents a 'convert_to_draft' event on a given pull request.
   """
   CONVERT_TO_DRAFT_EVENT
+
   """
   Represents a mention made by one issue or pull request to another.
   """
   CROSS_REFERENCED_EVENT
+
   """
   Represents a 'demilestoned' event on a given issue or pull request.
   """
   DEMILESTONED_EVENT
+
   """
   Represents a 'deployed' event on a given pull request.
   """
   DEPLOYED_EVENT
+
   """
   Represents a 'deployment_environment_changed' event on a given pull request.
   """
   DEPLOYMENT_ENVIRONMENT_CHANGED_EVENT
+
   """
   Represents a 'disconnected' event on a given issue or pull request.
   """
   DISCONNECTED_EVENT
+
   """
   Represents a 'head_ref_deleted' event on a given pull request.
   """
   HEAD_REF_DELETED_EVENT
+
   """
   Represents a 'head_ref_force_pushed' event on a given pull request.
   """
   HEAD_REF_FORCE_PUSHED_EVENT
+
   """
   Represents a 'head_ref_restored' event on a given pull request.
   """
   HEAD_REF_RESTORED_EVENT
+
   """
   Represents a comment on an Issue.
   """
   ISSUE_COMMENT
+
   """
   Represents a 'labeled' event on a given issue or pull request.
   """
   LABELED_EVENT
+
   """
   Represents a 'locked' event on a given issue or pull request.
   """
   LOCKED_EVENT
+
   """
   Represents a 'marked_as_duplicate' event on a given issue or pull request.
   """
   MARKED_AS_DUPLICATE_EVENT
+
   """
   Represents a 'mentioned' event on a given issue or pull request.
   """
   MENTIONED_EVENT
+
   """
   Represents a 'merged' event on a given pull request.
   """
   MERGED_EVENT
+
   """
   Represents a 'milestoned' event on a given issue or pull request.
   """
   MILESTONED_EVENT
+
   """
   Represents a 'moved_columns_in_project' event on a given issue or pull request.
   """
   MOVED_COLUMNS_IN_PROJECT_EVENT
+
   """
   Represents a 'pinned' event on a given issue or pull request.
   """
   PINNED_EVENT
+
   """
   Represents a Git commit part of a pull request.
   """
   PULL_REQUEST_COMMIT
+
   """
   Represents a commit comment thread part of a pull request.
   """
   PULL_REQUEST_COMMIT_COMMENT_THREAD
+
   """
   A review object for a given pull request.
   """
   PULL_REQUEST_REVIEW
+
   """
   A threaded list of comments for a given pull request.
   """
   PULL_REQUEST_REVIEW_THREAD
+
   """
   Represents the latest point in the pull request timeline for which the viewer has seen the pull request's commits.
   """
   PULL_REQUEST_REVISION_MARKER
+
   """
   Represents a 'ready_for_review' event on a given pull request.
   """
   READY_FOR_REVIEW_EVENT
+
   """
   Represents a 'referenced' event on a given `ReferencedSubject`.
   """
   REFERENCED_EVENT
+
   """
   Represents a 'removed_from_merge_queue' event on a given pull request.
   """
   REMOVED_FROM_MERGE_QUEUE_EVENT
+
   """
   Represents a 'removed_from_project' event on a given issue or pull request.
   """
   REMOVED_FROM_PROJECT_EVENT
+
   """
   Represents a 'renamed' event on a given issue or pull request
   """
   RENAMED_TITLE_EVENT
+
   """
   Represents a 'reopened' event on any `Closable`.
   """
   REOPENED_EVENT
+
   """
   Represents a 'review_dismissed' event on a given issue or pull request.
   """
   REVIEW_DISMISSED_EVENT
+
   """
   Represents an 'review_requested' event on a given pull request.
   """
   REVIEW_REQUESTED_EVENT
+
   """
   Represents an 'review_request_removed' event on a given pull request.
   """
   REVIEW_REQUEST_REMOVED_EVENT
+
   """
   Represents a 'subscribed' event on a given `Subscribable`.
   """
   SUBSCRIBED_EVENT
+
   """
   Represents a 'transferred' event on a given issue or pull request.
   """
   TRANSFERRED_EVENT
+
   """
   Represents an 'unassigned' event on any assignable object.
   """
   UNASSIGNED_EVENT
+
   """
   Represents an 'unlabeled' event on a given issue or pull request.
   """
   UNLABELED_EVENT
+
   """
   Represents an 'unlocked' event on a given issue or pull request.
   """
   UNLOCKED_EVENT
+
   """
   Represents an 'unmarked_as_duplicate' event on a given issue or pull request.
   """
   UNMARKED_AS_DUPLICATE_EVENT
+
   """
   Represents an 'unpinned' event on a given issue or pull request.
   """
   UNPINNED_EVENT
+
   """
   Represents an 'unsubscribed' event on a given `Subscribable`.
   """
   UNSUBSCRIBED_EVENT
+
   """
   Represents a 'user_blocked' event on a given user.
   """
@@ -36790,6 +37239,7 @@ enum PullRequestUpdateState {
   A pull request that has been closed without being merged.
   """
   CLOSED
+
   """
   A pull request that is still open.
   """
@@ -37613,30 +38063,37 @@ enum ReactionContent {
   Represents the `:confused:` emoji.
   """
   CONFUSED
+
   """
   Represents the `:eyes:` emoji.
   """
   EYES
+
   """
   Represents the `:heart:` emoji.
   """
   HEART
+
   """
   Represents the `:hooray:` emoji.
   """
   HOORAY
+
   """
   Represents the `:laugh:` emoji.
   """
   LAUGH
+
   """
   Represents the `:rocket:` emoji.
   """
   ROCKET
+
   """
   Represents the `:-1:` emoji.
   """
   THUMBS_DOWN
+
   """
   Represents the `:+1:` emoji.
   """
@@ -38035,6 +38492,7 @@ enum RefOrderField {
   Order refs by their alphanumeric name
   """
   ALPHABETICAL
+
   """
   Order refs by underlying commit date if the ref prefix is refs/tags/
   """
@@ -38637,6 +39095,7 @@ enum ReleaseOrderField {
   Order releases by creation time
   """
   CREATED_AT
+
   """
   Order releases alphabetically by name
   """
@@ -39438,10 +39897,12 @@ enum RepoAccessAuditEntryVisibility {
   The repository is visible only to users in the same business.
   """
   INTERNAL
+
   """
   The repository is visible only to those with explicit access.
   """
   PRIVATE
+
   """
   The repository is visible to everyone.
   """
@@ -39572,10 +40033,12 @@ enum RepoAddMemberAuditEntryVisibility {
   The repository is visible only to users in the same business.
   """
   INTERNAL
+
   """
   The repository is visible only to those with explicit access.
   """
   PRIVATE
+
   """
   The repository is visible to everyone.
   """
@@ -39827,10 +40290,12 @@ enum RepoArchivedAuditEntryVisibility {
   The repository is visible only to users in the same business.
   """
   INTERNAL
+
   """
   The repository is visible only to those with explicit access.
   """
   PRIVATE
+
   """
   The repository is visible to everyone.
   """
@@ -39966,10 +40431,12 @@ enum RepoChangeMergeSettingAuditEntryMergeType {
   The pull request is added to the base branch in a merge commit.
   """
   MERGE
+
   """
   Commits from the pull request are added onto the base branch individually without a merge commit.
   """
   REBASE
+
   """
   The pull request's commits are squashed into a single commit before they are merged to the base branch.
   """
@@ -41220,10 +41687,12 @@ enum RepoCreateAuditEntryVisibility {
   The repository is visible only to users in the same business.
   """
   INTERNAL
+
   """
   The repository is visible only to those with explicit access.
   """
   PRIVATE
+
   """
   The repository is visible to everyone.
   """
@@ -41354,10 +41823,12 @@ enum RepoDestroyAuditEntryVisibility {
   The repository is visible only to users in the same business.
   """
   INTERNAL
+
   """
   The repository is visible only to those with explicit access.
   """
   PRIVATE
+
   """
   The repository is visible to everyone.
   """
@@ -41488,10 +41959,12 @@ enum RepoRemoveMemberAuditEntryVisibility {
   The repository is visible only to users in the same business.
   """
   INTERNAL
+
   """
   The repository is visible only to those with explicit access.
   """
   PRIVATE
+
   """
   The repository is visible to everyone.
   """
@@ -41627,22 +42100,27 @@ enum ReportedContentClassifiers {
   An abusive or harassing piece of content
   """
   ABUSE
+
   """
   A duplicated piece of content
   """
   DUPLICATE
+
   """
   An irrelevant piece of content
   """
   OFF_TOPIC
+
   """
   An outdated piece of content
   """
   OUTDATED
+
   """
   The content has been resolved
   """
   RESOLVED
+
   """
   A spammy piece of content
   """
@@ -43308,11 +43786,13 @@ enum RepositoryAffiliation {
   Repositories that the user has been added to as a collaborator.
   """
   COLLABORATOR
+
   """
   Repositories that the user has access to through being a member of an
   organization. This includes every repository on every team that the user is on.
   """
   ORGANIZATION_MEMBER
+
   """
   Repositories that are owned by the authenticated user.
   """
@@ -43498,18 +43978,22 @@ enum RepositoryContributionType {
   Created a commit
   """
   COMMIT
+
   """
   Created an issue
   """
   ISSUE
+
   """
   Created a pull request
   """
   PULL_REQUEST
+
   """
   Reviewed a pull request
   """
   PULL_REQUEST_REVIEW
+
   """
   Created the repository
   """
@@ -43835,14 +44319,17 @@ enum RepositoryInteractionLimit {
   Users that are not collaborators will not be able to interact with the repository.
   """
   COLLABORATORS_ONLY
+
   """
   Users that have not previously committed to a repository’s default branch will be unable to interact with the repository.
   """
   CONTRIBUTORS_ONLY
+
   """
   Users that have recently created their account will be unable to interact with the repository.
   """
   EXISTING_USERS
+
   """
   No interaction limits are enabled.
   """
@@ -43857,18 +44344,22 @@ enum RepositoryInteractionLimitExpiry {
   The interaction limit will expire after 1 day.
   """
   ONE_DAY
+
   """
   The interaction limit will expire after 1 month.
   """
   ONE_MONTH
+
   """
   The interaction limit will expire after 1 week.
   """
   ONE_WEEK
+
   """
   The interaction limit will expire after 6 months.
   """
   SIX_MONTHS
+
   """
   The interaction limit will expire after 3 days.
   """
@@ -43883,10 +44374,12 @@ enum RepositoryInteractionLimitOrigin {
   A limit that is configured at the organization level.
   """
   ORGANIZATION
+
   """
   A limit that is configured at the repository level.
   """
   REPOSITORY
+
   """
   A limit that is configured at the user-wide level.
   """
@@ -44002,18 +44495,22 @@ enum RepositoryLockReason {
   The repository is locked due to a billing related reason.
   """
   BILLING
+
   """
   The repository is locked due to a migration.
   """
   MIGRATING
+
   """
   The repository is locked due to a move.
   """
   MOVING
+
   """
   The repository is locked due to a rename.
   """
   RENAME
+
   """
   The repository is locked due to a trade controls related reason.
   """
@@ -44140,6 +44637,7 @@ enum RepositoryMigrationOrderDirection {
   Specifies an ascending order for a given `orderBy` argument.
   """
   ASC
+
   """
   Specifies a descending order for a given `orderBy` argument.
   """
@@ -44231,18 +44729,22 @@ enum RepositoryOrderField {
   Order repositories by creation time
   """
   CREATED_AT
+
   """
   Order repositories by name
   """
   NAME
+
   """
   Order repositories by push time
   """
   PUSHED_AT
+
   """
   Order repositories by number of stargazers
   """
   STARGAZERS
+
   """
   Order repositories by update time
   """
@@ -44373,18 +44875,22 @@ enum RepositoryPermission {
   requests, and repository settings, including adding collaborators
   """
   ADMIN
+
   """
   Can read, clone, and push to this repository. They can also manage issues, pull requests, and some repository settings
   """
   MAINTAIN
+
   """
   Can read and clone this repository. Can also open and comment on issues and pull requests
   """
   READ
+
   """
   Can read and clone this repository. Can also manage issues and pull requests
   """
   TRIAGE
+
   """
   Can read, clone, and push to this repository. Can also manage issues and pull requests
   """
@@ -44399,6 +44905,7 @@ enum RepositoryPrivacy {
   Private
   """
   PRIVATE
+
   """
   Public
   """
@@ -44535,46 +45042,57 @@ enum RepositoryRuleType {
   Branch name pattern
   """
   BRANCH_NAME_PATTERN
+
   """
   Committer email pattern
   """
   COMMITTER_EMAIL_PATTERN
+
   """
   Commit author email pattern
   """
   COMMIT_AUTHOR_EMAIL_PATTERN
+
   """
   Commit message pattern
   """
   COMMIT_MESSAGE_PATTERN
+
   """
   Only allow users with bypass permission to create matching refs.
   """
   CREATION
+
   """
   Only allow users with bypass permissions to delete matching refs.
   """
   DELETION
+
   """
   Prevent users with push access from force pushing to refs.
   """
   NON_FAST_FORWARD
+
   """
   Require all commits be made to a non-target branch and submitted via a pull request before they can be merged.
   """
   PULL_REQUEST
+
   """
   Choose which environments must be successfully deployed to before refs can be merged into a branch that matches this rule.
   """
   REQUIRED_DEPLOYMENTS
+
   """
   Prevent merge commits from being pushed to matching refs.
   """
   REQUIRED_LINEAR_HISTORY
+
   """
   Commits pushed to matching refs must have verified signatures.
   """
   REQUIRED_SIGNATURES
+
   """
   Choose which status checks must pass before branches can be merged into a
   branch that matches this rule. When enabled, commits must first be pushed to
@@ -44582,10 +45100,12 @@ enum RepositoryRuleType {
   after status checks have passed.
   """
   REQUIRED_STATUS_CHECKS
+
   """
   Tag name pattern
   """
   TAG_NAME_PATTERN
+
   """
   Only allow users with bypass permission to update matching refs.
   """
@@ -44737,6 +45257,7 @@ enum RepositoryRulesetBypassActorBypassMode {
   The actor can always bypass rules
   """
   ALWAYS
+
   """
   The actor can only bypass rules via a pull request
   """
@@ -44857,6 +45378,7 @@ enum RepositoryRulesetTarget {
   Branch
   """
   BRANCH
+
   """
   Tag
   """
@@ -44933,10 +45455,12 @@ enum RepositoryVisibility {
   The repository is visible only to users in the same business.
   """
   INTERNAL
+
   """
   The repository is visible only to those with explicit access.
   """
   PRIVATE
+
   """
   The repository is visible to everyone.
   """
@@ -45279,6 +45803,7 @@ enum RepositoryVulnerabilityAlertDependencyScope {
   A dependency that is only used in development
   """
   DEVELOPMENT
+
   """
   A dependency that is leveraged during application runtime
   """
@@ -45308,14 +45833,17 @@ enum RepositoryVulnerabilityAlertState {
   An alert that has been automatically closed by Dependabot.
   """
   AUTO_DISMISSED
+
   """
   An alert that has been manually closed by a user.
   """
   DISMISSED
+
   """
   An alert that has been resolved by a code change.
   """
   FIXED
+
   """
   An alert that is still open.
   """
@@ -45385,18 +45913,22 @@ enum RequestableCheckStatusState {
   The check suite or run has been completed.
   """
   COMPLETED
+
   """
   The check suite or run is in progress.
   """
   IN_PROGRESS
+
   """
   The check suite or run is in pending state.
   """
   PENDING
+
   """
   The check suite or run has been queued.
   """
   QUEUED
+
   """
   The check suite or run is in waiting state.
   """
@@ -46101,10 +46633,12 @@ enum RoleInOrganization {
   A user who is a direct member of the organization.
   """
   DIRECT_MEMBER
+
   """
   A user with full administrative access to the organization.
   """
   OWNER
+
   """
   A user who is unaffiliated with the organization.
   """
@@ -46119,10 +46653,12 @@ enum RuleEnforcement {
   Rules will be enforced
   """
   ACTIVE
+
   """
   Do not evaluate or enforce rules
   """
   DISABLED
+
   """
   Allow admins to test rules before enforcing them. Admins can view insights on
   the Rule Insights page (`evaluate` is only available with GitHub Enterprise).
@@ -46206,14 +46742,17 @@ enum SamlDigestAlgorithm {
   SHA1
   """
   SHA1
+
   """
   SHA256
   """
   SHA256
+
   """
   SHA384
   """
   SHA384
+
   """
   SHA512
   """
@@ -46228,14 +46767,17 @@ enum SamlSignatureAlgorithm {
   RSA-SHA1
   """
   RSA_SHA1
+
   """
   RSA-SHA256
   """
   RSA_SHA256
+
   """
   RSA-SHA384
   """
   RSA_SHA384
+
   """
   RSA-SHA512
   """
@@ -46440,14 +46982,17 @@ enum SearchType {
   Returns matching discussions in repositories.
   """
   DISCUSSION
+
   """
   Returns results matching issues in repositories.
   """
   ISSUE
+
   """
   Returns results matching repositories.
   """
   REPOSITORY
+
   """
   Returns results matching users and organizations on GitHub.
   """
@@ -46619,6 +47164,7 @@ enum SecurityAdvisoryClassification {
   Classification of general advisories.
   """
   GENERAL
+
   """
   Classification of malware advisories.
   """
@@ -46658,46 +47204,57 @@ enum SecurityAdvisoryEcosystem {
   GitHub Actions
   """
   ACTIONS
+
   """
   PHP packages hosted at packagist.org
   """
   COMPOSER
+
   """
   Erlang/Elixir packages hosted at hex.pm
   """
   ERLANG
+
   """
   Go modules
   """
   GO
+
   """
   Java artifacts hosted at the Maven central repository
   """
   MAVEN
+
   """
   JavaScript packages hosted at npmjs.com
   """
   NPM
+
   """
   .NET packages hosted at the NuGet Gallery
   """
   NUGET
+
   """
   Python packages hosted at PyPI.org
   """
   PIP
+
   """
   Dart packages hosted at pub.dev
   """
   PUB
+
   """
   Ruby gems hosted at RubyGems.org
   """
   RUBYGEMS
+
   """
   Rust crates
   """
   RUST
+
   """
   Swift packages
   """
@@ -46757,6 +47314,7 @@ enum SecurityAdvisoryIdentifierType {
   Common Vulnerabilities and Exposures Identifier.
   """
   CVE
+
   """
   GitHub Security Advisory ID.
   """
@@ -46786,6 +47344,7 @@ enum SecurityAdvisoryOrderField {
   Order advisories by publication time
   """
   PUBLISHED_AT
+
   """
   Order advisories by update time
   """
@@ -46835,14 +47394,17 @@ enum SecurityAdvisorySeverity {
   Critical.
   """
   CRITICAL
+
   """
   High.
   """
   HIGH
+
   """
   Low.
   """
   LOW
+
   """
   Moderate.
   """
@@ -47239,38 +47801,47 @@ enum SocialAccountProvider {
   Social media and networking website.
   """
   FACEBOOK
+
   """
   Catch-all for social media providers that do not yet have specific handling.
   """
   GENERIC
+
   """
   Fork of Mastodon with a greater focus on local posting.
   """
   HOMETOWN
+
   """
   Social media website with a focus on photo and video sharing.
   """
   INSTAGRAM
+
   """
   Professional networking website.
   """
   LINKEDIN
+
   """
   Open-source federated microblogging service.
   """
   MASTODON
+
   """
   Social news aggregation and discussion website.
   """
   REDDIT
+
   """
   Live-streaming service.
   """
   TWITCH
+
   """
   Microblogging website.
   """
   TWITTER
+
   """
   Online video platform.
   """
@@ -47345,6 +47916,7 @@ enum SponsorOrderField {
   Order sponsorable entities by login (username).
   """
   LOGIN
+
   """
   Order sponsors by their relevance to the viewer.
   """
@@ -47814,22 +48386,27 @@ enum SponsorsActivityAction {
   The activity was cancelling a sponsorship.
   """
   CANCELLED_SPONSORSHIP
+
   """
   The activity was starting a sponsorship.
   """
   NEW_SPONSORSHIP
+
   """
   The activity was scheduling a downgrade or cancellation.
   """
   PENDING_CHANGE
+
   """
   The activity was funds being refunded to the sponsor or GitHub.
   """
   REFUND
+
   """
   The activity was disabling matching for a previously matched sponsorship.
   """
   SPONSOR_MATCH_DISABLED
+
   """
   The activity was changing the sponsorship tier, either directly by the sponsor or by a scheduled/pending change.
   """
@@ -47909,14 +48486,17 @@ enum SponsorsActivityPeriod {
   Don't restrict the activity to any date range, include all activity.
   """
   ALL
+
   """
   The previous calendar day.
   """
   DAY
+
   """
   The previous thirty days.
   """
   MONTH
+
   """
   The previous seven days.
   """
@@ -47931,982 +48511,1227 @@ enum SponsorsCountryOrRegionCode {
   Andorra
   """
   AD
+
   """
   United Arab Emirates
   """
   AE
+
   """
   Afghanistan
   """
   AF
+
   """
   Antigua and Barbuda
   """
   AG
+
   """
   Anguilla
   """
   AI
+
   """
   Albania
   """
   AL
+
   """
   Armenia
   """
   AM
+
   """
   Angola
   """
   AO
+
   """
   Antarctica
   """
   AQ
+
   """
   Argentina
   """
   AR
+
   """
   American Samoa
   """
   AS
+
   """
   Austria
   """
   AT
+
   """
   Australia
   """
   AU
+
   """
   Aruba
   """
   AW
+
   """
   Åland
   """
   AX
+
   """
   Azerbaijan
   """
   AZ
+
   """
   Bosnia and Herzegovina
   """
   BA
+
   """
   Barbados
   """
   BB
+
   """
   Bangladesh
   """
   BD
+
   """
   Belgium
   """
   BE
+
   """
   Burkina Faso
   """
   BF
+
   """
   Bulgaria
   """
   BG
+
   """
   Bahrain
   """
   BH
+
   """
   Burundi
   """
   BI
+
   """
   Benin
   """
   BJ
+
   """
   Saint Barthélemy
   """
   BL
+
   """
   Bermuda
   """
   BM
+
   """
   Brunei Darussalam
   """
   BN
+
   """
   Bolivia
   """
   BO
+
   """
   Bonaire, Sint Eustatius and Saba
   """
   BQ
+
   """
   Brazil
   """
   BR
+
   """
   Bahamas
   """
   BS
+
   """
   Bhutan
   """
   BT
+
   """
   Bouvet Island
   """
   BV
+
   """
   Botswana
   """
   BW
+
   """
   Belarus
   """
   BY
+
   """
   Belize
   """
   BZ
+
   """
   Canada
   """
   CA
+
   """
   Cocos (Keeling) Islands
   """
   CC
+
   """
   Congo (Kinshasa)
   """
   CD
+
   """
   Central African Republic
   """
   CF
+
   """
   Congo (Brazzaville)
   """
   CG
+
   """
   Switzerland
   """
   CH
+
   """
   Côte d'Ivoire
   """
   CI
+
   """
   Cook Islands
   """
   CK
+
   """
   Chile
   """
   CL
+
   """
   Cameroon
   """
   CM
+
   """
   China
   """
   CN
+
   """
   Colombia
   """
   CO
+
   """
   Costa Rica
   """
   CR
+
   """
   Cape Verde
   """
   CV
+
   """
   Curaçao
   """
   CW
+
   """
   Christmas Island
   """
   CX
+
   """
   Cyprus
   """
   CY
+
   """
   Czech Republic
   """
   CZ
+
   """
   Germany
   """
   DE
+
   """
   Djibouti
   """
   DJ
+
   """
   Denmark
   """
   DK
+
   """
   Dominica
   """
   DM
+
   """
   Dominican Republic
   """
   DO
+
   """
   Algeria
   """
   DZ
+
   """
   Ecuador
   """
   EC
+
   """
   Estonia
   """
   EE
+
   """
   Egypt
   """
   EG
+
   """
   Western Sahara
   """
   EH
+
   """
   Eritrea
   """
   ER
+
   """
   Spain
   """
   ES
+
   """
   Ethiopia
   """
   ET
+
   """
   Finland
   """
   FI
+
   """
   Fiji
   """
   FJ
+
   """
   Falkland Islands
   """
   FK
+
   """
   Micronesia
   """
   FM
+
   """
   Faroe Islands
   """
   FO
+
   """
   France
   """
   FR
+
   """
   Gabon
   """
   GA
+
   """
   United Kingdom
   """
   GB
+
   """
   Grenada
   """
   GD
+
   """
   Georgia
   """
   GE
+
   """
   French Guiana
   """
   GF
+
   """
   Guernsey
   """
   GG
+
   """
   Ghana
   """
   GH
+
   """
   Gibraltar
   """
   GI
+
   """
   Greenland
   """
   GL
+
   """
   Gambia
   """
   GM
+
   """
   Guinea
   """
   GN
+
   """
   Guadeloupe
   """
   GP
+
   """
   Equatorial Guinea
   """
   GQ
+
   """
   Greece
   """
   GR
+
   """
   South Georgia and South Sandwich Islands
   """
   GS
+
   """
   Guatemala
   """
   GT
+
   """
   Guam
   """
   GU
+
   """
   Guinea-Bissau
   """
   GW
+
   """
   Guyana
   """
   GY
+
   """
   Hong Kong
   """
   HK
+
   """
   Heard and McDonald Islands
   """
   HM
+
   """
   Honduras
   """
   HN
+
   """
   Croatia
   """
   HR
+
   """
   Haiti
   """
   HT
+
   """
   Hungary
   """
   HU
+
   """
   Indonesia
   """
   ID
+
   """
   Ireland
   """
   IE
+
   """
   Israel
   """
   IL
+
   """
   Isle of Man
   """
   IM
+
   """
   India
   """
   IN
+
   """
   British Indian Ocean Territory
   """
   IO
+
   """
   Iraq
   """
   IQ
+
   """
   Iran
   """
   IR
+
   """
   Iceland
   """
   IS
+
   """
   Italy
   """
   IT
+
   """
   Jersey
   """
   JE
+
   """
   Jamaica
   """
   JM
+
   """
   Jordan
   """
   JO
+
   """
   Japan
   """
   JP
+
   """
   Kenya
   """
   KE
+
   """
   Kyrgyzstan
   """
   KG
+
   """
   Cambodia
   """
   KH
+
   """
   Kiribati
   """
   KI
+
   """
   Comoros
   """
   KM
+
   """
   Saint Kitts and Nevis
   """
   KN
+
   """
   Korea, South
   """
   KR
+
   """
   Kuwait
   """
   KW
+
   """
   Cayman Islands
   """
   KY
+
   """
   Kazakhstan
   """
   KZ
+
   """
   Laos
   """
   LA
+
   """
   Lebanon
   """
   LB
+
   """
   Saint Lucia
   """
   LC
+
   """
   Liechtenstein
   """
   LI
+
   """
   Sri Lanka
   """
   LK
+
   """
   Liberia
   """
   LR
+
   """
   Lesotho
   """
   LS
+
   """
   Lithuania
   """
   LT
+
   """
   Luxembourg
   """
   LU
+
   """
   Latvia
   """
   LV
+
   """
   Libya
   """
   LY
+
   """
   Morocco
   """
   MA
+
   """
   Monaco
   """
   MC
+
   """
   Moldova
   """
   MD
+
   """
   Montenegro
   """
   ME
+
   """
   Saint Martin (French part)
   """
   MF
+
   """
   Madagascar
   """
   MG
+
   """
   Marshall Islands
   """
   MH
+
   """
   Macedonia
   """
   MK
+
   """
   Mali
   """
   ML
+
   """
   Myanmar
   """
   MM
+
   """
   Mongolia
   """
   MN
+
   """
   Macau
   """
   MO
+
   """
   Northern Mariana Islands
   """
   MP
+
   """
   Martinique
   """
   MQ
+
   """
   Mauritania
   """
   MR
+
   """
   Montserrat
   """
   MS
+
   """
   Malta
   """
   MT
+
   """
   Mauritius
   """
   MU
+
   """
   Maldives
   """
   MV
+
   """
   Malawi
   """
   MW
+
   """
   Mexico
   """
   MX
+
   """
   Malaysia
   """
   MY
+
   """
   Mozambique
   """
   MZ
+
   """
   Namibia
   """
   NA
+
   """
   New Caledonia
   """
   NC
+
   """
   Niger
   """
   NE
+
   """
   Norfolk Island
   """
   NF
+
   """
   Nigeria
   """
   NG
+
   """
   Nicaragua
   """
   NI
+
   """
   Netherlands
   """
   NL
+
   """
   Norway
   """
   NO
+
   """
   Nepal
   """
   NP
+
   """
   Nauru
   """
   NR
+
   """
   Niue
   """
   NU
+
   """
   New Zealand
   """
   NZ
+
   """
   Oman
   """
   OM
+
   """
   Panama
   """
   PA
+
   """
   Peru
   """
   PE
+
   """
   French Polynesia
   """
   PF
+
   """
   Papua New Guinea
   """
   PG
+
   """
   Philippines
   """
   PH
+
   """
   Pakistan
   """
   PK
+
   """
   Poland
   """
   PL
+
   """
   Saint Pierre and Miquelon
   """
   PM
+
   """
   Pitcairn
   """
   PN
+
   """
   Puerto Rico
   """
   PR
+
   """
   Palestine
   """
   PS
+
   """
   Portugal
   """
   PT
+
   """
   Palau
   """
   PW
+
   """
   Paraguay
   """
   PY
+
   """
   Qatar
   """
   QA
+
   """
   Reunion
   """
   RE
+
   """
   Romania
   """
   RO
+
   """
   Serbia
   """
   RS
+
   """
   Russian Federation
   """
   RU
+
   """
   Rwanda
   """
   RW
+
   """
   Saudi Arabia
   """
   SA
+
   """
   Solomon Islands
   """
   SB
+
   """
   Seychelles
   """
   SC
+
   """
   Sudan
   """
   SD
+
   """
   Sweden
   """
   SE
+
   """
   Singapore
   """
   SG
+
   """
   Saint Helena
   """
   SH
+
   """
   Slovenia
   """
   SI
+
   """
   Svalbard and Jan Mayen Islands
   """
   SJ
+
   """
   Slovakia
   """
   SK
+
   """
   Sierra Leone
   """
   SL
+
   """
   San Marino
   """
   SM
+
   """
   Senegal
   """
   SN
+
   """
   Somalia
   """
   SO
+
   """
   Suriname
   """
   SR
+
   """
   South Sudan
   """
   SS
+
   """
   Sao Tome and Principe
   """
   ST
+
   """
   El Salvador
   """
   SV
+
   """
   Sint Maarten (Dutch part)
   """
   SX
+
   """
   Swaziland
   """
   SZ
+
   """
   Turks and Caicos Islands
   """
   TC
+
   """
   Chad
   """
   TD
+
   """
   French Southern Lands
   """
   TF
+
   """
   Togo
   """
   TG
+
   """
   Thailand
   """
   TH
+
   """
   Tajikistan
   """
   TJ
+
   """
   Tokelau
   """
   TK
+
   """
   Timor-Leste
   """
   TL
+
   """
   Turkmenistan
   """
   TM
+
   """
   Tunisia
   """
   TN
+
   """
   Tonga
   """
   TO
+
   """
   Turkey
   """
   TR
+
   """
   Trinidad and Tobago
   """
   TT
+
   """
   Tuvalu
   """
   TV
+
   """
   Taiwan
   """
   TW
+
   """
   Tanzania
   """
   TZ
+
   """
   Ukraine
   """
   UA
+
   """
   Uganda
   """
   UG
+
   """
   United States Minor Outlying Islands
   """
   UM
+
   """
   United States of America
   """
   US
+
   """
   Uruguay
   """
   UY
+
   """
   Uzbekistan
   """
   UZ
+
   """
   Vatican City
   """
   VA
+
   """
   Saint Vincent and the Grenadines
   """
   VC
+
   """
   Venezuela
   """
   VE
+
   """
   Virgin Islands, British
   """
   VG
+
   """
   Virgin Islands, U.S.
   """
   VI
+
   """
   Vietnam
   """
   VN
+
   """
   Vanuatu
   """
   VU
+
   """
   Wallis and Futuna Islands
   """
   WF
+
   """
   Samoa
   """
   WS
+
   """
   Yemen
   """
   YE
+
   """
   Mayotte
   """
   YT
+
   """
   South Africa
   """
   ZA
+
   """
   Zambia
   """
   ZM
+
   """
   Zimbabwe
   """
@@ -48952,6 +49777,7 @@ enum SponsorsGoalKind {
   The goal is about getting a certain amount in USD from sponsorships each month.
   """
   MONTHLY_SPONSORSHIP_AMOUNT
+
   """
   The goal is about reaching a certain number of sponsors.
   """
@@ -49173,6 +49999,7 @@ enum SponsorsListingFeaturedItemFeatureableType {
   A repository owned by the user or organization with the GitHub Sponsors profile.
   """
   REPOSITORY
+
   """
   A user who belongs to the organization with the GitHub Sponsors profile.
   """
@@ -49378,6 +50205,7 @@ enum SponsorsTierOrderField {
   Order tiers by creation time.
   """
   CREATED_AT
+
   """
   Order tiers by their monthly price in cents
   """
@@ -49644,6 +50472,7 @@ enum SponsorshipPrivacy {
   Private
   """
   PRIVATE
+
   """
   Public
   """
@@ -49658,10 +50487,12 @@ enum SquashMergeCommitMessage {
   Default to a blank commit message.
   """
   BLANK
+
   """
   Default to the branch's commit messages.
   """
   COMMIT_MESSAGES
+
   """
   Default to the pull request's body.
   """
@@ -49676,6 +50507,7 @@ enum SquashMergeCommitTitle {
   Default to the commit's title (if only one commit) or the pull request's title (when more than one commit).
   """
   COMMIT_OR_PR_TITLE
+
   """
   Default to the pull request's title.
   """
@@ -50298,18 +51130,22 @@ enum StatusState {
   Status is errored.
   """
   ERROR
+
   """
   Status is expected.
   """
   EXPECTED
+
   """
   Status is failing.
   """
   FAILURE
+
   """
   Status is pending.
   """
   PENDING
+
   """
   Status is successful.
   """
@@ -50544,10 +51380,12 @@ enum SubscriptionState {
   The User is never notified.
   """
   IGNORED
+
   """
   The User is notified of all conversations.
   """
   SUBSCRIBED
+
   """
   The User is only notified when participating or @mentioned.
   """
@@ -52331,6 +53169,7 @@ enum TeamMemberOrderField {
   Order team members by creation time
   """
   CREATED_AT
+
   """
   Order team members by login
   """
@@ -52345,6 +53184,7 @@ enum TeamMemberRole {
   A team maintainer has permission to add and remove team members.
   """
   MAINTAINER
+
   """
   A team member has no administrative permissions on the team.
   """
@@ -52359,10 +53199,12 @@ enum TeamMembershipType {
   Includes immediate and child team members for the team.
   """
   ALL
+
   """
   Includes only child team members for the team.
   """
   CHILD_TEAM
+
   """
   Includes only immediate members of the team.
   """
@@ -52377,6 +53219,7 @@ enum TeamNotificationSetting {
   No one will receive notifications.
   """
   NOTIFICATIONS_DISABLED
+
   """
   Everyone will receive notifications when the team is @mentioned.
   """
@@ -52416,6 +53259,7 @@ enum TeamPrivacy {
   A secret team can only be seen by its members.
   """
   SECRET
+
   """
   A visible team can be seen and @mentioned by every member of the organization.
   """
@@ -52738,22 +53582,27 @@ enum TeamRepositoryOrderField {
   Order repositories by creation time
   """
   CREATED_AT
+
   """
   Order repositories by name
   """
   NAME
+
   """
   Order repositories by permission
   """
   PERMISSION
+
   """
   Order repositories by push time
   """
   PUSHED_AT
+
   """
   Order repositories by number of stargazers
   """
   STARGAZERS
+
   """
   Order repositories by update time
   """
@@ -52768,6 +53617,7 @@ enum TeamReviewAssignmentAlgorithm @preview(toggledBy: "stone-crop-preview") {
   Balance review load across the entire team
   """
   LOAD_BALANCE
+
   """
   Alternate reviews between each team member
   """
@@ -52782,6 +53632,7 @@ enum TeamRole {
   User has admin rights on the team.
   """
   ADMIN
+
   """
   User is a member of the team.
   """
@@ -52836,10 +53687,12 @@ enum ThreadSubscriptionFormAction {
   The User cannot subscribe or unsubscribe to the thread
   """
   NONE
+
   """
   The User can subscribe to the thread
   """
   SUBSCRIBE
+
   """
   The User can unsubscribe to the thread
   """
@@ -52854,34 +53707,42 @@ enum ThreadSubscriptionState {
   The subscription status is currently disabled.
   """
   DISABLED
+
   """
   The User is never notified because they are ignoring the list
   """
   IGNORING_LIST
+
   """
   The User is never notified because they are ignoring the thread
   """
   IGNORING_THREAD
+
   """
   The User is not recieving notifications from this thread
   """
   NONE
+
   """
   The User is notified becuase they are watching the list
   """
   SUBSCRIBED_TO_LIST
+
   """
   The User is notified because they are subscribed to the thread
   """
   SUBSCRIBED_TO_THREAD
+
   """
   The User is notified because they chose custom settings for this thread.
   """
   SUBSCRIBED_TO_THREAD_EVENTS
+
   """
   The User is notified because they chose custom settings for this thread.
   """
   SUBSCRIBED_TO_THREAD_TYPE
+
   """
   The subscription status is currently unavailable.
   """
@@ -53038,14 +53899,17 @@ enum TopicSuggestionDeclineReason {
   The suggested topic is not relevant to the repository.
   """
   NOT_RELEVANT
+
   """
   The viewer does not like the suggested topic.
   """
   PERSONAL_PREFERENCE
+
   """
   The suggested topic is too general for the repository.
   """
   TOO_GENERAL
+
   """
   The suggested topic is too specific for the repository (e.g. #ruby-on-rails-version-4-2-1).
   """
@@ -53060,6 +53924,7 @@ enum TrackedIssueStates {
   The tracked issue is closed
   """
   CLOSED
+
   """
   The tracked issue is open
   """
@@ -58327,18 +59192,22 @@ enum UserBlockDuration {
   The user was blocked for 1 day
   """
   ONE_DAY
+
   """
   The user was blocked for 30 days
   """
   ONE_MONTH
+
   """
   The user was blocked for 7 days
   """
   ONE_WEEK
+
   """
   The user was blocked permanently
   """
   PERMANENT
+
   """
   The user was blocked for 3 days
   """
@@ -58767,6 +59636,7 @@ enum VerifiableDomainOrderField {
   Order verifiable domains by their creation date.
   """
   CREATED_AT
+
   """
   Order verifiable domains by the domain name.
   """
@@ -59145,18 +60015,22 @@ enum WorkflowState {
   The workflow is active.
   """
   ACTIVE
+
   """
   The workflow was deleted from the git repository.
   """
   DELETED
+
   """
   The workflow was disabled by default on a fork.
   """
   DISABLED_FORK
+
   """
   The workflow was disabled for inactivity in the repository.
   """
   DISABLED_INACTIVITY
+
   """
   The workflow was disabled manually.
   """

--- a/cynic-parser/tests/snapshots/actual_schemas__starwars__snapshot.snap
+++ b/cynic-parser/tests/snapshots/actual_schemas__starwars__snapshot.snap
@@ -49,6 +49,7 @@ type Root {
     last: Int
   ): VehiclesConnection
   vehicle(id: ID, vehicleID: ID): Vehicle
+  
   """
   Fetches an object given its ID
   """
@@ -68,10 +69,12 @@ type FilmsConnection {
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   A list of edges.
   """
   edges: [FilmsEdge]
+  
   """
   A count of the total number of objects in this connection, ignoring pagination.
   This allows a client to fetch the first five objects by passing "5" as the
@@ -79,6 +82,7 @@ type FilmsConnection {
   for example.
   """
   totalCount: Int
+  
   """
   A list of all of the objects returned in the connection. This is a convenience
   field provided for quickly exploring the API; rather than querying for
@@ -98,14 +102,17 @@ type PageInfo {
   When paginating forwards, are there more items?
   """
   hasNextPage: Boolean!
+  
   """
   When paginating backwards, are there more items?
   """
   hasPreviousPage: Boolean!
+  
   """
   When paginating backwards, the cursor to continue.
   """
   startCursor: String
+  
   """
   When paginating forwards, the cursor to continue.
   """
@@ -120,6 +127,7 @@ type FilmsEdge {
   The item at the end of the edge
   """
   node: Film
+  
   """
   A cursor for use in pagination
   """
@@ -134,22 +142,27 @@ type Film implements Node {
   The title of this film.
   """
   title: String
+  
   """
   The episode number of this film.
   """
   episodeID: Int
+  
   """
   The opening paragraphs at the beginning of this film.
   """
   openingCrawl: String
+  
   """
   The name of the director of this film.
   """
   director: String
+  
   """
   The name(s) of the producer(s) of this film.
   """
   producers: [String]
+  
   """
   The ISO 8601 date format of film release at original creator country.
   """
@@ -184,14 +197,17 @@ type Film implements Node {
     before: String
     last: Int
   ): FilmPlanetsConnection
+  
   """
   The ISO 8601 date format of the time that this resource was created.
   """
   created: String
+  
   """
   The ISO 8601 date format of the time that this resource was edited.
   """
   edited: String
+  
   """
   The ID of an object
   """
@@ -216,10 +232,12 @@ type FilmSpeciesConnection {
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   A list of edges.
   """
   edges: [FilmSpeciesEdge]
+  
   """
   A count of the total number of objects in this connection, ignoring pagination.
   This allows a client to fetch the first five objects by passing "5" as the
@@ -227,6 +245,7 @@ type FilmSpeciesConnection {
   for example.
   """
   totalCount: Int
+  
   """
   A list of all of the objects returned in the connection. This is a convenience
   field provided for quickly exploring the API; rather than querying for
@@ -246,6 +265,7 @@ type FilmSpeciesEdge {
   The item at the end of the edge
   """
   node: Species
+  
   """
   A cursor for use in pagination
   """
@@ -260,41 +280,50 @@ type Species implements Node {
   The name of this species.
   """
   name: String
+  
   """
   The classification of this species, such as "mammal" or "reptile".
   """
   classification: String
+  
   """
   The designation of this species, such as "sentient".
   """
   designation: String
+  
   """
   The average height of this species in centimeters.
   """
   averageHeight: Float
+  
   """
   The average lifespan of this species in years, null if unknown.
   """
   averageLifespan: Int
+  
   """
   Common eye colors for this species, null if this species does not typically
   have eyes.
   """
   eyeColors: [String]
+  
   """
   Common hair colors for this species, null if this species does not typically
   have hair.
   """
   hairColors: [String]
+  
   """
   Common skin colors for this species, null if this species does not typically
   have skin.
   """
   skinColors: [String]
+  
   """
   The language commonly spoken by this species.
   """
   language: String
+  
   """
   A planet that this species originates from.
   """
@@ -311,14 +340,17 @@ type Species implements Node {
     before: String
     last: Int
   ): SpeciesFilmsConnection
+  
   """
   The ISO 8601 date format of the time that this resource was created.
   """
   created: String
+  
   """
   The ISO 8601 date format of the time that this resource was edited.
   """
   edited: String
+  
   """
   The ID of an object
   """
@@ -334,37 +366,45 @@ type Planet implements Node {
   The name of this planet.
   """
   name: String
+  
   """
   The diameter of this planet in kilometers.
   """
   diameter: Int
+  
   """
   The number of standard hours it takes for this planet to complete a single
   rotation on its axis.
   """
   rotationPeriod: Int
+  
   """
   The number of standard days it takes for this planet to complete a single orbit
   of its local star.
   """
   orbitalPeriod: Int
+  
   """
   A number denoting the gravity of this planet, where "1" is normal or 1 standard
   G. "2" is twice or 2 standard Gs. "0.5" is half or 0.5 standard Gs.
   """
   gravity: String
+  
   """
   The average population of sentient beings inhabiting this planet.
   """
   population: Float
+  
   """
   The climates of this planet.
   """
   climates: [String]
+  
   """
   The terrains of this planet.
   """
   terrains: [String]
+  
   """
   The percentage of the planet surface that is naturally occurring water or bodies
   of water.
@@ -382,14 +422,17 @@ type Planet implements Node {
     before: String
     last: Int
   ): PlanetFilmsConnection
+  
   """
   The ISO 8601 date format of the time that this resource was created.
   """
   created: String
+  
   """
   The ISO 8601 date format of the time that this resource was edited.
   """
   edited: String
+  
   """
   The ID of an object
   """
@@ -404,10 +447,12 @@ type PlanetResidentsConnection {
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   A list of edges.
   """
   edges: [PlanetResidentsEdge]
+  
   """
   A count of the total number of objects in this connection, ignoring pagination.
   This allows a client to fetch the first five objects by passing "5" as the
@@ -415,6 +460,7 @@ type PlanetResidentsConnection {
   for example.
   """
   totalCount: Int
+  
   """
   A list of all of the objects returned in the connection. This is a convenience
   field provided for quickly exploring the API; rather than querying for
@@ -434,6 +480,7 @@ type PlanetResidentsEdge {
   The item at the end of the edge
   """
   node: Person
+  
   """
   A cursor for use in pagination
   """
@@ -448,39 +495,47 @@ type Person implements Node {
   The name of this person.
   """
   name: String
+  
   """
   The birth year of the person, using the in-universe standard of BBY or ABY -
   Before the Battle of Yavin or After the Battle of Yavin. The Battle of Yavin is
   a battle that occurs at the end of Star Wars episode IV: A New Hope.
   """
   birthYear: String
+  
   """
   The eye color of this person. Will be "unknown" if not known or "n/a" if the
   person does not have an eye.
   """
   eyeColor: String
+  
   """
   The gender of this person. Either "Male", "Female" or "unknown",
   "n/a" if the person does not have a gender.
   """
   gender: String
+  
   """
   The hair color of this person. Will be "unknown" if not known or "n/a" if the
   person does not have hair.
   """
   hairColor: String
+  
   """
   The height of the person in centimeters.
   """
   height: Int
+  
   """
   The mass of the person in kilograms.
   """
   mass: Float
+  
   """
   The skin color of this person.
   """
   skinColor: String
+  
   """
   A planet that this person was born on or inhabits.
   """
@@ -491,6 +546,7 @@ type Person implements Node {
     before: String
     last: Int
   ): PersonFilmsConnection
+  
   """
   The species that this person belongs to, or null if unknown.
   """
@@ -507,14 +563,17 @@ type Person implements Node {
     before: String
     last: Int
   ): PersonVehiclesConnection
+  
   """
   The ISO 8601 date format of the time that this resource was created.
   """
   created: String
+  
   """
   The ISO 8601 date format of the time that this resource was edited.
   """
   edited: String
+  
   """
   The ID of an object
   """
@@ -529,10 +588,12 @@ type PersonFilmsConnection {
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   A list of edges.
   """
   edges: [PersonFilmsEdge]
+  
   """
   A count of the total number of objects in this connection, ignoring pagination.
   This allows a client to fetch the first five objects by passing "5" as the
@@ -540,6 +601,7 @@ type PersonFilmsConnection {
   for example.
   """
   totalCount: Int
+  
   """
   A list of all of the objects returned in the connection. This is a convenience
   field provided for quickly exploring the API; rather than querying for
@@ -559,6 +621,7 @@ type PersonFilmsEdge {
   The item at the end of the edge
   """
   node: Film
+  
   """
   A cursor for use in pagination
   """
@@ -573,10 +636,12 @@ type PersonStarshipsConnection {
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   A list of edges.
   """
   edges: [PersonStarshipsEdge]
+  
   """
   A count of the total number of objects in this connection, ignoring pagination.
   This allows a client to fetch the first five objects by passing "5" as the
@@ -584,6 +649,7 @@ type PersonStarshipsConnection {
   for example.
   """
   totalCount: Int
+  
   """
   A list of all of the objects returned in the connection. This is a convenience
   field provided for quickly exploring the API; rather than querying for
@@ -603,6 +669,7 @@ type PersonStarshipsEdge {
   The item at the end of the edge
   """
   node: Starship
+  
   """
   A cursor for use in pagination
   """
@@ -617,45 +684,55 @@ type Starship implements Node {
   The name of this starship. The common name, such as "Death Star".
   """
   name: String
+  
   """
   The model or official name of this starship. Such as "T-65 X-wing" or "DS-1
   Orbital Battle Station".
   """
   model: String
+  
   """
   The class of this starship, such as "Starfighter" or "Deep Space Mobile
   Battlestation"
   """
   starshipClass: String
+  
   """
   The manufacturers of this starship.
   """
   manufacturers: [String]
+  
   """
   The cost of this starship new, in galactic credits.
   """
   costInCredits: Float
+  
   """
   The length of this starship in meters.
   """
   length: Float
+  
   """
   The number of personnel needed to run or pilot this starship.
   """
   crew: String
+  
   """
   The number of non-essential people this starship can transport.
   """
   passengers: String
+  
   """
   The maximum speed of this starship in atmosphere. null if this starship is
   incapable of atmosphering flight.
   """
   maxAtmospheringSpeed: Int
+  
   """
   The class of this starships hyperdrive.
   """
   hyperdriveRating: Float
+  
   """
   The Maximum number of Megalights this starship can travel in a standard hour.
   A "Megalight" is a standard unit of distance and has never been defined before
@@ -664,10 +741,12 @@ type Starship implements Node {
   distance between our Sun (Sol) and Earth.
   """
   MGLT: Int
+  
   """
   The maximum number of kilograms that this starship can transport.
   """
   cargoCapacity: Float
+  
   """
   The maximum length of time that this starship can provide consumables for its
   entire crew without having to resupply.
@@ -685,14 +764,17 @@ type Starship implements Node {
     before: String
     last: Int
   ): StarshipFilmsConnection
+  
   """
   The ISO 8601 date format of the time that this resource was created.
   """
   created: String
+  
   """
   The ISO 8601 date format of the time that this resource was edited.
   """
   edited: String
+  
   """
   The ID of an object
   """
@@ -707,10 +789,12 @@ type StarshipPilotsConnection {
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   A list of edges.
   """
   edges: [StarshipPilotsEdge]
+  
   """
   A count of the total number of objects in this connection, ignoring pagination.
   This allows a client to fetch the first five objects by passing "5" as the
@@ -718,6 +802,7 @@ type StarshipPilotsConnection {
   for example.
   """
   totalCount: Int
+  
   """
   A list of all of the objects returned in the connection. This is a convenience
   field provided for quickly exploring the API; rather than querying for
@@ -737,6 +822,7 @@ type StarshipPilotsEdge {
   The item at the end of the edge
   """
   node: Person
+  
   """
   A cursor for use in pagination
   """
@@ -751,10 +837,12 @@ type StarshipFilmsConnection {
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   A list of edges.
   """
   edges: [StarshipFilmsEdge]
+  
   """
   A count of the total number of objects in this connection, ignoring pagination.
   This allows a client to fetch the first five objects by passing "5" as the
@@ -762,6 +850,7 @@ type StarshipFilmsConnection {
   for example.
   """
   totalCount: Int
+  
   """
   A list of all of the objects returned in the connection. This is a convenience
   field provided for quickly exploring the API; rather than querying for
@@ -781,6 +870,7 @@ type StarshipFilmsEdge {
   The item at the end of the edge
   """
   node: Film
+  
   """
   A cursor for use in pagination
   """
@@ -795,10 +885,12 @@ type PersonVehiclesConnection {
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   A list of edges.
   """
   edges: [PersonVehiclesEdge]
+  
   """
   A count of the total number of objects in this connection, ignoring pagination.
   This allows a client to fetch the first five objects by passing "5" as the
@@ -806,6 +898,7 @@ type PersonVehiclesConnection {
   for example.
   """
   totalCount: Int
+  
   """
   A list of all of the objects returned in the connection. This is a convenience
   field provided for quickly exploring the API; rather than querying for
@@ -825,6 +918,7 @@ type PersonVehiclesEdge {
   The item at the end of the edge
   """
   node: Vehicle
+  
   """
   A cursor for use in pagination
   """
@@ -840,43 +934,53 @@ type Vehicle implements Node {
   bike".
   """
   name: String
+  
   """
   The model or official name of this vehicle. Such as "All-Terrain Attack
   Transport".
   """
   model: String
+  
   """
   The class of this vehicle, such as "Wheeled" or "Repulsorcraft".
   """
   vehicleClass: String
+  
   """
   The manufacturers of this vehicle.
   """
   manufacturers: [String]
+  
   """
   The cost of this vehicle new, in Galactic Credits.
   """
   costInCredits: Float
+  
   """
   The length of this vehicle in meters.
   """
   length: Float
+  
   """
   The number of personnel needed to run or pilot this vehicle.
   """
   crew: String
+  
   """
   The number of non-essential people this vehicle can transport.
   """
   passengers: String
+  
   """
   The maximum speed of this vehicle in atmosphere.
   """
   maxAtmospheringSpeed: Int
+  
   """
   The maximum number of kilograms that this vehicle can transport.
   """
   cargoCapacity: Float
+  
   """
   The maximum length of time that this vehicle can provide consumables for its
   entire crew without having to resupply.
@@ -894,14 +998,17 @@ type Vehicle implements Node {
     before: String
     last: Int
   ): VehicleFilmsConnection
+  
   """
   The ISO 8601 date format of the time that this resource was created.
   """
   created: String
+  
   """
   The ISO 8601 date format of the time that this resource was edited.
   """
   edited: String
+  
   """
   The ID of an object
   """
@@ -916,10 +1023,12 @@ type VehiclePilotsConnection {
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   A list of edges.
   """
   edges: [VehiclePilotsEdge]
+  
   """
   A count of the total number of objects in this connection, ignoring pagination.
   This allows a client to fetch the first five objects by passing "5" as the
@@ -927,6 +1036,7 @@ type VehiclePilotsConnection {
   for example.
   """
   totalCount: Int
+  
   """
   A list of all of the objects returned in the connection. This is a convenience
   field provided for quickly exploring the API; rather than querying for
@@ -946,6 +1056,7 @@ type VehiclePilotsEdge {
   The item at the end of the edge
   """
   node: Person
+  
   """
   A cursor for use in pagination
   """
@@ -960,10 +1071,12 @@ type VehicleFilmsConnection {
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   A list of edges.
   """
   edges: [VehicleFilmsEdge]
+  
   """
   A count of the total number of objects in this connection, ignoring pagination.
   This allows a client to fetch the first five objects by passing "5" as the
@@ -971,6 +1084,7 @@ type VehicleFilmsConnection {
   for example.
   """
   totalCount: Int
+  
   """
   A list of all of the objects returned in the connection. This is a convenience
   field provided for quickly exploring the API; rather than querying for
@@ -990,6 +1104,7 @@ type VehicleFilmsEdge {
   The item at the end of the edge
   """
   node: Film
+  
   """
   A cursor for use in pagination
   """
@@ -1004,10 +1119,12 @@ type PlanetFilmsConnection {
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   A list of edges.
   """
   edges: [PlanetFilmsEdge]
+  
   """
   A count of the total number of objects in this connection, ignoring pagination.
   This allows a client to fetch the first five objects by passing "5" as the
@@ -1015,6 +1132,7 @@ type PlanetFilmsConnection {
   for example.
   """
   totalCount: Int
+  
   """
   A list of all of the objects returned in the connection. This is a convenience
   field provided for quickly exploring the API; rather than querying for
@@ -1034,6 +1152,7 @@ type PlanetFilmsEdge {
   The item at the end of the edge
   """
   node: Film
+  
   """
   A cursor for use in pagination
   """
@@ -1048,10 +1167,12 @@ type SpeciesPeopleConnection {
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   A list of edges.
   """
   edges: [SpeciesPeopleEdge]
+  
   """
   A count of the total number of objects in this connection, ignoring pagination.
   This allows a client to fetch the first five objects by passing "5" as the
@@ -1059,6 +1180,7 @@ type SpeciesPeopleConnection {
   for example.
   """
   totalCount: Int
+  
   """
   A list of all of the objects returned in the connection. This is a convenience
   field provided for quickly exploring the API; rather than querying for
@@ -1078,6 +1200,7 @@ type SpeciesPeopleEdge {
   The item at the end of the edge
   """
   node: Person
+  
   """
   A cursor for use in pagination
   """
@@ -1092,10 +1215,12 @@ type SpeciesFilmsConnection {
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   A list of edges.
   """
   edges: [SpeciesFilmsEdge]
+  
   """
   A count of the total number of objects in this connection, ignoring pagination.
   This allows a client to fetch the first five objects by passing "5" as the
@@ -1103,6 +1228,7 @@ type SpeciesFilmsConnection {
   for example.
   """
   totalCount: Int
+  
   """
   A list of all of the objects returned in the connection. This is a convenience
   field provided for quickly exploring the API; rather than querying for
@@ -1122,6 +1248,7 @@ type SpeciesFilmsEdge {
   The item at the end of the edge
   """
   node: Film
+  
   """
   A cursor for use in pagination
   """
@@ -1136,10 +1263,12 @@ type FilmStarshipsConnection {
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   A list of edges.
   """
   edges: [FilmStarshipsEdge]
+  
   """
   A count of the total number of objects in this connection, ignoring pagination.
   This allows a client to fetch the first five objects by passing "5" as the
@@ -1147,6 +1276,7 @@ type FilmStarshipsConnection {
   for example.
   """
   totalCount: Int
+  
   """
   A list of all of the objects returned in the connection. This is a convenience
   field provided for quickly exploring the API; rather than querying for
@@ -1166,6 +1296,7 @@ type FilmStarshipsEdge {
   The item at the end of the edge
   """
   node: Starship
+  
   """
   A cursor for use in pagination
   """
@@ -1180,10 +1311,12 @@ type FilmVehiclesConnection {
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   A list of edges.
   """
   edges: [FilmVehiclesEdge]
+  
   """
   A count of the total number of objects in this connection, ignoring pagination.
   This allows a client to fetch the first five objects by passing "5" as the
@@ -1191,6 +1324,7 @@ type FilmVehiclesConnection {
   for example.
   """
   totalCount: Int
+  
   """
   A list of all of the objects returned in the connection. This is a convenience
   field provided for quickly exploring the API; rather than querying for
@@ -1210,6 +1344,7 @@ type FilmVehiclesEdge {
   The item at the end of the edge
   """
   node: Vehicle
+  
   """
   A cursor for use in pagination
   """
@@ -1224,10 +1359,12 @@ type FilmCharactersConnection {
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   A list of edges.
   """
   edges: [FilmCharactersEdge]
+  
   """
   A count of the total number of objects in this connection, ignoring pagination.
   This allows a client to fetch the first five objects by passing "5" as the
@@ -1235,6 +1372,7 @@ type FilmCharactersConnection {
   for example.
   """
   totalCount: Int
+  
   """
   A list of all of the objects returned in the connection. This is a convenience
   field provided for quickly exploring the API; rather than querying for
@@ -1254,6 +1392,7 @@ type FilmCharactersEdge {
   The item at the end of the edge
   """
   node: Person
+  
   """
   A cursor for use in pagination
   """
@@ -1268,10 +1407,12 @@ type FilmPlanetsConnection {
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   A list of edges.
   """
   edges: [FilmPlanetsEdge]
+  
   """
   A count of the total number of objects in this connection, ignoring pagination.
   This allows a client to fetch the first five objects by passing "5" as the
@@ -1279,6 +1420,7 @@ type FilmPlanetsConnection {
   for example.
   """
   totalCount: Int
+  
   """
   A list of all of the objects returned in the connection. This is a convenience
   field provided for quickly exploring the API; rather than querying for
@@ -1298,6 +1440,7 @@ type FilmPlanetsEdge {
   The item at the end of the edge
   """
   node: Planet
+  
   """
   A cursor for use in pagination
   """
@@ -1312,10 +1455,12 @@ type PeopleConnection {
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   A list of edges.
   """
   edges: [PeopleEdge]
+  
   """
   A count of the total number of objects in this connection, ignoring pagination.
   This allows a client to fetch the first five objects by passing "5" as the
@@ -1323,6 +1468,7 @@ type PeopleConnection {
   for example.
   """
   totalCount: Int
+  
   """
   A list of all of the objects returned in the connection. This is a convenience
   field provided for quickly exploring the API; rather than querying for
@@ -1342,6 +1488,7 @@ type PeopleEdge {
   The item at the end of the edge
   """
   node: Person
+  
   """
   A cursor for use in pagination
   """
@@ -1356,10 +1503,12 @@ type PlanetsConnection {
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   A list of edges.
   """
   edges: [PlanetsEdge]
+  
   """
   A count of the total number of objects in this connection, ignoring pagination.
   This allows a client to fetch the first five objects by passing "5" as the
@@ -1367,6 +1516,7 @@ type PlanetsConnection {
   for example.
   """
   totalCount: Int
+  
   """
   A list of all of the objects returned in the connection. This is a convenience
   field provided for quickly exploring the API; rather than querying for
@@ -1386,6 +1536,7 @@ type PlanetsEdge {
   The item at the end of the edge
   """
   node: Planet
+  
   """
   A cursor for use in pagination
   """
@@ -1400,10 +1551,12 @@ type SpeciesConnection {
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   A list of edges.
   """
   edges: [SpeciesEdge]
+  
   """
   A count of the total number of objects in this connection, ignoring pagination.
   This allows a client to fetch the first five objects by passing "5" as the
@@ -1411,6 +1564,7 @@ type SpeciesConnection {
   for example.
   """
   totalCount: Int
+  
   """
   A list of all of the objects returned in the connection. This is a convenience
   field provided for quickly exploring the API; rather than querying for
@@ -1430,6 +1584,7 @@ type SpeciesEdge {
   The item at the end of the edge
   """
   node: Species
+  
   """
   A cursor for use in pagination
   """
@@ -1444,10 +1599,12 @@ type StarshipsConnection {
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   A list of edges.
   """
   edges: [StarshipsEdge]
+  
   """
   A count of the total number of objects in this connection, ignoring pagination.
   This allows a client to fetch the first five objects by passing "5" as the
@@ -1455,6 +1612,7 @@ type StarshipsConnection {
   for example.
   """
   totalCount: Int
+  
   """
   A list of all of the objects returned in the connection. This is a convenience
   field provided for quickly exploring the API; rather than querying for
@@ -1474,6 +1632,7 @@ type StarshipsEdge {
   The item at the end of the edge
   """
   node: Starship
+  
   """
   A cursor for use in pagination
   """
@@ -1488,10 +1647,12 @@ type VehiclesConnection {
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  
   """
   A list of edges.
   """
   edges: [VehiclesEdge]
+  
   """
   A count of the total number of objects in this connection, ignoring pagination.
   This allows a client to fetch the first five objects by passing "5" as the
@@ -1499,6 +1660,7 @@ type VehiclesConnection {
   for example.
   """
   totalCount: Int
+  
   """
   A list of all of the objects returned in the connection. This is a convenience
   field provided for quickly exploring the API; rather than querying for
@@ -1518,6 +1680,7 @@ type VehiclesEdge {
   The item at the end of the edge
   """
   node: Vehicle
+  
   """
   A cursor for use in pagination
   """

--- a/cynic-parser/tests/snapshots/actual_schemas__starwars__snapshot.snap
+++ b/cynic-parser/tests/snapshots/actual_schemas__starwars__snapshot.snap
@@ -49,7 +49,7 @@ type Root {
     last: Int
   ): VehiclesConnection
   vehicle(id: ID, vehicleID: ID): Vehicle
-  
+
   """
   Fetches an object given its ID
   """
@@ -69,12 +69,12 @@ type FilmsConnection {
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   A list of edges.
   """
   edges: [FilmsEdge]
-  
+
   """
   A count of the total number of objects in this connection, ignoring pagination.
   This allows a client to fetch the first five objects by passing "5" as the
@@ -82,7 +82,7 @@ type FilmsConnection {
   for example.
   """
   totalCount: Int
-  
+
   """
   A list of all of the objects returned in the connection. This is a convenience
   field provided for quickly exploring the API; rather than querying for
@@ -102,17 +102,17 @@ type PageInfo {
   When paginating forwards, are there more items?
   """
   hasNextPage: Boolean!
-  
+
   """
   When paginating backwards, are there more items?
   """
   hasPreviousPage: Boolean!
-  
+
   """
   When paginating backwards, the cursor to continue.
   """
   startCursor: String
-  
+
   """
   When paginating forwards, the cursor to continue.
   """
@@ -127,7 +127,7 @@ type FilmsEdge {
   The item at the end of the edge
   """
   node: Film
-  
+
   """
   A cursor for use in pagination
   """
@@ -142,27 +142,27 @@ type Film implements Node {
   The title of this film.
   """
   title: String
-  
+
   """
   The episode number of this film.
   """
   episodeID: Int
-  
+
   """
   The opening paragraphs at the beginning of this film.
   """
   openingCrawl: String
-  
+
   """
   The name of the director of this film.
   """
   director: String
-  
+
   """
   The name(s) of the producer(s) of this film.
   """
   producers: [String]
-  
+
   """
   The ISO 8601 date format of film release at original creator country.
   """
@@ -197,17 +197,17 @@ type Film implements Node {
     before: String
     last: Int
   ): FilmPlanetsConnection
-  
+
   """
   The ISO 8601 date format of the time that this resource was created.
   """
   created: String
-  
+
   """
   The ISO 8601 date format of the time that this resource was edited.
   """
   edited: String
-  
+
   """
   The ID of an object
   """
@@ -232,12 +232,12 @@ type FilmSpeciesConnection {
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   A list of edges.
   """
   edges: [FilmSpeciesEdge]
-  
+
   """
   A count of the total number of objects in this connection, ignoring pagination.
   This allows a client to fetch the first five objects by passing "5" as the
@@ -245,7 +245,7 @@ type FilmSpeciesConnection {
   for example.
   """
   totalCount: Int
-  
+
   """
   A list of all of the objects returned in the connection. This is a convenience
   field provided for quickly exploring the API; rather than querying for
@@ -265,7 +265,7 @@ type FilmSpeciesEdge {
   The item at the end of the edge
   """
   node: Species
-  
+
   """
   A cursor for use in pagination
   """
@@ -280,50 +280,50 @@ type Species implements Node {
   The name of this species.
   """
   name: String
-  
+
   """
   The classification of this species, such as "mammal" or "reptile".
   """
   classification: String
-  
+
   """
   The designation of this species, such as "sentient".
   """
   designation: String
-  
+
   """
   The average height of this species in centimeters.
   """
   averageHeight: Float
-  
+
   """
   The average lifespan of this species in years, null if unknown.
   """
   averageLifespan: Int
-  
+
   """
   Common eye colors for this species, null if this species does not typically
   have eyes.
   """
   eyeColors: [String]
-  
+
   """
   Common hair colors for this species, null if this species does not typically
   have hair.
   """
   hairColors: [String]
-  
+
   """
   Common skin colors for this species, null if this species does not typically
   have skin.
   """
   skinColors: [String]
-  
+
   """
   The language commonly spoken by this species.
   """
   language: String
-  
+
   """
   A planet that this species originates from.
   """
@@ -340,17 +340,17 @@ type Species implements Node {
     before: String
     last: Int
   ): SpeciesFilmsConnection
-  
+
   """
   The ISO 8601 date format of the time that this resource was created.
   """
   created: String
-  
+
   """
   The ISO 8601 date format of the time that this resource was edited.
   """
   edited: String
-  
+
   """
   The ID of an object
   """
@@ -366,45 +366,45 @@ type Planet implements Node {
   The name of this planet.
   """
   name: String
-  
+
   """
   The diameter of this planet in kilometers.
   """
   diameter: Int
-  
+
   """
   The number of standard hours it takes for this planet to complete a single
   rotation on its axis.
   """
   rotationPeriod: Int
-  
+
   """
   The number of standard days it takes for this planet to complete a single orbit
   of its local star.
   """
   orbitalPeriod: Int
-  
+
   """
   A number denoting the gravity of this planet, where "1" is normal or 1 standard
   G. "2" is twice or 2 standard Gs. "0.5" is half or 0.5 standard Gs.
   """
   gravity: String
-  
+
   """
   The average population of sentient beings inhabiting this planet.
   """
   population: Float
-  
+
   """
   The climates of this planet.
   """
   climates: [String]
-  
+
   """
   The terrains of this planet.
   """
   terrains: [String]
-  
+
   """
   The percentage of the planet surface that is naturally occurring water or bodies
   of water.
@@ -422,17 +422,17 @@ type Planet implements Node {
     before: String
     last: Int
   ): PlanetFilmsConnection
-  
+
   """
   The ISO 8601 date format of the time that this resource was created.
   """
   created: String
-  
+
   """
   The ISO 8601 date format of the time that this resource was edited.
   """
   edited: String
-  
+
   """
   The ID of an object
   """
@@ -447,12 +447,12 @@ type PlanetResidentsConnection {
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   A list of edges.
   """
   edges: [PlanetResidentsEdge]
-  
+
   """
   A count of the total number of objects in this connection, ignoring pagination.
   This allows a client to fetch the first five objects by passing "5" as the
@@ -460,7 +460,7 @@ type PlanetResidentsConnection {
   for example.
   """
   totalCount: Int
-  
+
   """
   A list of all of the objects returned in the connection. This is a convenience
   field provided for quickly exploring the API; rather than querying for
@@ -480,7 +480,7 @@ type PlanetResidentsEdge {
   The item at the end of the edge
   """
   node: Person
-  
+
   """
   A cursor for use in pagination
   """
@@ -495,47 +495,47 @@ type Person implements Node {
   The name of this person.
   """
   name: String
-  
+
   """
   The birth year of the person, using the in-universe standard of BBY or ABY -
   Before the Battle of Yavin or After the Battle of Yavin. The Battle of Yavin is
   a battle that occurs at the end of Star Wars episode IV: A New Hope.
   """
   birthYear: String
-  
+
   """
   The eye color of this person. Will be "unknown" if not known or "n/a" if the
   person does not have an eye.
   """
   eyeColor: String
-  
+
   """
   The gender of this person. Either "Male", "Female" or "unknown",
   "n/a" if the person does not have a gender.
   """
   gender: String
-  
+
   """
   The hair color of this person. Will be "unknown" if not known or "n/a" if the
   person does not have hair.
   """
   hairColor: String
-  
+
   """
   The height of the person in centimeters.
   """
   height: Int
-  
+
   """
   The mass of the person in kilograms.
   """
   mass: Float
-  
+
   """
   The skin color of this person.
   """
   skinColor: String
-  
+
   """
   A planet that this person was born on or inhabits.
   """
@@ -546,7 +546,7 @@ type Person implements Node {
     before: String
     last: Int
   ): PersonFilmsConnection
-  
+
   """
   The species that this person belongs to, or null if unknown.
   """
@@ -563,17 +563,17 @@ type Person implements Node {
     before: String
     last: Int
   ): PersonVehiclesConnection
-  
+
   """
   The ISO 8601 date format of the time that this resource was created.
   """
   created: String
-  
+
   """
   The ISO 8601 date format of the time that this resource was edited.
   """
   edited: String
-  
+
   """
   The ID of an object
   """
@@ -588,12 +588,12 @@ type PersonFilmsConnection {
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   A list of edges.
   """
   edges: [PersonFilmsEdge]
-  
+
   """
   A count of the total number of objects in this connection, ignoring pagination.
   This allows a client to fetch the first five objects by passing "5" as the
@@ -601,7 +601,7 @@ type PersonFilmsConnection {
   for example.
   """
   totalCount: Int
-  
+
   """
   A list of all of the objects returned in the connection. This is a convenience
   field provided for quickly exploring the API; rather than querying for
@@ -621,7 +621,7 @@ type PersonFilmsEdge {
   The item at the end of the edge
   """
   node: Film
-  
+
   """
   A cursor for use in pagination
   """
@@ -636,12 +636,12 @@ type PersonStarshipsConnection {
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   A list of edges.
   """
   edges: [PersonStarshipsEdge]
-  
+
   """
   A count of the total number of objects in this connection, ignoring pagination.
   This allows a client to fetch the first five objects by passing "5" as the
@@ -649,7 +649,7 @@ type PersonStarshipsConnection {
   for example.
   """
   totalCount: Int
-  
+
   """
   A list of all of the objects returned in the connection. This is a convenience
   field provided for quickly exploring the API; rather than querying for
@@ -669,7 +669,7 @@ type PersonStarshipsEdge {
   The item at the end of the edge
   """
   node: Starship
-  
+
   """
   A cursor for use in pagination
   """
@@ -684,55 +684,55 @@ type Starship implements Node {
   The name of this starship. The common name, such as "Death Star".
   """
   name: String
-  
+
   """
   The model or official name of this starship. Such as "T-65 X-wing" or "DS-1
   Orbital Battle Station".
   """
   model: String
-  
+
   """
   The class of this starship, such as "Starfighter" or "Deep Space Mobile
   Battlestation"
   """
   starshipClass: String
-  
+
   """
   The manufacturers of this starship.
   """
   manufacturers: [String]
-  
+
   """
   The cost of this starship new, in galactic credits.
   """
   costInCredits: Float
-  
+
   """
   The length of this starship in meters.
   """
   length: Float
-  
+
   """
   The number of personnel needed to run or pilot this starship.
   """
   crew: String
-  
+
   """
   The number of non-essential people this starship can transport.
   """
   passengers: String
-  
+
   """
   The maximum speed of this starship in atmosphere. null if this starship is
   incapable of atmosphering flight.
   """
   maxAtmospheringSpeed: Int
-  
+
   """
   The class of this starships hyperdrive.
   """
   hyperdriveRating: Float
-  
+
   """
   The Maximum number of Megalights this starship can travel in a standard hour.
   A "Megalight" is a standard unit of distance and has never been defined before
@@ -741,12 +741,12 @@ type Starship implements Node {
   distance between our Sun (Sol) and Earth.
   """
   MGLT: Int
-  
+
   """
   The maximum number of kilograms that this starship can transport.
   """
   cargoCapacity: Float
-  
+
   """
   The maximum length of time that this starship can provide consumables for its
   entire crew without having to resupply.
@@ -764,17 +764,17 @@ type Starship implements Node {
     before: String
     last: Int
   ): StarshipFilmsConnection
-  
+
   """
   The ISO 8601 date format of the time that this resource was created.
   """
   created: String
-  
+
   """
   The ISO 8601 date format of the time that this resource was edited.
   """
   edited: String
-  
+
   """
   The ID of an object
   """
@@ -789,12 +789,12 @@ type StarshipPilotsConnection {
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   A list of edges.
   """
   edges: [StarshipPilotsEdge]
-  
+
   """
   A count of the total number of objects in this connection, ignoring pagination.
   This allows a client to fetch the first five objects by passing "5" as the
@@ -802,7 +802,7 @@ type StarshipPilotsConnection {
   for example.
   """
   totalCount: Int
-  
+
   """
   A list of all of the objects returned in the connection. This is a convenience
   field provided for quickly exploring the API; rather than querying for
@@ -822,7 +822,7 @@ type StarshipPilotsEdge {
   The item at the end of the edge
   """
   node: Person
-  
+
   """
   A cursor for use in pagination
   """
@@ -837,12 +837,12 @@ type StarshipFilmsConnection {
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   A list of edges.
   """
   edges: [StarshipFilmsEdge]
-  
+
   """
   A count of the total number of objects in this connection, ignoring pagination.
   This allows a client to fetch the first five objects by passing "5" as the
@@ -850,7 +850,7 @@ type StarshipFilmsConnection {
   for example.
   """
   totalCount: Int
-  
+
   """
   A list of all of the objects returned in the connection. This is a convenience
   field provided for quickly exploring the API; rather than querying for
@@ -870,7 +870,7 @@ type StarshipFilmsEdge {
   The item at the end of the edge
   """
   node: Film
-  
+
   """
   A cursor for use in pagination
   """
@@ -885,12 +885,12 @@ type PersonVehiclesConnection {
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   A list of edges.
   """
   edges: [PersonVehiclesEdge]
-  
+
   """
   A count of the total number of objects in this connection, ignoring pagination.
   This allows a client to fetch the first five objects by passing "5" as the
@@ -898,7 +898,7 @@ type PersonVehiclesConnection {
   for example.
   """
   totalCount: Int
-  
+
   """
   A list of all of the objects returned in the connection. This is a convenience
   field provided for quickly exploring the API; rather than querying for
@@ -918,7 +918,7 @@ type PersonVehiclesEdge {
   The item at the end of the edge
   """
   node: Vehicle
-  
+
   """
   A cursor for use in pagination
   """
@@ -934,53 +934,53 @@ type Vehicle implements Node {
   bike".
   """
   name: String
-  
+
   """
   The model or official name of this vehicle. Such as "All-Terrain Attack
   Transport".
   """
   model: String
-  
+
   """
   The class of this vehicle, such as "Wheeled" or "Repulsorcraft".
   """
   vehicleClass: String
-  
+
   """
   The manufacturers of this vehicle.
   """
   manufacturers: [String]
-  
+
   """
   The cost of this vehicle new, in Galactic Credits.
   """
   costInCredits: Float
-  
+
   """
   The length of this vehicle in meters.
   """
   length: Float
-  
+
   """
   The number of personnel needed to run or pilot this vehicle.
   """
   crew: String
-  
+
   """
   The number of non-essential people this vehicle can transport.
   """
   passengers: String
-  
+
   """
   The maximum speed of this vehicle in atmosphere.
   """
   maxAtmospheringSpeed: Int
-  
+
   """
   The maximum number of kilograms that this vehicle can transport.
   """
   cargoCapacity: Float
-  
+
   """
   The maximum length of time that this vehicle can provide consumables for its
   entire crew without having to resupply.
@@ -998,17 +998,17 @@ type Vehicle implements Node {
     before: String
     last: Int
   ): VehicleFilmsConnection
-  
+
   """
   The ISO 8601 date format of the time that this resource was created.
   """
   created: String
-  
+
   """
   The ISO 8601 date format of the time that this resource was edited.
   """
   edited: String
-  
+
   """
   The ID of an object
   """
@@ -1023,12 +1023,12 @@ type VehiclePilotsConnection {
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   A list of edges.
   """
   edges: [VehiclePilotsEdge]
-  
+
   """
   A count of the total number of objects in this connection, ignoring pagination.
   This allows a client to fetch the first five objects by passing "5" as the
@@ -1036,7 +1036,7 @@ type VehiclePilotsConnection {
   for example.
   """
   totalCount: Int
-  
+
   """
   A list of all of the objects returned in the connection. This is a convenience
   field provided for quickly exploring the API; rather than querying for
@@ -1056,7 +1056,7 @@ type VehiclePilotsEdge {
   The item at the end of the edge
   """
   node: Person
-  
+
   """
   A cursor for use in pagination
   """
@@ -1071,12 +1071,12 @@ type VehicleFilmsConnection {
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   A list of edges.
   """
   edges: [VehicleFilmsEdge]
-  
+
   """
   A count of the total number of objects in this connection, ignoring pagination.
   This allows a client to fetch the first five objects by passing "5" as the
@@ -1084,7 +1084,7 @@ type VehicleFilmsConnection {
   for example.
   """
   totalCount: Int
-  
+
   """
   A list of all of the objects returned in the connection. This is a convenience
   field provided for quickly exploring the API; rather than querying for
@@ -1104,7 +1104,7 @@ type VehicleFilmsEdge {
   The item at the end of the edge
   """
   node: Film
-  
+
   """
   A cursor for use in pagination
   """
@@ -1119,12 +1119,12 @@ type PlanetFilmsConnection {
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   A list of edges.
   """
   edges: [PlanetFilmsEdge]
-  
+
   """
   A count of the total number of objects in this connection, ignoring pagination.
   This allows a client to fetch the first five objects by passing "5" as the
@@ -1132,7 +1132,7 @@ type PlanetFilmsConnection {
   for example.
   """
   totalCount: Int
-  
+
   """
   A list of all of the objects returned in the connection. This is a convenience
   field provided for quickly exploring the API; rather than querying for
@@ -1152,7 +1152,7 @@ type PlanetFilmsEdge {
   The item at the end of the edge
   """
   node: Film
-  
+
   """
   A cursor for use in pagination
   """
@@ -1167,12 +1167,12 @@ type SpeciesPeopleConnection {
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   A list of edges.
   """
   edges: [SpeciesPeopleEdge]
-  
+
   """
   A count of the total number of objects in this connection, ignoring pagination.
   This allows a client to fetch the first five objects by passing "5" as the
@@ -1180,7 +1180,7 @@ type SpeciesPeopleConnection {
   for example.
   """
   totalCount: Int
-  
+
   """
   A list of all of the objects returned in the connection. This is a convenience
   field provided for quickly exploring the API; rather than querying for
@@ -1200,7 +1200,7 @@ type SpeciesPeopleEdge {
   The item at the end of the edge
   """
   node: Person
-  
+
   """
   A cursor for use in pagination
   """
@@ -1215,12 +1215,12 @@ type SpeciesFilmsConnection {
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   A list of edges.
   """
   edges: [SpeciesFilmsEdge]
-  
+
   """
   A count of the total number of objects in this connection, ignoring pagination.
   This allows a client to fetch the first five objects by passing "5" as the
@@ -1228,7 +1228,7 @@ type SpeciesFilmsConnection {
   for example.
   """
   totalCount: Int
-  
+
   """
   A list of all of the objects returned in the connection. This is a convenience
   field provided for quickly exploring the API; rather than querying for
@@ -1248,7 +1248,7 @@ type SpeciesFilmsEdge {
   The item at the end of the edge
   """
   node: Film
-  
+
   """
   A cursor for use in pagination
   """
@@ -1263,12 +1263,12 @@ type FilmStarshipsConnection {
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   A list of edges.
   """
   edges: [FilmStarshipsEdge]
-  
+
   """
   A count of the total number of objects in this connection, ignoring pagination.
   This allows a client to fetch the first five objects by passing "5" as the
@@ -1276,7 +1276,7 @@ type FilmStarshipsConnection {
   for example.
   """
   totalCount: Int
-  
+
   """
   A list of all of the objects returned in the connection. This is a convenience
   field provided for quickly exploring the API; rather than querying for
@@ -1296,7 +1296,7 @@ type FilmStarshipsEdge {
   The item at the end of the edge
   """
   node: Starship
-  
+
   """
   A cursor for use in pagination
   """
@@ -1311,12 +1311,12 @@ type FilmVehiclesConnection {
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   A list of edges.
   """
   edges: [FilmVehiclesEdge]
-  
+
   """
   A count of the total number of objects in this connection, ignoring pagination.
   This allows a client to fetch the first five objects by passing "5" as the
@@ -1324,7 +1324,7 @@ type FilmVehiclesConnection {
   for example.
   """
   totalCount: Int
-  
+
   """
   A list of all of the objects returned in the connection. This is a convenience
   field provided for quickly exploring the API; rather than querying for
@@ -1344,7 +1344,7 @@ type FilmVehiclesEdge {
   The item at the end of the edge
   """
   node: Vehicle
-  
+
   """
   A cursor for use in pagination
   """
@@ -1359,12 +1359,12 @@ type FilmCharactersConnection {
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   A list of edges.
   """
   edges: [FilmCharactersEdge]
-  
+
   """
   A count of the total number of objects in this connection, ignoring pagination.
   This allows a client to fetch the first five objects by passing "5" as the
@@ -1372,7 +1372,7 @@ type FilmCharactersConnection {
   for example.
   """
   totalCount: Int
-  
+
   """
   A list of all of the objects returned in the connection. This is a convenience
   field provided for quickly exploring the API; rather than querying for
@@ -1392,7 +1392,7 @@ type FilmCharactersEdge {
   The item at the end of the edge
   """
   node: Person
-  
+
   """
   A cursor for use in pagination
   """
@@ -1407,12 +1407,12 @@ type FilmPlanetsConnection {
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   A list of edges.
   """
   edges: [FilmPlanetsEdge]
-  
+
   """
   A count of the total number of objects in this connection, ignoring pagination.
   This allows a client to fetch the first five objects by passing "5" as the
@@ -1420,7 +1420,7 @@ type FilmPlanetsConnection {
   for example.
   """
   totalCount: Int
-  
+
   """
   A list of all of the objects returned in the connection. This is a convenience
   field provided for quickly exploring the API; rather than querying for
@@ -1440,7 +1440,7 @@ type FilmPlanetsEdge {
   The item at the end of the edge
   """
   node: Planet
-  
+
   """
   A cursor for use in pagination
   """
@@ -1455,12 +1455,12 @@ type PeopleConnection {
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   A list of edges.
   """
   edges: [PeopleEdge]
-  
+
   """
   A count of the total number of objects in this connection, ignoring pagination.
   This allows a client to fetch the first five objects by passing "5" as the
@@ -1468,7 +1468,7 @@ type PeopleConnection {
   for example.
   """
   totalCount: Int
-  
+
   """
   A list of all of the objects returned in the connection. This is a convenience
   field provided for quickly exploring the API; rather than querying for
@@ -1488,7 +1488,7 @@ type PeopleEdge {
   The item at the end of the edge
   """
   node: Person
-  
+
   """
   A cursor for use in pagination
   """
@@ -1503,12 +1503,12 @@ type PlanetsConnection {
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   A list of edges.
   """
   edges: [PlanetsEdge]
-  
+
   """
   A count of the total number of objects in this connection, ignoring pagination.
   This allows a client to fetch the first five objects by passing "5" as the
@@ -1516,7 +1516,7 @@ type PlanetsConnection {
   for example.
   """
   totalCount: Int
-  
+
   """
   A list of all of the objects returned in the connection. This is a convenience
   field provided for quickly exploring the API; rather than querying for
@@ -1536,7 +1536,7 @@ type PlanetsEdge {
   The item at the end of the edge
   """
   node: Planet
-  
+
   """
   A cursor for use in pagination
   """
@@ -1551,12 +1551,12 @@ type SpeciesConnection {
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   A list of edges.
   """
   edges: [SpeciesEdge]
-  
+
   """
   A count of the total number of objects in this connection, ignoring pagination.
   This allows a client to fetch the first five objects by passing "5" as the
@@ -1564,7 +1564,7 @@ type SpeciesConnection {
   for example.
   """
   totalCount: Int
-  
+
   """
   A list of all of the objects returned in the connection. This is a convenience
   field provided for quickly exploring the API; rather than querying for
@@ -1584,7 +1584,7 @@ type SpeciesEdge {
   The item at the end of the edge
   """
   node: Species
-  
+
   """
   A cursor for use in pagination
   """
@@ -1599,12 +1599,12 @@ type StarshipsConnection {
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   A list of edges.
   """
   edges: [StarshipsEdge]
-  
+
   """
   A count of the total number of objects in this connection, ignoring pagination.
   This allows a client to fetch the first five objects by passing "5" as the
@@ -1612,7 +1612,7 @@ type StarshipsConnection {
   for example.
   """
   totalCount: Int
-  
+
   """
   A list of all of the objects returned in the connection. This is a convenience
   field provided for quickly exploring the API; rather than querying for
@@ -1632,7 +1632,7 @@ type StarshipsEdge {
   The item at the end of the edge
   """
   node: Starship
-  
+
   """
   A cursor for use in pagination
   """
@@ -1647,12 +1647,12 @@ type VehiclesConnection {
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-  
+
   """
   A list of edges.
   """
   edges: [VehiclesEdge]
-  
+
   """
   A count of the total number of objects in this connection, ignoring pagination.
   This allows a client to fetch the first five objects by passing "5" as the
@@ -1660,7 +1660,7 @@ type VehiclesConnection {
   for example.
   """
   totalCount: Int
-  
+
   """
   A list of all of the objects returned in the connection. This is a convenience
   field provided for quickly exploring the API; rather than querying for
@@ -1680,7 +1680,7 @@ type VehiclesEdge {
   The item at the end of the edge
   """
   node: Vehicle
-  
+
   """
   A cursor for use in pagination
   """


### PR DESCRIPTION
The cynic-parser pretty printing wasn't putting blank lines before fields & arguments that had docstrings, which made the output quite visually noisy.  This implements logic to do this, resulting in much nicer output for this case.