### PR TITLE
fix!: support ints larger than i32 in parser

### DIFF
--- a/cynic-parser/src/common/int_value.rs
+++ b/cynic-parser/src/common/int_value.rs
@@ -1,0 +1,30 @@
+/// An integer value
+///
+/// The GraphQl Int scalar is an i32, however the GraphQl language doesn't
+/// impose specific limits on integers.  Currently cynic-parser represents
+/// an IntValue as an i64, but we hide this fact behind a newtype to allow
+/// us to change the internal representaiton later if we need to.
+#[derive(Clone, Copy, PartialEq, Eq, Ord, PartialOrd, Hash)]
+pub struct IntValue(pub(crate) i64);
+
+impl IntValue {
+    pub fn as_i64(&self) -> i64 {
+        self.0
+    }
+
+    pub fn as_i32(&self) -> i32 {
+        self.0 as i32
+    }
+}
+
+impl std::fmt::Debug for IntValue {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl std::fmt::Display for IntValue {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}

--- a/cynic-parser/src/common/mod.rs
+++ b/cynic-parser/src/common/mod.rs
@@ -1,8 +1,10 @@
 mod id_range;
+mod int_value;
 mod strings;
 mod types;
 
 pub use id_range::{IdOperations, IdRange, IdRangeIter};
+pub use int_value::IntValue;
 pub use strings::MalformedStringError;
 pub use types::*;
 

--- a/cynic-parser/src/executable/value.rs
+++ b/cynic-parser/src/executable/value.rs
@@ -1,4 +1,4 @@
-use crate::AstLookup;
+use crate::{common::IntValue, AstLookup};
 
 use super::{
     ids::{StringId, ValueId},
@@ -7,7 +7,7 @@ use super::{
 
 pub enum ValueRecord {
     Variable(StringId),
-    Int(i32),
+    Int(i64),
     Float(f32),
     String(StringId),
     Boolean(bool),
@@ -23,7 +23,7 @@ pub enum ValueRecord {
 #[derive(Clone, Debug)]
 pub enum Value<'a> {
     Variable(&'a str),
-    Int(i32),
+    Int(IntValue),
     Float(f32),
     String(&'a str),
     Boolean(bool),
@@ -81,7 +81,7 @@ impl<'a> From<ReadContext<'a, ValueId>> for Value<'a> {
 
         match ast.lookup(reader.id) {
             ValueRecord::Variable(id) => Value::Variable(ast.lookup(*id)),
-            ValueRecord::Int(num) => Value::Int(*num),
+            ValueRecord::Int(num) => Value::Int(IntValue(*num)),
             ValueRecord::Float(num) => Value::Float(*num),
             ValueRecord::String(id) => Value::String(ast.lookup(*id)),
             ValueRecord::Boolean(val) => Value::Boolean(*val),

--- a/cynic-parser/src/type_system/values.rs
+++ b/cynic-parser/src/type_system/values.rs
@@ -1,10 +1,10 @@
-use crate::{type_system::ids::ValueId, AstLookup};
+use crate::{common::IntValue, type_system::ids::ValueId, AstLookup};
 
 use super::{BlockStringLiteralId, ReadContext, StringId, TypeSystemId};
 
 pub enum ValueRecord {
     Variable(StringId),
-    Int(i32),
+    Int(i64),
     Float(f32),
     String(StringId),
     BlockString(BlockStringLiteralId),
@@ -18,7 +18,7 @@ pub enum ValueRecord {
 #[derive(Clone, Debug)]
 pub enum Value<'a> {
     Variable(&'a str),
-    Int(i32),
+    Int(IntValue),
     Float(f32),
     String(&'a str),
     BlockString(&'a str),
@@ -84,7 +84,7 @@ impl<'a> From<ReadContext<'a, ValueId>> for Value<'a> {
 
         match ast.lookup(reader.id) {
             ValueRecord::Variable(id) => Value::Variable(ast.lookup(*id)),
-            ValueRecord::Int(num) => Value::Int(*num),
+            ValueRecord::Int(num) => Value::Int(IntValue(*num)),
             ValueRecord::Float(num) => Value::Float(*num),
             ValueRecord::String(id) => Value::String(ast.lookup(*id)),
             ValueRecord::BlockString(id) => Value::BlockString(ast.lookup(*id)),


### PR DESCRIPTION
The GraphQl `Int` scalar is an i32.  In cynic-parser I made the parsed `Int` an i32 as well.  However on closer inspection the spec doesn't really impose the i32 limit on `IntValue`s as represented in the language.  

It's possible that a custom `BigInt` scalar or similar might want to represent itself as a literal integer > an i32, and currently this is unsupported in cynic-parser.

This change adds a new `IntValue` wrapper around ints in the `Value` enums.  This hides the internal representation a bit, allowing us to change it later.  Also added support for numbers up to i64.
