### PR TITLE
fix!: remove copy footgun from parser iterators

### DIFF
--- a/cynic-parser/src/common/mod.rs
+++ b/cynic-parser/src/common/mod.rs
@@ -2,7 +2,7 @@ mod id_range;
 mod strings;
 mod types;
 
-pub use id_range::{IdOperations, IdRange};
+pub use id_range::{IdOperations, IdRange, IdRangeIter};
 pub use strings::MalformedStringError;
 pub use types::*;
 

--- a/cynic-parser/src/printing/display/executable.rs
+++ b/cynic-parser/src/printing/display/executable.rs
@@ -76,7 +76,7 @@ impl fmt::Display for iter::Iter<'_, VariableDefinition<'_>> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if self.len() != 0 {
             write!(f, "(")?;
-            for (i, definition) in self.enumerate() {
+            for (i, definition) in self.clone().enumerate() {
                 if i != 0 {
                     write!(f, ", ")?;
                 }
@@ -104,7 +104,7 @@ impl std::fmt::Display for iter::Iter<'_, Selection<'_>> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         if self.len() != 0 {
             writeln!(f, "{{")?;
-            for child in *self {
+            for child in self.clone() {
                 writeln!(indented(f, 2), "{}", child)?;
             }
             write!(f, "}}")?;
@@ -172,7 +172,7 @@ impl fmt::Display for FragmentSpread<'_> {
 
 impl fmt::Display for iter::Iter<'_, Directive<'_>> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        for directive in *self {
+        for directive in self.clone() {
             write!(f, " {directive}")?;
         }
         Ok(())
@@ -189,7 +189,7 @@ impl fmt::Display for iter::Iter<'_, Argument<'_>> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if self.len() != 0 {
             write!(f, "(")?;
-            for (i, arg) in self.enumerate() {
+            for (i, arg) in self.clone().enumerate() {
                 if i != 0 {
                     write!(f, ", ")?;
                 }


### PR DESCRIPTION
Having an Iterator that is `Copy` is quite easy to accidentally misuse. This change updates the various Iterators in cynic-parser to either not be Copy or implement IntoIterator instead of directly implementing Iterator.

Fixes #1031