### PR TITLE
fix: remove lifetimes from IdReader trait

### DIFF
--- a/cynic-parser/ast-generator/src/object.rs
+++ b/cynic-parser/ast-generator/src/object.rs
@@ -86,10 +86,11 @@ pub fn object_output(
     })?;
 
     let id_reader_impl = format_code(quote! {
-        impl<'a> IdReader<'a> for #reader_name<'a> {
+        impl IdReader for #reader_name<'_> {
             type Id = #id_name;
+            type Reader<'a> = #reader_name<'a>;
 
-            fn new(id: Self::Id, document: &'a #document_type) -> Self {
+            fn new<'a>(id: Self::Id, document: &'a #document_type) -> Self::Reader<'a> {
                 document.read(id)
             }
         }

--- a/cynic-parser/ast-generator/src/object.rs
+++ b/cynic-parser/ast-generator/src/object.rs
@@ -90,7 +90,7 @@ pub fn object_output(
             type Id = #id_name;
             type Reader<'a> = #reader_name<'a>;
 
-            fn new<'a>(id: Self::Id, document: &'a #document_type) -> Self::Reader<'a> {
+            fn new(id: Self::Id, document: &'_ #document_type) -> Self::Reader<'_> {
                 document.read(id)
             }
         }

--- a/cynic-parser/ast-generator/src/union.rs
+++ b/cynic-parser/ast-generator/src/union.rs
@@ -76,10 +76,11 @@ pub fn union_output(
     })?;
 
     let id_reader_impl = format_code(quote! {
-        impl<'a> IdReader<'a> for #reader_name<'a> {
+        impl IdReader for #reader_name<'_> {
             type Id = #id_name;
+            type Reader<'a> = #reader_name<'a>
 
-            fn new(id: Self::Id, document: &'a #document_type) -> Self {
+            fn new(id: Self::Id, document: &'_ #document_type) -> Self::Reader<'_> {
                 document.read(id)
             }
         }

--- a/cynic-parser/src/executable/generated/argument.rs
+++ b/cynic-parser/src/executable/generated/argument.rs
@@ -53,9 +53,10 @@ impl ExecutableId for ArgumentId {
     }
 }
 
-impl<'a> IdReader<'a> for Argument<'a> {
+impl IdReader for Argument<'_> {
     type Id = ArgumentId;
-    fn new(id: Self::Id, document: &'a ExecutableDocument) -> Self {
+    type Reader<'a> = Argument<'a>;
+    fn new(id: Self::Id, document: &'_ ExecutableDocument) -> Self::Reader<'_> {
         document.read(id)
     }
 }

--- a/cynic-parser/src/executable/generated/definition.rs
+++ b/cynic-parser/src/executable/generated/definition.rs
@@ -33,9 +33,11 @@ impl ExecutableId for ExecutableDefinitionId {
     }
 }
 
-impl<'a> IdReader<'a> for ExecutableDefinition<'a> {
+impl IdReader for ExecutableDefinition<'_> {
     type Id = ExecutableDefinitionId;
-    fn new(id: Self::Id, document: &'a ExecutableDocument) -> Self {
+    type Reader<'a> = ExecutableDefinition<'a>;
+
+    fn new(id: Self::Id, document: &'_ ExecutableDocument) -> Self::Reader<'_> {
         document.read(id)
     }
 }

--- a/cynic-parser/src/executable/generated/directive.rs
+++ b/cynic-parser/src/executable/generated/directive.rs
@@ -53,9 +53,10 @@ impl ExecutableId for DirectiveId {
     }
 }
 
-impl<'a> IdReader<'a> for Directive<'a> {
+impl IdReader for Directive<'_> {
     type Id = DirectiveId;
-    fn new(id: Self::Id, document: &'a ExecutableDocument) -> Self {
+    type Reader<'a> = Directive<'a>;
+    fn new(id: Self::Id, document: &'_ ExecutableDocument) -> Self::Reader<'_> {
         document.read(id)
     }
 }

--- a/cynic-parser/src/executable/generated/fragment.rs
+++ b/cynic-parser/src/executable/generated/fragment.rs
@@ -71,9 +71,10 @@ impl ExecutableId for FragmentDefinitionId {
     }
 }
 
-impl<'a> IdReader<'a> for FragmentDefinition<'a> {
+impl IdReader for FragmentDefinition<'_> {
     type Id = FragmentDefinitionId;
-    fn new(id: Self::Id, document: &'a ExecutableDocument) -> Self {
+    type Reader<'a> = FragmentDefinition<'a>;
+    fn new(id: Self::Id, document: &'_ ExecutableDocument) -> Self::Reader<'_> {
         document.read(id)
     }
 }

--- a/cynic-parser/src/executable/generated/operation.rs
+++ b/cynic-parser/src/executable/generated/operation.rs
@@ -81,9 +81,10 @@ impl ExecutableId for OperationDefinitionId {
     }
 }
 
-impl<'a> IdReader<'a> for OperationDefinition<'a> {
+impl IdReader for OperationDefinition<'_> {
     type Id = OperationDefinitionId;
-    fn new(id: Self::Id, document: &'a ExecutableDocument) -> Self {
+    type Reader<'a> = OperationDefinition<'a>;
+    fn new(id: Self::Id, document: &'_ ExecutableDocument) -> Self::Reader<'_> {
         document.read(id)
     }
 }

--- a/cynic-parser/src/executable/generated/selections.rs
+++ b/cynic-parser/src/executable/generated/selections.rs
@@ -34,9 +34,11 @@ impl ExecutableId for SelectionId {
     }
 }
 
-impl<'a> IdReader<'a> for Selection<'a> {
+impl IdReader for Selection<'_> {
     type Id = SelectionId;
-    fn new(id: Self::Id, document: &'a ExecutableDocument) -> Self {
+    type Reader<'a> = Selection<'a>;
+
+    fn new(id: Self::Id, document: &'_ ExecutableDocument) -> Self::Reader<'_> {
         document.read(id)
     }
 }
@@ -113,9 +115,10 @@ impl ExecutableId for FieldSelectionId {
     }
 }
 
-impl<'a> IdReader<'a> for FieldSelection<'a> {
+impl IdReader for FieldSelection<'_> {
     type Id = FieldSelectionId;
-    fn new(id: Self::Id, document: &'a ExecutableDocument) -> Self {
+    type Reader<'a> = FieldSelection<'a>;
+    fn new(id: Self::Id, document: &'_ ExecutableDocument) -> Self::Reader<'_> {
         document.read(id)
     }
 }
@@ -175,9 +178,10 @@ impl ExecutableId for InlineFragmentId {
     }
 }
 
-impl<'a> IdReader<'a> for InlineFragment<'a> {
+impl IdReader for InlineFragment<'_> {
     type Id = InlineFragmentId;
-    fn new(id: Self::Id, document: &'a ExecutableDocument) -> Self {
+    type Reader<'a> = InlineFragment<'a>;
+    fn new(id: Self::Id, document: &'_ ExecutableDocument) -> Self::Reader<'_> {
         document.read(id)
     }
 }
@@ -228,9 +232,10 @@ impl ExecutableId for FragmentSpreadId {
     }
 }
 
-impl<'a> IdReader<'a> for FragmentSpread<'a> {
+impl IdReader for FragmentSpread<'_> {
     type Id = FragmentSpreadId;
-    fn new(id: Self::Id, document: &'a ExecutableDocument) -> Self {
+    type Reader<'a> = FragmentSpread<'a>;
+    fn new(id: Self::Id, document: &'_ ExecutableDocument) -> Self::Reader<'_> {
         document.read(id)
     }
 }

--- a/cynic-parser/src/executable/generated/variable.rs
+++ b/cynic-parser/src/executable/generated/variable.rs
@@ -70,9 +70,10 @@ impl ExecutableId for VariableDefinitionId {
     }
 }
 
-impl<'a> IdReader<'a> for VariableDefinition<'a> {
+impl IdReader for VariableDefinition<'_> {
     type Id = VariableDefinitionId;
-    fn new(id: Self::Id, document: &'a ExecutableDocument) -> Self {
+    type Reader<'a> = VariableDefinition<'a>;
+    fn new(id: Self::Id, document: &'_ ExecutableDocument) -> Self::Reader<'_> {
         document.read(id)
     }
 }

--- a/cynic-parser/src/executable/iter.rs
+++ b/cynic-parser/src/executable/iter.rs
@@ -4,10 +4,11 @@ use crate::common::{IdOperations, IdRange, IdRangeIter};
 
 use super::{ExecutableDocument, ExecutableId};
 
-pub trait IdReader<'a> {
+pub trait IdReader {
     type Id: ExecutableId;
+    type Reader<'a>;
 
-    fn new(id: Self::Id, document: &'a ExecutableDocument) -> Self;
+    fn new(id: Self::Id, document: &'_ ExecutableDocument) -> Self::Reader<'_>;
 }
 
 /// Iterator for readers in the executable module
@@ -16,7 +17,7 @@ pub trait IdReader<'a> {
 #[derive(Clone)]
 pub struct Iter<'a, T>
 where
-    T: IdReader<'a>,
+    T: IdReader,
 {
     ids: IdRangeIter<T::Id>,
     document: &'a super::ExecutableDocument,
@@ -24,7 +25,7 @@ where
 
 impl<'a, T> Iter<'a, T>
 where
-    T: IdReader<'a>,
+    T: IdReader,
 {
     pub(crate) fn new(range: IdRange<T::Id>, document: &'a super::ExecutableDocument) -> Self
     where
@@ -52,10 +53,10 @@ where
 
 impl<'a, T> Iterator for Iter<'a, T>
 where
-    T: IdReader<'a>,
+    T: IdReader,
     T::Id: IdOperations,
 {
-    type Item = T;
+    type Item = T::Reader<'a>;
 
     fn next(&mut self) -> Option<Self::Item> {
         Some(T::new(self.ids.next()?, self.document))
@@ -68,21 +69,21 @@ where
 
 impl<'a, T> ExactSizeIterator for Iter<'a, T>
 where
-    T: IdReader<'a>,
+    T: IdReader,
     T::Id: IdOperations,
 {
 }
 
 impl<'a, T> FusedIterator for Iter<'a, T>
 where
-    T: IdReader<'a>,
+    T: IdReader,
     T::Id: IdOperations,
 {
 }
 
 impl<'a, T> DoubleEndedIterator for Iter<'a, T>
 where
-    T: IdReader<'a>,
+    T: IdReader,
     T::Id: IdOperations,
 {
     // Required method
@@ -93,7 +94,7 @@ where
 
 impl<'a, T> fmt::Debug for Iter<'a, T>
 where
-    T: IdReader<'a> + Copy,
+    T: IdReader + Copy,
     Self: Iterator,
     <Self as Iterator>::Item: fmt::Debug,
 {
@@ -108,7 +109,7 @@ where
 #[derive(Clone)]
 pub struct IdIter<'a, T>
 where
-    T: IdReader<'a>,
+    T: IdReader,
 {
     ids: IdRangeIter<T::Id>,
     document: &'a super::ExecutableDocument,
@@ -116,7 +117,7 @@ where
 
 impl<'a, T> Iterator for IdIter<'a, T>
 where
-    T: IdReader<'a>,
+    T: IdReader,
     T::Id: IdOperations,
 {
     type Item = (T::Id, <T::Id as ExecutableId>::Reader<'a>);
@@ -134,21 +135,21 @@ where
 
 impl<'a, T> ExactSizeIterator for IdIter<'a, T>
 where
-    T: IdReader<'a>,
+    T: IdReader,
     T::Id: IdOperations,
 {
 }
 
 impl<'a, T> FusedIterator for IdIter<'a, T>
 where
-    T: IdReader<'a>,
+    T: IdReader,
     T::Id: IdOperations,
 {
 }
 
 impl<'a, T> DoubleEndedIterator for IdIter<'a, T>
 where
-    T: IdReader<'a>,
+    T: IdReader,
     T::Id: IdOperations,
 {
     // Required method
@@ -161,7 +162,7 @@ where
 
 impl<'a, T> fmt::Debug for IdIter<'a, T>
 where
-    T: IdReader<'a> + Copy,
+    T: IdReader + Copy,
     Self: Iterator,
     <Self as Iterator>::Item: fmt::Debug,
 {

--- a/cynic-parser/src/printing/pretty/type_system/field_sequence.rs
+++ b/cynic-parser/src/printing/pretty/type_system/field_sequence.rs
@@ -1,4 +1,4 @@
-use std::{iter::Enumerate, marker::PhantomData};
+use std::iter::Enumerate;
 
 use pretty::{DocAllocator, Pretty};
 
@@ -20,16 +20,17 @@ use super::{
 /// but arguments should use ArgumentSequence
 pub(super) struct FieldSequence<'a, T>
 where
-    T: IdReader<'a> + Field<'a>,
+    T: IdReader,
+    T::Reader<'a>: Field<'a>,
 {
-    iterator: Enumerate<std::vec::IntoIter<T>>,
+    iterator: Enumerate<std::vec::IntoIter<T::Reader<'a>>>,
     options: PrettyOptions,
-    phantom: PhantomData<&'a T>,
 }
 
 impl<'a, T> FieldSequence<'a, T>
 where
-    T: IdReader<'a> + Field<'a>,
+    T: IdReader,
+    T::Reader<'a>: Field<'a>,
     T::Id: IdOperations,
 {
     pub fn new(iterator: crate::type_system::iter::Iter<'a, T>, options: PrettyOptions) -> Self {
@@ -41,7 +42,6 @@ where
         FieldSequence {
             iterator: fields.into_iter().enumerate(),
             options,
-            phantom: PhantomData,
         }
     }
 }
@@ -83,9 +83,10 @@ impl<'a> Field<'a> for EnumValueDefinition<'a> {
 
 impl<'a, T> Pretty<'a, Allocator<'a>> for FieldSequence<'a, T>
 where
-    T: Field<'a> + IdReader<'a>,
+    T: IdReader,
+    T::Reader<'a>: Field<'a>,
     T::Id: IdOperations,
-    NodeDisplay<T>: Pretty<'a, Allocator<'a>>,
+    NodeDisplay<T::Reader<'a>>: Pretty<'a, Allocator<'a>>,
 {
     fn pretty(self, allocator: &'a Allocator<'a>) -> pretty::DocBuilder<'a, Allocator<'a>, ()> {
         let mut document = allocator.nil();

--- a/cynic-parser/src/type_system/definitions.rs
+++ b/cynic-parser/src/type_system/definitions.rs
@@ -152,10 +152,11 @@ impl TypeSystemId for DefinitionId {
     }
 }
 
-impl<'a> IdReader<'a> for Definition<'a> {
+impl IdReader for Definition<'_> {
     type Id = DefinitionId;
+    type Reader<'a> = Definition<'a>;
 
-    fn new(id: Self::Id, document: &'a super::TypeSystemDocument) -> Self {
+    fn new(id: Self::Id, document: &'_ super::TypeSystemDocument) -> Self::Reader<'_> {
         document.read(id)
     }
 }

--- a/cynic-parser/src/type_system/generated/arguments.rs
+++ b/cynic-parser/src/type_system/generated/arguments.rs
@@ -59,9 +59,10 @@ impl TypeSystemId for ArgumentId {
     }
 }
 
-impl<'a> IdReader<'a> for Argument<'a> {
+impl IdReader for Argument<'_> {
     type Id = ArgumentId;
-    fn new(id: Self::Id, document: &'a TypeSystemDocument) -> Self {
+    type Reader<'a> = Argument<'a>;
+    fn new(id: Self::Id, document: &'_ TypeSystemDocument) -> Self::Reader<'_> {
         document.read(id)
     }
 }

--- a/cynic-parser/src/type_system/generated/descriptions.rs
+++ b/cynic-parser/src/type_system/generated/descriptions.rs
@@ -48,9 +48,10 @@ impl TypeSystemId for DescriptionId {
     }
 }
 
-impl<'a> IdReader<'a> for Description<'a> {
+impl IdReader for Description<'_> {
     type Id = DescriptionId;
-    fn new(id: Self::Id, document: &'a TypeSystemDocument) -> Self {
+    type Reader<'a> = Description<'a>;
+    fn new(id: Self::Id, document: &'_ TypeSystemDocument) -> Self::Reader<'_> {
         document.read(id)
     }
 }

--- a/cynic-parser/src/type_system/generated/directives.rs
+++ b/cynic-parser/src/type_system/generated/directives.rs
@@ -82,9 +82,10 @@ impl TypeSystemId for DirectiveDefinitionId {
     }
 }
 
-impl<'a> IdReader<'a> for DirectiveDefinition<'a> {
+impl IdReader for DirectiveDefinition<'_> {
     type Id = DirectiveDefinitionId;
-    fn new(id: Self::Id, document: &'a TypeSystemDocument) -> Self {
+    type Reader<'a> = DirectiveDefinition<'a>;
+    fn new(id: Self::Id, document: &'_ TypeSystemDocument) -> Self::Reader<'_> {
         document.read(id)
     }
 }
@@ -135,9 +136,10 @@ impl TypeSystemId for DirectiveId {
     }
 }
 
-impl<'a> IdReader<'a> for Directive<'a> {
+impl IdReader for Directive<'_> {
     type Id = DirectiveId;
-    fn new(id: Self::Id, document: &'a TypeSystemDocument) -> Self {
+    type Reader<'a> = Directive<'a>;
+    fn new(id: Self::Id, document: &'_ TypeSystemDocument) -> Self::Reader<'_> {
         document.read(id)
     }
 }

--- a/cynic-parser/src/type_system/generated/enums.rs
+++ b/cynic-parser/src/type_system/generated/enums.rs
@@ -75,9 +75,10 @@ impl TypeSystemId for EnumDefinitionId {
     }
 }
 
-impl<'a> IdReader<'a> for EnumDefinition<'a> {
+impl IdReader for EnumDefinition<'_> {
     type Id = EnumDefinitionId;
-    fn new(id: Self::Id, document: &'a TypeSystemDocument) -> Self {
+    type Reader<'a> = EnumDefinition<'a>;
+    fn new(id: Self::Id, document: &'_ TypeSystemDocument) -> Self::Reader<'_> {
         document.read(id)
     }
 }
@@ -143,9 +144,10 @@ impl TypeSystemId for EnumValueDefinitionId {
     }
 }
 
-impl<'a> IdReader<'a> for EnumValueDefinition<'a> {
+impl IdReader for EnumValueDefinition<'_> {
     type Id = EnumValueDefinitionId;
-    fn new(id: Self::Id, document: &'a TypeSystemDocument) -> Self {
+    type Reader<'a> = EnumValueDefinition<'a>;
+    fn new(id: Self::Id, document: &'_ TypeSystemDocument) -> Self::Reader<'_> {
         document.read(id)
     }
 }

--- a/cynic-parser/src/type_system/generated/fields.rs
+++ b/cynic-parser/src/type_system/generated/fields.rs
@@ -83,9 +83,10 @@ impl TypeSystemId for FieldDefinitionId {
     }
 }
 
-impl<'a> IdReader<'a> for FieldDefinition<'a> {
+impl IdReader for FieldDefinition<'_> {
     type Id = FieldDefinitionId;
-    fn new(id: Self::Id, document: &'a TypeSystemDocument) -> Self {
+    type Reader<'a> = FieldDefinition<'a>;
+    fn new(id: Self::Id, document: &'_ TypeSystemDocument) -> Self::Reader<'_> {
         document.read(id)
     }
 }

--- a/cynic-parser/src/type_system/generated/input_objects.rs
+++ b/cynic-parser/src/type_system/generated/input_objects.rs
@@ -76,9 +76,10 @@ impl TypeSystemId for InputObjectDefinitionId {
     }
 }
 
-impl<'a> IdReader<'a> for InputObjectDefinition<'a> {
+impl IdReader for InputObjectDefinition<'_> {
     type Id = InputObjectDefinitionId;
-    fn new(id: Self::Id, document: &'a TypeSystemDocument) -> Self {
+    type Reader<'a> = InputObjectDefinition<'a>;
+    fn new(id: Self::Id, document: &'_ TypeSystemDocument) -> Self::Reader<'_> {
         document.read(id)
     }
 }

--- a/cynic-parser/src/type_system/generated/input_values.rs
+++ b/cynic-parser/src/type_system/generated/input_values.rs
@@ -86,9 +86,10 @@ impl TypeSystemId for InputValueDefinitionId {
     }
 }
 
-impl<'a> IdReader<'a> for InputValueDefinition<'a> {
+impl IdReader for InputValueDefinition<'_> {
     type Id = InputValueDefinitionId;
-    fn new(id: Self::Id, document: &'a TypeSystemDocument) -> Self {
+    type Reader<'a> = InputValueDefinition<'a>;
+    fn new(id: Self::Id, document: &'_ TypeSystemDocument) -> Self::Reader<'_> {
         document.read(id)
     }
 }

--- a/cynic-parser/src/type_system/generated/interfaces.rs
+++ b/cynic-parser/src/type_system/generated/interfaces.rs
@@ -89,9 +89,10 @@ impl TypeSystemId for InterfaceDefinitionId {
     }
 }
 
-impl<'a> IdReader<'a> for InterfaceDefinition<'a> {
+impl IdReader for InterfaceDefinition<'_> {
     type Id = InterfaceDefinitionId;
-    fn new(id: Self::Id, document: &'a TypeSystemDocument) -> Self {
+    type Reader<'a> = InterfaceDefinition<'a>;
+    fn new(id: Self::Id, document: &'_ TypeSystemDocument) -> Self::Reader<'_> {
         document.read(id)
     }
 }

--- a/cynic-parser/src/type_system/generated/name.rs
+++ b/cynic-parser/src/type_system/generated/name.rs
@@ -1,0 +1,49 @@
+use super::prelude::*;
+use super::{ids::NameId, TypeSystemId};
+#[allow(unused_imports)]
+use std::fmt::{self, Write};
+
+pub struct NameRecord {
+    pub text: StringId,
+    pub span: Span,
+}
+
+#[derive(Clone, Copy)]
+pub struct Name<'a>(pub(in super::super) ReadContext<'a, NameId>);
+
+impl<'a> Name<'a> {
+    pub fn text(&self) -> &'a str {
+        let document = &self.0.document;
+        document.lookup(document.lookup(self.0.id).text)
+    }
+    pub fn span(&self) -> Span {
+        let document = self.0.document;
+        document.lookup(self.0.id).span
+    }
+}
+
+impl Name<'_> {
+    pub fn id(&self) -> NameId {
+        self.0.id
+    }
+}
+
+impl fmt::Debug for Name<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Name")
+            .field("text", &self.text())
+            .field("span", &self.span())
+            .finish()
+    }
+}
+
+impl TypeSystemId for NameId {
+    type Reader<'a> = Name<'a>;
+    fn read(self, document: &TypeSystemDocument) -> Self::Reader<'_> {
+        Name(ReadContext { id: self, document })
+    }
+}
+
+impl IdReader for Name<'_> {
+    type Id = NameId;
+}

--- a/cynic-parser/src/type_system/generated/objects.rs
+++ b/cynic-parser/src/type_system/generated/objects.rs
@@ -89,9 +89,10 @@ impl TypeSystemId for ObjectDefinitionId {
     }
 }
 
-impl<'a> IdReader<'a> for ObjectDefinition<'a> {
+impl IdReader for ObjectDefinition<'_> {
     type Id = ObjectDefinitionId;
-    fn new(id: Self::Id, document: &'a TypeSystemDocument) -> Self {
+    type Reader<'a> = ObjectDefinition<'a>;
+    fn new(id: Self::Id, document: &'_ TypeSystemDocument) -> Self::Reader<'_> {
         document.read(id)
     }
 }

--- a/cynic-parser/src/type_system/generated/scalars.rs
+++ b/cynic-parser/src/type_system/generated/scalars.rs
@@ -69,9 +69,10 @@ impl TypeSystemId for ScalarDefinitionId {
     }
 }
 
-impl<'a> IdReader<'a> for ScalarDefinition<'a> {
+impl IdReader for ScalarDefinition<'_> {
     type Id = ScalarDefinitionId;
-    fn new(id: Self::Id, document: &'a TypeSystemDocument) -> Self {
+    type Reader<'a> = ScalarDefinition<'a>;
+    fn new(id: Self::Id, document: &'_ TypeSystemDocument) -> Self::Reader<'_> {
         document.read(id)
     }
 }

--- a/cynic-parser/src/type_system/generated/schemas.rs
+++ b/cynic-parser/src/type_system/generated/schemas.rs
@@ -64,9 +64,10 @@ impl TypeSystemId for SchemaDefinitionId {
     }
 }
 
-impl<'a> IdReader<'a> for SchemaDefinition<'a> {
+impl IdReader for SchemaDefinition<'_> {
     type Id = SchemaDefinitionId;
-    fn new(id: Self::Id, document: &'a TypeSystemDocument) -> Self {
+    type Reader<'a> = SchemaDefinition<'a>;
+    fn new(id: Self::Id, document: &'_ TypeSystemDocument) -> Self::Reader<'_> {
         document.read(id)
     }
 }
@@ -130,9 +131,10 @@ impl TypeSystemId for RootOperationTypeDefinitionId {
     }
 }
 
-impl<'a> IdReader<'a> for RootOperationTypeDefinition<'a> {
+impl IdReader for RootOperationTypeDefinition<'_> {
     type Id = RootOperationTypeDefinitionId;
-    fn new(id: Self::Id, document: &'a TypeSystemDocument) -> Self {
+    type Reader<'a> = RootOperationTypeDefinition<'a>;
+    fn new(id: Self::Id, document: &'_ TypeSystemDocument) -> Self::Reader<'_> {
         document.read(id)
     }
 }

--- a/cynic-parser/src/type_system/generated/unions.rs
+++ b/cynic-parser/src/type_system/generated/unions.rs
@@ -75,9 +75,10 @@ impl TypeSystemId for UnionDefinitionId {
     }
 }
 
-impl<'a> IdReader<'a> for UnionDefinition<'a> {
+impl IdReader for UnionDefinition<'_> {
     type Id = UnionDefinitionId;
-    fn new(id: Self::Id, document: &'a TypeSystemDocument) -> Self {
+    type Reader<'a> = UnionDefinition<'a>;
+    fn new(id: Self::Id, document: &'_ TypeSystemDocument) -> Self::Reader<'_> {
         document.read(id)
     }
 }
@@ -123,9 +124,10 @@ impl TypeSystemId for UnionMemberId {
     }
 }
 
-impl<'a> IdReader<'a> for UnionMember<'a> {
+impl IdReader for UnionMember<'_> {
     type Id = UnionMemberId;
-    fn new(id: Self::Id, document: &'a TypeSystemDocument) -> Self {
+    type Reader<'a> = UnionMember<'a>;
+    fn new(id: Self::Id, document: &'_ TypeSystemDocument) -> Self::Reader<'_> {
         document.read(id)
     }
 }

--- a/cynic-parser/src/type_system/iter.rs
+++ b/cynic-parser/src/type_system/iter.rs
@@ -10,7 +10,7 @@ use super::{TypeSystemDocument, TypeSystemId};
 #[derive(Clone)]
 pub struct Iter<'a, T>
 where
-    T: IdReader<'a>,
+    T: IdReader,
 {
     ids: IdRangeIter<T::Id>,
     document: &'a super::TypeSystemDocument,
@@ -18,7 +18,7 @@ where
 
 impl<'a, T> Iter<'a, T>
 where
-    T: IdReader<'a>,
+    T: IdReader,
 {
     pub(crate) fn new(range: IdRange<T::Id>, document: &'a super::TypeSystemDocument) -> Self
     where
@@ -35,18 +35,19 @@ where
     }
 }
 
-pub trait IdReader<'a> {
+pub trait IdReader {
     type Id: TypeSystemId;
+    type Reader<'a>;
 
-    fn new(id: Self::Id, document: &'a TypeSystemDocument) -> Self;
+    fn new(id: Self::Id, document: &'_ TypeSystemDocument) -> Self::Reader<'_>;
 }
 
 impl<'a, T> Iterator for Iter<'a, T>
 where
-    T: IdReader<'a>,
+    T: IdReader,
     T::Id: IdOperations,
 {
-    type Item = T;
+    type Item = T::Reader<'a>;
 
     fn next(&mut self) -> Option<Self::Item> {
         Some(T::new(self.ids.next()?, self.document))
@@ -59,21 +60,21 @@ where
 
 impl<'a, T> ExactSizeIterator for Iter<'a, T>
 where
-    T: IdReader<'a>,
+    T: IdReader,
     T::Id: IdOperations,
 {
 }
 
 impl<'a, T> FusedIterator for Iter<'a, T>
 where
-    T: IdReader<'a>,
+    T: IdReader,
     T::Id: IdOperations,
 {
 }
 
 impl<'a, T> DoubleEndedIterator for Iter<'a, T>
 where
-    T: IdReader<'a>,
+    T: IdReader,
     T::Id: IdOperations,
 {
     // Required method
@@ -84,7 +85,7 @@ where
 
 impl<'a, T> fmt::Debug for Iter<'a, T>
 where
-    T: IdReader<'a> + Copy,
+    T: IdReader + Copy,
     Self: Iterator,
     <Self as Iterator>::Item: fmt::Debug,
 {


### PR DESCRIPTION
https://github.com/obmarg/cynic/pull/1064 improved some aspects of the IdReader API, but by using a lifetime parameter on the `IdReader` trait to implement `Iter` we tie the lifetimes in `Iter<'_, Whatever<'a>>` together.  This forces any usage sites of `Iter` to always have named lifetime parameters - otherwise the compiler complains.

This is not the API I want to expose: the dual lifetimes are only workable as they can be elided.

This fixes that somewhat.  It does regress some of the problems #1064 was meant to fix, but it's an acceptable tradeoff.