### PR TITLE
fix: resurrect default value span

### DIFF
--- a/cynic-parser/ast-generator/domain/type_system.graphql
+++ b/cynic-parser/ast-generator/domain/type_system.graphql
@@ -88,6 +88,7 @@ type InputValueDefinition @file(name: "input_values") {
   ty: Type!
   description: Description
   default_value: ConstValue
+  default_value_span: Span!
   directives: [Directive!]!
   span: Span!
 }

--- a/cynic-parser/src/parser/schema.lalrpop
+++ b/cynic-parser/src/parser/schema.lalrpop
@@ -366,7 +366,9 @@ InputValueDefinition: () = {
         <name:Name>
         <name_end:@R>
         ":" <ty:Type>
+        <default_start:@L>
         <default:DefaultValue?>
+        <default_end:@R>
         <directives:Directives>
         <end:@R>
     => {
@@ -377,6 +379,7 @@ InputValueDefinition: () = {
             description,
             directives,
             default_value: default,
+            default_value_span: Span::new(default_start, default_end),
             span: Span::new(start, end)
         });
     }

--- a/cynic-parser/src/parser/schema.rs
+++ b/cynic-parser/src/parser/schema.rs
@@ -1,5 +1,5 @@
 // auto-generated: "lalrpop 0.21.0"
-// sha3: 25f2508b042556101e2b7e758d756de383fbd0f637c2733fa7ada027448d7a12
+// sha3: 42a9bcdc947996d2ccdc87b6444b7ee866ed754e1cf55d25ded43a9db554c2c3
 use crate::lexer;
 use crate::{
     common::{
@@ -8664,7 +8664,9 @@ fn __action47<'input>(
     (_, name_end, _): (usize, usize, usize),
     (_, _, _): (usize, lexer::Token<'input>, usize),
     (_, ty, _): (usize, TypeId, usize),
+    (_, default_start, _): (usize, usize, usize),
     (_, default, _): (usize, Option<ConstValueId>, usize),
+    (_, default_end, _): (usize, usize, usize),
     (_, directives, _): (usize, IdRange<DirectiveId>, usize),
     (_, end, _): (usize, usize, usize),
 ) {
@@ -8676,6 +8678,7 @@ fn __action47<'input>(
             description,
             directives,
             default_value: default,
+            default_value_span: Span::new(default_start, default_end),
             span: Span::new(start, end),
         });
     }
@@ -10941,19 +10944,24 @@ fn __action180<'input>(
     __3: (usize, lexer::Token<'input>, usize),
     __4: (usize, TypeId, usize),
     __5: (usize, Option<ConstValueId>, usize),
-    __6: (usize, IdRange<DirectiveId>, usize),
-    __7: (usize, usize, usize),
+    __6: (usize, usize, usize),
+    __7: (usize, IdRange<DirectiveId>, usize),
+    __8: (usize, usize, usize),
 ) {
     let __start0 = __0.0;
     let __end0 = __0.0;
     let __start1 = __0.2;
     let __end1 = __1.0;
+    let __start2 = __4.2;
+    let __end2 = __5.0;
     let __temp0 = __action146(input, ast, &__start0, &__end0);
     let __temp0 = (__start0, __temp0, __end0);
     let __temp1 = __action146(input, ast, &__start1, &__end1);
     let __temp1 = (__start1, __temp1, __end1);
+    let __temp2 = __action146(input, ast, &__start2, &__end2);
+    let __temp2 = (__start2, __temp2, __end2);
     __action47(
-        input, ast, __temp0, __0, __temp1, __1, __2, __3, __4, __5, __6, __7,
+        input, ast, __temp0, __0, __temp1, __1, __2, __3, __4, __temp2, __5, __6, __7, __8,
     )
 }
 
@@ -11802,13 +11810,19 @@ fn __action217<'input>(
 ) {
     let __start0 = __1.2;
     let __end0 = __2.0;
-    let __start1 = __5.2;
-    let __end1 = __5.2;
+    let __start1 = __4.2;
+    let __end1 = __5.0;
+    let __start2 = __5.2;
+    let __end2 = __5.2;
     let __temp0 = __action145(input, ast, &__start0, &__end0);
     let __temp0 = (__start0, __temp0, __end0);
     let __temp1 = __action145(input, ast, &__start1, &__end1);
     let __temp1 = (__start1, __temp1, __end1);
-    __action180(input, ast, __0, __1, __temp0, __2, __3, __4, __5, __temp1)
+    let __temp2 = __action145(input, ast, &__start2, &__end2);
+    let __temp2 = (__start2, __temp2, __end2);
+    __action180(
+        input, ast, __0, __1, __temp0, __2, __3, __4, __temp1, __5, __temp2,
+    )
 }
 
 #[allow(unused_variables)]

--- a/cynic-parser/src/type_system/generated/input_values.rs
+++ b/cynic-parser/src/type_system/generated/input_values.rs
@@ -16,6 +16,7 @@ pub struct InputValueDefinitionRecord {
     pub ty: TypeId,
     pub description: Option<DescriptionId>,
     pub default_value: Option<ConstValueId>,
+    pub default_value_span: Span,
     pub directives: IdRange<DirectiveId>,
     pub span: Span,
 }
@@ -50,6 +51,10 @@ impl<'a> InputValueDefinition<'a> {
             .default_value
             .map(|id| document.read(id))
     }
+    pub fn default_value_span(&self) -> Span {
+        let document = self.0.document;
+        document.lookup(self.0.id).default_value_span
+    }
     pub fn directives(&self) -> Iter<'a, Directive<'a>> {
         let document = self.0.document;
         super::Iter::new(document.lookup(self.0.id).directives, document)
@@ -73,6 +78,7 @@ impl fmt::Debug for InputValueDefinition<'_> {
             .field("ty", &self.ty())
             .field("description", &self.description())
             .field("default_value", &self.default_value())
+            .field("default_value_span", &self.default_value_span())
             .field("directives", &self.directives())
             .field("span", &self.span())
             .finish()


### PR DESCRIPTION
The old default_value_span included the `= ` which is useful if you want to remove a default value or similar from the text.  So I'm going to bring this back.

Reverts obmarg/cynic#1071