### PR TITLE
feat: add `Type::definitions`

### DIFF
--- a/cynic-parser/src/type_system/mod.rs
+++ b/cynic-parser/src/type_system/mod.rs
@@ -35,7 +35,7 @@ pub use self::{
         unions::{UnionDefinition, UnionMember},
     },
     string_literal::{StringLiteral, StringLiteralKind},
-    types::Type,
+    types::{NamedTypeDefinition, NamedTypeDefinitions, Type},
 };
 use self::{ids::*, storage::DefinitionRecord};
 


### PR DESCRIPTION
#### Why are we making this change?

If you're working with a TypeSystemDocument, it's often useful to be able to go from a `Type` to the definition(s) of that type.  Currently this is a bit awkward: you need to pass the `TypeSystemDocument` around, potentially through several layers of indirection, so that you can use it again to look up the type.

#### What effects does this change have?

Adds a `Type::definitions` function that returns an `Iterator` of definitions that have the name contained within the `Type`.  This is currently not very efficient, but could be made more so later by adding indexes.