### PR TITLE
fix: a bunch of formatting inconsistencies

### DIFF
--- a/cynic-parser/src/printing/type_system.rs
+++ b/cynic-parser/src/printing/type_system.rs
@@ -330,19 +330,25 @@ impl<'a> Pretty<'a, Allocator<'a>> for NodeDisplay<UnionDefinition<'a>> {
 
         if members.peek().is_some() {
             let members = allocator
-                .intersperse(members, allocator.line().append(allocator.text("| ")))
-                .group();
-
-            let members = members.clone().nest(2).flat_alt(members);
+                .line()
+                .append(
+                    allocator
+                        .space()
+                        .append(allocator.space())
+                        .flat_alt(allocator.nil()),
+                )
+                .append(
+                    allocator.intersperse(members, allocator.line().append(allocator.text("| "))),
+                )
+                .nest(2);
 
             builder = builder
                 .append(allocator.space())
                 .append(allocator.text("="))
-                .append(allocator.space())
                 .append(members)
         }
 
-        builder
+        builder.group()
     }
 }
 

--- a/cynic-parser/src/printing/type_system.rs
+++ b/cynic-parser/src/printing/type_system.rs
@@ -416,9 +416,13 @@ impl<'a> Pretty<'a, Allocator<'a>> for NodeDisplay<EnumValueDefinition<'a>> {
 
         let mut directives = self.0.directives().peekable();
         if directives.peek().is_some() {
-            builder = builder
-                .append(allocator.space())
-                .append(allocator.intersperse(directives.map(NodeDisplay), allocator.softline()));
+            let directives_pretty = allocator
+                .line()
+                .append(allocator.intersperse(directives.map(NodeDisplay), allocator.line()))
+                .nest(2)
+                .group();
+
+            builder = builder.append(directives_pretty);
         }
 
         builder

--- a/cynic-parser/src/printing/type_system.rs
+++ b/cynic-parser/src/printing/type_system.rs
@@ -307,12 +307,6 @@ impl<'a> Pretty<'a, Allocator<'a>> for NodeDisplay<UnionDefinition<'a>> {
     fn pretty(self, allocator: &'a Allocator<'a>) -> pretty::DocBuilder<'a, Allocator<'a>, ()> {
         let mut builder = allocator.nil();
 
-        if let Some(description) = self.0.description() {
-            builder = builder
-                .append(NodeDisplay(description))
-                .append(allocator.hardline());
-        }
-
         builder = builder.append(allocator.text(format!("union {}", self.0.name())));
 
         let mut directives = self.0.directives().peekable();
@@ -348,7 +342,17 @@ impl<'a> Pretty<'a, Allocator<'a>> for NodeDisplay<UnionDefinition<'a>> {
                 .append(members)
         }
 
-        builder.group()
+        builder = builder.group();
+
+        if let Some(description) = self.0.description() {
+            builder = NodeDisplay(description)
+                .pretty(allocator)
+                .append(allocator.hardline())
+                .append(builder)
+                .group();
+        }
+
+        builder
     }
 }
 

--- a/cynic-parser/src/printing/type_system.rs
+++ b/cynic-parser/src/printing/type_system.rs
@@ -628,19 +628,25 @@ impl<'a> Pretty<'a, Allocator<'a>> for NodeDisplay<Value<'a>> {
                 allocator.nil().braces()
             }
             crate::type_system::Value::Object(items) => allocator
-                .intersperse(
-                    items.into_iter().map(|(name, value)| {
+                .line()
+                .append(
+                    allocator.intersperse(
+                        items.into_iter().map(|(name, value)| {
+                            allocator
+                                .text(name)
+                                .append(allocator.text(":"))
+                                .append(allocator.space())
+                                .append(NodeDisplay(value))
+                        }),
                         allocator
-                            .text(name)
-                            .append(allocator.text(":"))
-                            .append(allocator.space())
-                            .append(NodeDisplay(value))
-                    }),
-                    allocator.text(",").append(allocator.space()),
+                            .line_()
+                            .append(allocator.nil().flat_alt(allocator.text(", "))),
+                    ),
                 )
-                .group()
-                .enclose(allocator.softline(), allocator.softline())
-                .braces(),
+                .nest(2)
+                .append(allocator.line())
+                .braces()
+                .group(),
         }
     }
 }

--- a/cynic-parser/tests/sdl.rs
+++ b/cynic-parser/tests/sdl.rs
@@ -1,6 +1,11 @@
 use similar_asserts::assert_eq;
 
 #[test]
+fn test_argument_default_value_formatting() {
+    roundtrip_test("tests/sdl/argument_default_value_formatting.graphql");
+}
+
+#[test]
 fn test_enum() {
     roundtrip_test("tests/sdl/enum.graphql");
 }
@@ -162,7 +167,9 @@ fn schema_definition_directives_only() {
 
 fn roundtrip_test(filename: &str) {
     let data = std::fs::read_to_string(filename).unwrap();
-    let ast = cynic_parser::parse_type_system_document(&data).unwrap();
+    let ast = cynic_parser::parse_type_system_document(&data)
+        .map_err(|error| error.to_report(&data))
+        .unwrap();
 
     let output = ast.to_sdl();
 

--- a/cynic-parser/tests/sdl.rs
+++ b/cynic-parser/tests/sdl.rs
@@ -136,11 +136,6 @@ fn simple_object() {
 }
 
 #[test]
-fn union() {
-    roundtrip_test("tests/sdl/union.graphql");
-}
-
-#[test]
 fn string_escaping() {
     insta::assert_snapshot!(double_roundtrip_test("tests/sdl/string_escaping.graphql"))
 }
@@ -148,6 +143,16 @@ fn string_escaping() {
 #[test]
 fn union_extension() {
     roundtrip_test("tests/sdl/union_extension.graphql");
+}
+
+#[test]
+fn union_formatting() {
+    roundtrip_test("tests/sdl/union_formatting.graphql");
+}
+
+#[test]
+fn union() {
+    roundtrip_test("tests/sdl/union.graphql");
 }
 
 #[test]

--- a/cynic-parser/tests/sdl/argument_default_value_formatting.graphql
+++ b/cynic-parser/tests/sdl/argument_default_value_formatting.graphql
@@ -1,0 +1,9 @@
+type Whatever {
+  whatever(
+    orderBy: EnterpriseServerInstallationOrder = {
+      field: HOST_NAME
+      direction: ASC
+    }
+  ): String
+  whatever(orderBy: Smaller = { field: HOST_NAME, direction: ASC }): String
+}

--- a/cynic-parser/tests/sdl/enum.graphql
+++ b/cynic-parser/tests/sdl/enum.graphql
@@ -2,3 +2,11 @@ enum Site {
   DESKTOP
   MOBILE
 }
+
+enum Whatever {
+  OldThing
+    @deprecated(
+      reason: "A really long string: This value will be removed from this enum as this type will be migrated to not be used. Removal on 2022-11-21 UTC."
+    )
+  NewThing
+}

--- a/cynic-parser/tests/sdl/union_formatting.graphql
+++ b/cynic-parser/tests/sdl/union_formatting.graphql
@@ -6,3 +6,8 @@ union SomeUnion =
   | ThingD
   | Whatever
   | Blah
+
+"""
+Thing
+"""
+union SomeOtherUnion = Whatever | Thing

--- a/cynic-parser/tests/sdl/union_formatting.graphql
+++ b/cynic-parser/tests/sdl/union_formatting.graphql
@@ -1,0 +1,8 @@
+union SomeUnion =
+    ThingA
+  | ThingB
+  | ThingC
+  | ALongerThing
+  | ThingD
+  | Whatever
+  | Blah

--- a/cynic-parser/tests/snapshots/actual_schemas__github__snapshot.snap
+++ b/cynic-parser/tests/snapshots/actual_schemas__github__snapshot.snap
@@ -8477,7 +8477,8 @@ type CreatedIssueContributionEdge {
 """
 Represents either a issue the viewer can access or a restricted contribution.
 """
-union CreatedIssueOrRestrictedContribution = CreatedIssueContribution
+union CreatedIssueOrRestrictedContribution =
+    CreatedIssueContribution
   | RestrictedContribution
 
 """
@@ -8560,7 +8561,8 @@ type CreatedPullRequestContributionEdge {
 """
 Represents either a pull request the viewer can access or a restricted contribution.
 """
-union CreatedPullRequestOrRestrictedContribution = CreatedPullRequestContribution
+union CreatedPullRequestOrRestrictedContribution =
+    CreatedPullRequestContribution
   | RestrictedContribution
 
 """
@@ -8730,7 +8732,8 @@ type CreatedRepositoryContributionEdge {
 """
 Represents either a repository the viewer can access or a restricted contribution.
 """
-union CreatedRepositoryOrRestrictedContribution = CreatedRepositoryContribution
+union CreatedRepositoryOrRestrictedContribution =
+    CreatedRepositoryContribution
   | RestrictedContribution
 
 """
@@ -11714,7 +11717,9 @@ type DiscussionPoll implements Node {
     """
     How to order the options for the discussion poll.
     """
-    orderBy: DiscussionPollOptionOrder = { field: AUTHORED_ORDER, direction: ASC
+    orderBy: DiscussionPollOptionOrder = {
+      field: AUTHORED_ORDER
+      direction: ASC
     }
   ): DiscussionPollOptionConnection
 
@@ -13479,7 +13484,9 @@ type EnterpriseOwnerInfo {
     Ordering options for Enterprise Server installations returned.
     """
     orderBy: EnterpriseServerInstallationOrder = {
-    field: HOST_NAME, direction: ASC }
+      field: HOST_NAME
+      direction: ASC
+    }
   ): EnterpriseServerInstallationConnection!
 
   """
@@ -13998,7 +14005,9 @@ type EnterpriseOwnerInfo {
     Ordering options for pending enterprise administrator invitations returned from the connection.
     """
     orderBy: EnterpriseAdministratorInvitationOrder = {
-    field: CREATED_AT, direction: DESC }
+      field: CREATED_AT
+      direction: DESC
+    }
 
     """
     The search string to look for.
@@ -14472,7 +14481,9 @@ type EnterpriseServerInstallation implements Node {
     Ordering options for Enterprise Server user accounts uploads returned from the connection.
     """
     orderBy: EnterpriseServerUserAccountsUploadOrder = {
-    field: CREATED_AT, direction: DESC }
+      field: CREATED_AT
+      direction: DESC
+    }
   ): EnterpriseServerUserAccountsUploadConnection!
 }
 
@@ -14633,7 +14644,9 @@ type EnterpriseServerUserAccount implements Node {
     Ordering options for Enterprise Server user account emails returned from the connection.
     """
     orderBy: EnterpriseServerUserAccountEmailOrder = {
-    field: EMAIL, direction: ASC }
+      field: EMAIL
+      direction: ASC
+    }
   ): EnterpriseServerUserAccountEmailConnection!
 
   """
@@ -15012,7 +15025,9 @@ type EnterpriseUserAccount implements Actor & Node {
     Ordering options for installations returned from the connection.
     """
     orderBy: EnterpriseServerInstallationOrder = {
-    field: HOST_NAME, direction: ASC }
+      field: HOST_NAME
+      direction: ASC
+    }
 
     """
     The search string to look for.
@@ -18361,7 +18376,8 @@ type IssueTimelineConnection {
 """
 An item in an issue timeline
 """
-union IssueTimelineItem = AssignedEvent
+union IssueTimelineItem =
+    AssignedEvent
   | ClosedEvent
   | Commit
   | CrossReferencedEvent
@@ -18399,7 +18415,8 @@ type IssueTimelineItemEdge {
 """
 An item in an issue timeline
 """
-union IssueTimelineItems = AddedToProjectEvent
+union IssueTimelineItems =
+    AddedToProjectEvent
   | AssignedEvent
   | ClosedEvent
   | CommentDeletedEvent
@@ -20857,9 +20874,10 @@ enum MergeStateStatus {
   """
   The merge is blocked due to the pull request being a draft.
   """
-  DRAFT @deprecated(
-    reason: "DRAFT state will be removed from this enum and `isDraft` should be used instead Use PullRequest.isDraft instead. Removal on 2021-01-01 UTC."
-  )
+  DRAFT
+    @deprecated(
+      reason: "DRAFT state will be removed from this enum and `isDraft` should be used instead Use PullRequest.isDraft instead. Removal on 2021-01-01 UTC."
+    )
 
   """
   Mergeable with passing commit status and pre-receive hooks.
@@ -26740,7 +26758,8 @@ type OrgRestoreMemberAuditEntry implements AuditEntry & Node & OrganizationAudit
 """
 Types of memberships that can be restored for an Organization member.
 """
-union OrgRestoreMemberAuditEntryMembership = OrgRestoreMemberMembershipOrganizationAuditEntryData
+union OrgRestoreMemberAuditEntryMembership =
+    OrgRestoreMemberMembershipOrganizationAuditEntryData
   | OrgRestoreMemberMembershipRepositoryAuditEntryData
   | OrgRestoreMemberMembershipTeamAuditEntryData
 
@@ -28797,7 +28816,8 @@ type Organization implements Actor & AnnouncementBanner & MemberStatusable & Nod
 """
 An audit entry in an organization audit log.
 """
-union OrganizationAuditEntry = MembersCanDeleteReposClearAuditEntry
+union OrganizationAuditEntry =
+    MembersCanDeleteReposClearAuditEntry
   | MembersCanDeleteReposDisableAuditEntry
   | MembersCanDeleteReposEnableAuditEntry
   | OauthApplicationCreateAuditEntry
@@ -29909,30 +29929,34 @@ enum PackageType {
   """
   A docker image.
   """
-  DOCKER @deprecated(
-    reason: "DOCKER will be removed from this enum as this type will be migrated to only be used by the Packages REST API. Removal on 2021-06-21 UTC."
-  )
+  DOCKER
+    @deprecated(
+      reason: "DOCKER will be removed from this enum as this type will be migrated to only be used by the Packages REST API. Removal on 2021-06-21 UTC."
+    )
 
   """
   A maven package.
   """
-  MAVEN @deprecated(
-    reason: "MAVEN will be removed from this enum as this type will be migrated to only be used by the Packages REST API. Removal on 2023-02-10 UTC."
-  )
+  MAVEN
+    @deprecated(
+      reason: "MAVEN will be removed from this enum as this type will be migrated to only be used by the Packages REST API. Removal on 2023-02-10 UTC."
+    )
 
   """
   An npm package.
   """
-  NPM @deprecated(
-    reason: "NPM will be removed from this enum as this type will be migrated to only be used by the Packages REST API. Removal on 2022-11-21 UTC."
-  )
+  NPM
+    @deprecated(
+      reason: "NPM will be removed from this enum as this type will be migrated to only be used by the Packages REST API. Removal on 2022-11-21 UTC."
+    )
 
   """
   A nuget package.
   """
-  NUGET @deprecated(
-    reason: "NUGET will be removed from this enum as this type will be migrated to only be used by the Packages REST API. Removal on 2022-11-21 UTC."
-  )
+  NUGET
+    @deprecated(
+      reason: "NUGET will be removed from this enum as this type will be migrated to only be used by the Packages REST API. Removal on 2022-11-21 UTC."
+    )
 
   """
   A python package.
@@ -29942,9 +29966,10 @@ enum PackageType {
   """
   A rubygems package.
   """
-  RUBYGEMS @deprecated(
-    reason: "RUBYGEMS will be removed from this enum as this type will be migrated to only be used by the Packages REST API. Removal on 2022-12-28 UTC."
-  )
+  RUBYGEMS
+    @deprecated(
+      reason: "RUBYGEMS will be removed from this enum as this type will be migrated to only be used by the Packages REST API. Removal on 2022-12-28 UTC."
+    )
 }
 
 """
@@ -32172,7 +32197,8 @@ interface ProjectV2FieldCommon {
 """
 Configurations for project fields.
 """
-union ProjectV2FieldConfiguration = ProjectV2Field
+union ProjectV2FieldConfiguration =
+    ProjectV2Field
   | ProjectV2IterationField
   | ProjectV2SingleSelectField
 
@@ -32965,7 +32991,8 @@ type ProjectV2ItemFieldUserValue {
 """
 Project field values
 """
-union ProjectV2ItemFieldValue = ProjectV2ItemFieldDateValue
+union ProjectV2ItemFieldValue =
+    ProjectV2ItemFieldDateValue
   | ProjectV2ItemFieldIterationValue
   | ProjectV2ItemFieldLabelValue
   | ProjectV2ItemFieldMilestoneValue
@@ -36770,7 +36797,8 @@ type PullRequestTimelineConnection {
 """
 An item in a pull request timeline
 """
-union PullRequestTimelineItem = AssignedEvent
+union PullRequestTimelineItem =
+    AssignedEvent
   | BaseRefDeletedEvent
   | BaseRefForcePushedEvent
   | ClosedEvent
@@ -36822,7 +36850,8 @@ type PullRequestTimelineItemEdge {
 """
 An item in a pull request timeline
 """
-union PullRequestTimelineItems = AddedToMergeQueueEvent
+union PullRequestTimelineItems =
+    AddedToMergeQueueEvent
   | AddedToProjectEvent
   | AssignedEvent
   | AutoMergeDisabledEvent
@@ -37758,7 +37787,9 @@ type Query {
     """
     Ordering options for the returned topics.
     """
-    orderBy: SecurityVulnerabilityOrder = { field: UPDATED_AT, direction: DESC
+    orderBy: SecurityVulnerabilityOrder = {
+      field: UPDATED_AT
+      direction: DESC
     }
 
     """
@@ -46669,7 +46700,8 @@ enum RuleEnforcement {
 """
 Types which can be parameters for `RepositoryRule` objects.
 """
-union RuleParameters = BranchNamePatternParameters
+union RuleParameters =
+    BranchNamePatternParameters
   | CommitAuthorEmailPatternParameters
   | CommitMessagePatternParameters
   | CommitterEmailPatternParameters
@@ -46883,7 +46915,8 @@ enum SavedReplyOrderField {
 """
 The results of a search.
 """
-union SearchResultItem = App
+union SearchResultItem =
+    App
   | Discussion
   | Issue
   | MarketplaceListing
@@ -47136,7 +47169,9 @@ type SecurityAdvisory implements Node {
     """
     Ordering options for the returned topics.
     """
-    orderBy: SecurityVulnerabilityOrder = { field: UPDATED_AT, direction: DESC
+    orderBy: SecurityVulnerabilityOrder = {
+      field: UPDATED_AT
+      direction: DESC
     }
 
     """
@@ -49937,7 +49972,9 @@ type SponsorsListing implements Node {
     """
     Ordering options for Sponsors tiers returned from the connection.
     """
-    orderBy: SponsorsTierOrder = { field: MONTHLY_PRICE_IN_CENTS, direction: ASC
+    orderBy: SponsorsTierOrder = {
+      field: MONTHLY_PRICE_IN_CENTS
+      direction: ASC
     }
   ): SponsorsTierConnection
 


### PR DESCRIPTION
#### Why are we making this change?

My goal with the formatting in cynic-parser is to be compatible with prettier.  If a user dumps a schema from cynic-parser, and then runs prettier, that file should be unchanged.  This should reduce format churn and make it easier to use both prettier & cynic-parser at the same time.

But it's not quite there yet.

#### What effects does this change have?

Fixes a few issues I found in the formatting