### PR TITLE
fix: rework Description in cynic-parser a bit

### DIFF
--- a/cynic-parser/ast-generator/domain/type_system.graphql
+++ b/cynic-parser/ast-generator/domain/type_system.graphql
@@ -112,7 +112,7 @@ type Argument @file(name: "arguments") {
 }
 
 type Description @file(name: "descriptions") {
-  description: StringLiteral!
+  literal: StringLiteral!
   span: Span!
 }
 

--- a/cynic-parser/src/parser/schema.lalrpop
+++ b/cynic-parser/src/parser/schema.lalrpop
@@ -19,9 +19,9 @@ pub TypeSystemDocument: () = {
 }
 
 Description: DescriptionId = {
-    <start:@L> <description:StringValue> <end:@R> => {
+    <start:@L> <literal:StringValue> <end:@R> => {
         ast.description(DescriptionRecord {
-            description,
+            literal,
             span: Span::new(start, end),
         })
     }

--- a/cynic-parser/src/parser/schema.rs
+++ b/cynic-parser/src/parser/schema.rs
@@ -1,5 +1,5 @@
 // auto-generated: "lalrpop 0.21.0"
-// sha3: 95aa74acd6d446bc6135fe7fbfede28a7d3db53a669861b074f7c8b7c86637da
+// sha3: b60f4f8beb0fe63e9646619ee5f1a5eca15e01942cf12fafc9a11d7ace16c101
 use crate::lexer;
 use crate::{
     common::{
@@ -1354,14 +1354,14 @@ mod __parse__TypeSystemDocument {
         }).collect()
     }
     struct __StateMachine<'input, '__1>
-    where 
+    where
     {
         input: &'input str,
         ast: &'__1 mut TypeSystemAstWriter,
         __phantom: core::marker::PhantomData<(&'input ())>,
     }
     impl<'input, '__1> __state_machine::ParserDefinition for __StateMachine<'input, '__1>
-    where 
+    where
     {
         type Location = usize;
         type Error = crate::parser::AdditionalErrors;
@@ -7658,12 +7658,12 @@ fn __action2<'input>(
     input: &'input str,
     ast: &mut TypeSystemAstWriter,
     (_, start, _): (usize, usize, usize),
-    (_, description, _): (usize, StringLiteralId, usize),
+    (_, literal, _): (usize, StringLiteralId, usize),
     (_, end, _): (usize, usize, usize),
 ) -> DescriptionId {
     {
         ast.description(DescriptionRecord {
-            description,
+            literal,
             span: Span::new(start, end),
         })
     }

--- a/cynic-parser/src/printing/pretty/type_system.rs
+++ b/cynic-parser/src/printing/pretty/type_system.rs
@@ -116,7 +116,7 @@ impl<'a> Pretty<'a, Allocator<'a>> for NodeDisplay<SchemaDefinition<'a>> {
 
         if let Some(description) = self.0.description() {
             builder = builder
-                .append(self.with_node(description.description()))
+                .append(self.with_node(description))
                 .append(allocator.hardline());
         }
 
@@ -165,7 +165,7 @@ impl<'a> Pretty<'a, Allocator<'a>> for NodeDisplay<ScalarDefinition<'a>> {
 
         if let Some(description) = self.0.description() {
             builder = builder
-                .append(self.with_node(description.description()))
+                .append(self.with_node(description))
                 .append(allocator.hardline());
         }
 
@@ -189,7 +189,7 @@ impl<'a> Pretty<'a, Allocator<'a>> for NodeDisplay<ObjectDefinition<'a>> {
 
         if let Some(description) = self.0.description() {
             builder = builder
-                .append(self.with_node(description.description()))
+                .append(self.with_node(description))
                 .append(allocator.hardline());
         }
 
@@ -243,7 +243,7 @@ impl<'a> Pretty<'a, Allocator<'a>> for NodeDisplay<FieldDefinition<'a>> {
             .map(|description| {
                 allocator
                     .nil()
-                    .append(self.with_node(description.description()))
+                    .append(self.with_node(description))
                     .append(allocator.hardline())
             })
             .unwrap_or(allocator.softline_());
@@ -288,7 +288,7 @@ impl<'a> Pretty<'a, Allocator<'a>> for NodeDisplay<InterfaceDefinition<'a>> {
 
         if let Some(description) = self.0.description() {
             builder = builder
-                .append(self.with_node(description.description()))
+                .append(self.with_node(description))
                 .append(allocator.hardline());
         }
 
@@ -376,7 +376,7 @@ impl<'a> Pretty<'a, Allocator<'a>> for NodeDisplay<UnionDefinition<'a>> {
 
         if let Some(description) = self.0.description() {
             builder = self
-                .with_node(description.description())
+                .with_node(description)
                 .pretty(allocator)
                 .append(allocator.hardline())
                 .append(builder)
@@ -393,7 +393,7 @@ impl<'a> Pretty<'a, Allocator<'a>> for NodeDisplay<EnumDefinition<'a>> {
 
         if let Some(description) = self.0.description() {
             builder = builder
-                .append(self.with_node(description.description()))
+                .append(self.with_node(description))
                 .append(allocator.hardline());
         }
 
@@ -438,7 +438,7 @@ impl<'a> Pretty<'a, Allocator<'a>> for NodeDisplay<EnumValueDefinition<'a>> {
             .map(|description| {
                 allocator
                     .nil()
-                    .append(self.with_node(description.description()))
+                    .append(self.with_node(description))
                     .append(allocator.hardline())
             })
             .unwrap_or(allocator.softline_());
@@ -466,7 +466,7 @@ impl<'a> Pretty<'a, Allocator<'a>> for NodeDisplay<InputObjectDefinition<'a>> {
 
         if let Some(description) = self.0.description() {
             builder = builder
-                .append(self.with_node(description.description()))
+                .append(self.with_node(description))
                 .append(allocator.hardline());
         }
 
@@ -510,7 +510,7 @@ impl<'a> Pretty<'a, Allocator<'a>> for NodeDisplay<InputValueDefinition<'a>> {
             .map(|description| {
                 allocator
                     .nil()
-                    .append(self.with_node(description.description()))
+                    .append(self.with_node(description))
                     .append(allocator.hardline())
             })
             .unwrap_or(allocator.softline_());
@@ -549,7 +549,7 @@ impl<'a> Pretty<'a, Allocator<'a>> for NodeDisplay<DirectiveDefinition<'a>> {
 
         if let Some(description) = self.0.description() {
             builder = builder
-                .append(self.with_node(description.description()))
+                .append(self.with_node(description))
                 .append(allocator.hardline());
         }
 
@@ -687,6 +687,12 @@ impl<'a> Pretty<'a, Allocator<'a>> for NodeDisplay<Value<'a>> {
                 .braces()
                 .group(),
         }
+    }
+}
+
+impl<'a> Pretty<'a, Allocator<'a>> for NodeDisplay<Description<'a>> {
+    fn pretty(self, allocator: &'a Allocator<'a>) -> pretty::DocBuilder<'a, Allocator<'a>, ()> {
+        NodeDisplay(self.0.literal(), self.1).pretty(allocator)
     }
 }
 

--- a/cynic-parser/src/type_system/extensions.rs
+++ b/cynic-parser/src/type_system/extensions.rs
@@ -1,0 +1,11 @@
+use super::Description;
+
+impl<'a> Description<'a> {
+    pub fn to_cow(&self) -> Cow<'a, str> {
+        self.description().to_cow()
+    }
+
+    pub fn raw_str(&self) -> &'a str {
+        self.description().raw_str()
+    }
+}

--- a/cynic-parser/src/type_system/generated/descriptions.rs
+++ b/cynic-parser/src/type_system/generated/descriptions.rs
@@ -8,7 +8,7 @@ use super::{
 use std::fmt::{self, Write};
 
 pub struct DescriptionRecord {
-    pub description: StringLiteralId,
+    pub literal: StringLiteralId,
     pub span: Span,
 }
 
@@ -16,9 +16,9 @@ pub struct DescriptionRecord {
 pub struct Description<'a>(pub(in super::super) ReadContext<'a, DescriptionId>);
 
 impl<'a> Description<'a> {
-    pub fn description(&self) -> StringLiteral<'a> {
+    pub fn literal(&self) -> StringLiteral<'a> {
         let document = self.0.document;
-        document.read(document.lookup(self.0.id).description)
+        document.read(document.lookup(self.0.id).literal)
     }
     pub fn span(&self) -> Span {
         let document = self.0.document;
@@ -35,7 +35,7 @@ impl Description<'_> {
 impl fmt::Debug for Description<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Description")
-            .field("description", &self.description())
+            .field("literal", &self.literal())
             .field("span", &self.span())
             .finish()
     }


### PR DESCRIPTION
I spotted some `description.description()` calls that I didn't really like the look of so:

1. Renamed the `Description::description` function to `literal()`
2. Exposed some convenience functions on `Description` so you can just use it directly instead of going via the StringLiteral.