### PR TITLE
fix: make `Iter::with_ids` take by reference

### DIFF
--- a/cynic-parser/src/executable/iter.rs
+++ b/cynic-parser/src/executable/iter.rs
@@ -38,10 +38,13 @@ where
         self.ids.current_range()
     }
 
-    pub fn with_ids(self) -> IdIter<'a, T> {
+    pub fn with_ids(&self) -> IdIter<'a, T> {
         let Iter { ids, document } = self;
 
-        IdIter { ids, document }
+        IdIter {
+            ids: ids.clone(),
+            document,
+        }
     }
 }
 


### PR DESCRIPTION
Since `Iter` is no longer `Copy` this is a better API