### PR TITLE
feat: add IdIter to cynic-parser

### DIFF
--- a/cynic-parser/src/executable/iter.rs
+++ b/cynic-parser/src/executable/iter.rs
@@ -4,6 +4,10 @@ use crate::common::{IdOperations, IdRange};
 
 use super::ExecutableId;
 
+pub trait IdReader {
+    type Id: ExecutableId;
+}
+
 /// Iterator for readers in the executable module
 ///
 /// T indicates the type that will be yielded by the Iterator
@@ -27,10 +31,12 @@ where
     pub fn ids(&self) -> IdRange<T::Id> {
         self.range
     }
-}
 
-pub trait IdReader {
-    type Id: ExecutableId;
+    pub fn with_ids(self) -> IdIter<'a, T> {
+        let Iter { range, document } = self;
+
+        IdIter { range, document }
+    }
 }
 
 impl<'a, T> Iterator for Iter<'a, T>
@@ -75,6 +81,74 @@ where
 }
 
 impl<'a, T> fmt::Debug for Iter<'a, T>
+where
+    T: IdReader + Copy,
+    Self: Iterator,
+    <Self as Iterator>::Item: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_list().entries(*self).finish()
+    }
+}
+
+/// Iterator over an Id & a Reader for that Id
+///
+/// T indicates the reader type that will be yielded by the Iterator
+#[derive(Clone, Copy)]
+pub struct IdIter<'a, T>
+where
+    T: IdReader,
+{
+    range: IdRange<T::Id>,
+    document: &'a super::ExecutableDocument,
+}
+
+impl<'a, T> Iterator for IdIter<'a, T>
+where
+    T: IdReader,
+    T::Id: IdOperations,
+{
+    type Item = (T::Id, <T::Id as ExecutableId>::Reader<'a>);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let next = self.range.next()?;
+
+        Some((next, self.document.read(next)))
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.range.size_hint()
+    }
+}
+
+impl<'a, T> ExactSizeIterator for IdIter<'a, T>
+where
+    T: IdReader,
+    T::Id: IdOperations,
+{
+}
+
+impl<'a, T> FusedIterator for IdIter<'a, T>
+where
+    T: IdReader,
+    T::Id: IdOperations,
+{
+}
+
+impl<'a, T> DoubleEndedIterator for IdIter<'a, T>
+where
+    T: IdReader,
+    T::Id: IdOperations,
+{
+    // Required method
+    fn next_back(&mut self) -> Option<Self::Item> {
+        let next = self.range.next_back()?;
+
+        Some((next, self.document.read(next)))
+    }
+}
+
+impl<'a, T> fmt::Debug for IdIter<'a, T>
 where
     T: IdReader + Copy,
     Self: Iterator,

--- a/cynic-parser/src/type_system/generated.rs
+++ b/cynic-parser/src/type_system/generated.rs
@@ -18,18 +18,6 @@ mod prelude {
         },
         AstLookup, Span,
     };
-
-    pub(super) mod value {
-        pub use crate::type_system::Value;
-    }
-
-    pub(super) mod types {
-        pub use super::super::super::Type;
-    }
-
-    pub(super) mod strings {
-        pub use super::super::super::StringLiteral;
-    }
 }
 
 pub(super) mod value {


### PR DESCRIPTION
It's sometimes useful to have access to both the `id` and the underlying `Reader` when iterating over an `Iter`.  This adds a `with_ids -> IdIter` function that does just that.

I'm not especially happy with the name, so this might change later.