### PR TITLE
feat: impl Display for executable

### DIFF
--- a/cynic-parser/src/printing.rs
+++ b/cynic-parser/src/printing.rs
@@ -1,2 +1,25 @@
+use std::fmt::Write;
+
+mod display;
+mod indent;
+
 #[cfg(feature = "pretty")]
 mod pretty;
+
+fn escape_string(src: &str) -> String {
+    let mut dest = String::with_capacity(src.len());
+
+    for character in src.chars() {
+        match character {
+            '"' | '\\' | '\n' | '\r' | '\t' => {
+                dest.extend(character.escape_default());
+            }
+            other if other.is_control() => {
+                write!(&mut dest, "\\u{:04}", other as u32).ok();
+            }
+            _ => dest.push(character),
+        }
+    }
+
+    dest
+}

--- a/cynic-parser/src/printing/display.rs
+++ b/cynic-parser/src/printing/display.rs
@@ -1,0 +1,1 @@
+mod executable;

--- a/cynic-parser/src/printing/display/executable.rs
+++ b/cynic-parser/src/printing/display/executable.rs
@@ -1,0 +1,251 @@
+use std::fmt::{self, Write};
+
+use crate::{
+    common::OperationType,
+    executable::*,
+    printing::{escape_string, indent::indented},
+};
+
+impl fmt::Display for ExecutableDocument {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let use_short_form = {
+            let mut operation_iter = self.operations();
+            let first_op = operation_iter.next();
+            match (first_op, operation_iter.next()) {
+                (Some(first_op), None) => {
+                    first_op.name().is_none()
+                        && first_op.operation_type() == OperationType::Query
+                        && first_op.directives().len() == 0
+                        && first_op.variable_definitions().len() == 0
+                }
+                _ => false,
+            }
+        };
+
+        for (i, definition) in self.definitions().enumerate() {
+            if i != 0 {
+                writeln!(f)?;
+            }
+            match definition {
+                ExecutableDefinition::Operation(op) if use_short_form => {
+                    write!(f, "{}", op.selection_set())?;
+                }
+                ExecutableDefinition::Operation(op) => {
+                    write!(f, "{op}")?;
+                }
+                ExecutableDefinition::Fragment(fragment) => {
+                    write!(f, "{fragment}")?;
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl fmt::Display for OperationDefinition<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.operation_type())?;
+        if let Some(name) = self.name() {
+            write!(f, " {name}")?;
+        }
+        writeln!(
+            f,
+            "{}{} {}",
+            self.variable_definitions(),
+            self.directives(),
+            self.selection_set()
+        )
+    }
+}
+
+impl fmt::Display for FragmentDefinition<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(
+            f,
+            "fragment {} on {}{} {}",
+            self.name(),
+            self.type_condition(),
+            self.directives(),
+            self.selection_set()
+        )
+    }
+}
+
+impl fmt::Display for iter::Iter<'_, VariableDefinition<'_>> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.len() != 0 {
+            write!(f, "(")?;
+            for (i, definition) in self.enumerate() {
+                if i != 0 {
+                    write!(f, ", ")?;
+                }
+                write!(f, "{definition}")?;
+            }
+            write!(f, ")")?;
+        }
+        Ok(())
+    }
+}
+
+impl std::fmt::Display for VariableDefinition<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "${}: {}", self.name(), self.ty())?;
+
+        if let Some(default) = self.default_value() {
+            write!(f, " = {}", default)?;
+        }
+
+        write!(f, "{}", self.directives())
+    }
+}
+
+impl std::fmt::Display for iter::Iter<'_, Selection<'_>> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if self.len() != 0 {
+            writeln!(f, "{{")?;
+            for child in *self {
+                writeln!(indented(f, 2), "{}", child)?;
+            }
+            write!(f, "}}")?;
+        }
+        Ok(())
+    }
+}
+
+impl fmt::Display for Selection<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Selection::Field(field) => {
+                write!(f, "{field}")
+            }
+            Selection::InlineFragment(fragment) => {
+                write!(f, "{fragment}")
+            }
+            Selection::FragmentSpread(spread) => {
+                write!(f, "{spread}")
+            }
+        }
+    }
+}
+
+impl fmt::Display for FieldSelection<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if let Some(alias) = self.alias() {
+            write!(f, "{}: ", alias)?;
+        }
+
+        let space = if self.selection_set().len() != 0 {
+            " "
+        } else {
+            ""
+        };
+
+        write!(
+            f,
+            "{}{}{}{space}{}",
+            self.name(),
+            self.arguments(),
+            self.directives(),
+            self.selection_set()
+        )
+    }
+}
+
+impl fmt::Display for InlineFragment<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "...")?;
+
+        if let Some(on_type) = self.type_condition() {
+            write!(f, " on {}", on_type)?;
+        }
+
+        write!(f, "{} {}", self.directives(), self.selection_set())
+    }
+}
+
+impl fmt::Display for FragmentSpread<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "... {}{}", self.fragment_name(), self.directives())
+    }
+}
+
+impl fmt::Display for iter::Iter<'_, Directive<'_>> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for directive in *self {
+            write!(f, " {directive}")?;
+        }
+        Ok(())
+    }
+}
+
+impl fmt::Display for Directive<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "@{}{}", self.name(), self.arguments())
+    }
+}
+
+impl fmt::Display for iter::Iter<'_, Argument<'_>> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.len() != 0 {
+            write!(f, "(")?;
+            for (i, arg) in self.enumerate() {
+                if i != 0 {
+                    write!(f, ", ")?;
+                }
+                write!(f, "{}", arg)?;
+            }
+            write!(f, ")")?;
+        }
+        Ok(())
+    }
+}
+
+impl fmt::Display for Argument<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}: {}", self.name(), self.value())
+    }
+}
+
+impl fmt::Display for Value<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Value::Int(val) => write!(f, "{}", val),
+            Value::Float(val) => write!(f, "{}", val),
+            Value::Boolean(val) => write!(f, "{}", val),
+            Value::String(val) => {
+                let val = escape_string(val);
+                write!(f, "\"{val}\"")
+            }
+            Value::Object(fields) => {
+                write!(f, "{{")?;
+                for (i, (name, value)) in fields.iter().enumerate() {
+                    if i != 0 {
+                        write!(f, ", ")?;
+                    }
+                    write!(f, "{}: {}", name, value)?;
+                }
+                write!(f, "}}")
+            }
+            Value::List(vals) => {
+                write!(f, "[")?;
+                for (i, val) in vals.iter().enumerate() {
+                    if i != 0 {
+                        write!(f, ", ")?;
+                    }
+                    write!(f, "{}", val)?;
+                }
+                write!(f, "]")
+            }
+            Value::Variable(name) => {
+                write!(f, "${}", name)
+            }
+            Value::Null => {
+                write!(f, "null")
+            }
+            Value::Enum(name) => {
+                write!(f, "{name}")
+            }
+        }
+    }
+}

--- a/cynic-parser/src/printing/indent.rs
+++ b/cynic-parser/src/printing/indent.rs
@@ -1,0 +1,94 @@
+use std::fmt;
+
+pub struct Indented<'a, D: ?Sized> {
+    inner: &'a mut D,
+    level: usize,
+    indent_required: bool,
+}
+
+/// Helper function for creating a default indenter
+pub fn indented<D: ?Sized>(f: &mut D, level: usize) -> Indented<'_, D> {
+    Indented {
+        inner: f,
+        level,
+        indent_required: true,
+    }
+}
+
+impl<T> fmt::Write for Indented<'_, T>
+where
+    T: fmt::Write + ?Sized,
+{
+    fn write_str(&mut self, s: &str) -> fmt::Result {
+        for (ind, line) in s.split('\n').enumerate() {
+            if ind > 0 {
+                self.inner.write_char('\n')?;
+                self.indent_required = true;
+            }
+
+            if self.indent_required && !line.is_empty() {
+                write!(self.inner, "{:indent$}{}", "", line, indent = self.level)?;
+                self.indent_required = false;
+            } else if !line.is_empty() {
+                write!(self.inner, "{}", line)?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::fmt::Write;
+
+    #[test]
+    fn test_simple() {
+        let output = &mut String::new();
+        let input = "Hello!";
+        let expected = "    Hello!";
+
+        write!(indented(output, 4), "{}", input).unwrap();
+
+        assert_eq!(output, expected);
+    }
+
+    #[test]
+    fn test_multi_line() {
+        let output = &mut String::new();
+        let input = "Hello!\nThere!";
+        let expected = "    Hello!\n    There!";
+
+        write!(indented(output, 4), "{}", input).unwrap();
+
+        assert_eq!(output, expected);
+    }
+
+    #[test]
+    fn test_multi_write() {
+        let output = &mut String::new();
+        let input = "Hello!\nThere!";
+        let expected = "    Hello!\n    There!\n    Hello!\n    There!\n";
+
+        writeln!(indented(output, 4), "{}", input).unwrap();
+        writeln!(indented(output, 4), "{}", input).unwrap();
+
+        assert_eq!(output, expected);
+    }
+
+    #[test]
+    fn test_nested_indents() {
+        let output = &mut String::new();
+        let input = "Hello!\nThere!";
+
+        let mut level1 = indented(output, 2);
+        writeln!(level1, "{}", input).unwrap();
+
+        let mut level2 = indented(&mut level1, 2);
+        writeln!(level2, "{}", input).unwrap();
+
+        assert_eq!(output, "  Hello!\n  There!\n    Hello!\n    There!\n")
+    }
+}

--- a/cynic-parser/src/printing/pretty/executable.rs
+++ b/cynic-parser/src/printing/pretty/executable.rs
@@ -3,8 +3,7 @@ use pretty::{DocAllocator, Pretty};
 use crate::common::OperationType;
 
 use crate::executable::*;
-
-use super::escape_string;
+use crate::printing::escape_string;
 
 type Allocator<'a> = pretty::Arena<'a>;
 

--- a/cynic-parser/src/printing/pretty/mod.rs
+++ b/cynic-parser/src/printing/pretty/mod.rs
@@ -1,22 +1,2 @@
-use std::fmt::Write;
-
 mod executable;
 mod type_system;
-
-fn escape_string(src: &str) -> String {
-    let mut dest = String::with_capacity(src.len());
-
-    for character in src.chars() {
-        match character {
-            '"' | '\\' | '\n' | '\r' | '\t' => {
-                dest.extend(character.escape_default());
-            }
-            other if other.is_control() => {
-                write!(&mut dest, "\\u{:04}", other as u32).ok();
-            }
-            _ => dest.push(character),
-        }
-    }
-
-    dest
-}

--- a/cynic-parser/src/printing/pretty/type_system.rs
+++ b/cynic-parser/src/printing/pretty/type_system.rs
@@ -3,11 +3,9 @@ mod field_sequence;
 
 use pretty::{DocAllocator, Pretty};
 
-use crate::type_system::*;
+use crate::{printing::escape_string, type_system::*};
 
 use self::{argument_sequence::ArgumentSequence, field_sequence::FieldSequence};
-
-use super::escape_string;
 
 type Allocator<'a> = pretty::Arena<'a>;
 

--- a/cynic-parser/tests/executables.rs
+++ b/cynic-parser/tests/executables.rs
@@ -1,105 +1,128 @@
+use std::path::PathBuf;
+
 use similar_asserts::assert_eq;
 
 #[test]
 fn directive_args() {
     roundtrip_test("tests/executables/directive_args.graphql");
+    display_test("tests/executables/directive_args.graphql");
 }
 
 #[test]
 fn fragment() {
     roundtrip_test("tests/executables/fragment.graphql");
+    display_test("tests/executables/fragment.graphql");
 }
 
 #[test]
 fn fragment_spread() {
     roundtrip_test("tests/executables/fragment_spread.graphql");
+    display_test("tests/executables/fragment_spread.graphql");
 }
 
 #[test]
 fn inline_fragment() {
     roundtrip_test("tests/executables/inline_fragment.graphql");
+    display_test("tests/executables/inline_fragment.graphql");
 }
 
 #[test]
 fn inline_fragment_dir() {
     roundtrip_test("tests/executables/inline_fragment_dir.graphql");
+    display_test("tests/executables/inline_fragment_dir.graphql");
 }
 
 #[test]
 fn kitchen_sink() {
     double_roundtrip_test("tests/executables/kitchen-sink.graphql");
+    display_test("tests/executables/kitchen-sink.graphql");
 }
 
 #[test]
 fn kitchen_sink_canonical() {
     roundtrip_test("tests/executables/kitchen-sink_canonical.graphql");
+    display_test("tests/executables/kitchen-sink_canonical.graphql");
 }
 
 #[test]
 fn minimal() {
     roundtrip_test("tests/executables/minimal.graphql");
+    display_test("tests/executables/minimal.graphql");
 }
 
 #[test]
 fn minimal_mutation() {
     roundtrip_test("tests/executables/minimal_mutation.graphql");
+    display_test("tests/executables/minimal_mutation.graphql");
 }
 
 #[test]
 fn minimal_query() {
     double_roundtrip_test("tests/executables/minimal_query.graphql");
+    display_test("tests/executables/minimal_query.graphql");
 }
 
 #[test]
 fn multiline_string() {
     double_roundtrip_test("tests/executables/multiline_string.graphql");
+    display_test("tests/executables/multiline_string.graphql");
 }
 
 #[test]
 fn mutation_directive() {
     roundtrip_test("tests/executables/mutation_directive.graphql");
+    display_test("tests/executables/mutation_directive.graphql");
 }
 
 #[test]
 fn named_query() {
     roundtrip_test("tests/executables/named_query.graphql");
+    display_test("tests/executables/named_query.graphql");
 }
 
 #[test]
 fn nested_selection() {
     roundtrip_test("tests/executables/nested_selection.graphql");
+    display_test("tests/executables/nested_selection.graphql");
 }
 
 #[test]
 fn query_aliases() {
     roundtrip_test("tests/executables/query_aliases.graphql");
+    display_test("tests/executables/query_aliases.graphql");
 }
 
 #[test]
 fn query_arguments() {
-    insta::assert_snapshot!(double_roundtrip_test(
-        "tests/executables/query_arguments.graphql"
-    ));
+    insta::assert_snapshot!(
+        "query_arguments_double_roundtrip",
+        double_roundtrip_test("tests/executables/query_arguments.graphql")
+    );
+    display_test("tests/executables/query_arguments.graphql");
 }
 
 #[test]
 fn query_directive() {
     roundtrip_test("tests/executables/query_directive.graphql");
+    display_test("tests/executables/query_directive.graphql");
 }
 
 #[test]
 fn query_list_argument() {
     roundtrip_test("tests/executables/query_list_argument.graphql");
+    display_test("tests/executables/query_list_argument.graphql");
 }
 
 #[test]
 fn query_object_argument() {
     roundtrip_test("tests/executables/query_object_argument.graphql");
+    display_test("tests/executables/query_object_argument.graphql");
 }
 
 #[test]
 fn query_var_default_float() {
     roundtrip_test("tests/executables/query_var_default_float.graphql");
+    display_test("tests/executables/query_var_default_float.graphql");
 }
 
 #[test]
@@ -110,43 +133,51 @@ fn query_var_default_list() {
 #[test]
 fn query_var_default_object() {
     roundtrip_test("tests/executables/query_var_default_object.graphql");
+    display_test("tests/executables/query_var_default_object.graphql");
 }
 
 #[test]
 fn query_var_default_string() {
     roundtrip_test("tests/executables/query_var_default_string.graphql");
+    display_test("tests/executables/query_var_default_string.graphql");
 }
 
 #[test]
 fn query_var_defaults() {
     roundtrip_test("tests/executables/query_var_defaults.graphql");
+    display_test("tests/executables/query_var_defaults.graphql");
 }
 
 #[test]
 fn query_vars() {
     roundtrip_test("tests/executables/query_vars.graphql");
+    display_test("tests/executables/query_vars.graphql");
 }
 
 #[test]
 fn string_literal() {
     roundtrip_test("tests/executables/string_literal.graphql");
+    display_test("tests/executables/string_literal.graphql");
 }
 
 #[test]
 fn string_escaping() {
     insta::assert_snapshot!(double_roundtrip_test(
         "tests/executables/string_escaping.graphql"
-    ))
+    ));
+    display_test("tests/executables/string_escaping.graphql")
 }
 
 #[test]
 fn subscription_directive() {
     roundtrip_test("tests/executables/subscription_directive.graphql");
+    display_test("tests/executables/subscription_directive.graphql");
 }
 
 #[test]
 fn variable_directive() {
     roundtrip_test("tests/executables/variable_directive.graphql");
+    display_test("tests/executables/variable_directive.graphql");
 }
 
 fn roundtrip_test(filename: &str) {
@@ -158,6 +189,35 @@ fn roundtrip_test(filename: &str) {
     let output = ast.to_string_pretty();
 
     assert_eq!(data, output);
+}
+
+fn display_test(filename: &str) {
+    let output = display_roundtrip_test(filename);
+
+    let filename = filename.parse::<PathBuf>().unwrap();
+    let snapshot_name = filename.file_stem().unwrap().to_str().unwrap();
+
+    insta::assert_snapshot!(snapshot_name, output);
+}
+
+fn display_roundtrip_test(filename: &str) -> String {
+    let data = std::fs::read_to_string(filename).unwrap();
+    let ast = cynic_parser::parse_executable_document(&data)
+        .map_err(|error| error.to_report(&data))
+        .unwrap();
+
+    let expected = ast.to_string_pretty();
+    let display_output = ast.to_string();
+
+    let ast2 = cynic_parser::parse_executable_document(&display_output)
+        .map_err(|error| error.to_report(&data))
+        .unwrap();
+
+    let output = ast2.to_string_pretty();
+
+    assert_eq!(output, expected);
+
+    display_output
 }
 
 fn double_roundtrip_test(filename: &str) -> String {

--- a/cynic-parser/tests/snapshots/executables__directive_args.snap
+++ b/cynic-parser/tests/snapshots/executables__directive_args.snap
@@ -1,0 +1,7 @@
+---
+source: cynic-parser/tests/executables.rs
+expression: output
+---
+{
+  node @dir(a: 1, b: "2", c: true, d: false, e: null)
+}

--- a/cynic-parser/tests/snapshots/executables__fragment.snap
+++ b/cynic-parser/tests/snapshots/executables__fragment.snap
@@ -1,0 +1,12 @@
+---
+source: cynic-parser/tests/executables.rs
+expression: output
+---
+fragment frag on Friend {
+  __typename
+  node
+}
+
+{
+  __typename
+}

--- a/cynic-parser/tests/snapshots/executables__fragment_spread.snap
+++ b/cynic-parser/tests/snapshots/executables__fragment_spread.snap
@@ -1,0 +1,10 @@
+---
+source: cynic-parser/tests/executables.rs
+expression: output
+---
+{
+  node {
+    id
+    ... something
+  }
+}

--- a/cynic-parser/tests/snapshots/executables__inline_fragment.snap
+++ b/cynic-parser/tests/snapshots/executables__inline_fragment.snap
@@ -1,0 +1,12 @@
+---
+source: cynic-parser/tests/executables.rs
+expression: output
+---
+{
+  node {
+    id
+    ... on User {
+      name
+    }
+  }
+}

--- a/cynic-parser/tests/snapshots/executables__inline_fragment_dir.snap
+++ b/cynic-parser/tests/snapshots/executables__inline_fragment_dir.snap
@@ -1,0 +1,12 @@
+---
+source: cynic-parser/tests/executables.rs
+expression: output
+---
+{
+  node {
+    id
+    ... on User @defer {
+      name
+    }
+  }
+}

--- a/cynic-parser/tests/snapshots/executables__kitchen-sink.snap
+++ b/cynic-parser/tests/snapshots/executables__kitchen-sink.snap
@@ -1,0 +1,55 @@
+---
+source: cynic-parser/tests/executables.rs
+expression: output
+---
+query queryName($foo: ComplexType, $site: Site = MOBILE) {
+  whoever123is: node(id: [123, 456]) {
+    id
+    ... on User @defer {
+      field2 {
+        id
+        alias: field1(first: 10, after: $foo) @include(if: $foo) {
+          id
+          ... frag
+        }
+      }
+    }
+    ... @skip(unless: $foo) {
+      id
+    }
+    ... {
+      id
+    }
+  }
+}
+
+mutation likeStory {
+  like(story: 123) @defer {
+    story {
+      id
+    }
+  }
+}
+
+subscription StoryLikeSubscription($input: StoryLikeSubscribeInput) {
+  storyLikeSubscribe(input: $input) {
+    story {
+      likers {
+        count
+      }
+      likeSentence {
+        text
+      }
+    }
+  }
+}
+
+fragment frag on Friend {
+  foo(size: $size, bar: $b, obj: {key: "value"})
+}
+
+query otherQuery {
+  unnamed(truthy: true, falsey: false, nullish: null)
+  query
+}
+

--- a/cynic-parser/tests/snapshots/executables__kitchen-sink_canonical.snap
+++ b/cynic-parser/tests/snapshots/executables__kitchen-sink_canonical.snap
@@ -1,0 +1,55 @@
+---
+source: cynic-parser/tests/executables.rs
+expression: output
+---
+query queryName($foo: ComplexType, $site: Site = MOBILE) {
+  whoever123is: node(id: [123, 456]) {
+    id
+    ... on User @defer {
+      field2 {
+        id
+        alias: field1(first: 10, after: $foo) @include(if: $foo) {
+          id
+          ... frag
+        }
+      }
+    }
+    ... @skip(unless: $foo) {
+      id
+    }
+    ... {
+      id
+    }
+  }
+}
+
+mutation likeStory {
+  like(story: 123) @defer {
+    story {
+      id
+    }
+  }
+}
+
+subscription StoryLikeSubscription($input: StoryLikeSubscribeInput) {
+  storyLikeSubscribe(input: $input) {
+    story {
+      likers {
+        count
+      }
+      likeSentence {
+        text
+      }
+    }
+  }
+}
+
+fragment frag on Friend {
+  foo(size: $size, bar: $b, obj: {key: "value"})
+}
+
+query otherQuery {
+  unnamed(truthy: true, falsey: false, nullish: null)
+  query
+}
+

--- a/cynic-parser/tests/snapshots/executables__minimal.snap
+++ b/cynic-parser/tests/snapshots/executables__minimal.snap
@@ -1,0 +1,7 @@
+---
+source: cynic-parser/tests/executables.rs
+expression: output
+---
+{
+  a
+}

--- a/cynic-parser/tests/snapshots/executables__minimal_mutation.snap
+++ b/cynic-parser/tests/snapshots/executables__minimal_mutation.snap
@@ -1,0 +1,8 @@
+---
+source: cynic-parser/tests/executables.rs
+expression: output
+---
+mutation {
+  notify
+}
+

--- a/cynic-parser/tests/snapshots/executables__minimal_query.snap
+++ b/cynic-parser/tests/snapshots/executables__minimal_query.snap
@@ -1,0 +1,8 @@
+---
+source: cynic-parser/tests/executables.rs
+expression: output
+---
+{
+  node
+}
+

--- a/cynic-parser/tests/snapshots/executables__multiline_string.snap
+++ b/cynic-parser/tests/snapshots/executables__multiline_string.snap
@@ -1,0 +1,7 @@
+---
+source: cynic-parser/tests/executables.rs
+expression: output
+---
+{
+  a(s: "    a\n    b\n\n    c")
+}

--- a/cynic-parser/tests/snapshots/executables__mutation_directive.snap
+++ b/cynic-parser/tests/snapshots/executables__mutation_directive.snap
@@ -1,0 +1,8 @@
+---
+source: cynic-parser/tests/executables.rs
+expression: output
+---
+mutation @directive {
+  node
+}
+

--- a/cynic-parser/tests/snapshots/executables__named_query.snap
+++ b/cynic-parser/tests/snapshots/executables__named_query.snap
@@ -1,0 +1,8 @@
+---
+source: cynic-parser/tests/executables.rs
+expression: output
+---
+query Foo {
+  field
+}
+

--- a/cynic-parser/tests/snapshots/executables__nested_selection.snap
+++ b/cynic-parser/tests/snapshots/executables__nested_selection.snap
@@ -1,0 +1,9 @@
+---
+source: cynic-parser/tests/executables.rs
+expression: output
+---
+{
+  node {
+    id
+  }
+}

--- a/cynic-parser/tests/snapshots/executables__query_aliases.snap
+++ b/cynic-parser/tests/snapshots/executables__query_aliases.snap
@@ -1,0 +1,7 @@
+---
+source: cynic-parser/tests/executables.rs
+expression: output
+---
+{
+  an_alias: node
+}

--- a/cynic-parser/tests/snapshots/executables__query_arguments.snap
+++ b/cynic-parser/tests/snapshots/executables__query_arguments.snap
@@ -1,18 +1,8 @@
 ---
 source: cynic-parser/tests/executables.rs
-expression: "double_roundtrip_test(\"tests/executables/query_arguments.graphql\")"
+expression: output
 ---
 {
   node(id: 1)
-  node2(
-    id: -1
-    id1: 0
-    id2: 0
-    id3: -1.23
-    id4: 1.23
-    id5: 123
-    id6: 123
-    id7: 0.123
-  )
+  node2(id: -1, id1: 0, id2: 0, id3: -1.23, id4: 1.23, id5: 123, id6: 123, id7: 0.123)
 }
-

--- a/cynic-parser/tests/snapshots/executables__query_arguments_double_roundtrip.snap
+++ b/cynic-parser/tests/snapshots/executables__query_arguments_double_roundtrip.snap
@@ -1,0 +1,18 @@
+---
+source: cynic-parser/tests/executables.rs
+expression: "double_roundtrip_test(\"tests/executables/query_arguments.graphql\")"
+---
+{
+  node(id: 1)
+  node2(
+    id: -1
+    id1: 0
+    id2: 0
+    id3: -1.23
+    id4: 1.23
+    id5: 123
+    id6: 123
+    id7: 0.123
+  )
+}
+

--- a/cynic-parser/tests/snapshots/executables__query_directive.snap
+++ b/cynic-parser/tests/snapshots/executables__query_directive.snap
@@ -1,0 +1,8 @@
+---
+source: cynic-parser/tests/executables.rs
+expression: output
+---
+query @directive {
+  node
+}
+

--- a/cynic-parser/tests/snapshots/executables__query_list_argument.snap
+++ b/cynic-parser/tests/snapshots/executables__query_list_argument.snap
@@ -1,0 +1,7 @@
+---
+source: cynic-parser/tests/executables.rs
+expression: output
+---
+{
+  node(id: 1, list: [123, 456])
+}

--- a/cynic-parser/tests/snapshots/executables__query_object_argument.snap
+++ b/cynic-parser/tests/snapshots/executables__query_object_argument.snap
@@ -1,0 +1,7 @@
+---
+source: cynic-parser/tests/executables.rs
+expression: output
+---
+{
+  node(id: 1, obj: {key1: 123, key2: 456})
+}

--- a/cynic-parser/tests/snapshots/executables__query_var_default_float.snap
+++ b/cynic-parser/tests/snapshots/executables__query_var_default_float.snap
@@ -1,0 +1,8 @@
+---
+source: cynic-parser/tests/executables.rs
+expression: output
+---
+query Foo($site: Float = 0.5) {
+  field
+}
+

--- a/cynic-parser/tests/snapshots/executables__query_var_default_object.snap
+++ b/cynic-parser/tests/snapshots/executables__query_var_default_object.snap
@@ -1,0 +1,8 @@
+---
+source: cynic-parser/tests/executables.rs
+expression: output
+---
+query Foo($site: Site = {url: null}) {
+  field
+}
+

--- a/cynic-parser/tests/snapshots/executables__query_var_default_string.snap
+++ b/cynic-parser/tests/snapshots/executables__query_var_default_string.snap
@@ -1,0 +1,8 @@
+---
+source: cynic-parser/tests/executables.rs
+expression: output
+---
+query Foo($site: String = "string") {
+  field
+}
+

--- a/cynic-parser/tests/snapshots/executables__query_var_defaults.snap
+++ b/cynic-parser/tests/snapshots/executables__query_var_defaults.snap
@@ -1,0 +1,8 @@
+---
+source: cynic-parser/tests/executables.rs
+expression: output
+---
+query Foo($site: Site = MOBILE) {
+  field
+}
+

--- a/cynic-parser/tests/snapshots/executables__query_vars.snap
+++ b/cynic-parser/tests/snapshots/executables__query_vars.snap
@@ -1,0 +1,8 @@
+---
+source: cynic-parser/tests/executables.rs
+expression: output
+---
+query Foo($arg: SomeType) {
+  field
+}
+

--- a/cynic-parser/tests/snapshots/executables__string_literal.snap
+++ b/cynic-parser/tests/snapshots/executables__string_literal.snap
@@ -1,0 +1,7 @@
+---
+source: cynic-parser/tests/executables.rs
+expression: output
+---
+{
+  node(id: "hello")
+}

--- a/cynic-parser/tests/snapshots/executables__subscription_directive.snap
+++ b/cynic-parser/tests/snapshots/executables__subscription_directive.snap
@@ -1,0 +1,8 @@
+---
+source: cynic-parser/tests/executables.rs
+expression: output
+---
+subscription @directive {
+  node
+}
+

--- a/cynic-parser/tests/snapshots/executables__variable_directive.snap
+++ b/cynic-parser/tests/snapshots/executables__variable_directive.snap
@@ -1,0 +1,8 @@
+---
+source: cynic-parser/tests/executables.rs
+expression: output
+---
+query Foo($a: Int = 10 @directive, $b: Int @directive) {
+  value
+}
+


### PR DESCRIPTION
#### Why are we making this change?

cynic-parser currently only has a pretty printer.  This is nice, but there are some situations where that's not suitable.  Particularly if you care about performance over correctness.  

#### What effects does this change have?

Adds some `Display` powered non-pretty printing to cynic-parser, under the print flag
