### PR TITLE
feat: expose ids in cynic-parser

### DIFF
--- a/cynic-parser/ast-generator/src/object.rs
+++ b/cynic-parser/ast-generator/src/object.rs
@@ -60,6 +60,14 @@ pub fn object_output(
         }
     })?;
 
+    let reader_id_impl = format_code(quote! {
+        impl #reader_name<'_> {
+            pub fn id(&self) -> #id_name {
+                self.0.id
+            }
+        }
+    })?;
+
     let id_trait = Ident::new(id_trait, Span::call_site());
 
     let id_trait_impl = format_code(quote! {
@@ -89,6 +97,8 @@ pub fn object_output(
         {reader}
 
         {reader_impl}
+
+        {reader_id_impl}
 
         {reader_debug}
 

--- a/cynic-parser/src/executable/generated/argument.rs
+++ b/cynic-parser/src/executable/generated/argument.rs
@@ -26,6 +26,12 @@ impl<'a> Argument<'a> {
     }
 }
 
+impl Argument<'_> {
+    pub fn id(&self) -> ArgumentId {
+        self.0.id
+    }
+}
+
 impl fmt::Debug for Argument<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Argument")

--- a/cynic-parser/src/executable/generated/directive.rs
+++ b/cynic-parser/src/executable/generated/directive.rs
@@ -26,6 +26,12 @@ impl<'a> Directive<'a> {
     }
 }
 
+impl Directive<'_> {
+    pub fn id(&self) -> DirectiveId {
+        self.0.id
+    }
+}
+
 impl fmt::Debug for Directive<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Directive")

--- a/cynic-parser/src/executable/generated/fragment.rs
+++ b/cynic-parser/src/executable/generated/fragment.rs
@@ -37,6 +37,12 @@ impl<'a> FragmentDefinition<'a> {
     }
 }
 
+impl FragmentDefinition<'_> {
+    pub fn id(&self) -> FragmentDefinitionId {
+        self.0.id
+    }
+}
+
 impl fmt::Debug for FragmentDefinition<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("FragmentDefinition")

--- a/cynic-parser/src/executable/generated/operation.rs
+++ b/cynic-parser/src/executable/generated/operation.rs
@@ -46,6 +46,12 @@ impl<'a> OperationDefinition<'a> {
     }
 }
 
+impl OperationDefinition<'_> {
+    pub fn id(&self) -> OperationDefinitionId {
+        self.0.id
+    }
+}
+
 impl fmt::Debug for OperationDefinition<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("OperationDefinition")

--- a/cynic-parser/src/executable/generated/selections.rs
+++ b/cynic-parser/src/executable/generated/selections.rs
@@ -82,6 +82,12 @@ impl<'a> FieldSelection<'a> {
     }
 }
 
+impl FieldSelection<'_> {
+    pub fn id(&self) -> FieldSelectionId {
+        self.0.id
+    }
+}
+
 impl fmt::Debug for FieldSelection<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("FieldSelection")
@@ -135,6 +141,12 @@ impl<'a> InlineFragment<'a> {
     }
 }
 
+impl InlineFragment<'_> {
+    pub fn id(&self) -> InlineFragmentId {
+        self.0.id
+    }
+}
+
 impl fmt::Debug for InlineFragment<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("InlineFragment")
@@ -175,6 +187,12 @@ impl<'a> FragmentSpread<'a> {
     pub fn directives(&self) -> Iter<'a, Directive<'a>> {
         let document = self.0.document;
         super::Iter::new(document.lookup(self.0.id).directives, document)
+    }
+}
+
+impl FragmentSpread<'_> {
+    pub fn id(&self) -> FragmentSpreadId {
+        self.0.id
     }
 }
 

--- a/cynic-parser/src/executable/generated/variable.rs
+++ b/cynic-parser/src/executable/generated/variable.rs
@@ -41,6 +41,12 @@ impl<'a> VariableDefinition<'a> {
     }
 }
 
+impl VariableDefinition<'_> {
+    pub fn id(&self) -> VariableDefinitionId {
+        self.0.id
+    }
+}
+
 impl fmt::Debug for VariableDefinition<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("VariableDefinition")

--- a/cynic-parser/src/executable/iter.rs
+++ b/cynic-parser/src/executable/iter.rs
@@ -23,6 +23,10 @@ where
     pub(crate) fn new(range: IdRange<T::Id>, document: &'a super::ExecutableDocument) -> Self {
         Iter { range, document }
     }
+
+    pub fn ids(&self) -> IdRange<T::Id> {
+        self.range
+    }
 }
 
 pub trait IdReader {

--- a/cynic-parser/src/type_system/generated/arguments.rs
+++ b/cynic-parser/src/type_system/generated/arguments.rs
@@ -26,6 +26,12 @@ impl<'a> Argument<'a> {
     }
 }
 
+impl Argument<'_> {
+    pub fn id(&self) -> ArgumentId {
+        self.0.id
+    }
+}
+
 impl fmt::Debug for Argument<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Argument")

--- a/cynic-parser/src/type_system/generated/directives.rs
+++ b/cynic-parser/src/type_system/generated/directives.rs
@@ -53,6 +53,12 @@ impl<'a> DirectiveDefinition<'a> {
     }
 }
 
+impl DirectiveDefinition<'_> {
+    pub fn id(&self) -> DirectiveDefinitionId {
+        self.0.id
+    }
+}
+
 impl fmt::Debug for DirectiveDefinition<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("DirectiveDefinition")
@@ -96,6 +102,12 @@ impl<'a> Directive<'a> {
     pub fn arguments(&self) -> Iter<'a, Argument<'a>> {
         let document = self.0.document;
         super::Iter::new(document.lookup(self.0.id).arguments, document)
+    }
+}
+
+impl Directive<'_> {
+    pub fn id(&self) -> DirectiveId {
+        self.0.id
     }
 }
 

--- a/cynic-parser/src/type_system/generated/enums.rs
+++ b/cynic-parser/src/type_system/generated/enums.rs
@@ -45,6 +45,12 @@ impl<'a> EnumDefinition<'a> {
     }
 }
 
+impl EnumDefinition<'_> {
+    pub fn id(&self) -> EnumDefinitionId {
+        self.0.id
+    }
+}
+
 impl fmt::Debug for EnumDefinition<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("EnumDefinition")
@@ -100,6 +106,12 @@ impl<'a> EnumValueDefinition<'a> {
     pub fn span(&self) -> Span {
         let document = self.0.document;
         document.lookup(self.0.id).span
+    }
+}
+
+impl EnumValueDefinition<'_> {
+    pub fn id(&self) -> EnumValueDefinitionId {
+        self.0.id
     }
 }
 

--- a/cynic-parser/src/type_system/generated/fields.rs
+++ b/cynic-parser/src/type_system/generated/fields.rs
@@ -52,6 +52,12 @@ impl<'a> FieldDefinition<'a> {
     }
 }
 
+impl FieldDefinition<'_> {
+    pub fn id(&self) -> FieldDefinitionId {
+        self.0.id
+    }
+}
+
 impl fmt::Debug for FieldDefinition<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("FieldDefinition")

--- a/cynic-parser/src/type_system/generated/input_objects.rs
+++ b/cynic-parser/src/type_system/generated/input_objects.rs
@@ -46,6 +46,12 @@ impl<'a> InputObjectDefinition<'a> {
     }
 }
 
+impl InputObjectDefinition<'_> {
+    pub fn id(&self) -> InputObjectDefinitionId {
+        self.0.id
+    }
+}
+
 impl fmt::Debug for InputObjectDefinition<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("InputObjectDefinition")

--- a/cynic-parser/src/type_system/generated/input_values.rs
+++ b/cynic-parser/src/type_system/generated/input_values.rs
@@ -55,6 +55,12 @@ impl<'a> InputValueDefinition<'a> {
     }
 }
 
+impl InputValueDefinition<'_> {
+    pub fn id(&self) -> InputValueDefinitionId {
+        self.0.id
+    }
+}
+
 impl fmt::Debug for InputValueDefinition<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("InputValueDefinition")

--- a/cynic-parser/src/type_system/generated/interfaces.rs
+++ b/cynic-parser/src/type_system/generated/interfaces.rs
@@ -55,6 +55,12 @@ impl<'a> InterfaceDefinition<'a> {
     }
 }
 
+impl InterfaceDefinition<'_> {
+    pub fn id(&self) -> InterfaceDefinitionId {
+        self.0.id
+    }
+}
+
 impl fmt::Debug for InterfaceDefinition<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("InterfaceDefinition")

--- a/cynic-parser/src/type_system/generated/objects.rs
+++ b/cynic-parser/src/type_system/generated/objects.rs
@@ -55,6 +55,12 @@ impl<'a> ObjectDefinition<'a> {
     }
 }
 
+impl ObjectDefinition<'_> {
+    pub fn id(&self) -> ObjectDefinitionId {
+        self.0.id
+    }
+}
+
 impl fmt::Debug for ObjectDefinition<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("ObjectDefinition")

--- a/cynic-parser/src/type_system/generated/scalars.rs
+++ b/cynic-parser/src/type_system/generated/scalars.rs
@@ -40,6 +40,12 @@ impl<'a> ScalarDefinition<'a> {
     }
 }
 
+impl ScalarDefinition<'_> {
+    pub fn id(&self) -> ScalarDefinitionId {
+        self.0.id
+    }
+}
+
 impl fmt::Debug for ScalarDefinition<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("ScalarDefinition")

--- a/cynic-parser/src/type_system/generated/schemas.rs
+++ b/cynic-parser/src/type_system/generated/schemas.rs
@@ -35,6 +35,12 @@ impl<'a> SchemaDefinition<'a> {
     }
 }
 
+impl SchemaDefinition<'_> {
+    pub fn id(&self) -> SchemaDefinitionId {
+        self.0.id
+    }
+}
+
 impl fmt::Debug for SchemaDefinition<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("SchemaDefinition")
@@ -75,6 +81,12 @@ impl<'a> RootOperationTypeDefinition<'a> {
     pub fn named_type(&self) -> &'a str {
         let document = &self.0.document;
         document.lookup(document.lookup(self.0.id).named_type)
+    }
+}
+
+impl RootOperationTypeDefinition<'_> {
+    pub fn id(&self) -> RootOperationTypeDefinitionId {
+        self.0.id
     }
 }
 

--- a/cynic-parser/src/type_system/generated/unions.rs
+++ b/cynic-parser/src/type_system/generated/unions.rs
@@ -49,6 +49,12 @@ impl<'a> UnionDefinition<'a> {
     }
 }
 
+impl UnionDefinition<'_> {
+    pub fn id(&self) -> UnionDefinitionId {
+        self.0.id
+    }
+}
+
 impl fmt::Debug for UnionDefinition<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("UnionDefinition")

--- a/cynic-parser/src/type_system/iter.rs
+++ b/cynic-parser/src/type_system/iter.rs
@@ -23,6 +23,10 @@ where
     pub(crate) fn new(range: IdRange<T::Id>, document: &'a super::TypeSystemDocument) -> Self {
         Iter { range, document }
     }
+
+    pub fn ids(&self) -> IdRange<T::Id> {
+        self.range
+    }
 }
 
 pub trait IdReader {


### PR DESCRIPTION
#### Why are we making this change?

The readers in cynic-parser all just store an id that indexes into the underlying parsed Document.  I was a bit on the fence about whether to exppose these ids or not.  But I've run into a use case for the executable AST that'd be hard to do without the ids.

#### What effects does this change have?

1. Exposes an `id` function on all of the object readers.
2. Unions are unfortunately a bit more tricky, because they've generally throw away their ID in favour of an enum with readers inside that.  So for this case, I've added an `ids` function to the `Iter` type, which I think covers most of those cases.  Can revisit if it doesn't.
