### PR TITLE
feat: add variable inlining to OperationBuilder

### DIFF
--- a/cynic/src/queries/mod.rs
+++ b/cynic/src/queries/mod.rs
@@ -11,6 +11,8 @@ mod variables;
 
 use variables::VariableDefinitions;
 
+use crate::QueryVariableLiterals;
+
 pub use self::{
     ast::{Argument, InputLiteral, SelectionSet},
     builders::{SelectionBuilder, VariableMatch},
@@ -36,6 +38,7 @@ pub fn build_executable_document<Fragment, Variables>(
     r#type: OperationType,
     operation_name: Option<&str>,
     features_enabled: HashSet<String>,
+    inline_variables: Option<&dyn QueryVariableLiterals>,
 ) -> String
 where
     Fragment: crate::QueryFragment,
@@ -48,6 +51,7 @@ where
         &mut selection_set,
         &variable_tx,
         &features_enabled,
+        inline_variables,
     );
 
     Fragment::query(builder);

--- a/cynic/tests/variables.rs
+++ b/cynic/tests/variables.rs
@@ -1,6 +1,6 @@
 use serde_json::json;
 
-#[derive(cynic::QueryVariables)]
+#[derive(cynic::QueryVariables, cynic::QueryVariableLiterals)]
 struct TestArgs<'a> {
     #[cynic(skip_serializing_if = "Option::is_none")]
     a_str: Option<&'a str>,
@@ -52,6 +52,63 @@ fn test_unused_variables_not_rendered() {
     }
 
     "###);
+}
+
+mod variable_inlining {
+    use cynic::OperationBuilder;
+
+    use super::{schema, TestArgs, TestArgsFields};
+
+    #[derive(cynic::QueryFragment, PartialEq, Debug)]
+    #[cynic(schema_path = "../schemas/simple.graphql", variables = "TestArgs")]
+    struct TestStruct {
+        #[arguments(x: 1, y: $a_str)]
+        field_one: String,
+    }
+
+    #[derive(cynic::QueryFragment, PartialEq, Debug)]
+    #[cynic(
+        schema_path = "../schemas/simple.graphql",
+        graphql_type = "Query",
+        variables = "TestArgs"
+    )]
+    struct QueryWithArguments {
+        test_struct: Option<TestStruct>,
+    }
+
+    #[test]
+    fn test_variable_inlining() {
+        let operation = OperationBuilder::<QueryWithArguments, TestArgs<'_>>::query()
+            .with_variables(TestArgs {
+                a_str: Some("boom, this is interpolated"),
+            })
+            .build_with_variables_inlined()
+            .unwrap();
+
+        insta::assert_display_snapshot!(operation.query, @r###"
+        query QueryWithArguments {
+          testStruct {
+            fieldOne(x: 1, y: "boom, this is interpolated")
+          }
+        }
+        "###);
+    }
+
+    #[test]
+    fn test_skip_serializing_if_none_for_inlines() {
+        let operation = OperationBuilder::<QueryWithArguments, TestArgs<'_>>::query()
+            .with_variables(TestArgs { a_str: None })
+            .build_with_variables_inlined()
+            .unwrap();
+
+        insta::assert_display_snapshot!(operation.query, @r###"
+        query QueryWithArguments {
+          testStruct {
+            fieldOne(x: 1)
+          }
+        }
+        "###);
+    }
 }
 
 mod schema {


### PR DESCRIPTION
#### Why are we making this change?

Now that a49710 is merged it's quite easy to extract an `InputLiteral` from a `QueryVariables` struct by the name of the variable.  This makes it very easy to add variable inlining as a first class feature, rather than recommending post-processing as in #1007.

#### What effects does this change have?

Adds a new `build_with_variables_inlined` function to `OperationBuilder` that is available when `Variables` implements `QueryVariableLiterals`.  This will return an `Operation` with no variables entry and all the variables added into the `query` string as arguments.

I had wanted to do this as a setting inside the builder, but getting the types to work with that was tricky - so another build function seemed the best option.