### PR TITLE
fix: fragments on interfaces in the generator

### DIFF
--- a/cynic-querygen/src/schema/type_index.rs
+++ b/cynic-querygen/src/schema/type_index.rs
@@ -62,12 +62,17 @@ impl<'schema> TypeIndex<'schema> {
             .get(root_name.as_str())
             .ok_or_else(|| Error::CouldntFindRootType(root_name.clone()))?;
 
-        let field = if let TypeDefinition::Object(root_object) = root {
-            self.find_field_recursive(&root_object.fields, root_name.as_str(), &path.path)?
-        } else {
-            return Err(Error::ExpectedObject(root_name.to_string()));
+        let field = match root {
+            graphql_parser::schema::TypeDefinition::Object(object) => {
+                self.find_field_recursive(&object.fields, root_name.as_str(), &path.path)?
+            }
+            graphql_parser::schema::TypeDefinition::Interface(iface) => {
+                self.find_field_recursive(&iface.fields, root_name.as_str(), &path.path)?
+            }
+            _ => {
+                return Err(Error::ExpectedObject(root_name.to_string()));
+            }
         };
-
         Ok(OutputField::from_parser(&field, self))
     }
 

--- a/cynic-querygen/tests/github-tests.rs
+++ b/cynic-querygen/tests/github-tests.rs
@@ -19,10 +19,9 @@ macro_rules! test_query {
     };
 }
 
-test_query!(literal_enums, "literal-enums.graphql");
-test_query!(input_object_literals, "input-object-literals.graphql");
-test_query!(input_object_arguments, "input-object-arguments.graphql");
 test_query!(add_comment_mutation, "add-comment-mutation.graphql");
+test_query!(field_on_interface, "field-on-interface.graphql");
+test_query!(fragment_on_interface, "fragment-on-interface.graphql");
 test_query!(inline_fragment_on_union, "inline-fragment-on-union.graphql");
 test_query!(
     inline_fragment_with_arguments,
@@ -32,7 +31,9 @@ test_query!(
     inline_fragment_with_renames,
     "inline-fragment-with-renames.graphql"
 );
-test_query!(field_on_interface, "field-on-interface.graphql");
+test_query!(input_object_arguments, "input-object-arguments.graphql");
+test_query!(input_object_literals, "input-object-literals.graphql");
+test_query!(literal_enums, "literal-enums.graphql");
 test_query!(queries_with_typename, "queries-with-typename.graphql");
 
 test_query!(issue_786, "issue-786.graphql");

--- a/cynic-querygen/tests/queries/github/fragment-on-interface.graphql
+++ b/cynic-querygen/tests/queries/github/fragment-on-interface.graphql
@@ -1,0 +1,10 @@
+fragment NodeInfo on Node {
+  __typename
+  id
+}
+
+query {
+  nodes(ids: ["123"]) {
+    ...NodeInfo
+  }
+}

--- a/cynic-querygen/tests/snapshots/github_tests__fragment_on_interface.snap
+++ b/cynic-querygen/tests/snapshots/github_tests__fragment_on_interface.snap
@@ -1,0 +1,25 @@
+---
+source: cynic-querygen/tests/github-tests.rs
+expression: "document_to_fragment_structs(query, schema,\n        &QueryGenOptions::default()).expect(\"QueryGen Failed\")"
+---
+#[derive(cynic::QueryFragment, Debug)]
+pub struct Node {
+    pub __typename: String,
+    pub id: cynic::Id,
+}
+
+#[derive(cynic::QueryFragment, Debug)]
+#[cynic(graphql_type = "Query")]
+pub struct UnnamedQuery {
+    #[arguments(ids: ["123"])]
+    pub nodes: Vec<Option<Node>>,
+}
+
+#[derive(cynic::InlineFragments, Debug)]
+pub enum Node {
+    Node(Node),
+    #[cynic(fallback)]
+    Unknown
+}
+
+


### PR DESCRIPTION
The generator contains a function `field_from_path` that accepts a root type and a path.  This was originally written before I supported fragments, so assumed that the root type would always be an object (as it is for query, mutation & subscription roots).  For fragments though the root type can also be an interface or a union type.

This partially fixes the problem so that we support interfaces.  I didn't add support for unions because unions don't specifically have fields (except `__typename`) and I can't remember how this stuff works well enough to fix it for unions right now.

Suspect there might be other problems related to this in there, but that's a problem for another day.

Fixes #993