### PR TITLE
feat: lots of conveniences in parser

### DIFF
--- a/cynic-parser/CHANGELOG.md
+++ b/cynic-parser/CHANGELOG.md
@@ -9,6 +9,36 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ## Unreleased - xxxx-xx-xx
 
+### Breaking Changes
+
+- Lexing failures now include the token that failed to parse
+- `Description::raw_str` has been renamed `raw_untrimmed_str` to make its
+  purpose clearer.
+- `StringLiteral::raw_str` has been renamed `raw_untrimmed_str` to make its
+  purpose clearer.
+- `Float`s are now correctly represented as f64 rather than f32
+- `Value::as_f32` & `ConstValue::as_f32` are now `as_f64`
+
+### New Features
+
+- Added convenience functions to `SchemaDefintion` to get the individual
+  definitions from within
+- Added `get` function to `ConstList`, `List,`, `ConstObject` and `Object` to
+  get the value of an item or field from the list or object
+- `ConstList`, `List`, `ConstObject` and `Object` now implement `IntoIterator`,
+  which is equivalent to calling `items` or `fields`
+- Added `as_f64` & `as_str` & `as_bool` functions to the respective scalar
+  value types.
+
+### Bug Fixes
+
+- `Float`s are now correctly represented as f64 rather than f32
+
+### Changes
+
+- `Iter` types are now reexported in the `type_system` and `executable` modules
+- `Value` & `ConstValue` are now reexported from the crate root.
+
 ## v0.7.1 - 2024-10-25
 
 ### Bug Fixes
@@ -23,7 +53,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 - Removed `InputValueDefiniton::default_value_span` - you should now fetch the
   span from the `default_value` itself.
 - `RootOperationTypeDefinition::span` now covers the entire root operation type
-  definition.  For the old spans, use `RootOperationTypeDefinition::named_type_span`.
+  definition. For the old spans, use `RootOperationTypeDefinition::named_type_span`.
 
 ### New Features
 
@@ -33,7 +63,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ### Bug Fixes
 
-- Fixed an issue where explicit lifetimes had to be used on 
+- Fixed an issue where explicit lifetimes had to be used on
   `Iter<'_, Whatever<'_>>` ([#1072](https://github.com/obmarg/cynic/pull/1072))
 - Fixed some associated type definitions on Iter ([#1068](https://github.com/obmarg/cynic/pull/1068))
 

--- a/cynic-parser/src/errors.rs
+++ b/cynic-parser/src/errors.rs
@@ -131,7 +131,7 @@ impl fmt::Display for Error {
                 write!(f, "found a {token} after the expected end of the document")
             }
             Error::Lexical(error) => {
-                write!(f, "lexing error: {error}")
+                write!(f, "{error}")
             }
             Error::MalformedStringLiteral(error) => {
                 write!(f, "malformed string literal: {error}")

--- a/cynic-parser/src/executable/mod.rs
+++ b/cynic-parser/src/executable/mod.rs
@@ -23,10 +23,11 @@ pub use self::{
         selections::{FieldSelection, FragmentSpread, InlineFragment, Selection},
         variable::VariableDefinition,
     },
+    iter::Iter,
     types::Type,
 };
 
-use self::{ids::ExecutableDefinitionId, iter::Iter};
+use self::ids::ExecutableDefinitionId;
 
 #[derive(Default)]
 pub struct ExecutableDocument {

--- a/cynic-parser/src/lexer/mod.rs
+++ b/cynic-parser/src/lexer/mod.rs
@@ -11,18 +11,20 @@ pub type Spanned<Tok, Loc, Error> = Result<(Loc, Tok, Loc), Error>;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum LexicalError {
-    InvalidToken(Span),
+    InvalidToken(String, Span),
 }
 
 pub struct Lexer<'input> {
     // instead of an iterator over characters, we have a token iterator
     token_stream: SpannedIter<'input, Token<'input>>,
+    input: &'input str,
 }
 
 impl<'input> Lexer<'input> {
     pub fn new(input: &'input str) -> Self {
         Self {
             token_stream: Token::lexer(input).spanned(),
+            input,
         }
     }
 }
@@ -34,9 +36,12 @@ impl<'input> Iterator for Lexer<'input> {
         match self.token_stream.next() {
             None => None,
             Some((Ok(token), span)) => Some(Ok((span.start, token, span.end))),
-            Some((Err(_), span)) => Some(Err(AdditionalErrors::Lexical(
-                LexicalError::InvalidToken(Span::new(span.start, span.end)),
-            ))),
+            Some((Err(_), span)) => {
+                Some(Err(AdditionalErrors::Lexical(LexicalError::InvalidToken(
+                    self.input[span.start..span.end].to_string(),
+                    Span::new(span.start, span.end),
+                ))))
+            }
         }
     }
 }
@@ -44,7 +49,7 @@ impl<'input> Iterator for Lexer<'input> {
 impl LexicalError {
     pub fn span(&self) -> Span {
         match self {
-            LexicalError::InvalidToken(span) => *span,
+            LexicalError::InvalidToken(_, span) => *span,
         }
     }
 }
@@ -52,7 +57,7 @@ impl LexicalError {
 impl fmt::Display for LexicalError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            LexicalError::InvalidToken(_) => write!(f, "invalid token"),
+            LexicalError::InvalidToken(token, _span) => write!(f, "invalid token: {token}"),
         }
     }
 }

--- a/cynic-parser/src/lib.rs
+++ b/cynic-parser/src/lib.rs
@@ -17,7 +17,11 @@ pub mod printing;
 pub use errors::Report;
 
 pub use self::{
-    errors::Error, executable::ExecutableDocument, span::Span, type_system::TypeSystemDocument,
+    errors::Error,
+    executable::ExecutableDocument,
+    span::Span,
+    type_system::TypeSystemDocument,
+    values::{ConstValue, Value},
 };
 
 pub fn parse_type_system_document(input: &str) -> Result<TypeSystemDocument, Error> {

--- a/cynic-parser/src/printing/pretty/type_system.rs
+++ b/cynic-parser/src/printing/pretty/type_system.rs
@@ -627,7 +627,7 @@ impl<'a> Pretty<'a, Allocator<'a>> for NodeDisplay<StringLiteral<'a>> {
                 .text(escape_string(self.0.to_cow().as_ref()))
                 .double_quotes(),
             StringLiteralKind::Block => allocator
-                .text(self.0.raw_str())
+                .text(self.0.raw_untrimmed_str())
                 .double_quotes()
                 .double_quotes()
                 .double_quotes(),

--- a/cynic-parser/src/type_system/extensions.rs
+++ b/cynic-parser/src/type_system/extensions.rs
@@ -1,19 +1,49 @@
 use std::{borrow::Cow, fmt};
 
-use super::Description;
+use crate::common::OperationType;
+
+use super::{Argument, Description, Directive, RootOperationTypeDefinition, SchemaDefinition};
 
 impl<'a> Description<'a> {
     pub fn to_cow(&self) -> Cow<'a, str> {
         self.literal().to_cow()
     }
 
-    pub fn raw_str(&self) -> &'a str {
-        self.literal().raw_str()
+    pub fn raw_untrimmed_str(&self) -> &'a str {
+        self.literal().raw_untrimmed_str()
     }
 }
 
 impl fmt::Display for Description<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.literal().fmt(f)
+    }
+}
+
+impl<'a> SchemaDefinition<'a> {
+    pub fn root_definition(
+        &self,
+        operation_type: OperationType,
+    ) -> Option<RootOperationTypeDefinition<'a>> {
+        self.root_operations()
+            .find(|op| op.operation_type() == operation_type)
+    }
+
+    pub fn root_query_definition(&self) -> Option<RootOperationTypeDefinition<'a>> {
+        self.root_definition(OperationType::Query)
+    }
+
+    pub fn root_mutation_definition(&self) -> Option<RootOperationTypeDefinition<'a>> {
+        self.root_definition(OperationType::Mutation)
+    }
+
+    pub fn root_subscription_definition(&self) -> Option<RootOperationTypeDefinition<'a>> {
+        self.root_definition(OperationType::Subscription)
+    }
+}
+
+impl<'a> Directive<'a> {
+    pub fn argument(&self, name: &str) -> Option<Argument<'a>> {
+        self.arguments().find(|arg| arg.name() == name)
     }
 }

--- a/cynic-parser/src/type_system/mod.rs
+++ b/cynic-parser/src/type_system/mod.rs
@@ -1,7 +1,6 @@
 use std::{str::FromStr, sync::Arc};
 
 use indexmap::IndexSet;
-use iter::Iter;
 
 pub mod ids;
 pub mod iter;
@@ -34,6 +33,7 @@ pub use self::{
         schemas::{RootOperationTypeDefinition, SchemaDefinition},
         unions::{UnionDefinition, UnionMember},
     },
+    iter::Iter,
     string_literal::{StringLiteral, StringLiteralKind},
     types::{NamedTypeDefinition, NamedTypeDefinitions, Type},
 };

--- a/cynic-parser/src/type_system/string_literal.rs
+++ b/cynic-parser/src/type_system/string_literal.rs
@@ -32,7 +32,7 @@ impl<'a> StringLiteral<'a> {
         }
     }
 
-    pub fn raw_str(&self) -> &'a str {
+    pub fn raw_untrimmed_str(&self) -> &'a str {
         match self.0 {
             StringLiteralInner::String(string) => string,
             StringLiteralInner::BlockString(string) => string,

--- a/cynic-parser/src/values/const_lists.rs
+++ b/cynic-parser/src/values/const_lists.rs
@@ -31,10 +31,24 @@ impl<'a> ConstList<'a> {
 
         Iter::new(IdRange { start, end }, store)
     }
+
+    pub fn get(&self, index: usize) -> Option<ConstValue<'a>> {
+        self.items().nth(index)
+    }
 }
 
 impl fmt::Debug for ConstList<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_list().entries(self.items()).finish()
+    }
+}
+
+impl<'a> IntoIterator for ConstList<'a> {
+    type Item = ConstValue<'a>;
+
+    type IntoIter = Iter<'a, ConstValue<'a>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.items()
     }
 }

--- a/cynic-parser/src/values/const_objects.rs
+++ b/cynic-parser/src/values/const_objects.rs
@@ -34,6 +34,10 @@ impl<'a> ConstObject<'a> {
 
         Iter::new(IdRange { start, end }, store)
     }
+
+    pub fn get(&self, name: &str) -> Option<ConstValue<'a>> {
+        Some(self.fields().find(|field| field.name() == name)?.value())
+    }
 }
 
 impl fmt::Debug for ConstObject<'_> {
@@ -41,6 +45,16 @@ impl fmt::Debug for ConstObject<'_> {
         f.debug_map()
             .entries(self.fields().map(|field| (field.name(), field.value())))
             .finish()
+    }
+}
+
+impl<'a> IntoIterator for ConstObject<'a> {
+    type Item = ConstObjectField<'a>;
+
+    type IntoIter = Iter<'a, ConstObjectField<'a>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.fields()
     }
 }
 

--- a/cynic-parser/src/values/const_value.rs
+++ b/cynic-parser/src/values/const_value.rs
@@ -53,7 +53,7 @@ impl<'a> ConstValue<'a> {
         matches!(self, Self::Float(_))
     }
 
-    pub fn as_f32(&self) -> Option<f32> {
+    pub fn as_f64(&self) -> Option<f64> {
         match self {
             Self::Float(inner) => Some(inner.value()),
             _ => None,

--- a/cynic-parser/src/values/lists.rs
+++ b/cynic-parser/src/values/lists.rs
@@ -26,6 +26,10 @@ impl<'a> List<'a> {
         let store = &self.0.store;
         Iter::new(store.lookup(self.0.id).kind.as_list().unwrap(), store)
     }
+
+    pub fn get(&self, index: usize) -> Option<Value<'a>> {
+        self.items().nth(index)
+    }
 }
 
 impl PartialEq for List<'_> {
@@ -47,5 +51,15 @@ impl<'a> From<ConstList<'a>> for List<'a> {
         let id = id.into();
 
         List(Cursor { id, store })
+    }
+}
+
+impl<'a> IntoIterator for List<'a> {
+    type Item = Value<'a>;
+
+    type IntoIter = Iter<'a, Value<'a>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.items()
     }
 }

--- a/cynic-parser/src/values/objects.rs
+++ b/cynic-parser/src/values/objects.rs
@@ -38,6 +38,10 @@ impl<'a> Object<'a> {
         let store = self.0.store;
         Iter::new(store.lookup(self.0.id).kind.as_object().unwrap(), store)
     }
+
+    pub fn get(&self, name: &str) -> Option<Value<'a>> {
+        Some(self.fields().find(|field| field.name() == name)?.value())
+    }
 }
 
 impl PartialEq for Object<'_> {
@@ -72,6 +76,16 @@ impl<'a> From<ConstObject<'a>> for Object<'a> {
         let id = id.into();
 
         Object(Cursor { id, store })
+    }
+}
+
+impl<'a> IntoIterator for Object<'a> {
+    type Item = ObjectField<'a>;
+
+    type IntoIter = Iter<'a, ObjectField<'a>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.fields()
     }
 }
 

--- a/cynic-parser/src/values/scalars.rs
+++ b/cynic-parser/src/values/scalars.rs
@@ -57,9 +57,13 @@ impl std::fmt::Display for IntValue<'_> {
 pub struct FloatValue<'a>(pub(super) Cursor<'a, ValueId>);
 
 impl<'a> FloatValue<'a> {
-    pub fn value(&self) -> f32 {
+    pub fn value(&self) -> f64 {
         let store = self.0.store;
         store.lookup(self.0.id).kind.as_float().unwrap()
+    }
+
+    pub fn as_f64(&self) -> f64 {
+        self.value()
     }
 
     pub fn span(&self) -> Span {
@@ -101,6 +105,10 @@ impl<'a> StringValue<'a> {
         store.lookup(store.lookup(self.0.id).kind.as_string().unwrap())
     }
 
+    pub fn as_str(&self) -> &'a str {
+        self.value()
+    }
+
     pub fn span(&self) -> Span {
         let store = self.0.store;
         store.lookup(self.0.id).span
@@ -140,6 +148,10 @@ impl<'a> BooleanValue<'a> {
     pub fn value(&self) -> bool {
         let store = self.0.store;
         store.lookup(self.0.id).kind.as_boolean().unwrap()
+    }
+
+    pub fn as_bool(&self) -> bool {
+        self.value()
     }
 
     pub fn span(&self) -> Span {

--- a/cynic-parser/src/values/value.rs
+++ b/cynic-parser/src/values/value.rs
@@ -78,7 +78,7 @@ impl<'a> Value<'a> {
         matches!(self, Value::Float(_))
     }
 
-    pub fn as_f32(&self) -> Option<f32> {
+    pub fn as_f64(&self) -> Option<f64> {
         match self {
             Self::Float(inner) => Some(inner.value()),
             _ => None,
@@ -215,7 +215,7 @@ pub struct ValueRecord {
 pub enum ValueKind {
     Variable(StringId),
     Int(i64),
-    Float(f32),
+    Float(f64),
     String(StringId),
     Boolean(bool),
     Null,
@@ -239,7 +239,7 @@ impl ValueKind {
         }
     }
 
-    pub fn as_float(&self) -> Option<f32> {
+    pub fn as_float(&self) -> Option<f64> {
         match self {
             ValueKind::Float(inner) => Some(*inner),
             _ => None,


### PR DESCRIPTION
I've been using cynic-parser to do some things, and found a lot of convenience methods were missing, or issues with existing code.  This fixes all of those.