### PR TITLE
Fix typo: remove 's'

### DIFF
--- a/cynic/src/operation/builder.rs
+++ b/cynic/src/operation/builder.rs
@@ -97,7 +97,7 @@ where
         self.operation_name = Some(Cow::Owned(name.to_string()));
     }
 
-    /// Tries to builds an [Operation]
+    /// Tries to build an [Operation]
     pub fn build(self) -> Result<super::Operation<Fragment, Variables>, OperationBuildError> {
         use std::fmt::Write;
 


### PR DESCRIPTION
#### Why are we making this change?

<!-- Provide details of the context of and justification for this change -->
To fix a typo in the doc comment.

#### What effects does this change have?

<!-- Provide details of what this change contains, any new features it introduces (or how it changes existing ones) and any usage details -->
It just fixes a typo lol.

In other words, *users will derive enhanced benefits from an augmented experience attributable to the increased precision, accuracy, and grammatical perfection of documentation commentary.*