### PR TITLE
fix: use Iter in more places in parser

### DIFF
--- a/cynic-parser/src/type_system/definitions.rs
+++ b/cynic-parser/src/type_system/definitions.rs
@@ -1,7 +1,31 @@
+use crate::AstLookup;
+
 use super::{
-    Directive, DirectiveDefinition, EnumDefinition, InputObjectDefinition, InterfaceDefinition,
-    ObjectDefinition, ScalarDefinition, SchemaDefinition, UnionDefinition,
+    ids::*,
+    iter::{IdReader, Iter},
+    DefinitionId, Directive, DirectiveDefinition, EnumDefinition, InputObjectDefinition,
+    InterfaceDefinition, ObjectDefinition, ReadContext, ScalarDefinition, SchemaDefinition,
+    TypeSystemId, UnionDefinition,
 };
+
+#[derive(Clone, Copy)]
+pub enum DefinitionRecord {
+    Schema(SchemaDefinitionId),
+    Scalar(ScalarDefinitionId),
+    Object(ObjectDefinitionId),
+    Interface(InterfaceDefinitionId),
+    Union(UnionDefinitionId),
+    Enum(EnumDefinitionId),
+    InputObject(InputObjectDefinitionId),
+    SchemaExtension(SchemaDefinitionId),
+    ScalarExtension(ScalarDefinitionId),
+    ObjectExtension(ObjectDefinitionId),
+    InterfaceExtension(InterfaceDefinitionId),
+    UnionExtension(UnionDefinitionId),
+    EnumExtension(EnumDefinitionId),
+    InputObjectExtension(InputObjectDefinitionId),
+    Directive(DirectiveDefinitionId),
+}
 
 #[derive(Clone, Copy)]
 pub enum Definition<'a> {
@@ -34,16 +58,71 @@ impl<'a> TypeDefinition<'a> {
         }
     }
 
-    pub fn directives(&self) -> impl ExactSizeIterator<Item = Directive<'a>> + 'a {
-        let rv: Box<dyn ExactSizeIterator<Item = Directive<'a>> + 'a> = match self {
-            TypeDefinition::Scalar(inner) => Box::new(inner.directives()),
-            TypeDefinition::Object(inner) => Box::new(inner.directives()),
-            TypeDefinition::Interface(inner) => Box::new(inner.directives()),
-            TypeDefinition::Union(inner) => Box::new(inner.directives()),
-            TypeDefinition::Enum(inner) => Box::new(inner.directives()),
-            TypeDefinition::InputObject(inner) => Box::new(inner.directives()),
-        };
+    pub fn directives(&self) -> Iter<'a, Directive<'a>> {
+        match self {
+            TypeDefinition::Scalar(inner) => inner.directives(),
+            TypeDefinition::Object(inner) => inner.directives(),
+            TypeDefinition::Interface(inner) => inner.directives(),
+            TypeDefinition::Union(inner) => inner.directives(),
+            TypeDefinition::Enum(inner) => inner.directives(),
+            TypeDefinition::InputObject(inner) => inner.directives(),
+        }
+    }
+}
 
-        rv
+impl TypeSystemId for DefinitionId {
+    type Reader<'a> = Definition<'a>;
+}
+
+impl IdReader for Definition<'_> {
+    type Id = DefinitionId;
+}
+
+impl<'a> From<ReadContext<'a, DefinitionId>> for Definition<'a> {
+    fn from(value: ReadContext<'a, DefinitionId>) -> Self {
+        let document = value.document;
+        match document.lookup(value.id) {
+            DefinitionRecord::Schema(id) => Definition::Schema(document.read(*id)),
+            DefinitionRecord::Scalar(id) => {
+                Definition::Type(TypeDefinition::Scalar(document.read(*id)))
+            }
+            DefinitionRecord::Object(id) => {
+                Definition::Type(TypeDefinition::Object(document.read(*id)))
+            }
+            DefinitionRecord::Interface(id) => {
+                Definition::Type(TypeDefinition::Interface(document.read(*id)))
+            }
+            DefinitionRecord::Union(id) => {
+                Definition::Type(TypeDefinition::Union(document.read(*id)))
+            }
+            DefinitionRecord::Enum(id) => {
+                Definition::Type(TypeDefinition::Enum(document.read(*id)))
+            }
+            DefinitionRecord::InputObject(id) => {
+                Definition::Type(TypeDefinition::InputObject(document.read(*id)))
+            }
+            DefinitionRecord::SchemaExtension(id) => {
+                Definition::SchemaExtension(document.read(*id))
+            }
+            DefinitionRecord::ScalarExtension(id) => {
+                Definition::TypeExtension(TypeDefinition::Scalar(document.read(*id)))
+            }
+            DefinitionRecord::ObjectExtension(id) => {
+                Definition::TypeExtension(TypeDefinition::Object(document.read(*id)))
+            }
+            DefinitionRecord::InterfaceExtension(id) => {
+                Definition::TypeExtension(TypeDefinition::Interface(document.read(*id)))
+            }
+            DefinitionRecord::UnionExtension(id) => {
+                Definition::TypeExtension(TypeDefinition::Union(document.read(*id)))
+            }
+            DefinitionRecord::EnumExtension(id) => {
+                Definition::TypeExtension(TypeDefinition::Enum(document.read(*id)))
+            }
+            DefinitionRecord::InputObjectExtension(id) => {
+                Definition::TypeExtension(TypeDefinition::InputObject(document.read(*id)))
+            }
+            DefinitionRecord::Directive(id) => Definition::Directive(document.read(*id)),
+        }
     }
 }

--- a/cynic-parser/src/type_system/ids.rs
+++ b/cynic-parser/src/type_system/ids.rs
@@ -54,6 +54,7 @@ macro_rules! impl_id_range_ops {
 }
 
 make_id!(DefinitionId, DefinitionRecord, definitions);
+impl_id_range_ops!(DefinitionId);
 
 make_id!(
     SchemaDefinitionId,


### PR DESCRIPTION
I added `Iter` to cynic-parser a while back and moved to using it instead of `impl ExactSizeIterator` where possible.  Obviously missed a few places though - this updates those to also use `Iter`.