### PR TITLE
fix: implement ConstValue::span

### DIFF
--- a/cynic-parser/src/values/const_value.rs
+++ b/cynic-parser/src/values/const_value.rs
@@ -24,7 +24,16 @@ pub enum ConstValue<'a> {
 
 impl<'a> ConstValue<'a> {
     pub fn span(&self) -> Span {
-        todo!()
+        match self {
+            ConstValue::Int(inner) => inner.span(),
+            ConstValue::Float(inner) => inner.span(),
+            ConstValue::String(inner) => inner.span(),
+            ConstValue::Boolean(inner) => inner.span(),
+            ConstValue::Null(inner) => inner.span(),
+            ConstValue::Enum(inner) => inner.span(),
+            ConstValue::List(inner) => inner.span(),
+            ConstValue::Object(inner) => inner.span(),
+        }
     }
 }
 


### PR DESCRIPTION
I'd accidentally left a `todo!()` lying around.