### PR TITLE
chore: remove reliance on hosted swapi

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,6 +7,10 @@ name = "Inflector"
 version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
+dependencies = [
+ "lazy_static",
+ "regex",
+]
 
 [[package]]
 name = "addr2line"
@@ -248,6 +252,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eab1c04a571841102f5345a8fc0f6bb3d31c315dec879b5c6e42e40ce7ffa34e"
 
 [[package]]
+name = "ascii_utils"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71938f30533e4d95a6d17aa530939da3842c2ab6f4f84b9dae68447e4129f74a"
+
+[[package]]
 name = "assert-json-diff"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -308,7 +318,7 @@ dependencies = [
  "async-task",
  "concurrent-queue",
  "fastrand 1.9.0",
- "futures-lite",
+ "futures-lite 1.13.0",
  "slab",
 ]
 
@@ -323,8 +333,76 @@ dependencies = [
  "async-io",
  "async-lock",
  "blocking",
- "futures-lite",
+ "futures-lite 1.13.0",
  "once_cell",
+]
+
+[[package]]
+name = "async-graphql"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ad990024653fd2d0321a568f64e620404a894047b2ab8c475f7452c8bb82cf6"
+dependencies = [
+ "async-graphql-derive",
+ "async-graphql-parser",
+ "async-graphql-value",
+ "async-stream",
+ "async-trait",
+ "base64 0.13.1",
+ "bytes 1.5.0",
+ "fast_chemail",
+ "fnv",
+ "futures-util",
+ "handlebars",
+ "http 1.1.0",
+ "indexmap 2.5.0",
+ "mime",
+ "multer",
+ "num-traits",
+ "once_cell",
+ "pin-project-lite",
+ "regex",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "static_assertions",
+ "tempfile",
+ "thiserror",
+]
+
+[[package]]
+name = "async-graphql-axum"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb1c9aed04854fb55a9d3fbab94e013cfc7ca5e3cead0b49b439884f8a467039"
+dependencies = [
+ "async-graphql",
+ "async-trait",
+ "axum",
+ "bytes 1.5.0",
+ "futures-util",
+ "serde_json",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tower-service",
+]
+
+[[package]]
+name = "async-graphql-derive"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3909cc7228128099b603d057e5a920b9499ce24299f8f680d5d1f213d7b830c0"
+dependencies = [
+ "Inflector",
+ "async-graphql-parser",
+ "darling",
+ "proc-macro-crate 1.3.1",
+ "proc-macro2",
+ "quote",
+ "strum",
+ "syn 2.0.79",
+ "thiserror",
 ]
 
 [[package]]
@@ -377,7 +455,7 @@ dependencies = [
  "autocfg",
  "cfg-if",
  "concurrent-queue",
- "futures-lite",
+ "futures-lite 1.13.0",
  "log",
  "parking",
  "polling",
@@ -410,7 +488,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-io",
- "futures-lite",
+ "futures-lite 1.13.0",
  "gloo-timers",
  "kv-log-macro",
  "log",
@@ -420,6 +498,28 @@ dependencies = [
  "pin-utils",
  "slab",
  "wasm-bindgen-futures",
+]
+
+[[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -436,9 +536,9 @@ checksum = "d85a97c4a0ecce878efd3f945f119c78a646d8975340bca0398f9bb05c30cc52"
 dependencies = [
  "futures-core",
  "futures-io",
- "rustls 0.18.1",
+ "rustls",
  "webpki",
- "webpki-roots 0.20.0",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -473,6 +573,64 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.79",
+]
+
+[[package]]
+name = "axum"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "base64 0.22.1",
+ "bytes 1.5.0",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "http-body-util",
+ "hyper 1.2.0",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sha1 0.10.6",
+ "sync_wrapper 1.0.2",
+ "tokio",
+ "tokio-tungstenite",
+ "tower 0.5.2",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+dependencies = [
+ "async-trait",
+ "bytes 1.5.0",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper 1.0.2",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -513,6 +671,12 @@ name = "base64"
 version = "0.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ba43ea6f343b788c8764558649e08df62f86c6ef251fdaeb1ffd010a9ae50a2"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "basic-toml"
@@ -563,6 +727,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "blocking"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -573,7 +746,7 @@ dependencies = [
  "async-task",
  "atomic-waker",
  "fastrand 1.9.0",
- "futures-lite",
+ "futures-lite 1.13.0",
  "log",
 ]
 
@@ -867,7 +1040,7 @@ dependencies = [
  "hmac",
  "percent-encoding",
  "rand 0.8.5",
- "sha2",
+ "sha2 0.9.9",
  "time",
  "version_check",
 ]
@@ -908,15 +1081,6 @@ name = "cpuid-bool"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcb25d077389e53838a8158c8e99174c5a9d902dee4904320db714f3c653ffba"
-
-[[package]]
-name = "crc32fast"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
-dependencies = [
- "cfg-if",
-]
 
 [[package]]
 name = "crossbeam-channel"
@@ -969,6 +1133,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
 ]
 
 [[package]]
@@ -1088,6 +1262,7 @@ dependencies = [
  "cynic",
  "cynic-codegen",
  "github-schema",
+ "graphql-mocks",
  "insta",
  "reqwest",
  "surf",
@@ -1101,12 +1276,14 @@ dependencies = [
  "assert_matches",
  "cynic",
  "cynic-codegen",
+ "graphql-mocks",
  "indenter",
  "insta",
  "maplit",
  "reqwest",
  "serde_json",
  "thiserror",
+ "tokio",
 ]
 
 [[package]]
@@ -1228,6 +1405,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
+
+[[package]]
 name = "deadpool"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1248,6 +1431,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer 0.10.4",
+ "crypto-common",
 ]
 
 [[package]]
@@ -1348,6 +1541,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
+name = "fast_chemail"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "495a39d30d624c2caabe6312bfead73e7717692b44e0b32df168c275a2e8e9e4"
+dependencies = [
+ "ascii_utils",
+]
+
+[[package]]
 name = "fastrand"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1372,16 +1574,6 @@ dependencies = [
  "libc",
  "redox_syscall",
  "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "flate2"
-version = "1.0.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6c98ee8095e9d1dcbf2fcc6d95acccb90d1c81db1e44725c6a984b1dbdfb010"
-dependencies = [
- "crc32fast",
- "miniz_oxide",
 ]
 
 [[package]]
@@ -1492,6 +1684,19 @@ dependencies = [
  "parking",
  "pin-project-lite",
  "waker-fn",
+]
+
+[[package]]
+name = "futures-lite"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cef40d21ae2c515b51041df9ed313ed21e572df340ea58a922a0aefe7e8891a1"
+dependencies = [
+ "fastrand 2.0.0",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -1680,6 +1885,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "graphql-mocks"
+version = "0.0.0"
+dependencies = [
+ "async-graphql",
+ "async-graphql-axum",
+ "async-trait",
+ "axum",
+ "crossbeam-queue",
+ "cynic-parser",
+ "futures-lite 2.5.0",
+ "headers",
+ "http 1.1.0",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
+]
+
+[[package]]
 name = "graphql-parser"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1728,6 +1952,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "handlebars"
+version = "4.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faa67bab9ff362228eb3d00bd024a4965d8231bbb7921167f0cfa66c6626b225"
+dependencies = [
+ "log",
+ "pest",
+ "pest_derive",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1752,6 +1990,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 
 [[package]]
+name = "headers"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "322106e6bd0cba2d5ead589ddb8150a13d7c4217cf80d7c4f682ca994ccc6aa9"
+dependencies = [
+ "base64 0.21.4",
+ "bytes 1.5.0",
+ "headers-core",
+ "http 1.1.0",
+ "httpdate",
+ "mime",
+ "sha1 0.10.6",
+]
+
+[[package]]
+name = "headers-core"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
+dependencies = [
+ "http 1.1.0",
+]
+
+[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1769,7 +2031,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51ab2f639c231793c5f6114bdb9bbe50a7dbbfcd7c7c6bd8475dec2d991e964f"
 dependencies = [
- "digest",
+ "digest 0.9.0",
  "hmac",
 ]
 
@@ -1780,7 +2042,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1441c6b1e930e2817404b5046f1f989899143a12bf92de603b69f4e0aee1e15"
 dependencies = [
  "crypto-mac",
- "digest",
+ "digest 0.9.0",
 ]
 
 [[package]]
@@ -1856,7 +2118,7 @@ dependencies = [
  "http-types",
  "isahc",
  "log",
- "rustls 0.18.1",
+ "rustls",
 ]
 
 [[package]]
@@ -1870,7 +2132,7 @@ dependencies = [
  "async-std",
  "base64 0.13.1",
  "cookie",
- "futures-lite",
+ "futures-lite 1.13.0",
  "infer",
  "pin-project-lite",
  "rand 0.7.3",
@@ -1945,6 +2207,7 @@ dependencies = [
  "http 1.1.0",
  "http-body 1.0.0",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -1983,7 +2246,7 @@ dependencies = [
  "pin-project-lite",
  "socket2 0.5.4",
  "tokio",
- "tower",
+ "tower 0.4.13",
  "tower-service",
  "tracing",
 ]
@@ -2134,7 +2397,7 @@ dependencies = [
  "curl",
  "curl-sys",
  "flume",
- "futures-lite",
+ "futures-lite 1.13.0",
  "http 0.2.9",
  "log",
  "once_cell",
@@ -2321,6 +2584,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
+name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
 name = "memchr"
 version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2388,6 +2657,23 @@ dependencies = [
  "serde_urlencoded",
  "similar",
  "tokio",
+]
+
+[[package]]
+name = "multer"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83e87776546dc87511aa5ee218730c92b666d7264ab6ed41f9d215af9cd5224b"
+dependencies = [
+ "bytes 1.5.0",
+ "encoding_rs",
+ "futures-util",
+ "http 1.1.0",
+ "httparse",
+ "memchr",
+ "mime",
+ "spin 0.9.8",
+ "version_check",
 ]
 
 [[package]]
@@ -2591,6 +2877,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "pest_derive"
+version = "2.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcd6ab1236bbdb3a49027e920e693192ebfe8913f6d60e294de57463a493cfde"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a31940305ffc96863a735bef7c7994a00b325a7138fdbc5bda0f1a0476d3275"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.79",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7ff62f5259e53b78d1af898941cdcdccfae7385cf7d793a6e55de5d05bb4b7d"
+dependencies = [
+ "once_cell",
+ "pest",
+ "sha2 0.10.8",
+]
+
+[[package]]
 name = "pin-project"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2683,11 +3003,21 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
+dependencies = [
+ "once_cell",
+ "toml_edit 0.19.15",
+]
+
+[[package]]
+name = "proc-macro-crate"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b"
 dependencies = [
- "toml_edit",
+ "toml_edit 0.22.22",
 ]
 
 [[package]]
@@ -2756,10 +3086,12 @@ dependencies = [
  "cynic",
  "cynic-codegen",
  "cynic-querygen",
+ "graphql-mocks",
  "indoc",
+ "reqwest",
  "serde_json",
+ "tokio",
  "trybuild",
- "ureq",
 ]
 
 [[package]]
@@ -2986,7 +3318,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper",
+ "sync_wrapper 0.1.2",
  "system-configuration",
  "tokio",
  "tokio-native-tls",
@@ -3007,7 +3339,7 @@ dependencies = [
  "cc",
  "libc",
  "once_cell",
- "spin",
+ "spin 0.5.2",
  "untrusted",
  "web-sys",
  "winapi",
@@ -3166,20 +3498,8 @@ dependencies = [
  "base64 0.12.3",
  "log",
  "ring",
- "sct 0.6.1",
+ "sct",
  "webpki",
-]
-
-[[package]]
-name = "rustls"
-version = "0.21.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd8d6c9f025a446bc4d18ad9632e69aec8f287aa84499ee335599fabd20c3fd8"
-dependencies = [
- "log",
- "ring",
- "rustls-webpki 0.101.5",
- "sct 0.7.0",
 ]
 
 [[package]]
@@ -3189,26 +3509,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
  "base64 0.21.4",
-]
-
-[[package]]
-name = "rustls-webpki"
-version = "0.100.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6a5fc258f1c1276dfe3016516945546e2d5383911efc0fc4f1cdc5df3a4ae3"
-dependencies = [
- "ring",
- "untrusted",
-]
-
-[[package]]
-name = "rustls-webpki"
-version = "0.101.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45a27e3b59326c16e23d30aeb7a36a24cc0d29e71d68ff611cdfb4a01d013bed"
-dependencies = [
- "ring",
- "untrusted",
 ]
 
 [[package]]
@@ -3258,16 +3558,6 @@ name = "sct"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b362b83898e0e69f38515b82ee15aa80636befe47c3b6d3d89a911e78fc228ce"
-dependencies = [
- "ring",
- "untrusted",
-]
-
-[[package]]
-name = "sct"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
 dependencies = [
  "ring",
  "untrusted",
@@ -3347,18 +3637,18 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.188"
+version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9e0fcba69a370eed61bcf2b728575f726b50b55cba78064753d708ddc7549e"
+checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.188"
+version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
+checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3373,6 +3663,16 @@ checksum = "6b420ce6e3d8bd882e9b243c6eed35dbc9a6110c9769e74b584e0d68d1f20c65"
 dependencies = [
  "itoa",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af99884400da37c88f5e9146b7f1fd0fbcae8f6eec4e9da38b67d05486f814a6"
+dependencies = [
+ "itoa",
  "serde",
 ]
 
@@ -3418,6 +3718,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.10.7",
+]
+
+[[package]]
 name = "sha1_smol"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3429,11 +3740,22 @@ version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.9.0",
  "cfg-if",
  "cpufeatures",
- "digest",
+ "digest 0.9.0",
  "opaque-debug",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -3561,6 +3883,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
 name = "spinning_top"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3623,7 +3951,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "sha1",
+ "sha1 0.6.1",
  "syn 1.0.109",
 ]
 
@@ -3644,6 +3972,28 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.25.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.79",
+]
 
 [[package]]
 name = "subtle"
@@ -3669,7 +4019,7 @@ dependencies = [
  "mime_guess",
  "once_cell",
  "pin-project-lite",
- "rustls 0.18.1",
+ "rustls",
  "serde",
  "serde_json",
  "web-sys",
@@ -3702,6 +4052,12 @@ name = "sync_wrapper"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 
 [[package]]
 name = "system-configuration"
@@ -3881,6 +4237,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-stream"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3888,6 +4267,7 @@ checksum = "806fe8c2c87eccc8b3267cbae29ed3ab2d0bd37fca70ab622e46aaa9375ddb7d"
 dependencies = [
  "bytes 1.5.0",
  "futures-core",
+ "futures-io",
  "futures-sink",
  "pin-project-lite",
  "tokio",
@@ -3914,6 +4294,17 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
+version = "0.19.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
+dependencies = [
+ "indexmap 2.5.0",
+ "toml_datetime",
+ "winnow 0.5.40",
+]
+
+[[package]]
+name = "toml_edit"
 version = "0.22.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
@@ -3922,7 +4313,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow",
+ "winnow 0.6.20",
 ]
 
 [[package]]
@@ -3942,16 +4333,32 @@ dependencies = [
 ]
 
 [[package]]
-name = "tower-layer"
-version = "0.3.2"
+name = "tower"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
+checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper 1.0.2",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
 
 [[package]]
 name = "tower-service"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
@@ -4031,7 +4438,25 @@ dependencies = [
  "serde",
  "shlex",
  "snapbox",
- "toml_edit",
+ "toml_edit 0.22.22",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18e5b8366ee7a95b16d32197d0b2604b43a0be89dc5fac9f8e96ccafbaedda8a"
+dependencies = [
+ "byteorder",
+ "bytes 1.5.0",
+ "data-encoding",
+ "http 1.1.0",
+ "httparse",
+ "log",
+ "rand 0.8.5",
+ "sha1 0.10.6",
+ "thiserror",
+ "utf-8",
 ]
 
 [[package]]
@@ -4129,24 +4554,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
-name = "ureq"
-version = "2.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b11c96ac7ee530603dcdf68ed1557050f374ce55a5a07193ebf8cbc9f8927e9"
-dependencies = [
- "base64 0.21.4",
- "flate2",
- "log",
- "once_cell",
- "rustls 0.21.7",
- "rustls-webpki 0.100.3",
- "serde",
- "serde_json",
- "url",
- "webpki-roots 0.23.1",
-]
-
-[[package]]
 name = "url"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4157,6 +4564,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8parse"
@@ -4360,15 +4773,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f20dea7535251981a9670857150d571846545088359b28e4951d350bdaf179f"
 dependencies = [
  "webpki",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "0.23.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b03058f88386e5ff5310d9111d53f48b17d732b401aeb83a8d5190f2ac459338"
-dependencies = [
- "rustls-webpki 0.100.3",
 ]
 
 [[package]]
@@ -4615,6 +5019,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
+
+[[package]]
+name = "winnow"
+version = "0.5.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ members = [
     "cynic-parser/ast-generator",
     "cynic-parser-deser",
     "cynic-parser-deser-macros",
+    "graphql-mocks",
 ]
 exclude = ["cynic-parser/parser-generator"]
 resolver = "2"
@@ -42,6 +43,7 @@ rust-version = "1.76"
 cynic-parser = { path = "cynic-parser", version = "0.8.7" }
 cynic-parser-deser-macros = { path = "cynic-parser-deser-macros", version = "0.8.7" }
 darling = "0.20"
+graphql-mocks.path = "graphql-mocks"
 rstest = "0.23"
 syn = "2"
 

--- a/cynic-introspection/Cargo.toml
+++ b/cynic-introspection/Cargo.toml
@@ -27,8 +27,10 @@ version = "3"
 
 [dev-dependencies]
 assert_matches = "1.4"
+graphql-mocks.workspace = true
 insta = "1.4"
 maplit = "1.0.2"
+tokio = { version = "1", features = ["macros"] }
 reqwest = "0.12"
 serde_json = "1"
 

--- a/cynic-introspection/src/detection.rs
+++ b/cynic-introspection/src/detection.rs
@@ -15,18 +15,25 @@ use super::query::schema;
 /// server has implemented support for.
 ///
 /// ```rust
-/// use cynic::{QueryBuilder, http::ReqwestBlockingExt};
+/// use cynic::{QueryBuilder, http::ReqwestExt};
 /// use cynic_introspection::CapabilitiesQuery;
+/// # #[tokio::main]
+/// # async fn main() {
+/// # let server = graphql_mocks::mocks::swapi::serve().await;
+/// # let url = server.url();
+/// # let url = url.as_ref();
 ///
-/// let data = reqwest::blocking::Client::new()
-///     .post("https://swapi-graphql.netlify.app/.netlify/functions/index")
+/// let data = reqwest::Client::new()
+///     .post(url)
 ///     .run_graphql(CapabilitiesQuery::build(()))
+///     .await
 ///     .unwrap()
 ///     .data
 ///     .unwrap();
 ///
 /// let capabilities = data.capabilities();
 /// println!("This server supports {capabilities:?}");
+/// # }
 /// ```
 pub struct CapabilitiesQuery {
     #[cynic(rename = "__type")]

--- a/cynic-introspection/src/lib.rs
+++ b/cynic-introspection/src/lib.rs
@@ -10,13 +10,19 @@
 //! results directly.
 //!
 //! ```rust
-//! use cynic::{QueryBuilder, http::ReqwestBlockingExt};
+//! use cynic::{QueryBuilder, http::ReqwestExt};
 //! use cynic_introspection::IntrospectionQuery;
+//! # #[tokio::main]
+//! # async fn main() {
+//! # let server = graphql_mocks::mocks::swapi::serve().await;
+//! # let url = server.url();
+//! # let url = url.as_ref();
 //!
 //! // We can run an introspection query and unwrap the data contained within
-//! let introspection_data = reqwest::blocking::Client::new()
-//!     .post("https://swapi-graphql.netlify.app/.netlify/functions/index")
+//! let introspection_data = reqwest::Client::new()
+//!     .post(url)
 //!     .run_graphql(IntrospectionQuery::build(()))
+//!     .await
 //!     .unwrap()
 //!     .data
 //!     .unwrap();
@@ -25,6 +31,7 @@
 //! let schema = introspection_data.into_schema().unwrap();
 //!
 //! assert_eq!(schema.query_type, "Root");
+//! # }
 //! ```
 //!
 //! ### GraphQL Versions
@@ -68,23 +75,29 @@
 //! `Introspection::with_capabilities`:
 //!
 //! ```rust
-//!
-//! use cynic::{QueryBuilder, http::ReqwestBlockingExt};
+//! use cynic::{QueryBuilder, http::ReqwestExt};
 //! use cynic_introspection::{CapabilitiesQuery, IntrospectionQuery};
+//! # #[tokio::main]
+//! # async fn main() {
+//! # let server = graphql_mocks::mocks::swapi::serve().await;
+//! # let url = server.url();
+//! # let url = url.as_ref();
 //!
 //! // First we run a capabilites query to check what the server supports
-//! let capabilities = reqwest::blocking::Client::new()
-//!     .post("https://swapi-graphql.netlify.app/.netlify/functions/index")
+//! let capabilities = reqwest::Client::new()
+//!     .post(url)
 //!     .run_graphql(CapabilitiesQuery::build(()))
+//!     .await
 //!     .unwrap()
 //!     .data
 //!     .unwrap()
 //!     .capabilities();
 //!
 //! // Now we can safely run introspection, only querying for what the server supports.
-//! let introspection_data = reqwest::blocking::Client::new()
-//!     .post("https://swapi-graphql.netlify.app/.netlify/functions/index")
+//! let introspection_data = reqwest::Client::new()
+//!     .post(url)
 //!     .run_graphql(IntrospectionQuery::with_capabilities(capabilities))
+//!     .await
 //!     .unwrap()
 //!     .data
 //!     .unwrap();
@@ -93,6 +106,7 @@
 //! let schema = introspection_data.into_schema().unwrap();
 //!
 //! assert_eq!(schema.query_type, "Root");
+//! # }
 //! ```
 //!
 //! [1]: http://spec.graphql.org/October2021/#sec-Introspection

--- a/cynic-introspection/tests/sdl_tests.rs
+++ b/cynic-introspection/tests/sdl_tests.rs
@@ -1,15 +1,18 @@
+use cynic::http::ReqwestExt;
 use cynic_introspection::{IntrospectionQuery, SpecificationVersion};
+use graphql_mocks::mocks;
 
-#[test]
-fn test_starwars_sdl_conversion() {
-    use cynic::http::ReqwestBlockingExt;
+#[tokio::test]
+async fn test_starwars_sdl_conversion() {
+    let mock_server = mocks::swapi::serve().await;
 
     let query =
         IntrospectionQuery::with_capabilities(SpecificationVersion::June2018.capabilities());
 
-    let result = reqwest::blocking::Client::new()
-        .post("https://swapi-graphql.netlify.app/.netlify/functions/index")
+    let result = reqwest::Client::new()
+        .post(mock_server.url())
         .run_graphql(query)
+        .await
         .unwrap();
 
     if result.errors.is_some() {

--- a/cynic-introspection/tests/snapshots/sdl_tests__starwars_sdl_conversion.snap
+++ b/cynic-introspection/tests/snapshots/sdl_tests__starwars_sdl_conversion.snap
@@ -1,100 +1,11 @@
 ---
 source: cynic-introspection/tests/sdl_tests.rs
 expression: result.data.unwrap().into_schema().unwrap().to_sdl()
+snapshot_kind: text
 ---
 schema {
   query: Root
 }
-type Root {
-  allFilms(after: String, first: Int, before: String, last: Int): FilmsConnection
-  film(id: ID, filmID: ID): Film
-  allPeople(after: String, first: Int, before: String, last: Int): PeopleConnection
-  person(id: ID, personID: ID): Person
-  allPlanets(after: String, first: Int, before: String, last: Int): PlanetsConnection
-  planet(id: ID, planetID: ID): Planet
-  allSpecies(after: String, first: Int, before: String, last: Int): SpeciesConnection
-  species(id: ID, speciesID: ID): Species
-  allStarships(after: String, first: Int, before: String, last: Int): StarshipsConnection
-  starship(id: ID, starshipID: ID): Starship
-  allVehicles(after: String, first: Int, before: String, last: Int): VehiclesConnection
-  vehicle(id: ID, vehicleID: ID): Vehicle
-  """
-  Fetches an object given its ID
-  """
-  node(
-    """
-    The ID of an object
-    """
-    id: ID!
-  ): Node
-}
-
-"""
-A connection to a list of items.
-"""
-type FilmsConnection {
-  """
-  Information to aid in pagination.
-  """
-  pageInfo: PageInfo!
-  """
-  A list of edges.
-  """
-  edges: [FilmsEdge]
-  """
-  A count of the total number of objects in this connection, ignoring pagination.
-  This allows a client to fetch the first five objects by passing "5" as the
-  argument to "first", then fetch the total count so it could display "5 of 83",
-  for example.
-  """
-  totalCount: Int
-  """
-  A list of all of the objects returned in the connection. This is a convenience
-  field provided for quickly exploring the API; rather than querying for
-  "{ edges { node } }" when no edge data is needed, this field can be be used
-  instead. Note that when clients like Relay need to fetch the "cursor" field on
-  the edge to enable efficient pagination, this shortcut cannot be used, and the
-  full "{ edges { node } }" version should be used instead.
-  """
-  films: [Film]
-}
-
-"""
-Information about pagination in a connection.
-"""
-type PageInfo {
-  """
-  When paginating forwards, are there more items?
-  """
-  hasNextPage: Boolean!
-  """
-  When paginating backwards, are there more items?
-  """
-  hasPreviousPage: Boolean!
-  """
-  When paginating backwards, the cursor to continue.
-  """
-  startCursor: String
-  """
-  When paginating forwards, the cursor to continue.
-  """
-  endCursor: String
-}
-
-"""
-An edge in a connection.
-"""
-type FilmsEdge {
-  """
-  The item at the end of the edge
-  """
-  node: Film
-  """
-  A cursor for use in pagination
-  """
-  cursor: String!
-}
-
 """
 A single film.
 """
@@ -143,13 +54,91 @@ type Film implements Node {
 }
 
 """
-An object with an ID
+A connection to a list of items.
 """
-interface Node {
+type FilmCharactersConnection {
   """
-  The id of the object.
+  Information to aid in pagination.
   """
-  id: ID!
+  pageInfo: PageInfo!
+  """
+  A list of edges.
+  """
+  edges: [FilmCharactersEdge]
+  """
+  A count of the total number of objects in this connection, ignoring pagination.
+  This allows a client to fetch the first five objects by passing "5" as the
+  argument to "first", then fetch the total count so it could display "5 of 83",
+  for example.
+  """
+  totalCount: Int
+  """
+  A list of all of the objects returned in the connection. This is a convenience
+  field provided for quickly exploring the API; rather than querying for
+  "{ edges { node } }" when no edge data is needed, this field can be be used
+  instead. Note that when clients like Relay need to fetch the "cursor" field on
+  the edge to enable efficient pagination, this shortcut cannot be used, and the
+  full "{ edges { node } }" version should be used instead.
+  """
+  characters: [Person]
+}
+
+"""
+An edge in a connection.
+"""
+type FilmCharactersEdge {
+  """
+  The item at the end of the edge
+  """
+  node: Person
+  """
+  A cursor for use in pagination
+  """
+  cursor: String!
+}
+
+"""
+A connection to a list of items.
+"""
+type FilmPlanetsConnection {
+  """
+  Information to aid in pagination.
+  """
+  pageInfo: PageInfo!
+  """
+  A list of edges.
+  """
+  edges: [FilmPlanetsEdge]
+  """
+  A count of the total number of objects in this connection, ignoring pagination.
+  This allows a client to fetch the first five objects by passing "5" as the
+  argument to "first", then fetch the total count so it could display "5 of 83",
+  for example.
+  """
+  totalCount: Int
+  """
+  A list of all of the objects returned in the connection. This is a convenience
+  field provided for quickly exploring the API; rather than querying for
+  "{ edges { node } }" when no edge data is needed, this field can be be used
+  instead. Note that when clients like Relay need to fetch the "cursor" field on
+  the edge to enable efficient pagination, this shortcut cannot be used, and the
+  full "{ edges { node } }" version should be used instead.
+  """
+  planets: [Planet]
+}
+
+"""
+An edge in a connection.
+"""
+type FilmPlanetsEdge {
+  """
+  The item at the end of the edge
+  """
+  node: Planet
+  """
+  A cursor for use in pagination
+  """
+  cursor: String!
 }
 
 """
@@ -197,133 +186,9 @@ type FilmSpeciesEdge {
 }
 
 """
-A type of person or character within the Star Wars Universe.
-"""
-type Species implements Node {
-  """
-  The name of this species.
-  """
-  name: String
-  """
-  The classification of this species, such as "mammal" or "reptile".
-  """
-  classification: String
-  """
-  The designation of this species, such as "sentient".
-  """
-  designation: String
-  """
-  The average height of this species in centimeters.
-  """
-  averageHeight: Float
-  """
-  The average lifespan of this species in years, null if unknown.
-  """
-  averageLifespan: Int
-  """
-  Common eye colors for this species, null if this species does not typically
-  have eyes.
-  """
-  eyeColors: [String]
-  """
-  Common hair colors for this species, null if this species does not typically
-  have hair.
-  """
-  hairColors: [String]
-  """
-  Common skin colors for this species, null if this species does not typically
-  have skin.
-  """
-  skinColors: [String]
-  """
-  The language commonly spoken by this species.
-  """
-  language: String
-  """
-  A planet that this species originates from.
-  """
-  homeworld: Planet
-  personConnection(after: String, first: Int, before: String, last: Int): SpeciesPeopleConnection
-  filmConnection(after: String, first: Int, before: String, last: Int): SpeciesFilmsConnection
-  """
-  The ISO 8601 date format of the time that this resource was created.
-  """
-  created: String
-  """
-  The ISO 8601 date format of the time that this resource was edited.
-  """
-  edited: String
-  """
-  The ID of an object
-  """
-  id: ID!
-}
-
-"""
-A large mass, planet or planetoid in the Star Wars Universe, at the time of
-0 ABY.
-"""
-type Planet implements Node {
-  """
-  The name of this planet.
-  """
-  name: String
-  """
-  The diameter of this planet in kilometers.
-  """
-  diameter: Int
-  """
-  The number of standard hours it takes for this planet to complete a single
-  rotation on its axis.
-  """
-  rotationPeriod: Int
-  """
-  The number of standard days it takes for this planet to complete a single orbit
-  of its local star.
-  """
-  orbitalPeriod: Int
-  """
-  A number denoting the gravity of this planet, where "1" is normal or 1 standard
-  G. "2" is twice or 2 standard Gs. "0.5" is half or 0.5 standard Gs.
-  """
-  gravity: String
-  """
-  The average population of sentient beings inhabiting this planet.
-  """
-  population: Float
-  """
-  The climates of this planet.
-  """
-  climates: [String]
-  """
-  The terrains of this planet.
-  """
-  terrains: [String]
-  """
-  The percentage of the planet surface that is naturally occurring water or bodies
-  of water.
-  """
-  surfaceWater: Float
-  residentConnection(after: String, first: Int, before: String, last: Int): PlanetResidentsConnection
-  filmConnection(after: String, first: Int, before: String, last: Int): PlanetFilmsConnection
-  """
-  The ISO 8601 date format of the time that this resource was created.
-  """
-  created: String
-  """
-  The ISO 8601 date format of the time that this resource was edited.
-  """
-  edited: String
-  """
-  The ID of an object
-  """
-  id: ID!
-}
-
-"""
 A connection to a list of items.
 """
-type PlanetResidentsConnection {
+type FilmStarshipsConnection {
   """
   Information to aid in pagination.
   """
@@ -331,7 +196,7 @@ type PlanetResidentsConnection {
   """
   A list of edges.
   """
-  edges: [PlanetResidentsEdge]
+  edges: [FilmStarshipsEdge]
   """
   A count of the total number of objects in this connection, ignoring pagination.
   This allows a client to fetch the first five objects by passing "5" as the
@@ -347,13 +212,174 @@ type PlanetResidentsConnection {
   the edge to enable efficient pagination, this shortcut cannot be used, and the
   full "{ edges { node } }" version should be used instead.
   """
-  residents: [Person]
+  starships: [Starship]
 }
 
 """
 An edge in a connection.
 """
-type PlanetResidentsEdge {
+type FilmStarshipsEdge {
+  """
+  The item at the end of the edge
+  """
+  node: Starship
+  """
+  A cursor for use in pagination
+  """
+  cursor: String!
+}
+
+"""
+A connection to a list of items.
+"""
+type FilmVehiclesConnection {
+  """
+  Information to aid in pagination.
+  """
+  pageInfo: PageInfo!
+  """
+  A list of edges.
+  """
+  edges: [FilmVehiclesEdge]
+  """
+  A count of the total number of objects in this connection, ignoring pagination.
+  This allows a client to fetch the first five objects by passing "5" as the
+  argument to "first", then fetch the total count so it could display "5 of 83",
+  for example.
+  """
+  totalCount: Int
+  """
+  A list of all of the objects returned in the connection. This is a convenience
+  field provided for quickly exploring the API; rather than querying for
+  "{ edges { node } }" when no edge data is needed, this field can be be used
+  instead. Note that when clients like Relay need to fetch the "cursor" field on
+  the edge to enable efficient pagination, this shortcut cannot be used, and the
+  full "{ edges { node } }" version should be used instead.
+  """
+  vehicles: [Vehicle]
+}
+
+"""
+An edge in a connection.
+"""
+type FilmVehiclesEdge {
+  """
+  The item at the end of the edge
+  """
+  node: Vehicle
+  """
+  A cursor for use in pagination
+  """
+  cursor: String!
+}
+
+"""
+A connection to a list of items.
+"""
+type FilmsConnection {
+  """
+  Information to aid in pagination.
+  """
+  pageInfo: PageInfo!
+  """
+  A list of edges.
+  """
+  edges: [FilmsEdge]
+  """
+  A count of the total number of objects in this connection, ignoring pagination.
+  This allows a client to fetch the first five objects by passing "5" as the
+  argument to "first", then fetch the total count so it could display "5 of 83",
+  for example.
+  """
+  totalCount: Int
+  """
+  A list of all of the objects returned in the connection. This is a convenience
+  field provided for quickly exploring the API; rather than querying for
+  "{ edges { node } }" when no edge data is needed, this field can be be used
+  instead. Note that when clients like Relay need to fetch the "cursor" field on
+  the edge to enable efficient pagination, this shortcut cannot be used, and the
+  full "{ edges { node } }" version should be used instead.
+  """
+  films: [Film]
+}
+
+"""
+An edge in a connection.
+"""
+type FilmsEdge {
+  """
+  The item at the end of the edge
+  """
+  node: Film
+  """
+  A cursor for use in pagination
+  """
+  cursor: String!
+}
+
+"""
+An object with an ID
+"""
+interface Node {
+  id: ID!
+}
+
+"""
+Information about pagination in a connection.
+"""
+type PageInfo {
+  """
+  When paginating forwards, are there more items?
+  """
+  hasNextPage: Boolean!
+  """
+  When paginating backwards, are there more items?
+  """
+  hasPreviousPage: Boolean!
+  """
+  When paginating backwards, the cursor to continue.
+  """
+  startCursor: String
+  """
+  When paginating forwards, the cursor to continue.
+  """
+  endCursor: String
+}
+
+"""
+A connection to a list of items.
+"""
+type PeopleConnection {
+  """
+  Information to aid in pagination.
+  """
+  pageInfo: PageInfo!
+  """
+  A list of edges.
+  """
+  edges: [PeopleEdge]
+  """
+  A count of the total number of objects in this connection, ignoring pagination.
+  This allows a client to fetch the first five objects by passing "5" as the
+  argument to "first", then fetch the total count so it could display "5 of 83",
+  for example.
+  """
+  totalCount: Int
+  """
+  A list of all of the objects returned in the connection. This is a convenience
+  field provided for quickly exploring the API; rather than querying for
+  "{ edges { node } }" when no edge data is needed, this field can be be used
+  instead. Note that when clients like Relay need to fetch the "cursor" field on
+  the edge to enable efficient pagination, this shortcut cannot be used, and the
+  full "{ edges { node } }" version should be used instead.
+  """
+  people: [Person]
+}
+
+"""
+An edge in a connection.
+"""
+type PeopleEdge {
   """
   The item at the end of the edge
   """
@@ -519,6 +545,462 @@ type PersonStarshipsEdge {
 }
 
 """
+A connection to a list of items.
+"""
+type PersonVehiclesConnection {
+  """
+  Information to aid in pagination.
+  """
+  pageInfo: PageInfo!
+  """
+  A list of edges.
+  """
+  edges: [PersonVehiclesEdge]
+  """
+  A count of the total number of objects in this connection, ignoring pagination.
+  This allows a client to fetch the first five objects by passing "5" as the
+  argument to "first", then fetch the total count so it could display "5 of 83",
+  for example.
+  """
+  totalCount: Int
+  """
+  A list of all of the objects returned in the connection. This is a convenience
+  field provided for quickly exploring the API; rather than querying for
+  "{ edges { node } }" when no edge data is needed, this field can be be used
+  instead. Note that when clients like Relay need to fetch the "cursor" field on
+  the edge to enable efficient pagination, this shortcut cannot be used, and the
+  full "{ edges { node } }" version should be used instead.
+  """
+  vehicles: [Vehicle]
+}
+
+"""
+An edge in a connection.
+"""
+type PersonVehiclesEdge {
+  """
+  The item at the end of the edge
+  """
+  node: Vehicle
+  """
+  A cursor for use in pagination
+  """
+  cursor: String!
+}
+
+"""
+A large mass, planet or planetoid in the Star Wars Universe, at the time of
+0 ABY.
+"""
+type Planet implements Node {
+  """
+  The name of this planet.
+  """
+  name: String
+  """
+  The diameter of this planet in kilometers.
+  """
+  diameter: Int
+  """
+  The number of standard hours it takes for this planet to complete a single
+  rotation on its axis.
+  """
+  rotationPeriod: Int
+  """
+  The number of standard days it takes for this planet to complete a single orbit
+  of its local star.
+  """
+  orbitalPeriod: Int
+  """
+  A number denoting the gravity of this planet, where "1" is normal or 1 standard
+  G. "2" is twice or 2 standard Gs. "0.5" is half or 0.5 standard Gs.
+  """
+  gravity: String
+  """
+  The average population of sentient beings inhabiting this planet.
+  """
+  population: Float
+  """
+  The climates of this planet.
+  """
+  climates: [String]
+  """
+  The terrains of this planet.
+  """
+  terrains: [String]
+  """
+  The percentage of the planet surface that is naturally occurring water or bodies
+  of water.
+  """
+  surfaceWater: Float
+  residentConnection(after: String, first: Int, before: String, last: Int): PlanetResidentsConnection
+  filmConnection(after: String, first: Int, before: String, last: Int): PlanetFilmsConnection
+  """
+  The ISO 8601 date format of the time that this resource was created.
+  """
+  created: String
+  """
+  The ISO 8601 date format of the time that this resource was edited.
+  """
+  edited: String
+  """
+  The ID of an object
+  """
+  id: ID!
+}
+
+"""
+A connection to a list of items.
+"""
+type PlanetFilmsConnection {
+  """
+  Information to aid in pagination.
+  """
+  pageInfo: PageInfo!
+  """
+  A list of edges.
+  """
+  edges: [PlanetFilmsEdge]
+  """
+  A count of the total number of objects in this connection, ignoring pagination.
+  This allows a client to fetch the first five objects by passing "5" as the
+  argument to "first", then fetch the total count so it could display "5 of 83",
+  for example.
+  """
+  totalCount: Int
+  """
+  A list of all of the objects returned in the connection. This is a convenience
+  field provided for quickly exploring the API; rather than querying for
+  "{ edges { node } }" when no edge data is needed, this field can be be used
+  instead. Note that when clients like Relay need to fetch the "cursor" field on
+  the edge to enable efficient pagination, this shortcut cannot be used, and the
+  full "{ edges { node } }" version should be used instead.
+  """
+  films: [Film]
+}
+
+"""
+An edge in a connection.
+"""
+type PlanetFilmsEdge {
+  """
+  The item at the end of the edge
+  """
+  node: Film
+  """
+  A cursor for use in pagination
+  """
+  cursor: String!
+}
+
+"""
+A connection to a list of items.
+"""
+type PlanetResidentsConnection {
+  """
+  Information to aid in pagination.
+  """
+  pageInfo: PageInfo!
+  """
+  A list of edges.
+  """
+  edges: [PlanetResidentsEdge]
+  """
+  A count of the total number of objects in this connection, ignoring pagination.
+  This allows a client to fetch the first five objects by passing "5" as the
+  argument to "first", then fetch the total count so it could display "5 of 83",
+  for example.
+  """
+  totalCount: Int
+  """
+  A list of all of the objects returned in the connection. This is a convenience
+  field provided for quickly exploring the API; rather than querying for
+  "{ edges { node } }" when no edge data is needed, this field can be be used
+  instead. Note that when clients like Relay need to fetch the "cursor" field on
+  the edge to enable efficient pagination, this shortcut cannot be used, and the
+  full "{ edges { node } }" version should be used instead.
+  """
+  residents: [Person]
+}
+
+"""
+An edge in a connection.
+"""
+type PlanetResidentsEdge {
+  """
+  The item at the end of the edge
+  """
+  node: Person
+  """
+  A cursor for use in pagination
+  """
+  cursor: String!
+}
+
+"""
+A connection to a list of items.
+"""
+type PlanetsConnection {
+  """
+  Information to aid in pagination.
+  """
+  pageInfo: PageInfo!
+  """
+  A list of edges.
+  """
+  edges: [PlanetsEdge]
+  """
+  A count of the total number of objects in this connection, ignoring pagination.
+  This allows a client to fetch the first five objects by passing "5" as the
+  argument to "first", then fetch the total count so it could display "5 of 83",
+  for example.
+  """
+  totalCount: Int
+  """
+  A list of all of the objects returned in the connection. This is a convenience
+  field provided for quickly exploring the API; rather than querying for
+  "{ edges { node } }" when no edge data is needed, this field can be be used
+  instead. Note that when clients like Relay need to fetch the "cursor" field on
+  the edge to enable efficient pagination, this shortcut cannot be used, and the
+  full "{ edges { node } }" version should be used instead.
+  """
+  planets: [Planet]
+}
+
+"""
+An edge in a connection.
+"""
+type PlanetsEdge {
+  """
+  The item at the end of the edge
+  """
+  node: Planet
+  """
+  A cursor for use in pagination
+  """
+  cursor: String!
+}
+
+type Root {
+  allFilms(after: String, first: Int, before: String, last: Int): FilmsConnection
+  film(id: ID, filmID: ID): Film
+  allPeople(after: String, first: Int, before: String, last: Int): PeopleConnection
+  person(id: ID, personID: ID): Person
+  allPlanets(after: String, first: Int, before: String, last: Int): PlanetsConnection
+  planet(id: ID, planetID: ID): Planet
+  allSpecies(after: String, first: Int, before: String, last: Int): SpeciesConnection
+  species(id: ID, speciesID: ID): Species
+  allStarships(after: String, first: Int, before: String, last: Int): StarshipsConnection
+  starship(id: ID, starshipID: ID): Starship
+  allVehicles(after: String, first: Int, before: String, last: Int): VehiclesConnection
+  vehicle(id: ID, vehicleID: ID): Vehicle
+  """
+  Fetches an object given its ID
+  """
+  node(
+    """
+    The ID of an object
+    """
+    id: ID!
+  ): Node
+}
+
+"""
+A type of person or character within the Star Wars Universe.
+"""
+type Species implements Node {
+  """
+  The name of this species.
+  """
+  name: String
+  """
+  The classification of this species, such as "mammal" or "reptile".
+  """
+  classification: String
+  """
+  The designation of this species, such as "sentient".
+  """
+  designation: String
+  """
+  The average height of this species in centimeters.
+  """
+  averageHeight: Float
+  """
+  The average lifespan of this species in years, null if unknown.
+  """
+  averageLifespan: Int
+  """
+  Common eye colors for this species, null if this species does not typically
+  have eyes.
+  """
+  eyeColors: [String]
+  """
+  Common hair colors for this species, null if this species does not typically
+  have hair.
+  """
+  hairColors: [String]
+  """
+  Common skin colors for this species, null if this species does not typically
+  have skin.
+  """
+  skinColors: [String]
+  """
+  The language commonly spoken by this species.
+  """
+  language: String
+  """
+  A planet that this species originates from.
+  """
+  homeworld: Planet
+  personConnection(after: String, first: Int, before: String, last: Int): SpeciesPeopleConnection
+  filmConnection(after: String, first: Int, before: String, last: Int): SpeciesFilmsConnection
+  """
+  The ISO 8601 date format of the time that this resource was created.
+  """
+  created: String
+  """
+  The ISO 8601 date format of the time that this resource was edited.
+  """
+  edited: String
+  """
+  The ID of an object
+  """
+  id: ID!
+}
+
+"""
+A connection to a list of items.
+"""
+type SpeciesConnection {
+  """
+  Information to aid in pagination.
+  """
+  pageInfo: PageInfo!
+  """
+  A list of edges.
+  """
+  edges: [SpeciesEdge]
+  """
+  A count of the total number of objects in this connection, ignoring pagination.
+  This allows a client to fetch the first five objects by passing "5" as the
+  argument to "first", then fetch the total count so it could display "5 of 83",
+  for example.
+  """
+  totalCount: Int
+  """
+  A list of all of the objects returned in the connection. This is a convenience
+  field provided for quickly exploring the API; rather than querying for
+  "{ edges { node } }" when no edge data is needed, this field can be be used
+  instead. Note that when clients like Relay need to fetch the "cursor" field on
+  the edge to enable efficient pagination, this shortcut cannot be used, and the
+  full "{ edges { node } }" version should be used instead.
+  """
+  species: [Species]
+}
+
+"""
+An edge in a connection.
+"""
+type SpeciesEdge {
+  """
+  The item at the end of the edge
+  """
+  node: Species
+  """
+  A cursor for use in pagination
+  """
+  cursor: String!
+}
+
+"""
+A connection to a list of items.
+"""
+type SpeciesFilmsConnection {
+  """
+  Information to aid in pagination.
+  """
+  pageInfo: PageInfo!
+  """
+  A list of edges.
+  """
+  edges: [SpeciesFilmsEdge]
+  """
+  A count of the total number of objects in this connection, ignoring pagination.
+  This allows a client to fetch the first five objects by passing "5" as the
+  argument to "first", then fetch the total count so it could display "5 of 83",
+  for example.
+  """
+  totalCount: Int
+  """
+  A list of all of the objects returned in the connection. This is a convenience
+  field provided for quickly exploring the API; rather than querying for
+  "{ edges { node } }" when no edge data is needed, this field can be be used
+  instead. Note that when clients like Relay need to fetch the "cursor" field on
+  the edge to enable efficient pagination, this shortcut cannot be used, and the
+  full "{ edges { node } }" version should be used instead.
+  """
+  films: [Film]
+}
+
+"""
+An edge in a connection.
+"""
+type SpeciesFilmsEdge {
+  """
+  The item at the end of the edge
+  """
+  node: Film
+  """
+  A cursor for use in pagination
+  """
+  cursor: String!
+}
+
+"""
+A connection to a list of items.
+"""
+type SpeciesPeopleConnection {
+  """
+  Information to aid in pagination.
+  """
+  pageInfo: PageInfo!
+  """
+  A list of edges.
+  """
+  edges: [SpeciesPeopleEdge]
+  """
+  A count of the total number of objects in this connection, ignoring pagination.
+  This allows a client to fetch the first five objects by passing "5" as the
+  argument to "first", then fetch the total count so it could display "5 of 83",
+  for example.
+  """
+  totalCount: Int
+  """
+  A list of all of the objects returned in the connection. This is a convenience
+  field provided for quickly exploring the API; rather than querying for
+  "{ edges { node } }" when no edge data is needed, this field can be be used
+  instead. Note that when clients like Relay need to fetch the "cursor" field on
+  the edge to enable efficient pagination, this shortcut cannot be used, and the
+  full "{ edges { node } }" version should be used instead.
+  """
+  people: [Person]
+}
+
+"""
+An edge in a connection.
+"""
+type SpeciesPeopleEdge {
+  """
+  The item at the end of the edge
+  """
+  node: Person
+  """
+  A cursor for use in pagination
+  """
+  cursor: String!
+}
+
+"""
 A single transport craft that has hyperdrive capability.
 """
 type Starship implements Node {
@@ -601,50 +1083,6 @@ type Starship implements Node {
 """
 A connection to a list of items.
 """
-type StarshipPilotsConnection {
-  """
-  Information to aid in pagination.
-  """
-  pageInfo: PageInfo!
-  """
-  A list of edges.
-  """
-  edges: [StarshipPilotsEdge]
-  """
-  A count of the total number of objects in this connection, ignoring pagination.
-  This allows a client to fetch the first five objects by passing "5" as the
-  argument to "first", then fetch the total count so it could display "5 of 83",
-  for example.
-  """
-  totalCount: Int
-  """
-  A list of all of the objects returned in the connection. This is a convenience
-  field provided for quickly exploring the API; rather than querying for
-  "{ edges { node } }" when no edge data is needed, this field can be be used
-  instead. Note that when clients like Relay need to fetch the "cursor" field on
-  the edge to enable efficient pagination, this shortcut cannot be used, and the
-  full "{ edges { node } }" version should be used instead.
-  """
-  pilots: [Person]
-}
-
-"""
-An edge in a connection.
-"""
-type StarshipPilotsEdge {
-  """
-  The item at the end of the edge
-  """
-  node: Person
-  """
-  A cursor for use in pagination
-  """
-  cursor: String!
-}
-
-"""
-A connection to a list of items.
-"""
 type StarshipFilmsConnection {
   """
   Information to aid in pagination.
@@ -689,7 +1127,7 @@ type StarshipFilmsEdge {
 """
 A connection to a list of items.
 """
-type PersonVehiclesConnection {
+type StarshipPilotsConnection {
   """
   Information to aid in pagination.
   """
@@ -697,7 +1135,7 @@ type PersonVehiclesConnection {
   """
   A list of edges.
   """
-  edges: [PersonVehiclesEdge]
+  edges: [StarshipPilotsEdge]
   """
   A count of the total number of objects in this connection, ignoring pagination.
   This allows a client to fetch the first five objects by passing "5" as the
@@ -713,17 +1151,61 @@ type PersonVehiclesConnection {
   the edge to enable efficient pagination, this shortcut cannot be used, and the
   full "{ edges { node } }" version should be used instead.
   """
-  vehicles: [Vehicle]
+  pilots: [Person]
 }
 
 """
 An edge in a connection.
 """
-type PersonVehiclesEdge {
+type StarshipPilotsEdge {
   """
   The item at the end of the edge
   """
-  node: Vehicle
+  node: Person
+  """
+  A cursor for use in pagination
+  """
+  cursor: String!
+}
+
+"""
+A connection to a list of items.
+"""
+type StarshipsConnection {
+  """
+  Information to aid in pagination.
+  """
+  pageInfo: PageInfo!
+  """
+  A list of edges.
+  """
+  edges: [StarshipsEdge]
+  """
+  A count of the total number of objects in this connection, ignoring pagination.
+  This allows a client to fetch the first five objects by passing "5" as the
+  argument to "first", then fetch the total count so it could display "5 of 83",
+  for example.
+  """
+  totalCount: Int
+  """
+  A list of all of the objects returned in the connection. This is a convenience
+  field provided for quickly exploring the API; rather than querying for
+  "{ edges { node } }" when no edge data is needed, this field can be be used
+  instead. Note that when clients like Relay need to fetch the "cursor" field on
+  the edge to enable efficient pagination, this shortcut cannot be used, and the
+  full "{ edges { node } }" version should be used instead.
+  """
+  starships: [Starship]
+}
+
+"""
+An edge in a connection.
+"""
+type StarshipsEdge {
+  """
+  The item at the end of the edge
+  """
+  node: Starship
   """
   A cursor for use in pagination
   """
@@ -800,50 +1282,6 @@ type Vehicle implements Node {
 """
 A connection to a list of items.
 """
-type VehiclePilotsConnection {
-  """
-  Information to aid in pagination.
-  """
-  pageInfo: PageInfo!
-  """
-  A list of edges.
-  """
-  edges: [VehiclePilotsEdge]
-  """
-  A count of the total number of objects in this connection, ignoring pagination.
-  This allows a client to fetch the first five objects by passing "5" as the
-  argument to "first", then fetch the total count so it could display "5 of 83",
-  for example.
-  """
-  totalCount: Int
-  """
-  A list of all of the objects returned in the connection. This is a convenience
-  field provided for quickly exploring the API; rather than querying for
-  "{ edges { node } }" when no edge data is needed, this field can be be used
-  instead. Note that when clients like Relay need to fetch the "cursor" field on
-  the edge to enable efficient pagination, this shortcut cannot be used, and the
-  full "{ edges { node } }" version should be used instead.
-  """
-  pilots: [Person]
-}
-
-"""
-An edge in a connection.
-"""
-type VehiclePilotsEdge {
-  """
-  The item at the end of the edge
-  """
-  node: Person
-  """
-  A cursor for use in pagination
-  """
-  cursor: String!
-}
-
-"""
-A connection to a list of items.
-"""
 type VehicleFilmsConnection {
   """
   Information to aid in pagination.
@@ -888,7 +1326,7 @@ type VehicleFilmsEdge {
 """
 A connection to a list of items.
 """
-type PlanetFilmsConnection {
+type VehiclePilotsConnection {
   """
   Information to aid in pagination.
   """
@@ -896,7 +1334,7 @@ type PlanetFilmsConnection {
   """
   A list of edges.
   """
-  edges: [PlanetFilmsEdge]
+  edges: [VehiclePilotsEdge]
   """
   A count of the total number of objects in this connection, ignoring pagination.
   This allows a client to fetch the first five objects by passing "5" as the
@@ -912,457 +1350,17 @@ type PlanetFilmsConnection {
   the edge to enable efficient pagination, this shortcut cannot be used, and the
   full "{ edges { node } }" version should be used instead.
   """
-  films: [Film]
+  pilots: [Person]
 }
 
 """
 An edge in a connection.
 """
-type PlanetFilmsEdge {
-  """
-  The item at the end of the edge
-  """
-  node: Film
-  """
-  A cursor for use in pagination
-  """
-  cursor: String!
-}
-
-"""
-A connection to a list of items.
-"""
-type SpeciesPeopleConnection {
-  """
-  Information to aid in pagination.
-  """
-  pageInfo: PageInfo!
-  """
-  A list of edges.
-  """
-  edges: [SpeciesPeopleEdge]
-  """
-  A count of the total number of objects in this connection, ignoring pagination.
-  This allows a client to fetch the first five objects by passing "5" as the
-  argument to "first", then fetch the total count so it could display "5 of 83",
-  for example.
-  """
-  totalCount: Int
-  """
-  A list of all of the objects returned in the connection. This is a convenience
-  field provided for quickly exploring the API; rather than querying for
-  "{ edges { node } }" when no edge data is needed, this field can be be used
-  instead. Note that when clients like Relay need to fetch the "cursor" field on
-  the edge to enable efficient pagination, this shortcut cannot be used, and the
-  full "{ edges { node } }" version should be used instead.
-  """
-  people: [Person]
-}
-
-"""
-An edge in a connection.
-"""
-type SpeciesPeopleEdge {
+type VehiclePilotsEdge {
   """
   The item at the end of the edge
   """
   node: Person
-  """
-  A cursor for use in pagination
-  """
-  cursor: String!
-}
-
-"""
-A connection to a list of items.
-"""
-type SpeciesFilmsConnection {
-  """
-  Information to aid in pagination.
-  """
-  pageInfo: PageInfo!
-  """
-  A list of edges.
-  """
-  edges: [SpeciesFilmsEdge]
-  """
-  A count of the total number of objects in this connection, ignoring pagination.
-  This allows a client to fetch the first five objects by passing "5" as the
-  argument to "first", then fetch the total count so it could display "5 of 83",
-  for example.
-  """
-  totalCount: Int
-  """
-  A list of all of the objects returned in the connection. This is a convenience
-  field provided for quickly exploring the API; rather than querying for
-  "{ edges { node } }" when no edge data is needed, this field can be be used
-  instead. Note that when clients like Relay need to fetch the "cursor" field on
-  the edge to enable efficient pagination, this shortcut cannot be used, and the
-  full "{ edges { node } }" version should be used instead.
-  """
-  films: [Film]
-}
-
-"""
-An edge in a connection.
-"""
-type SpeciesFilmsEdge {
-  """
-  The item at the end of the edge
-  """
-  node: Film
-  """
-  A cursor for use in pagination
-  """
-  cursor: String!
-}
-
-"""
-A connection to a list of items.
-"""
-type FilmStarshipsConnection {
-  """
-  Information to aid in pagination.
-  """
-  pageInfo: PageInfo!
-  """
-  A list of edges.
-  """
-  edges: [FilmStarshipsEdge]
-  """
-  A count of the total number of objects in this connection, ignoring pagination.
-  This allows a client to fetch the first five objects by passing "5" as the
-  argument to "first", then fetch the total count so it could display "5 of 83",
-  for example.
-  """
-  totalCount: Int
-  """
-  A list of all of the objects returned in the connection. This is a convenience
-  field provided for quickly exploring the API; rather than querying for
-  "{ edges { node } }" when no edge data is needed, this field can be be used
-  instead. Note that when clients like Relay need to fetch the "cursor" field on
-  the edge to enable efficient pagination, this shortcut cannot be used, and the
-  full "{ edges { node } }" version should be used instead.
-  """
-  starships: [Starship]
-}
-
-"""
-An edge in a connection.
-"""
-type FilmStarshipsEdge {
-  """
-  The item at the end of the edge
-  """
-  node: Starship
-  """
-  A cursor for use in pagination
-  """
-  cursor: String!
-}
-
-"""
-A connection to a list of items.
-"""
-type FilmVehiclesConnection {
-  """
-  Information to aid in pagination.
-  """
-  pageInfo: PageInfo!
-  """
-  A list of edges.
-  """
-  edges: [FilmVehiclesEdge]
-  """
-  A count of the total number of objects in this connection, ignoring pagination.
-  This allows a client to fetch the first five objects by passing "5" as the
-  argument to "first", then fetch the total count so it could display "5 of 83",
-  for example.
-  """
-  totalCount: Int
-  """
-  A list of all of the objects returned in the connection. This is a convenience
-  field provided for quickly exploring the API; rather than querying for
-  "{ edges { node } }" when no edge data is needed, this field can be be used
-  instead. Note that when clients like Relay need to fetch the "cursor" field on
-  the edge to enable efficient pagination, this shortcut cannot be used, and the
-  full "{ edges { node } }" version should be used instead.
-  """
-  vehicles: [Vehicle]
-}
-
-"""
-An edge in a connection.
-"""
-type FilmVehiclesEdge {
-  """
-  The item at the end of the edge
-  """
-  node: Vehicle
-  """
-  A cursor for use in pagination
-  """
-  cursor: String!
-}
-
-"""
-A connection to a list of items.
-"""
-type FilmCharactersConnection {
-  """
-  Information to aid in pagination.
-  """
-  pageInfo: PageInfo!
-  """
-  A list of edges.
-  """
-  edges: [FilmCharactersEdge]
-  """
-  A count of the total number of objects in this connection, ignoring pagination.
-  This allows a client to fetch the first five objects by passing "5" as the
-  argument to "first", then fetch the total count so it could display "5 of 83",
-  for example.
-  """
-  totalCount: Int
-  """
-  A list of all of the objects returned in the connection. This is a convenience
-  field provided for quickly exploring the API; rather than querying for
-  "{ edges { node } }" when no edge data is needed, this field can be be used
-  instead. Note that when clients like Relay need to fetch the "cursor" field on
-  the edge to enable efficient pagination, this shortcut cannot be used, and the
-  full "{ edges { node } }" version should be used instead.
-  """
-  characters: [Person]
-}
-
-"""
-An edge in a connection.
-"""
-type FilmCharactersEdge {
-  """
-  The item at the end of the edge
-  """
-  node: Person
-  """
-  A cursor for use in pagination
-  """
-  cursor: String!
-}
-
-"""
-A connection to a list of items.
-"""
-type FilmPlanetsConnection {
-  """
-  Information to aid in pagination.
-  """
-  pageInfo: PageInfo!
-  """
-  A list of edges.
-  """
-  edges: [FilmPlanetsEdge]
-  """
-  A count of the total number of objects in this connection, ignoring pagination.
-  This allows a client to fetch the first five objects by passing "5" as the
-  argument to "first", then fetch the total count so it could display "5 of 83",
-  for example.
-  """
-  totalCount: Int
-  """
-  A list of all of the objects returned in the connection. This is a convenience
-  field provided for quickly exploring the API; rather than querying for
-  "{ edges { node } }" when no edge data is needed, this field can be be used
-  instead. Note that when clients like Relay need to fetch the "cursor" field on
-  the edge to enable efficient pagination, this shortcut cannot be used, and the
-  full "{ edges { node } }" version should be used instead.
-  """
-  planets: [Planet]
-}
-
-"""
-An edge in a connection.
-"""
-type FilmPlanetsEdge {
-  """
-  The item at the end of the edge
-  """
-  node: Planet
-  """
-  A cursor for use in pagination
-  """
-  cursor: String!
-}
-
-"""
-A connection to a list of items.
-"""
-type PeopleConnection {
-  """
-  Information to aid in pagination.
-  """
-  pageInfo: PageInfo!
-  """
-  A list of edges.
-  """
-  edges: [PeopleEdge]
-  """
-  A count of the total number of objects in this connection, ignoring pagination.
-  This allows a client to fetch the first five objects by passing "5" as the
-  argument to "first", then fetch the total count so it could display "5 of 83",
-  for example.
-  """
-  totalCount: Int
-  """
-  A list of all of the objects returned in the connection. This is a convenience
-  field provided for quickly exploring the API; rather than querying for
-  "{ edges { node } }" when no edge data is needed, this field can be be used
-  instead. Note that when clients like Relay need to fetch the "cursor" field on
-  the edge to enable efficient pagination, this shortcut cannot be used, and the
-  full "{ edges { node } }" version should be used instead.
-  """
-  people: [Person]
-}
-
-"""
-An edge in a connection.
-"""
-type PeopleEdge {
-  """
-  The item at the end of the edge
-  """
-  node: Person
-  """
-  A cursor for use in pagination
-  """
-  cursor: String!
-}
-
-"""
-A connection to a list of items.
-"""
-type PlanetsConnection {
-  """
-  Information to aid in pagination.
-  """
-  pageInfo: PageInfo!
-  """
-  A list of edges.
-  """
-  edges: [PlanetsEdge]
-  """
-  A count of the total number of objects in this connection, ignoring pagination.
-  This allows a client to fetch the first five objects by passing "5" as the
-  argument to "first", then fetch the total count so it could display "5 of 83",
-  for example.
-  """
-  totalCount: Int
-  """
-  A list of all of the objects returned in the connection. This is a convenience
-  field provided for quickly exploring the API; rather than querying for
-  "{ edges { node } }" when no edge data is needed, this field can be be used
-  instead. Note that when clients like Relay need to fetch the "cursor" field on
-  the edge to enable efficient pagination, this shortcut cannot be used, and the
-  full "{ edges { node } }" version should be used instead.
-  """
-  planets: [Planet]
-}
-
-"""
-An edge in a connection.
-"""
-type PlanetsEdge {
-  """
-  The item at the end of the edge
-  """
-  node: Planet
-  """
-  A cursor for use in pagination
-  """
-  cursor: String!
-}
-
-"""
-A connection to a list of items.
-"""
-type SpeciesConnection {
-  """
-  Information to aid in pagination.
-  """
-  pageInfo: PageInfo!
-  """
-  A list of edges.
-  """
-  edges: [SpeciesEdge]
-  """
-  A count of the total number of objects in this connection, ignoring pagination.
-  This allows a client to fetch the first five objects by passing "5" as the
-  argument to "first", then fetch the total count so it could display "5 of 83",
-  for example.
-  """
-  totalCount: Int
-  """
-  A list of all of the objects returned in the connection. This is a convenience
-  field provided for quickly exploring the API; rather than querying for
-  "{ edges { node } }" when no edge data is needed, this field can be be used
-  instead. Note that when clients like Relay need to fetch the "cursor" field on
-  the edge to enable efficient pagination, this shortcut cannot be used, and the
-  full "{ edges { node } }" version should be used instead.
-  """
-  species: [Species]
-}
-
-"""
-An edge in a connection.
-"""
-type SpeciesEdge {
-  """
-  The item at the end of the edge
-  """
-  node: Species
-  """
-  A cursor for use in pagination
-  """
-  cursor: String!
-}
-
-"""
-A connection to a list of items.
-"""
-type StarshipsConnection {
-  """
-  Information to aid in pagination.
-  """
-  pageInfo: PageInfo!
-  """
-  A list of edges.
-  """
-  edges: [StarshipsEdge]
-  """
-  A count of the total number of objects in this connection, ignoring pagination.
-  This allows a client to fetch the first five objects by passing "5" as the
-  argument to "first", then fetch the total count so it could display "5 of 83",
-  for example.
-  """
-  totalCount: Int
-  """
-  A list of all of the objects returned in the connection. This is a convenience
-  field provided for quickly exploring the API; rather than querying for
-  "{ edges { node } }" when no edge data is needed, this field can be be used
-  instead. Note that when clients like Relay need to fetch the "cursor" field on
-  the edge to enable efficient pagination, this shortcut cannot be used, and the
-  full "{ edges { node } }" version should be used instead.
-  """
-  starships: [Starship]
-}
-
-"""
-An edge in a connection.
-"""
-type StarshipsEdge {
-  """
-  The item at the end of the edge
-  """
-  node: Starship
   """
   A cursor for use in pagination
   """
@@ -1412,5 +1410,3 @@ type VehiclesEdge {
   """
   cursor: String!
 }
-
-

--- a/cynic-introspection/tests/snapshots/tests__2018_schema_conversion.snap
+++ b/cynic-introspection/tests/snapshots/tests__2018_schema_conversion.snap
@@ -1,637 +1,13 @@
 ---
 source: cynic-introspection/tests/tests.rs
 expression: result.data.unwrap().into_schema().unwrap()
+snapshot_kind: text
 ---
 Schema {
     query_type: "Root",
     mutation_type: None,
     subscription_type: None,
     types: [
-        Object(
-            ObjectType {
-                name: "Root",
-                description: None,
-                fields: [
-                    Field {
-                        name: "allFilms",
-                        description: None,
-                        args: [
-                            InputValue {
-                                name: "after",
-                                description: None,
-                                ty: FieldType {
-                                    wrapping: [],
-                                    name: "String",
-                                },
-                                default_value: None,
-                            },
-                            InputValue {
-                                name: "first",
-                                description: None,
-                                ty: FieldType {
-                                    wrapping: [],
-                                    name: "Int",
-                                },
-                                default_value: None,
-                            },
-                            InputValue {
-                                name: "before",
-                                description: None,
-                                ty: FieldType {
-                                    wrapping: [],
-                                    name: "String",
-                                },
-                                default_value: None,
-                            },
-                            InputValue {
-                                name: "last",
-                                description: None,
-                                ty: FieldType {
-                                    wrapping: [],
-                                    name: "Int",
-                                },
-                                default_value: None,
-                            },
-                        ],
-                        ty: FieldType {
-                            wrapping: [],
-                            name: "FilmsConnection",
-                        },
-                        deprecated: No,
-                    },
-                    Field {
-                        name: "film",
-                        description: None,
-                        args: [
-                            InputValue {
-                                name: "id",
-                                description: None,
-                                ty: FieldType {
-                                    wrapping: [],
-                                    name: "ID",
-                                },
-                                default_value: None,
-                            },
-                            InputValue {
-                                name: "filmID",
-                                description: None,
-                                ty: FieldType {
-                                    wrapping: [],
-                                    name: "ID",
-                                },
-                                default_value: None,
-                            },
-                        ],
-                        ty: FieldType {
-                            wrapping: [],
-                            name: "Film",
-                        },
-                        deprecated: No,
-                    },
-                    Field {
-                        name: "allPeople",
-                        description: None,
-                        args: [
-                            InputValue {
-                                name: "after",
-                                description: None,
-                                ty: FieldType {
-                                    wrapping: [],
-                                    name: "String",
-                                },
-                                default_value: None,
-                            },
-                            InputValue {
-                                name: "first",
-                                description: None,
-                                ty: FieldType {
-                                    wrapping: [],
-                                    name: "Int",
-                                },
-                                default_value: None,
-                            },
-                            InputValue {
-                                name: "before",
-                                description: None,
-                                ty: FieldType {
-                                    wrapping: [],
-                                    name: "String",
-                                },
-                                default_value: None,
-                            },
-                            InputValue {
-                                name: "last",
-                                description: None,
-                                ty: FieldType {
-                                    wrapping: [],
-                                    name: "Int",
-                                },
-                                default_value: None,
-                            },
-                        ],
-                        ty: FieldType {
-                            wrapping: [],
-                            name: "PeopleConnection",
-                        },
-                        deprecated: No,
-                    },
-                    Field {
-                        name: "person",
-                        description: None,
-                        args: [
-                            InputValue {
-                                name: "id",
-                                description: None,
-                                ty: FieldType {
-                                    wrapping: [],
-                                    name: "ID",
-                                },
-                                default_value: None,
-                            },
-                            InputValue {
-                                name: "personID",
-                                description: None,
-                                ty: FieldType {
-                                    wrapping: [],
-                                    name: "ID",
-                                },
-                                default_value: None,
-                            },
-                        ],
-                        ty: FieldType {
-                            wrapping: [],
-                            name: "Person",
-                        },
-                        deprecated: No,
-                    },
-                    Field {
-                        name: "allPlanets",
-                        description: None,
-                        args: [
-                            InputValue {
-                                name: "after",
-                                description: None,
-                                ty: FieldType {
-                                    wrapping: [],
-                                    name: "String",
-                                },
-                                default_value: None,
-                            },
-                            InputValue {
-                                name: "first",
-                                description: None,
-                                ty: FieldType {
-                                    wrapping: [],
-                                    name: "Int",
-                                },
-                                default_value: None,
-                            },
-                            InputValue {
-                                name: "before",
-                                description: None,
-                                ty: FieldType {
-                                    wrapping: [],
-                                    name: "String",
-                                },
-                                default_value: None,
-                            },
-                            InputValue {
-                                name: "last",
-                                description: None,
-                                ty: FieldType {
-                                    wrapping: [],
-                                    name: "Int",
-                                },
-                                default_value: None,
-                            },
-                        ],
-                        ty: FieldType {
-                            wrapping: [],
-                            name: "PlanetsConnection",
-                        },
-                        deprecated: No,
-                    },
-                    Field {
-                        name: "planet",
-                        description: None,
-                        args: [
-                            InputValue {
-                                name: "id",
-                                description: None,
-                                ty: FieldType {
-                                    wrapping: [],
-                                    name: "ID",
-                                },
-                                default_value: None,
-                            },
-                            InputValue {
-                                name: "planetID",
-                                description: None,
-                                ty: FieldType {
-                                    wrapping: [],
-                                    name: "ID",
-                                },
-                                default_value: None,
-                            },
-                        ],
-                        ty: FieldType {
-                            wrapping: [],
-                            name: "Planet",
-                        },
-                        deprecated: No,
-                    },
-                    Field {
-                        name: "allSpecies",
-                        description: None,
-                        args: [
-                            InputValue {
-                                name: "after",
-                                description: None,
-                                ty: FieldType {
-                                    wrapping: [],
-                                    name: "String",
-                                },
-                                default_value: None,
-                            },
-                            InputValue {
-                                name: "first",
-                                description: None,
-                                ty: FieldType {
-                                    wrapping: [],
-                                    name: "Int",
-                                },
-                                default_value: None,
-                            },
-                            InputValue {
-                                name: "before",
-                                description: None,
-                                ty: FieldType {
-                                    wrapping: [],
-                                    name: "String",
-                                },
-                                default_value: None,
-                            },
-                            InputValue {
-                                name: "last",
-                                description: None,
-                                ty: FieldType {
-                                    wrapping: [],
-                                    name: "Int",
-                                },
-                                default_value: None,
-                            },
-                        ],
-                        ty: FieldType {
-                            wrapping: [],
-                            name: "SpeciesConnection",
-                        },
-                        deprecated: No,
-                    },
-                    Field {
-                        name: "species",
-                        description: None,
-                        args: [
-                            InputValue {
-                                name: "id",
-                                description: None,
-                                ty: FieldType {
-                                    wrapping: [],
-                                    name: "ID",
-                                },
-                                default_value: None,
-                            },
-                            InputValue {
-                                name: "speciesID",
-                                description: None,
-                                ty: FieldType {
-                                    wrapping: [],
-                                    name: "ID",
-                                },
-                                default_value: None,
-                            },
-                        ],
-                        ty: FieldType {
-                            wrapping: [],
-                            name: "Species",
-                        },
-                        deprecated: No,
-                    },
-                    Field {
-                        name: "allStarships",
-                        description: None,
-                        args: [
-                            InputValue {
-                                name: "after",
-                                description: None,
-                                ty: FieldType {
-                                    wrapping: [],
-                                    name: "String",
-                                },
-                                default_value: None,
-                            },
-                            InputValue {
-                                name: "first",
-                                description: None,
-                                ty: FieldType {
-                                    wrapping: [],
-                                    name: "Int",
-                                },
-                                default_value: None,
-                            },
-                            InputValue {
-                                name: "before",
-                                description: None,
-                                ty: FieldType {
-                                    wrapping: [],
-                                    name: "String",
-                                },
-                                default_value: None,
-                            },
-                            InputValue {
-                                name: "last",
-                                description: None,
-                                ty: FieldType {
-                                    wrapping: [],
-                                    name: "Int",
-                                },
-                                default_value: None,
-                            },
-                        ],
-                        ty: FieldType {
-                            wrapping: [],
-                            name: "StarshipsConnection",
-                        },
-                        deprecated: No,
-                    },
-                    Field {
-                        name: "starship",
-                        description: None,
-                        args: [
-                            InputValue {
-                                name: "id",
-                                description: None,
-                                ty: FieldType {
-                                    wrapping: [],
-                                    name: "ID",
-                                },
-                                default_value: None,
-                            },
-                            InputValue {
-                                name: "starshipID",
-                                description: None,
-                                ty: FieldType {
-                                    wrapping: [],
-                                    name: "ID",
-                                },
-                                default_value: None,
-                            },
-                        ],
-                        ty: FieldType {
-                            wrapping: [],
-                            name: "Starship",
-                        },
-                        deprecated: No,
-                    },
-                    Field {
-                        name: "allVehicles",
-                        description: None,
-                        args: [
-                            InputValue {
-                                name: "after",
-                                description: None,
-                                ty: FieldType {
-                                    wrapping: [],
-                                    name: "String",
-                                },
-                                default_value: None,
-                            },
-                            InputValue {
-                                name: "first",
-                                description: None,
-                                ty: FieldType {
-                                    wrapping: [],
-                                    name: "Int",
-                                },
-                                default_value: None,
-                            },
-                            InputValue {
-                                name: "before",
-                                description: None,
-                                ty: FieldType {
-                                    wrapping: [],
-                                    name: "String",
-                                },
-                                default_value: None,
-                            },
-                            InputValue {
-                                name: "last",
-                                description: None,
-                                ty: FieldType {
-                                    wrapping: [],
-                                    name: "Int",
-                                },
-                                default_value: None,
-                            },
-                        ],
-                        ty: FieldType {
-                            wrapping: [],
-                            name: "VehiclesConnection",
-                        },
-                        deprecated: No,
-                    },
-                    Field {
-                        name: "vehicle",
-                        description: None,
-                        args: [
-                            InputValue {
-                                name: "id",
-                                description: None,
-                                ty: FieldType {
-                                    wrapping: [],
-                                    name: "ID",
-                                },
-                                default_value: None,
-                            },
-                            InputValue {
-                                name: "vehicleID",
-                                description: None,
-                                ty: FieldType {
-                                    wrapping: [],
-                                    name: "ID",
-                                },
-                                default_value: None,
-                            },
-                        ],
-                        ty: FieldType {
-                            wrapping: [],
-                            name: "Vehicle",
-                        },
-                        deprecated: No,
-                    },
-                    Field {
-                        name: "node",
-                        description: Some(
-                            "Fetches an object given its ID",
-                        ),
-                        args: [
-                            InputValue {
-                                name: "id",
-                                description: Some(
-                                    "The ID of an object",
-                                ),
-                                ty: FieldType {
-                                    wrapping: [NonNull],
-                                    name: "ID",
-                                },
-                                default_value: None,
-                            },
-                        ],
-                        ty: FieldType {
-                            wrapping: [],
-                            name: "Node",
-                        },
-                        deprecated: No,
-                    },
-                ],
-                interfaces: [],
-            },
-        ),
-        Scalar(
-            ScalarType {
-                name: "String",
-                description: Some(
-                    "The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text.",
-                ),
-                specified_by_url: None,
-            },
-        ),
-        Scalar(
-            ScalarType {
-                name: "Int",
-                description: Some(
-                    "The `Int` scalar type represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1.",
-                ),
-                specified_by_url: None,
-            },
-        ),
-        Object(
-            ObjectType {
-                name: "FilmsConnection",
-                description: Some(
-                    "A connection to a list of items.",
-                ),
-                fields: [
-                    Field {
-                        name: "pageInfo",
-                        description: Some(
-                            "Information to aid in pagination.",
-                        ),
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [NonNull],
-                            name: "PageInfo",
-                        },
-                        deprecated: No,
-                    },
-                    Field {
-                        name: "edges",
-                        description: Some(
-                            "A list of edges.",
-                        ),
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [List],
-                            name: "FilmsEdge",
-                        },
-                        deprecated: No,
-                    },
-                    Field {
-                        name: "totalCount",
-                        description: Some(
-                            "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
-                        ),
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [],
-                            name: "Int",
-                        },
-                        deprecated: No,
-                    },
-                    Field {
-                        name: "films",
-                        description: Some(
-                            "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
-                        ),
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [List],
-                            name: "Film",
-                        },
-                        deprecated: No,
-                    },
-                ],
-                interfaces: [],
-            },
-        ),
-        Object(
-            ObjectType {
-                name: "PageInfo",
-                description: Some(
-                    "Information about pagination in a connection.",
-                ),
-                fields: [
-                    Field {
-                        name: "hasNextPage",
-                        description: Some(
-                            "When paginating forwards, are there more items?",
-                        ),
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [NonNull],
-                            name: "Boolean",
-                        },
-                        deprecated: No,
-                    },
-                    Field {
-                        name: "hasPreviousPage",
-                        description: Some(
-                            "When paginating backwards, are there more items?",
-                        ),
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [NonNull],
-                            name: "Boolean",
-                        },
-                        deprecated: No,
-                    },
-                    Field {
-                        name: "startCursor",
-                        description: Some(
-                            "When paginating backwards, the cursor to continue.",
-                        ),
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [],
-                            name: "String",
-                        },
-                        deprecated: No,
-                    },
-                    Field {
-                        name: "endCursor",
-                        description: Some(
-                            "When paginating forwards, the cursor to continue.",
-                        ),
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [],
-                            name: "String",
-                        },
-                        deprecated: No,
-                    },
-                ],
-                interfaces: [],
-            },
-        ),
         Scalar(
             ScalarType {
                 name: "Boolean",
@@ -639,41 +15,6 @@ Schema {
                     "The `Boolean` scalar type represents `true` or `false`.",
                 ),
                 specified_by_url: None,
-            },
-        ),
-        Object(
-            ObjectType {
-                name: "FilmsEdge",
-                description: Some(
-                    "An edge in a connection.",
-                ),
-                fields: [
-                    Field {
-                        name: "node",
-                        description: Some(
-                            "The item at the end of the edge",
-                        ),
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [],
-                            name: "Film",
-                        },
-                        deprecated: No,
-                    },
-                    Field {
-                        name: "cursor",
-                        description: Some(
-                            "A cursor for use in pagination",
-                        ),
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [NonNull],
-                            name: "String",
-                        },
-                        deprecated: No,
-                    },
-                ],
-                interfaces: [],
             },
         ),
         Object(
@@ -1032,44 +373,192 @@ Schema {
                 ],
             },
         ),
-        Interface(
-            InterfaceType {
-                name: "Node",
+        Object(
+            ObjectType {
+                name: "FilmCharactersConnection",
                 description: Some(
-                    "An object with an ID",
+                    "A connection to a list of items.",
                 ),
                 fields: [
                     Field {
-                        name: "id",
+                        name: "pageInfo",
                         description: Some(
-                            "The id of the object.",
+                            "Information to aid in pagination.",
                         ),
                         args: [],
                         ty: FieldType {
                             wrapping: [NonNull],
-                            name: "ID",
+                            name: "PageInfo",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "edges",
+                        description: Some(
+                            "A list of edges.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [List],
+                            name: "FilmCharactersEdge",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "totalCount",
+                        description: Some(
+                            "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "Int",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "characters",
+                        description: Some(
+                            "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [List],
+                            name: "Person",
                         },
                         deprecated: No,
                     },
                 ],
                 interfaces: [],
-                possible_types: [
-                    "Film",
-                    "Species",
-                    "Planet",
-                    "Person",
-                    "Starship",
-                    "Vehicle",
-                ],
             },
         ),
-        Scalar(
-            ScalarType {
-                name: "ID",
+        Object(
+            ObjectType {
+                name: "FilmCharactersEdge",
                 description: Some(
-                    "The `ID` scalar type represents a unique identifier, often used to refetch an object or as key for a cache. The ID type appears in a JSON response as a String; however, it is not intended to be human-readable. When expected as an input type, any string (such as `\"4\"`) or integer (such as `4`) input value will be accepted as an ID.",
+                    "An edge in a connection.",
                 ),
-                specified_by_url: None,
+                fields: [
+                    Field {
+                        name: "node",
+                        description: Some(
+                            "The item at the end of the edge",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "Person",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "cursor",
+                        description: Some(
+                            "A cursor for use in pagination",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [NonNull],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                ],
+                interfaces: [],
+            },
+        ),
+        Object(
+            ObjectType {
+                name: "FilmPlanetsConnection",
+                description: Some(
+                    "A connection to a list of items.",
+                ),
+                fields: [
+                    Field {
+                        name: "pageInfo",
+                        description: Some(
+                            "Information to aid in pagination.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [NonNull],
+                            name: "PageInfo",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "edges",
+                        description: Some(
+                            "A list of edges.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [List],
+                            name: "FilmPlanetsEdge",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "totalCount",
+                        description: Some(
+                            "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "Int",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "planets",
+                        description: Some(
+                            "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [List],
+                            name: "Planet",
+                        },
+                        deprecated: No,
+                    },
+                ],
+                interfaces: [],
+            },
+        ),
+        Object(
+            ObjectType {
+                name: "FilmPlanetsEdge",
+                description: Some(
+                    "An edge in a connection.",
+                ),
+                fields: [
+                    Field {
+                        name: "node",
+                        description: Some(
+                            "The item at the end of the edge",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "Planet",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "cursor",
+                        description: Some(
+                            "A cursor for use in pagination",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [NonNull],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                ],
+                interfaces: [],
             },
         ),
         Object(
@@ -1168,530 +657,7 @@ Schema {
         ),
         Object(
             ObjectType {
-                name: "Species",
-                description: Some(
-                    "A type of person or character within the Star Wars Universe.",
-                ),
-                fields: [
-                    Field {
-                        name: "name",
-                        description: Some(
-                            "The name of this species.",
-                        ),
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [],
-                            name: "String",
-                        },
-                        deprecated: No,
-                    },
-                    Field {
-                        name: "classification",
-                        description: Some(
-                            "The classification of this species, such as \"mammal\" or \"reptile\".",
-                        ),
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [],
-                            name: "String",
-                        },
-                        deprecated: No,
-                    },
-                    Field {
-                        name: "designation",
-                        description: Some(
-                            "The designation of this species, such as \"sentient\".",
-                        ),
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [],
-                            name: "String",
-                        },
-                        deprecated: No,
-                    },
-                    Field {
-                        name: "averageHeight",
-                        description: Some(
-                            "The average height of this species in centimeters.",
-                        ),
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [],
-                            name: "Float",
-                        },
-                        deprecated: No,
-                    },
-                    Field {
-                        name: "averageLifespan",
-                        description: Some(
-                            "The average lifespan of this species in years, null if unknown.",
-                        ),
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [],
-                            name: "Int",
-                        },
-                        deprecated: No,
-                    },
-                    Field {
-                        name: "eyeColors",
-                        description: Some(
-                            "Common eye colors for this species, null if this species does not typically\nhave eyes.",
-                        ),
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [List],
-                            name: "String",
-                        },
-                        deprecated: No,
-                    },
-                    Field {
-                        name: "hairColors",
-                        description: Some(
-                            "Common hair colors for this species, null if this species does not typically\nhave hair.",
-                        ),
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [List],
-                            name: "String",
-                        },
-                        deprecated: No,
-                    },
-                    Field {
-                        name: "skinColors",
-                        description: Some(
-                            "Common skin colors for this species, null if this species does not typically\nhave skin.",
-                        ),
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [List],
-                            name: "String",
-                        },
-                        deprecated: No,
-                    },
-                    Field {
-                        name: "language",
-                        description: Some(
-                            "The language commonly spoken by this species.",
-                        ),
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [],
-                            name: "String",
-                        },
-                        deprecated: No,
-                    },
-                    Field {
-                        name: "homeworld",
-                        description: Some(
-                            "A planet that this species originates from.",
-                        ),
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [],
-                            name: "Planet",
-                        },
-                        deprecated: No,
-                    },
-                    Field {
-                        name: "personConnection",
-                        description: None,
-                        args: [
-                            InputValue {
-                                name: "after",
-                                description: None,
-                                ty: FieldType {
-                                    wrapping: [],
-                                    name: "String",
-                                },
-                                default_value: None,
-                            },
-                            InputValue {
-                                name: "first",
-                                description: None,
-                                ty: FieldType {
-                                    wrapping: [],
-                                    name: "Int",
-                                },
-                                default_value: None,
-                            },
-                            InputValue {
-                                name: "before",
-                                description: None,
-                                ty: FieldType {
-                                    wrapping: [],
-                                    name: "String",
-                                },
-                                default_value: None,
-                            },
-                            InputValue {
-                                name: "last",
-                                description: None,
-                                ty: FieldType {
-                                    wrapping: [],
-                                    name: "Int",
-                                },
-                                default_value: None,
-                            },
-                        ],
-                        ty: FieldType {
-                            wrapping: [],
-                            name: "SpeciesPeopleConnection",
-                        },
-                        deprecated: No,
-                    },
-                    Field {
-                        name: "filmConnection",
-                        description: None,
-                        args: [
-                            InputValue {
-                                name: "after",
-                                description: None,
-                                ty: FieldType {
-                                    wrapping: [],
-                                    name: "String",
-                                },
-                                default_value: None,
-                            },
-                            InputValue {
-                                name: "first",
-                                description: None,
-                                ty: FieldType {
-                                    wrapping: [],
-                                    name: "Int",
-                                },
-                                default_value: None,
-                            },
-                            InputValue {
-                                name: "before",
-                                description: None,
-                                ty: FieldType {
-                                    wrapping: [],
-                                    name: "String",
-                                },
-                                default_value: None,
-                            },
-                            InputValue {
-                                name: "last",
-                                description: None,
-                                ty: FieldType {
-                                    wrapping: [],
-                                    name: "Int",
-                                },
-                                default_value: None,
-                            },
-                        ],
-                        ty: FieldType {
-                            wrapping: [],
-                            name: "SpeciesFilmsConnection",
-                        },
-                        deprecated: No,
-                    },
-                    Field {
-                        name: "created",
-                        description: Some(
-                            "The ISO 8601 date format of the time that this resource was created.",
-                        ),
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [],
-                            name: "String",
-                        },
-                        deprecated: No,
-                    },
-                    Field {
-                        name: "edited",
-                        description: Some(
-                            "The ISO 8601 date format of the time that this resource was edited.",
-                        ),
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [],
-                            name: "String",
-                        },
-                        deprecated: No,
-                    },
-                    Field {
-                        name: "id",
-                        description: Some(
-                            "The ID of an object",
-                        ),
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [NonNull],
-                            name: "ID",
-                        },
-                        deprecated: No,
-                    },
-                ],
-                interfaces: [
-                    "Node",
-                ],
-            },
-        ),
-        Scalar(
-            ScalarType {
-                name: "Float",
-                description: Some(
-                    "The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](https://en.wikipedia.org/wiki/IEEE_floating_point).",
-                ),
-                specified_by_url: None,
-            },
-        ),
-        Object(
-            ObjectType {
-                name: "Planet",
-                description: Some(
-                    "A large mass, planet or planetoid in the Star Wars Universe, at the time of\n0 ABY.",
-                ),
-                fields: [
-                    Field {
-                        name: "name",
-                        description: Some(
-                            "The name of this planet.",
-                        ),
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [],
-                            name: "String",
-                        },
-                        deprecated: No,
-                    },
-                    Field {
-                        name: "diameter",
-                        description: Some(
-                            "The diameter of this planet in kilometers.",
-                        ),
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [],
-                            name: "Int",
-                        },
-                        deprecated: No,
-                    },
-                    Field {
-                        name: "rotationPeriod",
-                        description: Some(
-                            "The number of standard hours it takes for this planet to complete a single\nrotation on its axis.",
-                        ),
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [],
-                            name: "Int",
-                        },
-                        deprecated: No,
-                    },
-                    Field {
-                        name: "orbitalPeriod",
-                        description: Some(
-                            "The number of standard days it takes for this planet to complete a single orbit\nof its local star.",
-                        ),
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [],
-                            name: "Int",
-                        },
-                        deprecated: No,
-                    },
-                    Field {
-                        name: "gravity",
-                        description: Some(
-                            "A number denoting the gravity of this planet, where \"1\" is normal or 1 standard\nG. \"2\" is twice or 2 standard Gs. \"0.5\" is half or 0.5 standard Gs.",
-                        ),
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [],
-                            name: "String",
-                        },
-                        deprecated: No,
-                    },
-                    Field {
-                        name: "population",
-                        description: Some(
-                            "The average population of sentient beings inhabiting this planet.",
-                        ),
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [],
-                            name: "Float",
-                        },
-                        deprecated: No,
-                    },
-                    Field {
-                        name: "climates",
-                        description: Some(
-                            "The climates of this planet.",
-                        ),
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [List],
-                            name: "String",
-                        },
-                        deprecated: No,
-                    },
-                    Field {
-                        name: "terrains",
-                        description: Some(
-                            "The terrains of this planet.",
-                        ),
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [List],
-                            name: "String",
-                        },
-                        deprecated: No,
-                    },
-                    Field {
-                        name: "surfaceWater",
-                        description: Some(
-                            "The percentage of the planet surface that is naturally occurring water or bodies\nof water.",
-                        ),
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [],
-                            name: "Float",
-                        },
-                        deprecated: No,
-                    },
-                    Field {
-                        name: "residentConnection",
-                        description: None,
-                        args: [
-                            InputValue {
-                                name: "after",
-                                description: None,
-                                ty: FieldType {
-                                    wrapping: [],
-                                    name: "String",
-                                },
-                                default_value: None,
-                            },
-                            InputValue {
-                                name: "first",
-                                description: None,
-                                ty: FieldType {
-                                    wrapping: [],
-                                    name: "Int",
-                                },
-                                default_value: None,
-                            },
-                            InputValue {
-                                name: "before",
-                                description: None,
-                                ty: FieldType {
-                                    wrapping: [],
-                                    name: "String",
-                                },
-                                default_value: None,
-                            },
-                            InputValue {
-                                name: "last",
-                                description: None,
-                                ty: FieldType {
-                                    wrapping: [],
-                                    name: "Int",
-                                },
-                                default_value: None,
-                            },
-                        ],
-                        ty: FieldType {
-                            wrapping: [],
-                            name: "PlanetResidentsConnection",
-                        },
-                        deprecated: No,
-                    },
-                    Field {
-                        name: "filmConnection",
-                        description: None,
-                        args: [
-                            InputValue {
-                                name: "after",
-                                description: None,
-                                ty: FieldType {
-                                    wrapping: [],
-                                    name: "String",
-                                },
-                                default_value: None,
-                            },
-                            InputValue {
-                                name: "first",
-                                description: None,
-                                ty: FieldType {
-                                    wrapping: [],
-                                    name: "Int",
-                                },
-                                default_value: None,
-                            },
-                            InputValue {
-                                name: "before",
-                                description: None,
-                                ty: FieldType {
-                                    wrapping: [],
-                                    name: "String",
-                                },
-                                default_value: None,
-                            },
-                            InputValue {
-                                name: "last",
-                                description: None,
-                                ty: FieldType {
-                                    wrapping: [],
-                                    name: "Int",
-                                },
-                                default_value: None,
-                            },
-                        ],
-                        ty: FieldType {
-                            wrapping: [],
-                            name: "PlanetFilmsConnection",
-                        },
-                        deprecated: No,
-                    },
-                    Field {
-                        name: "created",
-                        description: Some(
-                            "The ISO 8601 date format of the time that this resource was created.",
-                        ),
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [],
-                            name: "String",
-                        },
-                        deprecated: No,
-                    },
-                    Field {
-                        name: "edited",
-                        description: Some(
-                            "The ISO 8601 date format of the time that this resource was edited.",
-                        ),
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [],
-                            name: "String",
-                        },
-                        deprecated: No,
-                    },
-                    Field {
-                        name: "id",
-                        description: Some(
-                            "The ID of an object",
-                        ),
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [NonNull],
-                            name: "ID",
-                        },
-                        deprecated: No,
-                    },
-                ],
-                interfaces: [
-                    "Node",
-                ],
-            },
-        ),
-        Object(
-            ObjectType {
-                name: "PlanetResidentsConnection",
+                name: "FilmStarshipsConnection",
                 description: Some(
                     "A connection to a list of items.",
                 ),
@@ -1716,7 +682,7 @@ Schema {
                         args: [],
                         ty: FieldType {
                             wrapping: [List],
-                            name: "PlanetResidentsEdge",
+                            name: "FilmStarshipsEdge",
                         },
                         deprecated: No,
                     },
@@ -1733,7 +699,402 @@ Schema {
                         deprecated: No,
                     },
                     Field {
-                        name: "residents",
+                        name: "starships",
+                        description: Some(
+                            "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [List],
+                            name: "Starship",
+                        },
+                        deprecated: No,
+                    },
+                ],
+                interfaces: [],
+            },
+        ),
+        Object(
+            ObjectType {
+                name: "FilmStarshipsEdge",
+                description: Some(
+                    "An edge in a connection.",
+                ),
+                fields: [
+                    Field {
+                        name: "node",
+                        description: Some(
+                            "The item at the end of the edge",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "Starship",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "cursor",
+                        description: Some(
+                            "A cursor for use in pagination",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [NonNull],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                ],
+                interfaces: [],
+            },
+        ),
+        Object(
+            ObjectType {
+                name: "FilmVehiclesConnection",
+                description: Some(
+                    "A connection to a list of items.",
+                ),
+                fields: [
+                    Field {
+                        name: "pageInfo",
+                        description: Some(
+                            "Information to aid in pagination.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [NonNull],
+                            name: "PageInfo",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "edges",
+                        description: Some(
+                            "A list of edges.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [List],
+                            name: "FilmVehiclesEdge",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "totalCount",
+                        description: Some(
+                            "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "Int",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "vehicles",
+                        description: Some(
+                            "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [List],
+                            name: "Vehicle",
+                        },
+                        deprecated: No,
+                    },
+                ],
+                interfaces: [],
+            },
+        ),
+        Object(
+            ObjectType {
+                name: "FilmVehiclesEdge",
+                description: Some(
+                    "An edge in a connection.",
+                ),
+                fields: [
+                    Field {
+                        name: "node",
+                        description: Some(
+                            "The item at the end of the edge",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "Vehicle",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "cursor",
+                        description: Some(
+                            "A cursor for use in pagination",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [NonNull],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                ],
+                interfaces: [],
+            },
+        ),
+        Object(
+            ObjectType {
+                name: "FilmsConnection",
+                description: Some(
+                    "A connection to a list of items.",
+                ),
+                fields: [
+                    Field {
+                        name: "pageInfo",
+                        description: Some(
+                            "Information to aid in pagination.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [NonNull],
+                            name: "PageInfo",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "edges",
+                        description: Some(
+                            "A list of edges.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [List],
+                            name: "FilmsEdge",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "totalCount",
+                        description: Some(
+                            "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "Int",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "films",
+                        description: Some(
+                            "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [List],
+                            name: "Film",
+                        },
+                        deprecated: No,
+                    },
+                ],
+                interfaces: [],
+            },
+        ),
+        Object(
+            ObjectType {
+                name: "FilmsEdge",
+                description: Some(
+                    "An edge in a connection.",
+                ),
+                fields: [
+                    Field {
+                        name: "node",
+                        description: Some(
+                            "The item at the end of the edge",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "Film",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "cursor",
+                        description: Some(
+                            "A cursor for use in pagination",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [NonNull],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                ],
+                interfaces: [],
+            },
+        ),
+        Scalar(
+            ScalarType {
+                name: "Float",
+                description: Some(
+                    "The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](https://en.wikipedia.org/wiki/IEEE_floating_point).",
+                ),
+                specified_by_url: None,
+            },
+        ),
+        Scalar(
+            ScalarType {
+                name: "ID",
+                description: None,
+                specified_by_url: None,
+            },
+        ),
+        Scalar(
+            ScalarType {
+                name: "Int",
+                description: Some(
+                    "The `Int` scalar type represents non-fractional whole numeric values.",
+                ),
+                specified_by_url: None,
+            },
+        ),
+        Interface(
+            InterfaceType {
+                name: "Node",
+                description: Some(
+                    "An object with an ID",
+                ),
+                fields: [
+                    Field {
+                        name: "id",
+                        description: None,
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [NonNull],
+                            name: "ID",
+                        },
+                        deprecated: No,
+                    },
+                ],
+                interfaces: [],
+                possible_types: [
+                    "Film",
+                    "Species",
+                    "Planet",
+                    "Person",
+                    "Starship",
+                    "Vehicle",
+                ],
+            },
+        ),
+        Object(
+            ObjectType {
+                name: "PageInfo",
+                description: Some(
+                    "Information about pagination in a connection.",
+                ),
+                fields: [
+                    Field {
+                        name: "hasNextPage",
+                        description: Some(
+                            "When paginating forwards, are there more items?",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [NonNull],
+                            name: "Boolean",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "hasPreviousPage",
+                        description: Some(
+                            "When paginating backwards, are there more items?",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [NonNull],
+                            name: "Boolean",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "startCursor",
+                        description: Some(
+                            "When paginating backwards, the cursor to continue.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "endCursor",
+                        description: Some(
+                            "When paginating forwards, the cursor to continue.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                ],
+                interfaces: [],
+            },
+        ),
+        Object(
+            ObjectType {
+                name: "PeopleConnection",
+                description: Some(
+                    "A connection to a list of items.",
+                ),
+                fields: [
+                    Field {
+                        name: "pageInfo",
+                        description: Some(
+                            "Information to aid in pagination.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [NonNull],
+                            name: "PageInfo",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "edges",
+                        description: Some(
+                            "A list of edges.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [List],
+                            name: "PeopleEdge",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "totalCount",
+                        description: Some(
+                            "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "Int",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "people",
                         description: Some(
                             "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
                         ),
@@ -1750,7 +1111,7 @@ Schema {
         ),
         Object(
             ObjectType {
-                name: "PlanetResidentsEdge",
+                name: "PeopleEdge",
                 description: Some(
                     "An edge in a connection.",
                 ),
@@ -2283,6 +1644,1667 @@ Schema {
         ),
         Object(
             ObjectType {
+                name: "PersonVehiclesConnection",
+                description: Some(
+                    "A connection to a list of items.",
+                ),
+                fields: [
+                    Field {
+                        name: "pageInfo",
+                        description: Some(
+                            "Information to aid in pagination.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [NonNull],
+                            name: "PageInfo",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "edges",
+                        description: Some(
+                            "A list of edges.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [List],
+                            name: "PersonVehiclesEdge",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "totalCount",
+                        description: Some(
+                            "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "Int",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "vehicles",
+                        description: Some(
+                            "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [List],
+                            name: "Vehicle",
+                        },
+                        deprecated: No,
+                    },
+                ],
+                interfaces: [],
+            },
+        ),
+        Object(
+            ObjectType {
+                name: "PersonVehiclesEdge",
+                description: Some(
+                    "An edge in a connection.",
+                ),
+                fields: [
+                    Field {
+                        name: "node",
+                        description: Some(
+                            "The item at the end of the edge",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "Vehicle",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "cursor",
+                        description: Some(
+                            "A cursor for use in pagination",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [NonNull],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                ],
+                interfaces: [],
+            },
+        ),
+        Object(
+            ObjectType {
+                name: "Planet",
+                description: Some(
+                    "A large mass, planet or planetoid in the Star Wars Universe, at the time of\n0 ABY.",
+                ),
+                fields: [
+                    Field {
+                        name: "name",
+                        description: Some(
+                            "The name of this planet.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "diameter",
+                        description: Some(
+                            "The diameter of this planet in kilometers.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "Int",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "rotationPeriod",
+                        description: Some(
+                            "The number of standard hours it takes for this planet to complete a single\nrotation on its axis.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "Int",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "orbitalPeriod",
+                        description: Some(
+                            "The number of standard days it takes for this planet to complete a single orbit\nof its local star.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "Int",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "gravity",
+                        description: Some(
+                            "A number denoting the gravity of this planet, where \"1\" is normal or 1 standard\nG. \"2\" is twice or 2 standard Gs. \"0.5\" is half or 0.5 standard Gs.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "population",
+                        description: Some(
+                            "The average population of sentient beings inhabiting this planet.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "Float",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "climates",
+                        description: Some(
+                            "The climates of this planet.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [List],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "terrains",
+                        description: Some(
+                            "The terrains of this planet.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [List],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "surfaceWater",
+                        description: Some(
+                            "The percentage of the planet surface that is naturally occurring water or bodies\nof water.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "Float",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "residentConnection",
+                        description: None,
+                        args: [
+                            InputValue {
+                                name: "after",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "String",
+                                },
+                                default_value: None,
+                            },
+                            InputValue {
+                                name: "first",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "Int",
+                                },
+                                default_value: None,
+                            },
+                            InputValue {
+                                name: "before",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "String",
+                                },
+                                default_value: None,
+                            },
+                            InputValue {
+                                name: "last",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "Int",
+                                },
+                                default_value: None,
+                            },
+                        ],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "PlanetResidentsConnection",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "filmConnection",
+                        description: None,
+                        args: [
+                            InputValue {
+                                name: "after",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "String",
+                                },
+                                default_value: None,
+                            },
+                            InputValue {
+                                name: "first",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "Int",
+                                },
+                                default_value: None,
+                            },
+                            InputValue {
+                                name: "before",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "String",
+                                },
+                                default_value: None,
+                            },
+                            InputValue {
+                                name: "last",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "Int",
+                                },
+                                default_value: None,
+                            },
+                        ],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "PlanetFilmsConnection",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "created",
+                        description: Some(
+                            "The ISO 8601 date format of the time that this resource was created.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "edited",
+                        description: Some(
+                            "The ISO 8601 date format of the time that this resource was edited.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "id",
+                        description: Some(
+                            "The ID of an object",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [NonNull],
+                            name: "ID",
+                        },
+                        deprecated: No,
+                    },
+                ],
+                interfaces: [
+                    "Node",
+                ],
+            },
+        ),
+        Object(
+            ObjectType {
+                name: "PlanetFilmsConnection",
+                description: Some(
+                    "A connection to a list of items.",
+                ),
+                fields: [
+                    Field {
+                        name: "pageInfo",
+                        description: Some(
+                            "Information to aid in pagination.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [NonNull],
+                            name: "PageInfo",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "edges",
+                        description: Some(
+                            "A list of edges.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [List],
+                            name: "PlanetFilmsEdge",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "totalCount",
+                        description: Some(
+                            "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "Int",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "films",
+                        description: Some(
+                            "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [List],
+                            name: "Film",
+                        },
+                        deprecated: No,
+                    },
+                ],
+                interfaces: [],
+            },
+        ),
+        Object(
+            ObjectType {
+                name: "PlanetFilmsEdge",
+                description: Some(
+                    "An edge in a connection.",
+                ),
+                fields: [
+                    Field {
+                        name: "node",
+                        description: Some(
+                            "The item at the end of the edge",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "Film",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "cursor",
+                        description: Some(
+                            "A cursor for use in pagination",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [NonNull],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                ],
+                interfaces: [],
+            },
+        ),
+        Object(
+            ObjectType {
+                name: "PlanetResidentsConnection",
+                description: Some(
+                    "A connection to a list of items.",
+                ),
+                fields: [
+                    Field {
+                        name: "pageInfo",
+                        description: Some(
+                            "Information to aid in pagination.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [NonNull],
+                            name: "PageInfo",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "edges",
+                        description: Some(
+                            "A list of edges.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [List],
+                            name: "PlanetResidentsEdge",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "totalCount",
+                        description: Some(
+                            "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "Int",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "residents",
+                        description: Some(
+                            "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [List],
+                            name: "Person",
+                        },
+                        deprecated: No,
+                    },
+                ],
+                interfaces: [],
+            },
+        ),
+        Object(
+            ObjectType {
+                name: "PlanetResidentsEdge",
+                description: Some(
+                    "An edge in a connection.",
+                ),
+                fields: [
+                    Field {
+                        name: "node",
+                        description: Some(
+                            "The item at the end of the edge",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "Person",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "cursor",
+                        description: Some(
+                            "A cursor for use in pagination",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [NonNull],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                ],
+                interfaces: [],
+            },
+        ),
+        Object(
+            ObjectType {
+                name: "PlanetsConnection",
+                description: Some(
+                    "A connection to a list of items.",
+                ),
+                fields: [
+                    Field {
+                        name: "pageInfo",
+                        description: Some(
+                            "Information to aid in pagination.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [NonNull],
+                            name: "PageInfo",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "edges",
+                        description: Some(
+                            "A list of edges.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [List],
+                            name: "PlanetsEdge",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "totalCount",
+                        description: Some(
+                            "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "Int",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "planets",
+                        description: Some(
+                            "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [List],
+                            name: "Planet",
+                        },
+                        deprecated: No,
+                    },
+                ],
+                interfaces: [],
+            },
+        ),
+        Object(
+            ObjectType {
+                name: "PlanetsEdge",
+                description: Some(
+                    "An edge in a connection.",
+                ),
+                fields: [
+                    Field {
+                        name: "node",
+                        description: Some(
+                            "The item at the end of the edge",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "Planet",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "cursor",
+                        description: Some(
+                            "A cursor for use in pagination",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [NonNull],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                ],
+                interfaces: [],
+            },
+        ),
+        Object(
+            ObjectType {
+                name: "Root",
+                description: None,
+                fields: [
+                    Field {
+                        name: "allFilms",
+                        description: None,
+                        args: [
+                            InputValue {
+                                name: "after",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "String",
+                                },
+                                default_value: None,
+                            },
+                            InputValue {
+                                name: "first",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "Int",
+                                },
+                                default_value: None,
+                            },
+                            InputValue {
+                                name: "before",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "String",
+                                },
+                                default_value: None,
+                            },
+                            InputValue {
+                                name: "last",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "Int",
+                                },
+                                default_value: None,
+                            },
+                        ],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "FilmsConnection",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "film",
+                        description: None,
+                        args: [
+                            InputValue {
+                                name: "id",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "ID",
+                                },
+                                default_value: None,
+                            },
+                            InputValue {
+                                name: "filmID",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "ID",
+                                },
+                                default_value: None,
+                            },
+                        ],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "Film",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "allPeople",
+                        description: None,
+                        args: [
+                            InputValue {
+                                name: "after",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "String",
+                                },
+                                default_value: None,
+                            },
+                            InputValue {
+                                name: "first",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "Int",
+                                },
+                                default_value: None,
+                            },
+                            InputValue {
+                                name: "before",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "String",
+                                },
+                                default_value: None,
+                            },
+                            InputValue {
+                                name: "last",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "Int",
+                                },
+                                default_value: None,
+                            },
+                        ],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "PeopleConnection",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "person",
+                        description: None,
+                        args: [
+                            InputValue {
+                                name: "id",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "ID",
+                                },
+                                default_value: None,
+                            },
+                            InputValue {
+                                name: "personID",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "ID",
+                                },
+                                default_value: None,
+                            },
+                        ],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "Person",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "allPlanets",
+                        description: None,
+                        args: [
+                            InputValue {
+                                name: "after",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "String",
+                                },
+                                default_value: None,
+                            },
+                            InputValue {
+                                name: "first",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "Int",
+                                },
+                                default_value: None,
+                            },
+                            InputValue {
+                                name: "before",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "String",
+                                },
+                                default_value: None,
+                            },
+                            InputValue {
+                                name: "last",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "Int",
+                                },
+                                default_value: None,
+                            },
+                        ],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "PlanetsConnection",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "planet",
+                        description: None,
+                        args: [
+                            InputValue {
+                                name: "id",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "ID",
+                                },
+                                default_value: None,
+                            },
+                            InputValue {
+                                name: "planetID",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "ID",
+                                },
+                                default_value: None,
+                            },
+                        ],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "Planet",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "allSpecies",
+                        description: None,
+                        args: [
+                            InputValue {
+                                name: "after",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "String",
+                                },
+                                default_value: None,
+                            },
+                            InputValue {
+                                name: "first",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "Int",
+                                },
+                                default_value: None,
+                            },
+                            InputValue {
+                                name: "before",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "String",
+                                },
+                                default_value: None,
+                            },
+                            InputValue {
+                                name: "last",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "Int",
+                                },
+                                default_value: None,
+                            },
+                        ],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "SpeciesConnection",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "species",
+                        description: None,
+                        args: [
+                            InputValue {
+                                name: "id",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "ID",
+                                },
+                                default_value: None,
+                            },
+                            InputValue {
+                                name: "speciesID",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "ID",
+                                },
+                                default_value: None,
+                            },
+                        ],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "Species",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "allStarships",
+                        description: None,
+                        args: [
+                            InputValue {
+                                name: "after",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "String",
+                                },
+                                default_value: None,
+                            },
+                            InputValue {
+                                name: "first",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "Int",
+                                },
+                                default_value: None,
+                            },
+                            InputValue {
+                                name: "before",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "String",
+                                },
+                                default_value: None,
+                            },
+                            InputValue {
+                                name: "last",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "Int",
+                                },
+                                default_value: None,
+                            },
+                        ],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "StarshipsConnection",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "starship",
+                        description: None,
+                        args: [
+                            InputValue {
+                                name: "id",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "ID",
+                                },
+                                default_value: None,
+                            },
+                            InputValue {
+                                name: "starshipID",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "ID",
+                                },
+                                default_value: None,
+                            },
+                        ],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "Starship",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "allVehicles",
+                        description: None,
+                        args: [
+                            InputValue {
+                                name: "after",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "String",
+                                },
+                                default_value: None,
+                            },
+                            InputValue {
+                                name: "first",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "Int",
+                                },
+                                default_value: None,
+                            },
+                            InputValue {
+                                name: "before",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "String",
+                                },
+                                default_value: None,
+                            },
+                            InputValue {
+                                name: "last",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "Int",
+                                },
+                                default_value: None,
+                            },
+                        ],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "VehiclesConnection",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "vehicle",
+                        description: None,
+                        args: [
+                            InputValue {
+                                name: "id",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "ID",
+                                },
+                                default_value: None,
+                            },
+                            InputValue {
+                                name: "vehicleID",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "ID",
+                                },
+                                default_value: None,
+                            },
+                        ],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "Vehicle",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "node",
+                        description: Some(
+                            "Fetches an object given its ID",
+                        ),
+                        args: [
+                            InputValue {
+                                name: "id",
+                                description: Some(
+                                    "The ID of an object",
+                                ),
+                                ty: FieldType {
+                                    wrapping: [NonNull],
+                                    name: "ID",
+                                },
+                                default_value: None,
+                            },
+                        ],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "Node",
+                        },
+                        deprecated: No,
+                    },
+                ],
+                interfaces: [],
+            },
+        ),
+        Object(
+            ObjectType {
+                name: "Species",
+                description: Some(
+                    "A type of person or character within the Star Wars Universe.",
+                ),
+                fields: [
+                    Field {
+                        name: "name",
+                        description: Some(
+                            "The name of this species.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "classification",
+                        description: Some(
+                            "The classification of this species, such as \"mammal\" or \"reptile\".",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "designation",
+                        description: Some(
+                            "The designation of this species, such as \"sentient\".",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "averageHeight",
+                        description: Some(
+                            "The average height of this species in centimeters.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "Float",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "averageLifespan",
+                        description: Some(
+                            "The average lifespan of this species in years, null if unknown.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "Int",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "eyeColors",
+                        description: Some(
+                            "Common eye colors for this species, null if this species does not typically\nhave eyes.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [List],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "hairColors",
+                        description: Some(
+                            "Common hair colors for this species, null if this species does not typically\nhave hair.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [List],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "skinColors",
+                        description: Some(
+                            "Common skin colors for this species, null if this species does not typically\nhave skin.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [List],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "language",
+                        description: Some(
+                            "The language commonly spoken by this species.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "homeworld",
+                        description: Some(
+                            "A planet that this species originates from.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "Planet",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "personConnection",
+                        description: None,
+                        args: [
+                            InputValue {
+                                name: "after",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "String",
+                                },
+                                default_value: None,
+                            },
+                            InputValue {
+                                name: "first",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "Int",
+                                },
+                                default_value: None,
+                            },
+                            InputValue {
+                                name: "before",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "String",
+                                },
+                                default_value: None,
+                            },
+                            InputValue {
+                                name: "last",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "Int",
+                                },
+                                default_value: None,
+                            },
+                        ],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "SpeciesPeopleConnection",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "filmConnection",
+                        description: None,
+                        args: [
+                            InputValue {
+                                name: "after",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "String",
+                                },
+                                default_value: None,
+                            },
+                            InputValue {
+                                name: "first",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "Int",
+                                },
+                                default_value: None,
+                            },
+                            InputValue {
+                                name: "before",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "String",
+                                },
+                                default_value: None,
+                            },
+                            InputValue {
+                                name: "last",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [],
+                                    name: "Int",
+                                },
+                                default_value: None,
+                            },
+                        ],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "SpeciesFilmsConnection",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "created",
+                        description: Some(
+                            "The ISO 8601 date format of the time that this resource was created.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "edited",
+                        description: Some(
+                            "The ISO 8601 date format of the time that this resource was edited.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "id",
+                        description: Some(
+                            "The ID of an object",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [NonNull],
+                            name: "ID",
+                        },
+                        deprecated: No,
+                    },
+                ],
+                interfaces: [
+                    "Node",
+                ],
+            },
+        ),
+        Object(
+            ObjectType {
+                name: "SpeciesConnection",
+                description: Some(
+                    "A connection to a list of items.",
+                ),
+                fields: [
+                    Field {
+                        name: "pageInfo",
+                        description: Some(
+                            "Information to aid in pagination.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [NonNull],
+                            name: "PageInfo",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "edges",
+                        description: Some(
+                            "A list of edges.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [List],
+                            name: "SpeciesEdge",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "totalCount",
+                        description: Some(
+                            "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "Int",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "species",
+                        description: Some(
+                            "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [List],
+                            name: "Species",
+                        },
+                        deprecated: No,
+                    },
+                ],
+                interfaces: [],
+            },
+        ),
+        Object(
+            ObjectType {
+                name: "SpeciesEdge",
+                description: Some(
+                    "An edge in a connection.",
+                ),
+                fields: [
+                    Field {
+                        name: "node",
+                        description: Some(
+                            "The item at the end of the edge",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "Species",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "cursor",
+                        description: Some(
+                            "A cursor for use in pagination",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [NonNull],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                ],
+                interfaces: [],
+            },
+        ),
+        Object(
+            ObjectType {
+                name: "SpeciesFilmsConnection",
+                description: Some(
+                    "A connection to a list of items.",
+                ),
+                fields: [
+                    Field {
+                        name: "pageInfo",
+                        description: Some(
+                            "Information to aid in pagination.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [NonNull],
+                            name: "PageInfo",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "edges",
+                        description: Some(
+                            "A list of edges.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [List],
+                            name: "SpeciesFilmsEdge",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "totalCount",
+                        description: Some(
+                            "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "Int",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "films",
+                        description: Some(
+                            "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [List],
+                            name: "Film",
+                        },
+                        deprecated: No,
+                    },
+                ],
+                interfaces: [],
+            },
+        ),
+        Object(
+            ObjectType {
+                name: "SpeciesFilmsEdge",
+                description: Some(
+                    "An edge in a connection.",
+                ),
+                fields: [
+                    Field {
+                        name: "node",
+                        description: Some(
+                            "The item at the end of the edge",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "Film",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "cursor",
+                        description: Some(
+                            "A cursor for use in pagination",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [NonNull],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                ],
+                interfaces: [],
+            },
+        ),
+        Object(
+            ObjectType {
+                name: "SpeciesPeopleConnection",
+                description: Some(
+                    "A connection to a list of items.",
+                ),
+                fields: [
+                    Field {
+                        name: "pageInfo",
+                        description: Some(
+                            "Information to aid in pagination.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [NonNull],
+                            name: "PageInfo",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "edges",
+                        description: Some(
+                            "A list of edges.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [List],
+                            name: "SpeciesPeopleEdge",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "totalCount",
+                        description: Some(
+                            "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "Int",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "people",
+                        description: Some(
+                            "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [List],
+                            name: "Person",
+                        },
+                        deprecated: No,
+                    },
+                ],
+                interfaces: [],
+            },
+        ),
+        Object(
+            ObjectType {
+                name: "SpeciesPeopleEdge",
+                description: Some(
+                    "An edge in a connection.",
+                ),
+                fields: [
+                    Field {
+                        name: "node",
+                        description: Some(
+                            "The item at the end of the edge",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "Person",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "cursor",
+                        description: Some(
+                            "A cursor for use in pagination",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [NonNull],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                ],
+                interfaces: [],
+            },
+        ),
+        Object(
+            ObjectType {
                 name: "Starship",
                 description: Some(
                     "A single transport craft that has hyperdrive capability.",
@@ -2582,100 +3604,6 @@ Schema {
         ),
         Object(
             ObjectType {
-                name: "StarshipPilotsConnection",
-                description: Some(
-                    "A connection to a list of items.",
-                ),
-                fields: [
-                    Field {
-                        name: "pageInfo",
-                        description: Some(
-                            "Information to aid in pagination.",
-                        ),
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [NonNull],
-                            name: "PageInfo",
-                        },
-                        deprecated: No,
-                    },
-                    Field {
-                        name: "edges",
-                        description: Some(
-                            "A list of edges.",
-                        ),
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [List],
-                            name: "StarshipPilotsEdge",
-                        },
-                        deprecated: No,
-                    },
-                    Field {
-                        name: "totalCount",
-                        description: Some(
-                            "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
-                        ),
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [],
-                            name: "Int",
-                        },
-                        deprecated: No,
-                    },
-                    Field {
-                        name: "pilots",
-                        description: Some(
-                            "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
-                        ),
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [List],
-                            name: "Person",
-                        },
-                        deprecated: No,
-                    },
-                ],
-                interfaces: [],
-            },
-        ),
-        Object(
-            ObjectType {
-                name: "StarshipPilotsEdge",
-                description: Some(
-                    "An edge in a connection.",
-                ),
-                fields: [
-                    Field {
-                        name: "node",
-                        description: Some(
-                            "The item at the end of the edge",
-                        ),
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [],
-                            name: "Person",
-                        },
-                        deprecated: No,
-                    },
-                    Field {
-                        name: "cursor",
-                        description: Some(
-                            "A cursor for use in pagination",
-                        ),
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [NonNull],
-                            name: "String",
-                        },
-                        deprecated: No,
-                    },
-                ],
-                interfaces: [],
-            },
-        ),
-        Object(
-            ObjectType {
                 name: "StarshipFilmsConnection",
                 description: Some(
                     "A connection to a list of items.",
@@ -2770,7 +3698,7 @@ Schema {
         ),
         Object(
             ObjectType {
-                name: "PersonVehiclesConnection",
+                name: "StarshipPilotsConnection",
                 description: Some(
                     "A connection to a list of items.",
                 ),
@@ -2795,7 +3723,7 @@ Schema {
                         args: [],
                         ty: FieldType {
                             wrapping: [List],
-                            name: "PersonVehiclesEdge",
+                            name: "StarshipPilotsEdge",
                         },
                         deprecated: No,
                     },
@@ -2812,14 +3740,14 @@ Schema {
                         deprecated: No,
                     },
                     Field {
-                        name: "vehicles",
+                        name: "pilots",
                         description: Some(
                             "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
                         ),
                         args: [],
                         ty: FieldType {
                             wrapping: [List],
-                            name: "Vehicle",
+                            name: "Person",
                         },
                         deprecated: No,
                     },
@@ -2829,7 +3757,7 @@ Schema {
         ),
         Object(
             ObjectType {
-                name: "PersonVehiclesEdge",
+                name: "StarshipPilotsEdge",
                 description: Some(
                     "An edge in a connection.",
                 ),
@@ -2842,7 +3770,7 @@ Schema {
                         args: [],
                         ty: FieldType {
                             wrapping: [],
-                            name: "Vehicle",
+                            name: "Person",
                         },
                         deprecated: No,
                     },
@@ -2860,6 +3788,109 @@ Schema {
                     },
                 ],
                 interfaces: [],
+            },
+        ),
+        Object(
+            ObjectType {
+                name: "StarshipsConnection",
+                description: Some(
+                    "A connection to a list of items.",
+                ),
+                fields: [
+                    Field {
+                        name: "pageInfo",
+                        description: Some(
+                            "Information to aid in pagination.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [NonNull],
+                            name: "PageInfo",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "edges",
+                        description: Some(
+                            "A list of edges.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [List],
+                            name: "StarshipsEdge",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "totalCount",
+                        description: Some(
+                            "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "Int",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "starships",
+                        description: Some(
+                            "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [List],
+                            name: "Starship",
+                        },
+                        deprecated: No,
+                    },
+                ],
+                interfaces: [],
+            },
+        ),
+        Object(
+            ObjectType {
+                name: "StarshipsEdge",
+                description: Some(
+                    "An edge in a connection.",
+                ),
+                fields: [
+                    Field {
+                        name: "node",
+                        description: Some(
+                            "The item at the end of the edge",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "Starship",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "cursor",
+                        description: Some(
+                            "A cursor for use in pagination",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [NonNull],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                ],
+                interfaces: [],
+            },
+        ),
+        Scalar(
+            ScalarType {
+                name: "String",
+                description: Some(
+                    "The `String` scalar type represents textual data, represented as UTF-8\ncharacter sequences. The String type is most often used by GraphQL to\nrepresent free-form human-readable text.",
+                ),
+                specified_by_url: None,
             },
         ),
         Object(
@@ -3139,100 +4170,6 @@ Schema {
         ),
         Object(
             ObjectType {
-                name: "VehiclePilotsConnection",
-                description: Some(
-                    "A connection to a list of items.",
-                ),
-                fields: [
-                    Field {
-                        name: "pageInfo",
-                        description: Some(
-                            "Information to aid in pagination.",
-                        ),
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [NonNull],
-                            name: "PageInfo",
-                        },
-                        deprecated: No,
-                    },
-                    Field {
-                        name: "edges",
-                        description: Some(
-                            "A list of edges.",
-                        ),
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [List],
-                            name: "VehiclePilotsEdge",
-                        },
-                        deprecated: No,
-                    },
-                    Field {
-                        name: "totalCount",
-                        description: Some(
-                            "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
-                        ),
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [],
-                            name: "Int",
-                        },
-                        deprecated: No,
-                    },
-                    Field {
-                        name: "pilots",
-                        description: Some(
-                            "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
-                        ),
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [List],
-                            name: "Person",
-                        },
-                        deprecated: No,
-                    },
-                ],
-                interfaces: [],
-            },
-        ),
-        Object(
-            ObjectType {
-                name: "VehiclePilotsEdge",
-                description: Some(
-                    "An edge in a connection.",
-                ),
-                fields: [
-                    Field {
-                        name: "node",
-                        description: Some(
-                            "The item at the end of the edge",
-                        ),
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [],
-                            name: "Person",
-                        },
-                        deprecated: No,
-                    },
-                    Field {
-                        name: "cursor",
-                        description: Some(
-                            "A cursor for use in pagination",
-                        ),
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [NonNull],
-                            name: "String",
-                        },
-                        deprecated: No,
-                    },
-                ],
-                interfaces: [],
-            },
-        ),
-        Object(
-            ObjectType {
                 name: "VehicleFilmsConnection",
                 description: Some(
                     "A connection to a list of items.",
@@ -3327,7 +4264,7 @@ Schema {
         ),
         Object(
             ObjectType {
-                name: "PlanetFilmsConnection",
+                name: "VehiclePilotsConnection",
                 description: Some(
                     "A connection to a list of items.",
                 ),
@@ -3352,7 +4289,7 @@ Schema {
                         args: [],
                         ty: FieldType {
                             wrapping: [List],
-                            name: "PlanetFilmsEdge",
+                            name: "VehiclePilotsEdge",
                         },
                         deprecated: No,
                     },
@@ -3369,101 +4306,7 @@ Schema {
                         deprecated: No,
                     },
                     Field {
-                        name: "films",
-                        description: Some(
-                            "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
-                        ),
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [List],
-                            name: "Film",
-                        },
-                        deprecated: No,
-                    },
-                ],
-                interfaces: [],
-            },
-        ),
-        Object(
-            ObjectType {
-                name: "PlanetFilmsEdge",
-                description: Some(
-                    "An edge in a connection.",
-                ),
-                fields: [
-                    Field {
-                        name: "node",
-                        description: Some(
-                            "The item at the end of the edge",
-                        ),
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [],
-                            name: "Film",
-                        },
-                        deprecated: No,
-                    },
-                    Field {
-                        name: "cursor",
-                        description: Some(
-                            "A cursor for use in pagination",
-                        ),
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [NonNull],
-                            name: "String",
-                        },
-                        deprecated: No,
-                    },
-                ],
-                interfaces: [],
-            },
-        ),
-        Object(
-            ObjectType {
-                name: "SpeciesPeopleConnection",
-                description: Some(
-                    "A connection to a list of items.",
-                ),
-                fields: [
-                    Field {
-                        name: "pageInfo",
-                        description: Some(
-                            "Information to aid in pagination.",
-                        ),
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [NonNull],
-                            name: "PageInfo",
-                        },
-                        deprecated: No,
-                    },
-                    Field {
-                        name: "edges",
-                        description: Some(
-                            "A list of edges.",
-                        ),
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [List],
-                            name: "SpeciesPeopleEdge",
-                        },
-                        deprecated: No,
-                    },
-                    Field {
-                        name: "totalCount",
-                        description: Some(
-                            "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
-                        ),
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [],
-                            name: "Int",
-                        },
-                        deprecated: No,
-                    },
-                    Field {
-                        name: "people",
+                        name: "pilots",
                         description: Some(
                             "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
                         ),
@@ -3480,7 +4323,7 @@ Schema {
         ),
         Object(
             ObjectType {
-                name: "SpeciesPeopleEdge",
+                name: "VehiclePilotsEdge",
                 description: Some(
                     "An edge in a connection.",
                 ),
@@ -3494,852 +4337,6 @@ Schema {
                         ty: FieldType {
                             wrapping: [],
                             name: "Person",
-                        },
-                        deprecated: No,
-                    },
-                    Field {
-                        name: "cursor",
-                        description: Some(
-                            "A cursor for use in pagination",
-                        ),
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [NonNull],
-                            name: "String",
-                        },
-                        deprecated: No,
-                    },
-                ],
-                interfaces: [],
-            },
-        ),
-        Object(
-            ObjectType {
-                name: "SpeciesFilmsConnection",
-                description: Some(
-                    "A connection to a list of items.",
-                ),
-                fields: [
-                    Field {
-                        name: "pageInfo",
-                        description: Some(
-                            "Information to aid in pagination.",
-                        ),
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [NonNull],
-                            name: "PageInfo",
-                        },
-                        deprecated: No,
-                    },
-                    Field {
-                        name: "edges",
-                        description: Some(
-                            "A list of edges.",
-                        ),
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [List],
-                            name: "SpeciesFilmsEdge",
-                        },
-                        deprecated: No,
-                    },
-                    Field {
-                        name: "totalCount",
-                        description: Some(
-                            "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
-                        ),
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [],
-                            name: "Int",
-                        },
-                        deprecated: No,
-                    },
-                    Field {
-                        name: "films",
-                        description: Some(
-                            "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
-                        ),
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [List],
-                            name: "Film",
-                        },
-                        deprecated: No,
-                    },
-                ],
-                interfaces: [],
-            },
-        ),
-        Object(
-            ObjectType {
-                name: "SpeciesFilmsEdge",
-                description: Some(
-                    "An edge in a connection.",
-                ),
-                fields: [
-                    Field {
-                        name: "node",
-                        description: Some(
-                            "The item at the end of the edge",
-                        ),
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [],
-                            name: "Film",
-                        },
-                        deprecated: No,
-                    },
-                    Field {
-                        name: "cursor",
-                        description: Some(
-                            "A cursor for use in pagination",
-                        ),
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [NonNull],
-                            name: "String",
-                        },
-                        deprecated: No,
-                    },
-                ],
-                interfaces: [],
-            },
-        ),
-        Object(
-            ObjectType {
-                name: "FilmStarshipsConnection",
-                description: Some(
-                    "A connection to a list of items.",
-                ),
-                fields: [
-                    Field {
-                        name: "pageInfo",
-                        description: Some(
-                            "Information to aid in pagination.",
-                        ),
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [NonNull],
-                            name: "PageInfo",
-                        },
-                        deprecated: No,
-                    },
-                    Field {
-                        name: "edges",
-                        description: Some(
-                            "A list of edges.",
-                        ),
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [List],
-                            name: "FilmStarshipsEdge",
-                        },
-                        deprecated: No,
-                    },
-                    Field {
-                        name: "totalCount",
-                        description: Some(
-                            "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
-                        ),
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [],
-                            name: "Int",
-                        },
-                        deprecated: No,
-                    },
-                    Field {
-                        name: "starships",
-                        description: Some(
-                            "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
-                        ),
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [List],
-                            name: "Starship",
-                        },
-                        deprecated: No,
-                    },
-                ],
-                interfaces: [],
-            },
-        ),
-        Object(
-            ObjectType {
-                name: "FilmStarshipsEdge",
-                description: Some(
-                    "An edge in a connection.",
-                ),
-                fields: [
-                    Field {
-                        name: "node",
-                        description: Some(
-                            "The item at the end of the edge",
-                        ),
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [],
-                            name: "Starship",
-                        },
-                        deprecated: No,
-                    },
-                    Field {
-                        name: "cursor",
-                        description: Some(
-                            "A cursor for use in pagination",
-                        ),
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [NonNull],
-                            name: "String",
-                        },
-                        deprecated: No,
-                    },
-                ],
-                interfaces: [],
-            },
-        ),
-        Object(
-            ObjectType {
-                name: "FilmVehiclesConnection",
-                description: Some(
-                    "A connection to a list of items.",
-                ),
-                fields: [
-                    Field {
-                        name: "pageInfo",
-                        description: Some(
-                            "Information to aid in pagination.",
-                        ),
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [NonNull],
-                            name: "PageInfo",
-                        },
-                        deprecated: No,
-                    },
-                    Field {
-                        name: "edges",
-                        description: Some(
-                            "A list of edges.",
-                        ),
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [List],
-                            name: "FilmVehiclesEdge",
-                        },
-                        deprecated: No,
-                    },
-                    Field {
-                        name: "totalCount",
-                        description: Some(
-                            "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
-                        ),
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [],
-                            name: "Int",
-                        },
-                        deprecated: No,
-                    },
-                    Field {
-                        name: "vehicles",
-                        description: Some(
-                            "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
-                        ),
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [List],
-                            name: "Vehicle",
-                        },
-                        deprecated: No,
-                    },
-                ],
-                interfaces: [],
-            },
-        ),
-        Object(
-            ObjectType {
-                name: "FilmVehiclesEdge",
-                description: Some(
-                    "An edge in a connection.",
-                ),
-                fields: [
-                    Field {
-                        name: "node",
-                        description: Some(
-                            "The item at the end of the edge",
-                        ),
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [],
-                            name: "Vehicle",
-                        },
-                        deprecated: No,
-                    },
-                    Field {
-                        name: "cursor",
-                        description: Some(
-                            "A cursor for use in pagination",
-                        ),
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [NonNull],
-                            name: "String",
-                        },
-                        deprecated: No,
-                    },
-                ],
-                interfaces: [],
-            },
-        ),
-        Object(
-            ObjectType {
-                name: "FilmCharactersConnection",
-                description: Some(
-                    "A connection to a list of items.",
-                ),
-                fields: [
-                    Field {
-                        name: "pageInfo",
-                        description: Some(
-                            "Information to aid in pagination.",
-                        ),
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [NonNull],
-                            name: "PageInfo",
-                        },
-                        deprecated: No,
-                    },
-                    Field {
-                        name: "edges",
-                        description: Some(
-                            "A list of edges.",
-                        ),
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [List],
-                            name: "FilmCharactersEdge",
-                        },
-                        deprecated: No,
-                    },
-                    Field {
-                        name: "totalCount",
-                        description: Some(
-                            "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
-                        ),
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [],
-                            name: "Int",
-                        },
-                        deprecated: No,
-                    },
-                    Field {
-                        name: "characters",
-                        description: Some(
-                            "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
-                        ),
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [List],
-                            name: "Person",
-                        },
-                        deprecated: No,
-                    },
-                ],
-                interfaces: [],
-            },
-        ),
-        Object(
-            ObjectType {
-                name: "FilmCharactersEdge",
-                description: Some(
-                    "An edge in a connection.",
-                ),
-                fields: [
-                    Field {
-                        name: "node",
-                        description: Some(
-                            "The item at the end of the edge",
-                        ),
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [],
-                            name: "Person",
-                        },
-                        deprecated: No,
-                    },
-                    Field {
-                        name: "cursor",
-                        description: Some(
-                            "A cursor for use in pagination",
-                        ),
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [NonNull],
-                            name: "String",
-                        },
-                        deprecated: No,
-                    },
-                ],
-                interfaces: [],
-            },
-        ),
-        Object(
-            ObjectType {
-                name: "FilmPlanetsConnection",
-                description: Some(
-                    "A connection to a list of items.",
-                ),
-                fields: [
-                    Field {
-                        name: "pageInfo",
-                        description: Some(
-                            "Information to aid in pagination.",
-                        ),
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [NonNull],
-                            name: "PageInfo",
-                        },
-                        deprecated: No,
-                    },
-                    Field {
-                        name: "edges",
-                        description: Some(
-                            "A list of edges.",
-                        ),
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [List],
-                            name: "FilmPlanetsEdge",
-                        },
-                        deprecated: No,
-                    },
-                    Field {
-                        name: "totalCount",
-                        description: Some(
-                            "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
-                        ),
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [],
-                            name: "Int",
-                        },
-                        deprecated: No,
-                    },
-                    Field {
-                        name: "planets",
-                        description: Some(
-                            "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
-                        ),
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [List],
-                            name: "Planet",
-                        },
-                        deprecated: No,
-                    },
-                ],
-                interfaces: [],
-            },
-        ),
-        Object(
-            ObjectType {
-                name: "FilmPlanetsEdge",
-                description: Some(
-                    "An edge in a connection.",
-                ),
-                fields: [
-                    Field {
-                        name: "node",
-                        description: Some(
-                            "The item at the end of the edge",
-                        ),
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [],
-                            name: "Planet",
-                        },
-                        deprecated: No,
-                    },
-                    Field {
-                        name: "cursor",
-                        description: Some(
-                            "A cursor for use in pagination",
-                        ),
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [NonNull],
-                            name: "String",
-                        },
-                        deprecated: No,
-                    },
-                ],
-                interfaces: [],
-            },
-        ),
-        Object(
-            ObjectType {
-                name: "PeopleConnection",
-                description: Some(
-                    "A connection to a list of items.",
-                ),
-                fields: [
-                    Field {
-                        name: "pageInfo",
-                        description: Some(
-                            "Information to aid in pagination.",
-                        ),
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [NonNull],
-                            name: "PageInfo",
-                        },
-                        deprecated: No,
-                    },
-                    Field {
-                        name: "edges",
-                        description: Some(
-                            "A list of edges.",
-                        ),
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [List],
-                            name: "PeopleEdge",
-                        },
-                        deprecated: No,
-                    },
-                    Field {
-                        name: "totalCount",
-                        description: Some(
-                            "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
-                        ),
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [],
-                            name: "Int",
-                        },
-                        deprecated: No,
-                    },
-                    Field {
-                        name: "people",
-                        description: Some(
-                            "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
-                        ),
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [List],
-                            name: "Person",
-                        },
-                        deprecated: No,
-                    },
-                ],
-                interfaces: [],
-            },
-        ),
-        Object(
-            ObjectType {
-                name: "PeopleEdge",
-                description: Some(
-                    "An edge in a connection.",
-                ),
-                fields: [
-                    Field {
-                        name: "node",
-                        description: Some(
-                            "The item at the end of the edge",
-                        ),
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [],
-                            name: "Person",
-                        },
-                        deprecated: No,
-                    },
-                    Field {
-                        name: "cursor",
-                        description: Some(
-                            "A cursor for use in pagination",
-                        ),
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [NonNull],
-                            name: "String",
-                        },
-                        deprecated: No,
-                    },
-                ],
-                interfaces: [],
-            },
-        ),
-        Object(
-            ObjectType {
-                name: "PlanetsConnection",
-                description: Some(
-                    "A connection to a list of items.",
-                ),
-                fields: [
-                    Field {
-                        name: "pageInfo",
-                        description: Some(
-                            "Information to aid in pagination.",
-                        ),
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [NonNull],
-                            name: "PageInfo",
-                        },
-                        deprecated: No,
-                    },
-                    Field {
-                        name: "edges",
-                        description: Some(
-                            "A list of edges.",
-                        ),
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [List],
-                            name: "PlanetsEdge",
-                        },
-                        deprecated: No,
-                    },
-                    Field {
-                        name: "totalCount",
-                        description: Some(
-                            "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
-                        ),
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [],
-                            name: "Int",
-                        },
-                        deprecated: No,
-                    },
-                    Field {
-                        name: "planets",
-                        description: Some(
-                            "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
-                        ),
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [List],
-                            name: "Planet",
-                        },
-                        deprecated: No,
-                    },
-                ],
-                interfaces: [],
-            },
-        ),
-        Object(
-            ObjectType {
-                name: "PlanetsEdge",
-                description: Some(
-                    "An edge in a connection.",
-                ),
-                fields: [
-                    Field {
-                        name: "node",
-                        description: Some(
-                            "The item at the end of the edge",
-                        ),
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [],
-                            name: "Planet",
-                        },
-                        deprecated: No,
-                    },
-                    Field {
-                        name: "cursor",
-                        description: Some(
-                            "A cursor for use in pagination",
-                        ),
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [NonNull],
-                            name: "String",
-                        },
-                        deprecated: No,
-                    },
-                ],
-                interfaces: [],
-            },
-        ),
-        Object(
-            ObjectType {
-                name: "SpeciesConnection",
-                description: Some(
-                    "A connection to a list of items.",
-                ),
-                fields: [
-                    Field {
-                        name: "pageInfo",
-                        description: Some(
-                            "Information to aid in pagination.",
-                        ),
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [NonNull],
-                            name: "PageInfo",
-                        },
-                        deprecated: No,
-                    },
-                    Field {
-                        name: "edges",
-                        description: Some(
-                            "A list of edges.",
-                        ),
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [List],
-                            name: "SpeciesEdge",
-                        },
-                        deprecated: No,
-                    },
-                    Field {
-                        name: "totalCount",
-                        description: Some(
-                            "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
-                        ),
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [],
-                            name: "Int",
-                        },
-                        deprecated: No,
-                    },
-                    Field {
-                        name: "species",
-                        description: Some(
-                            "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
-                        ),
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [List],
-                            name: "Species",
-                        },
-                        deprecated: No,
-                    },
-                ],
-                interfaces: [],
-            },
-        ),
-        Object(
-            ObjectType {
-                name: "SpeciesEdge",
-                description: Some(
-                    "An edge in a connection.",
-                ),
-                fields: [
-                    Field {
-                        name: "node",
-                        description: Some(
-                            "The item at the end of the edge",
-                        ),
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [],
-                            name: "Species",
-                        },
-                        deprecated: No,
-                    },
-                    Field {
-                        name: "cursor",
-                        description: Some(
-                            "A cursor for use in pagination",
-                        ),
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [NonNull],
-                            name: "String",
-                        },
-                        deprecated: No,
-                    },
-                ],
-                interfaces: [],
-            },
-        ),
-        Object(
-            ObjectType {
-                name: "StarshipsConnection",
-                description: Some(
-                    "A connection to a list of items.",
-                ),
-                fields: [
-                    Field {
-                        name: "pageInfo",
-                        description: Some(
-                            "Information to aid in pagination.",
-                        ),
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [NonNull],
-                            name: "PageInfo",
-                        },
-                        deprecated: No,
-                    },
-                    Field {
-                        name: "edges",
-                        description: Some(
-                            "A list of edges.",
-                        ),
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [List],
-                            name: "StarshipsEdge",
-                        },
-                        deprecated: No,
-                    },
-                    Field {
-                        name: "totalCount",
-                        description: Some(
-                            "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
-                        ),
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [],
-                            name: "Int",
-                        },
-                        deprecated: No,
-                    },
-                    Field {
-                        name: "starships",
-                        description: Some(
-                            "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
-                        ),
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [List],
-                            name: "Starship",
-                        },
-                        deprecated: No,
-                    },
-                ],
-                interfaces: [],
-            },
-        ),
-        Object(
-            ObjectType {
-                name: "StarshipsEdge",
-                description: Some(
-                    "An edge in a connection.",
-                ),
-                fields: [
-                    Field {
-                        name: "node",
-                        description: Some(
-                            "The item at the end of the edge",
-                        ),
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [],
-                            name: "Starship",
                         },
                         deprecated: No,
                     },
@@ -4455,446 +4452,9 @@ Schema {
         ),
         Object(
             ObjectType {
-                name: "__Schema",
-                description: Some(
-                    "A GraphQL Schema defines the capabilities of a GraphQL server. It exposes all available types and directives on the server, as well as the entry points for query, mutation, and subscription operations.",
-                ),
-                fields: [
-                    Field {
-                        name: "types",
-                        description: Some(
-                            "A list of all types supported by this server.",
-                        ),
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [NonNull, List, NonNull],
-                            name: "__Type",
-                        },
-                        deprecated: No,
-                    },
-                    Field {
-                        name: "queryType",
-                        description: Some(
-                            "The type that query operations will be rooted at.",
-                        ),
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [NonNull],
-                            name: "__Type",
-                        },
-                        deprecated: No,
-                    },
-                    Field {
-                        name: "mutationType",
-                        description: Some(
-                            "If this server supports mutation, the type that mutation operations will be rooted at.",
-                        ),
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [],
-                            name: "__Type",
-                        },
-                        deprecated: No,
-                    },
-                    Field {
-                        name: "subscriptionType",
-                        description: Some(
-                            "If this server support subscription, the type that subscription operations will be rooted at.",
-                        ),
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [],
-                            name: "__Type",
-                        },
-                        deprecated: No,
-                    },
-                    Field {
-                        name: "directives",
-                        description: Some(
-                            "A list of all directives supported by this server.",
-                        ),
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [NonNull, List, NonNull],
-                            name: "__Directive",
-                        },
-                        deprecated: No,
-                    },
-                ],
-                interfaces: [],
-            },
-        ),
-        Object(
-            ObjectType {
-                name: "__Type",
-                description: Some(
-                    "The fundamental unit of any GraphQL Schema is the type. There are many kinds of types in GraphQL as represented by the `__TypeKind` enum.\n\nDepending on the kind of a type, certain fields describe information about that type. Scalar types provide no information beyond a name and description, while Enum types provide their values. Object and Interface types provide the fields they describe. Abstract types, Union and Interface, provide the Object types possible at runtime. List and NonNull types compose other types.",
-                ),
-                fields: [
-                    Field {
-                        name: "kind",
-                        description: None,
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [NonNull],
-                            name: "__TypeKind",
-                        },
-                        deprecated: No,
-                    },
-                    Field {
-                        name: "name",
-                        description: None,
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [],
-                            name: "String",
-                        },
-                        deprecated: No,
-                    },
-                    Field {
-                        name: "description",
-                        description: None,
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [],
-                            name: "String",
-                        },
-                        deprecated: No,
-                    },
-                    Field {
-                        name: "fields",
-                        description: None,
-                        args: [
-                            InputValue {
-                                name: "includeDeprecated",
-                                description: None,
-                                ty: FieldType {
-                                    wrapping: [],
-                                    name: "Boolean",
-                                },
-                                default_value: Some(
-                                    "false",
-                                ),
-                            },
-                        ],
-                        ty: FieldType {
-                            wrapping: [List, NonNull],
-                            name: "__Field",
-                        },
-                        deprecated: No,
-                    },
-                    Field {
-                        name: "interfaces",
-                        description: None,
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [List, NonNull],
-                            name: "__Type",
-                        },
-                        deprecated: No,
-                    },
-                    Field {
-                        name: "possibleTypes",
-                        description: None,
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [List, NonNull],
-                            name: "__Type",
-                        },
-                        deprecated: No,
-                    },
-                    Field {
-                        name: "enumValues",
-                        description: None,
-                        args: [
-                            InputValue {
-                                name: "includeDeprecated",
-                                description: None,
-                                ty: FieldType {
-                                    wrapping: [],
-                                    name: "Boolean",
-                                },
-                                default_value: Some(
-                                    "false",
-                                ),
-                            },
-                        ],
-                        ty: FieldType {
-                            wrapping: [List, NonNull],
-                            name: "__EnumValue",
-                        },
-                        deprecated: No,
-                    },
-                    Field {
-                        name: "inputFields",
-                        description: None,
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [List, NonNull],
-                            name: "__InputValue",
-                        },
-                        deprecated: No,
-                    },
-                    Field {
-                        name: "ofType",
-                        description: None,
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [],
-                            name: "__Type",
-                        },
-                        deprecated: No,
-                    },
-                ],
-                interfaces: [],
-            },
-        ),
-        Enum(
-            EnumType {
-                name: "__TypeKind",
-                description: Some(
-                    "An enum describing what kind of type a given `__Type` is.",
-                ),
-                values: [
-                    EnumValue {
-                        name: "SCALAR",
-                        description: Some(
-                            "Indicates this type is a scalar.",
-                        ),
-                        deprecated: No,
-                    },
-                    EnumValue {
-                        name: "OBJECT",
-                        description: Some(
-                            "Indicates this type is an object. `fields` and `interfaces` are valid fields.",
-                        ),
-                        deprecated: No,
-                    },
-                    EnumValue {
-                        name: "INTERFACE",
-                        description: Some(
-                            "Indicates this type is an interface. `fields` and `possibleTypes` are valid fields.",
-                        ),
-                        deprecated: No,
-                    },
-                    EnumValue {
-                        name: "UNION",
-                        description: Some(
-                            "Indicates this type is a union. `possibleTypes` is a valid field.",
-                        ),
-                        deprecated: No,
-                    },
-                    EnumValue {
-                        name: "ENUM",
-                        description: Some(
-                            "Indicates this type is an enum. `enumValues` is a valid field.",
-                        ),
-                        deprecated: No,
-                    },
-                    EnumValue {
-                        name: "INPUT_OBJECT",
-                        description: Some(
-                            "Indicates this type is an input object. `inputFields` is a valid field.",
-                        ),
-                        deprecated: No,
-                    },
-                    EnumValue {
-                        name: "LIST",
-                        description: Some(
-                            "Indicates this type is a list. `ofType` is a valid field.",
-                        ),
-                        deprecated: No,
-                    },
-                    EnumValue {
-                        name: "NON_NULL",
-                        description: Some(
-                            "Indicates this type is a non-null. `ofType` is a valid field.",
-                        ),
-                        deprecated: No,
-                    },
-                ],
-            },
-        ),
-        Object(
-            ObjectType {
-                name: "__Field",
-                description: Some(
-                    "Object and Interface types are described by a list of Fields, each of which has a name, potentially a list of arguments, and a return type.",
-                ),
-                fields: [
-                    Field {
-                        name: "name",
-                        description: None,
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [NonNull],
-                            name: "String",
-                        },
-                        deprecated: No,
-                    },
-                    Field {
-                        name: "description",
-                        description: None,
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [],
-                            name: "String",
-                        },
-                        deprecated: No,
-                    },
-                    Field {
-                        name: "args",
-                        description: None,
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [NonNull, List, NonNull],
-                            name: "__InputValue",
-                        },
-                        deprecated: No,
-                    },
-                    Field {
-                        name: "type",
-                        description: None,
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [NonNull],
-                            name: "__Type",
-                        },
-                        deprecated: No,
-                    },
-                    Field {
-                        name: "isDeprecated",
-                        description: None,
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [NonNull],
-                            name: "Boolean",
-                        },
-                        deprecated: No,
-                    },
-                    Field {
-                        name: "deprecationReason",
-                        description: None,
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [],
-                            name: "String",
-                        },
-                        deprecated: No,
-                    },
-                ],
-                interfaces: [],
-            },
-        ),
-        Object(
-            ObjectType {
-                name: "__InputValue",
-                description: Some(
-                    "Arguments provided to Fields or Directives and the input fields of an InputObject are represented as Input Values which describe their type and optionally a default value.",
-                ),
-                fields: [
-                    Field {
-                        name: "name",
-                        description: None,
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [NonNull],
-                            name: "String",
-                        },
-                        deprecated: No,
-                    },
-                    Field {
-                        name: "description",
-                        description: None,
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [],
-                            name: "String",
-                        },
-                        deprecated: No,
-                    },
-                    Field {
-                        name: "type",
-                        description: None,
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [NonNull],
-                            name: "__Type",
-                        },
-                        deprecated: No,
-                    },
-                    Field {
-                        name: "defaultValue",
-                        description: Some(
-                            "A GraphQL-formatted string representing the default value for this input value.",
-                        ),
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [],
-                            name: "String",
-                        },
-                        deprecated: No,
-                    },
-                ],
-                interfaces: [],
-            },
-        ),
-        Object(
-            ObjectType {
-                name: "__EnumValue",
-                description: Some(
-                    "One possible value for a given Enum. Enum values are unique values, not a placeholder for a string or numeric value. However an Enum value is returned in a JSON response as a string.",
-                ),
-                fields: [
-                    Field {
-                        name: "name",
-                        description: None,
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [NonNull],
-                            name: "String",
-                        },
-                        deprecated: No,
-                    },
-                    Field {
-                        name: "description",
-                        description: None,
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [],
-                            name: "String",
-                        },
-                        deprecated: No,
-                    },
-                    Field {
-                        name: "isDeprecated",
-                        description: None,
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [NonNull],
-                            name: "Boolean",
-                        },
-                        deprecated: No,
-                    },
-                    Field {
-                        name: "deprecationReason",
-                        description: None,
-                        args: [],
-                        ty: FieldType {
-                            wrapping: [],
-                            name: "String",
-                        },
-                        deprecated: No,
-                    },
-                ],
-                interfaces: [],
-            },
-        ),
-        Object(
-            ObjectType {
                 name: "__Directive",
                 description: Some(
-                    "A Directive provides a way to describe alternate runtime execution and type validation behavior in a GraphQL document.\n\nIn some cases, you need to provide options to alter GraphQL's execution behavior in ways field arguments will not suffice, such as conditionally including or skipping a field. Directives provide this by describing additional information to the executor.",
+                    "A Directive provides a way to describe alternate runtime execution and type\nvalidation behavior in a GraphQL document.\n\nIn some cases, you need to provide options to alter GraphQL's execution\nbehavior in ways field arguments will not suffice, such as conditionally\nincluding or skipping a field. Directives provide this by describing\nadditional information to the executor.",
                 ),
                 fields: [
                     Field {
@@ -4937,6 +4497,16 @@ Schema {
                         },
                         deprecated: No,
                     },
+                    Field {
+                        name: "isRepeatable",
+                        description: None,
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [NonNull],
+                            name: "Boolean",
+                        },
+                        deprecated: No,
+                    },
                 ],
                 interfaces: [],
             },
@@ -4945,7 +4515,7 @@ Schema {
             EnumType {
                 name: "__DirectiveLocation",
                 description: Some(
-                    "A Directive can be adjacent to many parts of the GraphQL language, a __DirectiveLocation describes one such possible adjacencies.",
+                    "A Directive can be adjacent to many parts of the GraphQL language, a\n__DirectiveLocation describes one such possible adjacencies.",
                 ),
                 values: [
                     EnumValue {
@@ -5084,6 +4654,461 @@ Schema {
                 ],
             },
         ),
+        Object(
+            ObjectType {
+                name: "__EnumValue",
+                description: Some(
+                    "One possible value for a given Enum. Enum values are unique values, not a\nplaceholder for a string or numeric value. However an Enum value is returned\nin a JSON response as a string.",
+                ),
+                fields: [
+                    Field {
+                        name: "name",
+                        description: None,
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [NonNull],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "description",
+                        description: None,
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "isDeprecated",
+                        description: None,
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [NonNull],
+                            name: "Boolean",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "deprecationReason",
+                        description: None,
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                ],
+                interfaces: [],
+            },
+        ),
+        Object(
+            ObjectType {
+                name: "__Field",
+                description: Some(
+                    "Object and Interface types are described by a list of Fields, each of which\nhas a name, potentially a list of arguments, and a return type.",
+                ),
+                fields: [
+                    Field {
+                        name: "name",
+                        description: None,
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [NonNull],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "description",
+                        description: None,
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "args",
+                        description: None,
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [NonNull, List, NonNull],
+                            name: "__InputValue",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "type",
+                        description: None,
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [NonNull],
+                            name: "__Type",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "isDeprecated",
+                        description: None,
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [NonNull],
+                            name: "Boolean",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "deprecationReason",
+                        description: None,
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                ],
+                interfaces: [],
+            },
+        ),
+        Object(
+            ObjectType {
+                name: "__InputValue",
+                description: Some(
+                    "Arguments provided to Fields or Directives and the input fields of an\nInputObject are represented as Input Values which describe their type and\noptionally a default value.",
+                ),
+                fields: [
+                    Field {
+                        name: "name",
+                        description: None,
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [NonNull],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "description",
+                        description: None,
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "type",
+                        description: None,
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [NonNull],
+                            name: "__Type",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "defaultValue",
+                        description: None,
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                ],
+                interfaces: [],
+            },
+        ),
+        Object(
+            ObjectType {
+                name: "__Schema",
+                description: Some(
+                    "A GraphQL Schema defines the capabilities of a GraphQL server. It exposes\nall available types and directives on the server, as well as the entry\npoints for query, mutation, and subscription operations.",
+                ),
+                fields: [
+                    Field {
+                        name: "types",
+                        description: Some(
+                            "A list of all types supported by this server.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [NonNull, List, NonNull],
+                            name: "__Type",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "queryType",
+                        description: Some(
+                            "The type that query operations will be rooted at.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [NonNull],
+                            name: "__Type",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "mutationType",
+                        description: Some(
+                            "If this server supports mutation, the type that mutation operations will\nbe rooted at.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "__Type",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "subscriptionType",
+                        description: Some(
+                            "If this server support subscription, the type that subscription\noperations will be rooted at.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "__Type",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "directives",
+                        description: Some(
+                            "A list of all directives supported by this server.",
+                        ),
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [NonNull, List, NonNull],
+                            name: "__Directive",
+                        },
+                        deprecated: No,
+                    },
+                ],
+                interfaces: [],
+            },
+        ),
+        Object(
+            ObjectType {
+                name: "__Type",
+                description: Some(
+                    "The fundamental unit of any GraphQL Schema is the type. There are many kinds\nof types in GraphQL as represented by the `__TypeKind` enum.\n\nDepending on the kind of a type, certain fields describe information about\nthat type. Scalar types provide no information beyond a name and\ndescription, while Enum types provide their values. Object and Interface\ntypes provide the fields they describe. Abstract types, Union and Interface,\nprovide the Object types possible at runtime. List and NonNull types compose\nother types.",
+                ),
+                fields: [
+                    Field {
+                        name: "kind",
+                        description: None,
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [NonNull],
+                            name: "__TypeKind",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "name",
+                        description: None,
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "description",
+                        description: None,
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "fields",
+                        description: None,
+                        args: [
+                            InputValue {
+                                name: "includeDeprecated",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [NonNull],
+                                    name: "Boolean",
+                                },
+                                default_value: Some(
+                                    "false",
+                                ),
+                            },
+                        ],
+                        ty: FieldType {
+                            wrapping: [List, NonNull],
+                            name: "__Field",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "interfaces",
+                        description: None,
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [List, NonNull],
+                            name: "__Type",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "possibleTypes",
+                        description: None,
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [List, NonNull],
+                            name: "__Type",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "enumValues",
+                        description: None,
+                        args: [
+                            InputValue {
+                                name: "includeDeprecated",
+                                description: None,
+                                ty: FieldType {
+                                    wrapping: [NonNull],
+                                    name: "Boolean",
+                                },
+                                default_value: Some(
+                                    "false",
+                                ),
+                            },
+                        ],
+                        ty: FieldType {
+                            wrapping: [List, NonNull],
+                            name: "__EnumValue",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "inputFields",
+                        description: None,
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [List, NonNull],
+                            name: "__InputValue",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "ofType",
+                        description: None,
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "__Type",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "specifiedByURL",
+                        description: None,
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "String",
+                        },
+                        deprecated: No,
+                    },
+                    Field {
+                        name: "isOneOf",
+                        description: None,
+                        args: [],
+                        ty: FieldType {
+                            wrapping: [],
+                            name: "Boolean",
+                        },
+                        deprecated: No,
+                    },
+                ],
+                interfaces: [],
+            },
+        ),
+        Enum(
+            EnumType {
+                name: "__TypeKind",
+                description: Some(
+                    "An enum describing what kind of type a given `__Type` is.",
+                ),
+                values: [
+                    EnumValue {
+                        name: "SCALAR",
+                        description: Some(
+                            "Indicates this type is a scalar.",
+                        ),
+                        deprecated: No,
+                    },
+                    EnumValue {
+                        name: "OBJECT",
+                        description: Some(
+                            "Indicates this type is an object. `fields` and `interfaces` are valid\nfields.",
+                        ),
+                        deprecated: No,
+                    },
+                    EnumValue {
+                        name: "INTERFACE",
+                        description: Some(
+                            "Indicates this type is an interface. `fields` and `possibleTypes` are\nvalid fields.",
+                        ),
+                        deprecated: No,
+                    },
+                    EnumValue {
+                        name: "UNION",
+                        description: Some(
+                            "Indicates this type is a union. `possibleTypes` is a valid field.",
+                        ),
+                        deprecated: No,
+                    },
+                    EnumValue {
+                        name: "ENUM",
+                        description: Some(
+                            "Indicates this type is an enum. `enumValues` is a valid field.",
+                        ),
+                        deprecated: No,
+                    },
+                    EnumValue {
+                        name: "INPUT_OBJECT",
+                        description: Some(
+                            "Indicates this type is an input object. `inputFields` is a valid field.",
+                        ),
+                        deprecated: No,
+                    },
+                    EnumValue {
+                        name: "LIST",
+                        description: Some(
+                            "Indicates this type is a list. `ofType` is a valid field.",
+                        ),
+                        deprecated: No,
+                    },
+                    EnumValue {
+                        name: "NON_NULL",
+                        description: Some(
+                            "Indicates this type is a non-null. `ofType` is a valid field.",
+                        ),
+                        deprecated: No,
+                    },
+                ],
+            },
+        ),
     ],
     directives: [
         Directive {
@@ -5132,31 +5157,6 @@ Schema {
                 Field,
                 FragmentSpread,
                 InlineFragment,
-            ],
-        },
-        Directive {
-            name: "deprecated",
-            description: Some(
-                "Marks an element of a GraphQL schema as no longer supported.",
-            ),
-            args: [
-                InputValue {
-                    name: "reason",
-                    description: Some(
-                        "Explains why this element was deprecated, usually also including a suggestion for how to access supported similar data. Formatted using the Markdown syntax (as specified by [CommonMark](https://commonmark.org/).",
-                    ),
-                    ty: FieldType {
-                        wrapping: [],
-                        name: "String",
-                    },
-                    default_value: Some(
-                        "\"No longer supported\"",
-                    ),
-                },
-            ],
-            locations: [
-                FieldDefinition,
-                EnumValue,
             ],
         },
     ],

--- a/cynic-introspection/tests/snapshots/tests__running_2018_query.snap
+++ b/cynic-introspection/tests/snapshots/tests__running_2018_query.snap
@@ -1,6 +1,7 @@
 ---
 source: cynic-introspection/tests/tests.rs
 expression: result.data
+snapshot_kind: text
 ---
 Some(
     IntrospectionQuery {
@@ -15,901 +16,6 @@ Some(
                 subscription_type: None,
                 types: [
                     Type {
-                        kind: Object,
-                        name: Some(
-                            "Root",
-                        ),
-                        description: None,
-                        fields: Some(
-                            [
-                                Field {
-                                    name: "allFilms",
-                                    description: None,
-                                    args: [
-                                        InputValue {
-                                            name: "after",
-                                            description: None,
-                                            ty: FieldType {
-                                                kind: Scalar,
-                                                name: Some(
-                                                    "String",
-                                                ),
-                                                of_type: None,
-                                            },
-                                            default_value: None,
-                                        },
-                                        InputValue {
-                                            name: "first",
-                                            description: None,
-                                            ty: FieldType {
-                                                kind: Scalar,
-                                                name: Some(
-                                                    "Int",
-                                                ),
-                                                of_type: None,
-                                            },
-                                            default_value: None,
-                                        },
-                                        InputValue {
-                                            name: "before",
-                                            description: None,
-                                            ty: FieldType {
-                                                kind: Scalar,
-                                                name: Some(
-                                                    "String",
-                                                ),
-                                                of_type: None,
-                                            },
-                                            default_value: None,
-                                        },
-                                        InputValue {
-                                            name: "last",
-                                            description: None,
-                                            ty: FieldType {
-                                                kind: Scalar,
-                                                name: Some(
-                                                    "Int",
-                                                ),
-                                                of_type: None,
-                                            },
-                                            default_value: None,
-                                        },
-                                    ],
-                                    ty: FieldType {
-                                        kind: Object,
-                                        name: Some(
-                                            "FilmsConnection",
-                                        ),
-                                        of_type: None,
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                Field {
-                                    name: "film",
-                                    description: None,
-                                    args: [
-                                        InputValue {
-                                            name: "id",
-                                            description: None,
-                                            ty: FieldType {
-                                                kind: Scalar,
-                                                name: Some(
-                                                    "ID",
-                                                ),
-                                                of_type: None,
-                                            },
-                                            default_value: None,
-                                        },
-                                        InputValue {
-                                            name: "filmID",
-                                            description: None,
-                                            ty: FieldType {
-                                                kind: Scalar,
-                                                name: Some(
-                                                    "ID",
-                                                ),
-                                                of_type: None,
-                                            },
-                                            default_value: None,
-                                        },
-                                    ],
-                                    ty: FieldType {
-                                        kind: Object,
-                                        name: Some(
-                                            "Film",
-                                        ),
-                                        of_type: None,
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                Field {
-                                    name: "allPeople",
-                                    description: None,
-                                    args: [
-                                        InputValue {
-                                            name: "after",
-                                            description: None,
-                                            ty: FieldType {
-                                                kind: Scalar,
-                                                name: Some(
-                                                    "String",
-                                                ),
-                                                of_type: None,
-                                            },
-                                            default_value: None,
-                                        },
-                                        InputValue {
-                                            name: "first",
-                                            description: None,
-                                            ty: FieldType {
-                                                kind: Scalar,
-                                                name: Some(
-                                                    "Int",
-                                                ),
-                                                of_type: None,
-                                            },
-                                            default_value: None,
-                                        },
-                                        InputValue {
-                                            name: "before",
-                                            description: None,
-                                            ty: FieldType {
-                                                kind: Scalar,
-                                                name: Some(
-                                                    "String",
-                                                ),
-                                                of_type: None,
-                                            },
-                                            default_value: None,
-                                        },
-                                        InputValue {
-                                            name: "last",
-                                            description: None,
-                                            ty: FieldType {
-                                                kind: Scalar,
-                                                name: Some(
-                                                    "Int",
-                                                ),
-                                                of_type: None,
-                                            },
-                                            default_value: None,
-                                        },
-                                    ],
-                                    ty: FieldType {
-                                        kind: Object,
-                                        name: Some(
-                                            "PeopleConnection",
-                                        ),
-                                        of_type: None,
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                Field {
-                                    name: "person",
-                                    description: None,
-                                    args: [
-                                        InputValue {
-                                            name: "id",
-                                            description: None,
-                                            ty: FieldType {
-                                                kind: Scalar,
-                                                name: Some(
-                                                    "ID",
-                                                ),
-                                                of_type: None,
-                                            },
-                                            default_value: None,
-                                        },
-                                        InputValue {
-                                            name: "personID",
-                                            description: None,
-                                            ty: FieldType {
-                                                kind: Scalar,
-                                                name: Some(
-                                                    "ID",
-                                                ),
-                                                of_type: None,
-                                            },
-                                            default_value: None,
-                                        },
-                                    ],
-                                    ty: FieldType {
-                                        kind: Object,
-                                        name: Some(
-                                            "Person",
-                                        ),
-                                        of_type: None,
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                Field {
-                                    name: "allPlanets",
-                                    description: None,
-                                    args: [
-                                        InputValue {
-                                            name: "after",
-                                            description: None,
-                                            ty: FieldType {
-                                                kind: Scalar,
-                                                name: Some(
-                                                    "String",
-                                                ),
-                                                of_type: None,
-                                            },
-                                            default_value: None,
-                                        },
-                                        InputValue {
-                                            name: "first",
-                                            description: None,
-                                            ty: FieldType {
-                                                kind: Scalar,
-                                                name: Some(
-                                                    "Int",
-                                                ),
-                                                of_type: None,
-                                            },
-                                            default_value: None,
-                                        },
-                                        InputValue {
-                                            name: "before",
-                                            description: None,
-                                            ty: FieldType {
-                                                kind: Scalar,
-                                                name: Some(
-                                                    "String",
-                                                ),
-                                                of_type: None,
-                                            },
-                                            default_value: None,
-                                        },
-                                        InputValue {
-                                            name: "last",
-                                            description: None,
-                                            ty: FieldType {
-                                                kind: Scalar,
-                                                name: Some(
-                                                    "Int",
-                                                ),
-                                                of_type: None,
-                                            },
-                                            default_value: None,
-                                        },
-                                    ],
-                                    ty: FieldType {
-                                        kind: Object,
-                                        name: Some(
-                                            "PlanetsConnection",
-                                        ),
-                                        of_type: None,
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                Field {
-                                    name: "planet",
-                                    description: None,
-                                    args: [
-                                        InputValue {
-                                            name: "id",
-                                            description: None,
-                                            ty: FieldType {
-                                                kind: Scalar,
-                                                name: Some(
-                                                    "ID",
-                                                ),
-                                                of_type: None,
-                                            },
-                                            default_value: None,
-                                        },
-                                        InputValue {
-                                            name: "planetID",
-                                            description: None,
-                                            ty: FieldType {
-                                                kind: Scalar,
-                                                name: Some(
-                                                    "ID",
-                                                ),
-                                                of_type: None,
-                                            },
-                                            default_value: None,
-                                        },
-                                    ],
-                                    ty: FieldType {
-                                        kind: Object,
-                                        name: Some(
-                                            "Planet",
-                                        ),
-                                        of_type: None,
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                Field {
-                                    name: "allSpecies",
-                                    description: None,
-                                    args: [
-                                        InputValue {
-                                            name: "after",
-                                            description: None,
-                                            ty: FieldType {
-                                                kind: Scalar,
-                                                name: Some(
-                                                    "String",
-                                                ),
-                                                of_type: None,
-                                            },
-                                            default_value: None,
-                                        },
-                                        InputValue {
-                                            name: "first",
-                                            description: None,
-                                            ty: FieldType {
-                                                kind: Scalar,
-                                                name: Some(
-                                                    "Int",
-                                                ),
-                                                of_type: None,
-                                            },
-                                            default_value: None,
-                                        },
-                                        InputValue {
-                                            name: "before",
-                                            description: None,
-                                            ty: FieldType {
-                                                kind: Scalar,
-                                                name: Some(
-                                                    "String",
-                                                ),
-                                                of_type: None,
-                                            },
-                                            default_value: None,
-                                        },
-                                        InputValue {
-                                            name: "last",
-                                            description: None,
-                                            ty: FieldType {
-                                                kind: Scalar,
-                                                name: Some(
-                                                    "Int",
-                                                ),
-                                                of_type: None,
-                                            },
-                                            default_value: None,
-                                        },
-                                    ],
-                                    ty: FieldType {
-                                        kind: Object,
-                                        name: Some(
-                                            "SpeciesConnection",
-                                        ),
-                                        of_type: None,
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                Field {
-                                    name: "species",
-                                    description: None,
-                                    args: [
-                                        InputValue {
-                                            name: "id",
-                                            description: None,
-                                            ty: FieldType {
-                                                kind: Scalar,
-                                                name: Some(
-                                                    "ID",
-                                                ),
-                                                of_type: None,
-                                            },
-                                            default_value: None,
-                                        },
-                                        InputValue {
-                                            name: "speciesID",
-                                            description: None,
-                                            ty: FieldType {
-                                                kind: Scalar,
-                                                name: Some(
-                                                    "ID",
-                                                ),
-                                                of_type: None,
-                                            },
-                                            default_value: None,
-                                        },
-                                    ],
-                                    ty: FieldType {
-                                        kind: Object,
-                                        name: Some(
-                                            "Species",
-                                        ),
-                                        of_type: None,
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                Field {
-                                    name: "allStarships",
-                                    description: None,
-                                    args: [
-                                        InputValue {
-                                            name: "after",
-                                            description: None,
-                                            ty: FieldType {
-                                                kind: Scalar,
-                                                name: Some(
-                                                    "String",
-                                                ),
-                                                of_type: None,
-                                            },
-                                            default_value: None,
-                                        },
-                                        InputValue {
-                                            name: "first",
-                                            description: None,
-                                            ty: FieldType {
-                                                kind: Scalar,
-                                                name: Some(
-                                                    "Int",
-                                                ),
-                                                of_type: None,
-                                            },
-                                            default_value: None,
-                                        },
-                                        InputValue {
-                                            name: "before",
-                                            description: None,
-                                            ty: FieldType {
-                                                kind: Scalar,
-                                                name: Some(
-                                                    "String",
-                                                ),
-                                                of_type: None,
-                                            },
-                                            default_value: None,
-                                        },
-                                        InputValue {
-                                            name: "last",
-                                            description: None,
-                                            ty: FieldType {
-                                                kind: Scalar,
-                                                name: Some(
-                                                    "Int",
-                                                ),
-                                                of_type: None,
-                                            },
-                                            default_value: None,
-                                        },
-                                    ],
-                                    ty: FieldType {
-                                        kind: Object,
-                                        name: Some(
-                                            "StarshipsConnection",
-                                        ),
-                                        of_type: None,
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                Field {
-                                    name: "starship",
-                                    description: None,
-                                    args: [
-                                        InputValue {
-                                            name: "id",
-                                            description: None,
-                                            ty: FieldType {
-                                                kind: Scalar,
-                                                name: Some(
-                                                    "ID",
-                                                ),
-                                                of_type: None,
-                                            },
-                                            default_value: None,
-                                        },
-                                        InputValue {
-                                            name: "starshipID",
-                                            description: None,
-                                            ty: FieldType {
-                                                kind: Scalar,
-                                                name: Some(
-                                                    "ID",
-                                                ),
-                                                of_type: None,
-                                            },
-                                            default_value: None,
-                                        },
-                                    ],
-                                    ty: FieldType {
-                                        kind: Object,
-                                        name: Some(
-                                            "Starship",
-                                        ),
-                                        of_type: None,
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                Field {
-                                    name: "allVehicles",
-                                    description: None,
-                                    args: [
-                                        InputValue {
-                                            name: "after",
-                                            description: None,
-                                            ty: FieldType {
-                                                kind: Scalar,
-                                                name: Some(
-                                                    "String",
-                                                ),
-                                                of_type: None,
-                                            },
-                                            default_value: None,
-                                        },
-                                        InputValue {
-                                            name: "first",
-                                            description: None,
-                                            ty: FieldType {
-                                                kind: Scalar,
-                                                name: Some(
-                                                    "Int",
-                                                ),
-                                                of_type: None,
-                                            },
-                                            default_value: None,
-                                        },
-                                        InputValue {
-                                            name: "before",
-                                            description: None,
-                                            ty: FieldType {
-                                                kind: Scalar,
-                                                name: Some(
-                                                    "String",
-                                                ),
-                                                of_type: None,
-                                            },
-                                            default_value: None,
-                                        },
-                                        InputValue {
-                                            name: "last",
-                                            description: None,
-                                            ty: FieldType {
-                                                kind: Scalar,
-                                                name: Some(
-                                                    "Int",
-                                                ),
-                                                of_type: None,
-                                            },
-                                            default_value: None,
-                                        },
-                                    ],
-                                    ty: FieldType {
-                                        kind: Object,
-                                        name: Some(
-                                            "VehiclesConnection",
-                                        ),
-                                        of_type: None,
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                Field {
-                                    name: "vehicle",
-                                    description: None,
-                                    args: [
-                                        InputValue {
-                                            name: "id",
-                                            description: None,
-                                            ty: FieldType {
-                                                kind: Scalar,
-                                                name: Some(
-                                                    "ID",
-                                                ),
-                                                of_type: None,
-                                            },
-                                            default_value: None,
-                                        },
-                                        InputValue {
-                                            name: "vehicleID",
-                                            description: None,
-                                            ty: FieldType {
-                                                kind: Scalar,
-                                                name: Some(
-                                                    "ID",
-                                                ),
-                                                of_type: None,
-                                            },
-                                            default_value: None,
-                                        },
-                                    ],
-                                    ty: FieldType {
-                                        kind: Object,
-                                        name: Some(
-                                            "Vehicle",
-                                        ),
-                                        of_type: None,
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                Field {
-                                    name: "node",
-                                    description: Some(
-                                        "Fetches an object given its ID",
-                                    ),
-                                    args: [
-                                        InputValue {
-                                            name: "id",
-                                            description: Some(
-                                                "The ID of an object",
-                                            ),
-                                            ty: FieldType {
-                                                kind: NonNull,
-                                                name: None,
-                                                of_type: Some(
-                                                    FieldType {
-                                                        kind: Scalar,
-                                                        name: Some(
-                                                            "ID",
-                                                        ),
-                                                        of_type: None,
-                                                    },
-                                                ),
-                                            },
-                                            default_value: None,
-                                        },
-                                    ],
-                                    ty: FieldType {
-                                        kind: Interface,
-                                        name: Some(
-                                            "Node",
-                                        ),
-                                        of_type: None,
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                            ],
-                        ),
-                        input_fields: None,
-                        interfaces: Some(
-                            [],
-                        ),
-                        enum_values: None,
-                        possible_types: None,
-                        specified_by_url: None,
-                    },
-                    Type {
-                        kind: Scalar,
-                        name: Some(
-                            "String",
-                        ),
-                        description: Some(
-                            "The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text.",
-                        ),
-                        fields: None,
-                        input_fields: None,
-                        interfaces: None,
-                        enum_values: None,
-                        possible_types: None,
-                        specified_by_url: None,
-                    },
-                    Type {
-                        kind: Scalar,
-                        name: Some(
-                            "Int",
-                        ),
-                        description: Some(
-                            "The `Int` scalar type represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1.",
-                        ),
-                        fields: None,
-                        input_fields: None,
-                        interfaces: None,
-                        enum_values: None,
-                        possible_types: None,
-                        specified_by_url: None,
-                    },
-                    Type {
-                        kind: Object,
-                        name: Some(
-                            "FilmsConnection",
-                        ),
-                        description: Some(
-                            "A connection to a list of items.",
-                        ),
-                        fields: Some(
-                            [
-                                Field {
-                                    name: "pageInfo",
-                                    description: Some(
-                                        "Information to aid in pagination.",
-                                    ),
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: NonNull,
-                                        name: None,
-                                        of_type: Some(
-                                            FieldType {
-                                                kind: Object,
-                                                name: Some(
-                                                    "PageInfo",
-                                                ),
-                                                of_type: None,
-                                            },
-                                        ),
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                Field {
-                                    name: "edges",
-                                    description: Some(
-                                        "A list of edges.",
-                                    ),
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: List,
-                                        name: None,
-                                        of_type: Some(
-                                            FieldType {
-                                                kind: Object,
-                                                name: Some(
-                                                    "FilmsEdge",
-                                                ),
-                                                of_type: None,
-                                            },
-                                        ),
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                Field {
-                                    name: "totalCount",
-                                    description: Some(
-                                        "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
-                                    ),
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: Scalar,
-                                        name: Some(
-                                            "Int",
-                                        ),
-                                        of_type: None,
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                Field {
-                                    name: "films",
-                                    description: Some(
-                                        "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
-                                    ),
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: List,
-                                        name: None,
-                                        of_type: Some(
-                                            FieldType {
-                                                kind: Object,
-                                                name: Some(
-                                                    "Film",
-                                                ),
-                                                of_type: None,
-                                            },
-                                        ),
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                            ],
-                        ),
-                        input_fields: None,
-                        interfaces: Some(
-                            [],
-                        ),
-                        enum_values: None,
-                        possible_types: None,
-                        specified_by_url: None,
-                    },
-                    Type {
-                        kind: Object,
-                        name: Some(
-                            "PageInfo",
-                        ),
-                        description: Some(
-                            "Information about pagination in a connection.",
-                        ),
-                        fields: Some(
-                            [
-                                Field {
-                                    name: "hasNextPage",
-                                    description: Some(
-                                        "When paginating forwards, are there more items?",
-                                    ),
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: NonNull,
-                                        name: None,
-                                        of_type: Some(
-                                            FieldType {
-                                                kind: Scalar,
-                                                name: Some(
-                                                    "Boolean",
-                                                ),
-                                                of_type: None,
-                                            },
-                                        ),
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                Field {
-                                    name: "hasPreviousPage",
-                                    description: Some(
-                                        "When paginating backwards, are there more items?",
-                                    ),
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: NonNull,
-                                        name: None,
-                                        of_type: Some(
-                                            FieldType {
-                                                kind: Scalar,
-                                                name: Some(
-                                                    "Boolean",
-                                                ),
-                                                of_type: None,
-                                            },
-                                        ),
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                Field {
-                                    name: "startCursor",
-                                    description: Some(
-                                        "When paginating backwards, the cursor to continue.",
-                                    ),
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: Scalar,
-                                        name: Some(
-                                            "String",
-                                        ),
-                                        of_type: None,
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                Field {
-                                    name: "endCursor",
-                                    description: Some(
-                                        "When paginating forwards, the cursor to continue.",
-                                    ),
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: Scalar,
-                                        name: Some(
-                                            "String",
-                                        ),
-                                        of_type: None,
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                            ],
-                        ),
-                        input_fields: None,
-                        interfaces: Some(
-                            [],
-                        ),
-                        enum_values: None,
-                        possible_types: None,
-                        specified_by_url: None,
-                    },
-                    Type {
                         kind: Scalar,
                         name: Some(
                             "Boolean",
@@ -920,64 +26,6 @@ Some(
                         fields: None,
                         input_fields: None,
                         interfaces: None,
-                        enum_values: None,
-                        possible_types: None,
-                        specified_by_url: None,
-                    },
-                    Type {
-                        kind: Object,
-                        name: Some(
-                            "FilmsEdge",
-                        ),
-                        description: Some(
-                            "An edge in a connection.",
-                        ),
-                        fields: Some(
-                            [
-                                Field {
-                                    name: "node",
-                                    description: Some(
-                                        "The item at the end of the edge",
-                                    ),
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: Object,
-                                        name: Some(
-                                            "Film",
-                                        ),
-                                        of_type: None,
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                Field {
-                                    name: "cursor",
-                                    description: Some(
-                                        "A cursor for use in pagination",
-                                    ),
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: NonNull,
-                                        name: None,
-                                        of_type: Some(
-                                            FieldType {
-                                                kind: Scalar,
-                                                name: Some(
-                                                    "String",
-                                                ),
-                                                of_type: None,
-                                            },
-                                        ),
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                            ],
-                        ),
-                        input_fields: None,
-                        interfaces: Some(
-                            [],
-                        ),
                         enum_values: None,
                         possible_types: None,
                         specified_by_url: None,
@@ -1480,19 +528,19 @@ Some(
                         specified_by_url: None,
                     },
                     Type {
-                        kind: Interface,
+                        kind: Object,
                         name: Some(
-                            "Node",
+                            "FilmCharactersConnection",
                         ),
                         description: Some(
-                            "An object with an ID",
+                            "A connection to a list of items.",
                         ),
                         fields: Some(
                             [
                                 Field {
-                                    name: "id",
+                                    name: "pageInfo",
                                     description: Some(
-                                        "The id of the object.",
+                                        "Information to aid in pagination.",
                                     ),
                                     args: [],
                                     ty: FieldType {
@@ -1500,9 +548,69 @@ Some(
                                         name: None,
                                         of_type: Some(
                                             FieldType {
-                                                kind: Scalar,
+                                                kind: Object,
                                                 name: Some(
-                                                    "ID",
+                                                    "PageInfo",
+                                                ),
+                                                of_type: None,
+                                            },
+                                        ),
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                Field {
+                                    name: "edges",
+                                    description: Some(
+                                        "A list of edges.",
+                                    ),
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: List,
+                                        name: None,
+                                        of_type: Some(
+                                            FieldType {
+                                                kind: Object,
+                                                name: Some(
+                                                    "FilmCharactersEdge",
+                                                ),
+                                                of_type: None,
+                                            },
+                                        ),
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                Field {
+                                    name: "totalCount",
+                                    description: Some(
+                                        "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
+                                    ),
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: Scalar,
+                                        name: Some(
+                                            "Int",
+                                        ),
+                                        of_type: None,
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                Field {
+                                    name: "characters",
+                                    description: Some(
+                                        "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
+                                    ),
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: List,
+                                        name: None,
+                                        of_type: Some(
+                                            FieldType {
+                                                kind: Object,
+                                                name: Some(
+                                                    "Person",
                                                 ),
                                                 of_type: None,
                                             },
@@ -1514,55 +622,227 @@ Some(
                             ],
                         ),
                         input_fields: None,
-                        interfaces: None,
-                        enum_values: None,
-                        possible_types: Some(
-                            [
-                                NamedType {
-                                    name: Some(
-                                        "Film",
-                                    ),
-                                },
-                                NamedType {
-                                    name: Some(
-                                        "Species",
-                                    ),
-                                },
-                                NamedType {
-                                    name: Some(
-                                        "Planet",
-                                    ),
-                                },
-                                NamedType {
-                                    name: Some(
-                                        "Person",
-                                    ),
-                                },
-                                NamedType {
-                                    name: Some(
-                                        "Starship",
-                                    ),
-                                },
-                                NamedType {
-                                    name: Some(
-                                        "Vehicle",
-                                    ),
-                                },
-                            ],
+                        interfaces: Some(
+                            [],
                         ),
+                        enum_values: None,
+                        possible_types: None,
                         specified_by_url: None,
                     },
                     Type {
-                        kind: Scalar,
+                        kind: Object,
                         name: Some(
-                            "ID",
+                            "FilmCharactersEdge",
                         ),
                         description: Some(
-                            "The `ID` scalar type represents a unique identifier, often used to refetch an object or as key for a cache. The ID type appears in a JSON response as a String; however, it is not intended to be human-readable. When expected as an input type, any string (such as `\"4\"`) or integer (such as `4`) input value will be accepted as an ID.",
+                            "An edge in a connection.",
                         ),
-                        fields: None,
+                        fields: Some(
+                            [
+                                Field {
+                                    name: "node",
+                                    description: Some(
+                                        "The item at the end of the edge",
+                                    ),
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: Object,
+                                        name: Some(
+                                            "Person",
+                                        ),
+                                        of_type: None,
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                Field {
+                                    name: "cursor",
+                                    description: Some(
+                                        "A cursor for use in pagination",
+                                    ),
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: NonNull,
+                                        name: None,
+                                        of_type: Some(
+                                            FieldType {
+                                                kind: Scalar,
+                                                name: Some(
+                                                    "String",
+                                                ),
+                                                of_type: None,
+                                            },
+                                        ),
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                            ],
+                        ),
                         input_fields: None,
-                        interfaces: None,
+                        interfaces: Some(
+                            [],
+                        ),
+                        enum_values: None,
+                        possible_types: None,
+                        specified_by_url: None,
+                    },
+                    Type {
+                        kind: Object,
+                        name: Some(
+                            "FilmPlanetsConnection",
+                        ),
+                        description: Some(
+                            "A connection to a list of items.",
+                        ),
+                        fields: Some(
+                            [
+                                Field {
+                                    name: "pageInfo",
+                                    description: Some(
+                                        "Information to aid in pagination.",
+                                    ),
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: NonNull,
+                                        name: None,
+                                        of_type: Some(
+                                            FieldType {
+                                                kind: Object,
+                                                name: Some(
+                                                    "PageInfo",
+                                                ),
+                                                of_type: None,
+                                            },
+                                        ),
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                Field {
+                                    name: "edges",
+                                    description: Some(
+                                        "A list of edges.",
+                                    ),
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: List,
+                                        name: None,
+                                        of_type: Some(
+                                            FieldType {
+                                                kind: Object,
+                                                name: Some(
+                                                    "FilmPlanetsEdge",
+                                                ),
+                                                of_type: None,
+                                            },
+                                        ),
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                Field {
+                                    name: "totalCount",
+                                    description: Some(
+                                        "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
+                                    ),
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: Scalar,
+                                        name: Some(
+                                            "Int",
+                                        ),
+                                        of_type: None,
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                Field {
+                                    name: "planets",
+                                    description: Some(
+                                        "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
+                                    ),
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: List,
+                                        name: None,
+                                        of_type: Some(
+                                            FieldType {
+                                                kind: Object,
+                                                name: Some(
+                                                    "Planet",
+                                                ),
+                                                of_type: None,
+                                            },
+                                        ),
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                            ],
+                        ),
+                        input_fields: None,
+                        interfaces: Some(
+                            [],
+                        ),
+                        enum_values: None,
+                        possible_types: None,
+                        specified_by_url: None,
+                    },
+                    Type {
+                        kind: Object,
+                        name: Some(
+                            "FilmPlanetsEdge",
+                        ),
+                        description: Some(
+                            "An edge in a connection.",
+                        ),
+                        fields: Some(
+                            [
+                                Field {
+                                    name: "node",
+                                    description: Some(
+                                        "The item at the end of the edge",
+                                    ),
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: Object,
+                                        name: Some(
+                                            "Planet",
+                                        ),
+                                        of_type: None,
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                Field {
+                                    name: "cursor",
+                                    description: Some(
+                                        "A cursor for use in pagination",
+                                    ),
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: NonNull,
+                                        name: None,
+                                        of_type: Some(
+                                            FieldType {
+                                                kind: Scalar,
+                                                name: Some(
+                                                    "String",
+                                                ),
+                                                of_type: None,
+                                            },
+                                        ),
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                            ],
+                        ),
+                        input_fields: None,
+                        interfaces: Some(
+                            [],
+                        ),
                         enum_values: None,
                         possible_types: None,
                         specified_by_url: None,
@@ -1730,768 +1010,7 @@ Some(
                     Type {
                         kind: Object,
                         name: Some(
-                            "Species",
-                        ),
-                        description: Some(
-                            "A type of person or character within the Star Wars Universe.",
-                        ),
-                        fields: Some(
-                            [
-                                Field {
-                                    name: "name",
-                                    description: Some(
-                                        "The name of this species.",
-                                    ),
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: Scalar,
-                                        name: Some(
-                                            "String",
-                                        ),
-                                        of_type: None,
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                Field {
-                                    name: "classification",
-                                    description: Some(
-                                        "The classification of this species, such as \"mammal\" or \"reptile\".",
-                                    ),
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: Scalar,
-                                        name: Some(
-                                            "String",
-                                        ),
-                                        of_type: None,
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                Field {
-                                    name: "designation",
-                                    description: Some(
-                                        "The designation of this species, such as \"sentient\".",
-                                    ),
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: Scalar,
-                                        name: Some(
-                                            "String",
-                                        ),
-                                        of_type: None,
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                Field {
-                                    name: "averageHeight",
-                                    description: Some(
-                                        "The average height of this species in centimeters.",
-                                    ),
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: Scalar,
-                                        name: Some(
-                                            "Float",
-                                        ),
-                                        of_type: None,
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                Field {
-                                    name: "averageLifespan",
-                                    description: Some(
-                                        "The average lifespan of this species in years, null if unknown.",
-                                    ),
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: Scalar,
-                                        name: Some(
-                                            "Int",
-                                        ),
-                                        of_type: None,
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                Field {
-                                    name: "eyeColors",
-                                    description: Some(
-                                        "Common eye colors for this species, null if this species does not typically\nhave eyes.",
-                                    ),
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: List,
-                                        name: None,
-                                        of_type: Some(
-                                            FieldType {
-                                                kind: Scalar,
-                                                name: Some(
-                                                    "String",
-                                                ),
-                                                of_type: None,
-                                            },
-                                        ),
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                Field {
-                                    name: "hairColors",
-                                    description: Some(
-                                        "Common hair colors for this species, null if this species does not typically\nhave hair.",
-                                    ),
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: List,
-                                        name: None,
-                                        of_type: Some(
-                                            FieldType {
-                                                kind: Scalar,
-                                                name: Some(
-                                                    "String",
-                                                ),
-                                                of_type: None,
-                                            },
-                                        ),
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                Field {
-                                    name: "skinColors",
-                                    description: Some(
-                                        "Common skin colors for this species, null if this species does not typically\nhave skin.",
-                                    ),
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: List,
-                                        name: None,
-                                        of_type: Some(
-                                            FieldType {
-                                                kind: Scalar,
-                                                name: Some(
-                                                    "String",
-                                                ),
-                                                of_type: None,
-                                            },
-                                        ),
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                Field {
-                                    name: "language",
-                                    description: Some(
-                                        "The language commonly spoken by this species.",
-                                    ),
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: Scalar,
-                                        name: Some(
-                                            "String",
-                                        ),
-                                        of_type: None,
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                Field {
-                                    name: "homeworld",
-                                    description: Some(
-                                        "A planet that this species originates from.",
-                                    ),
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: Object,
-                                        name: Some(
-                                            "Planet",
-                                        ),
-                                        of_type: None,
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                Field {
-                                    name: "personConnection",
-                                    description: None,
-                                    args: [
-                                        InputValue {
-                                            name: "after",
-                                            description: None,
-                                            ty: FieldType {
-                                                kind: Scalar,
-                                                name: Some(
-                                                    "String",
-                                                ),
-                                                of_type: None,
-                                            },
-                                            default_value: None,
-                                        },
-                                        InputValue {
-                                            name: "first",
-                                            description: None,
-                                            ty: FieldType {
-                                                kind: Scalar,
-                                                name: Some(
-                                                    "Int",
-                                                ),
-                                                of_type: None,
-                                            },
-                                            default_value: None,
-                                        },
-                                        InputValue {
-                                            name: "before",
-                                            description: None,
-                                            ty: FieldType {
-                                                kind: Scalar,
-                                                name: Some(
-                                                    "String",
-                                                ),
-                                                of_type: None,
-                                            },
-                                            default_value: None,
-                                        },
-                                        InputValue {
-                                            name: "last",
-                                            description: None,
-                                            ty: FieldType {
-                                                kind: Scalar,
-                                                name: Some(
-                                                    "Int",
-                                                ),
-                                                of_type: None,
-                                            },
-                                            default_value: None,
-                                        },
-                                    ],
-                                    ty: FieldType {
-                                        kind: Object,
-                                        name: Some(
-                                            "SpeciesPeopleConnection",
-                                        ),
-                                        of_type: None,
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                Field {
-                                    name: "filmConnection",
-                                    description: None,
-                                    args: [
-                                        InputValue {
-                                            name: "after",
-                                            description: None,
-                                            ty: FieldType {
-                                                kind: Scalar,
-                                                name: Some(
-                                                    "String",
-                                                ),
-                                                of_type: None,
-                                            },
-                                            default_value: None,
-                                        },
-                                        InputValue {
-                                            name: "first",
-                                            description: None,
-                                            ty: FieldType {
-                                                kind: Scalar,
-                                                name: Some(
-                                                    "Int",
-                                                ),
-                                                of_type: None,
-                                            },
-                                            default_value: None,
-                                        },
-                                        InputValue {
-                                            name: "before",
-                                            description: None,
-                                            ty: FieldType {
-                                                kind: Scalar,
-                                                name: Some(
-                                                    "String",
-                                                ),
-                                                of_type: None,
-                                            },
-                                            default_value: None,
-                                        },
-                                        InputValue {
-                                            name: "last",
-                                            description: None,
-                                            ty: FieldType {
-                                                kind: Scalar,
-                                                name: Some(
-                                                    "Int",
-                                                ),
-                                                of_type: None,
-                                            },
-                                            default_value: None,
-                                        },
-                                    ],
-                                    ty: FieldType {
-                                        kind: Object,
-                                        name: Some(
-                                            "SpeciesFilmsConnection",
-                                        ),
-                                        of_type: None,
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                Field {
-                                    name: "created",
-                                    description: Some(
-                                        "The ISO 8601 date format of the time that this resource was created.",
-                                    ),
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: Scalar,
-                                        name: Some(
-                                            "String",
-                                        ),
-                                        of_type: None,
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                Field {
-                                    name: "edited",
-                                    description: Some(
-                                        "The ISO 8601 date format of the time that this resource was edited.",
-                                    ),
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: Scalar,
-                                        name: Some(
-                                            "String",
-                                        ),
-                                        of_type: None,
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                Field {
-                                    name: "id",
-                                    description: Some(
-                                        "The ID of an object",
-                                    ),
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: NonNull,
-                                        name: None,
-                                        of_type: Some(
-                                            FieldType {
-                                                kind: Scalar,
-                                                name: Some(
-                                                    "ID",
-                                                ),
-                                                of_type: None,
-                                            },
-                                        ),
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                            ],
-                        ),
-                        input_fields: None,
-                        interfaces: Some(
-                            [
-                                NamedType {
-                                    name: Some(
-                                        "Node",
-                                    ),
-                                },
-                            ],
-                        ),
-                        enum_values: None,
-                        possible_types: None,
-                        specified_by_url: None,
-                    },
-                    Type {
-                        kind: Scalar,
-                        name: Some(
-                            "Float",
-                        ),
-                        description: Some(
-                            "The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](https://en.wikipedia.org/wiki/IEEE_floating_point).",
-                        ),
-                        fields: None,
-                        input_fields: None,
-                        interfaces: None,
-                        enum_values: None,
-                        possible_types: None,
-                        specified_by_url: None,
-                    },
-                    Type {
-                        kind: Object,
-                        name: Some(
-                            "Planet",
-                        ),
-                        description: Some(
-                            "A large mass, planet or planetoid in the Star Wars Universe, at the time of\n0 ABY.",
-                        ),
-                        fields: Some(
-                            [
-                                Field {
-                                    name: "name",
-                                    description: Some(
-                                        "The name of this planet.",
-                                    ),
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: Scalar,
-                                        name: Some(
-                                            "String",
-                                        ),
-                                        of_type: None,
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                Field {
-                                    name: "diameter",
-                                    description: Some(
-                                        "The diameter of this planet in kilometers.",
-                                    ),
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: Scalar,
-                                        name: Some(
-                                            "Int",
-                                        ),
-                                        of_type: None,
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                Field {
-                                    name: "rotationPeriod",
-                                    description: Some(
-                                        "The number of standard hours it takes for this planet to complete a single\nrotation on its axis.",
-                                    ),
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: Scalar,
-                                        name: Some(
-                                            "Int",
-                                        ),
-                                        of_type: None,
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                Field {
-                                    name: "orbitalPeriod",
-                                    description: Some(
-                                        "The number of standard days it takes for this planet to complete a single orbit\nof its local star.",
-                                    ),
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: Scalar,
-                                        name: Some(
-                                            "Int",
-                                        ),
-                                        of_type: None,
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                Field {
-                                    name: "gravity",
-                                    description: Some(
-                                        "A number denoting the gravity of this planet, where \"1\" is normal or 1 standard\nG. \"2\" is twice or 2 standard Gs. \"0.5\" is half or 0.5 standard Gs.",
-                                    ),
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: Scalar,
-                                        name: Some(
-                                            "String",
-                                        ),
-                                        of_type: None,
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                Field {
-                                    name: "population",
-                                    description: Some(
-                                        "The average population of sentient beings inhabiting this planet.",
-                                    ),
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: Scalar,
-                                        name: Some(
-                                            "Float",
-                                        ),
-                                        of_type: None,
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                Field {
-                                    name: "climates",
-                                    description: Some(
-                                        "The climates of this planet.",
-                                    ),
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: List,
-                                        name: None,
-                                        of_type: Some(
-                                            FieldType {
-                                                kind: Scalar,
-                                                name: Some(
-                                                    "String",
-                                                ),
-                                                of_type: None,
-                                            },
-                                        ),
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                Field {
-                                    name: "terrains",
-                                    description: Some(
-                                        "The terrains of this planet.",
-                                    ),
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: List,
-                                        name: None,
-                                        of_type: Some(
-                                            FieldType {
-                                                kind: Scalar,
-                                                name: Some(
-                                                    "String",
-                                                ),
-                                                of_type: None,
-                                            },
-                                        ),
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                Field {
-                                    name: "surfaceWater",
-                                    description: Some(
-                                        "The percentage of the planet surface that is naturally occurring water or bodies\nof water.",
-                                    ),
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: Scalar,
-                                        name: Some(
-                                            "Float",
-                                        ),
-                                        of_type: None,
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                Field {
-                                    name: "residentConnection",
-                                    description: None,
-                                    args: [
-                                        InputValue {
-                                            name: "after",
-                                            description: None,
-                                            ty: FieldType {
-                                                kind: Scalar,
-                                                name: Some(
-                                                    "String",
-                                                ),
-                                                of_type: None,
-                                            },
-                                            default_value: None,
-                                        },
-                                        InputValue {
-                                            name: "first",
-                                            description: None,
-                                            ty: FieldType {
-                                                kind: Scalar,
-                                                name: Some(
-                                                    "Int",
-                                                ),
-                                                of_type: None,
-                                            },
-                                            default_value: None,
-                                        },
-                                        InputValue {
-                                            name: "before",
-                                            description: None,
-                                            ty: FieldType {
-                                                kind: Scalar,
-                                                name: Some(
-                                                    "String",
-                                                ),
-                                                of_type: None,
-                                            },
-                                            default_value: None,
-                                        },
-                                        InputValue {
-                                            name: "last",
-                                            description: None,
-                                            ty: FieldType {
-                                                kind: Scalar,
-                                                name: Some(
-                                                    "Int",
-                                                ),
-                                                of_type: None,
-                                            },
-                                            default_value: None,
-                                        },
-                                    ],
-                                    ty: FieldType {
-                                        kind: Object,
-                                        name: Some(
-                                            "PlanetResidentsConnection",
-                                        ),
-                                        of_type: None,
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                Field {
-                                    name: "filmConnection",
-                                    description: None,
-                                    args: [
-                                        InputValue {
-                                            name: "after",
-                                            description: None,
-                                            ty: FieldType {
-                                                kind: Scalar,
-                                                name: Some(
-                                                    "String",
-                                                ),
-                                                of_type: None,
-                                            },
-                                            default_value: None,
-                                        },
-                                        InputValue {
-                                            name: "first",
-                                            description: None,
-                                            ty: FieldType {
-                                                kind: Scalar,
-                                                name: Some(
-                                                    "Int",
-                                                ),
-                                                of_type: None,
-                                            },
-                                            default_value: None,
-                                        },
-                                        InputValue {
-                                            name: "before",
-                                            description: None,
-                                            ty: FieldType {
-                                                kind: Scalar,
-                                                name: Some(
-                                                    "String",
-                                                ),
-                                                of_type: None,
-                                            },
-                                            default_value: None,
-                                        },
-                                        InputValue {
-                                            name: "last",
-                                            description: None,
-                                            ty: FieldType {
-                                                kind: Scalar,
-                                                name: Some(
-                                                    "Int",
-                                                ),
-                                                of_type: None,
-                                            },
-                                            default_value: None,
-                                        },
-                                    ],
-                                    ty: FieldType {
-                                        kind: Object,
-                                        name: Some(
-                                            "PlanetFilmsConnection",
-                                        ),
-                                        of_type: None,
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                Field {
-                                    name: "created",
-                                    description: Some(
-                                        "The ISO 8601 date format of the time that this resource was created.",
-                                    ),
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: Scalar,
-                                        name: Some(
-                                            "String",
-                                        ),
-                                        of_type: None,
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                Field {
-                                    name: "edited",
-                                    description: Some(
-                                        "The ISO 8601 date format of the time that this resource was edited.",
-                                    ),
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: Scalar,
-                                        name: Some(
-                                            "String",
-                                        ),
-                                        of_type: None,
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                Field {
-                                    name: "id",
-                                    description: Some(
-                                        "The ID of an object",
-                                    ),
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: NonNull,
-                                        name: None,
-                                        of_type: Some(
-                                            FieldType {
-                                                kind: Scalar,
-                                                name: Some(
-                                                    "ID",
-                                                ),
-                                                of_type: None,
-                                            },
-                                        ),
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                            ],
-                        ),
-                        input_fields: None,
-                        interfaces: Some(
-                            [
-                                NamedType {
-                                    name: Some(
-                                        "Node",
-                                    ),
-                                },
-                            ],
-                        ),
-                        enum_values: None,
-                        possible_types: None,
-                        specified_by_url: None,
-                    },
-                    Type {
-                        kind: Object,
-                        name: Some(
-                            "PlanetResidentsConnection",
+                            "FilmStarshipsConnection",
                         ),
                         description: Some(
                             "A connection to a list of items.",
@@ -2533,7 +1052,7 @@ Some(
                                             FieldType {
                                                 kind: Object,
                                                 name: Some(
-                                                    "PlanetResidentsEdge",
+                                                    "FilmStarshipsEdge",
                                                 ),
                                                 of_type: None,
                                             },
@@ -2559,7 +1078,697 @@ Some(
                                     deprecation_reason: None,
                                 },
                                 Field {
-                                    name: "residents",
+                                    name: "starships",
+                                    description: Some(
+                                        "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
+                                    ),
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: List,
+                                        name: None,
+                                        of_type: Some(
+                                            FieldType {
+                                                kind: Object,
+                                                name: Some(
+                                                    "Starship",
+                                                ),
+                                                of_type: None,
+                                            },
+                                        ),
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                            ],
+                        ),
+                        input_fields: None,
+                        interfaces: Some(
+                            [],
+                        ),
+                        enum_values: None,
+                        possible_types: None,
+                        specified_by_url: None,
+                    },
+                    Type {
+                        kind: Object,
+                        name: Some(
+                            "FilmStarshipsEdge",
+                        ),
+                        description: Some(
+                            "An edge in a connection.",
+                        ),
+                        fields: Some(
+                            [
+                                Field {
+                                    name: "node",
+                                    description: Some(
+                                        "The item at the end of the edge",
+                                    ),
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: Object,
+                                        name: Some(
+                                            "Starship",
+                                        ),
+                                        of_type: None,
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                Field {
+                                    name: "cursor",
+                                    description: Some(
+                                        "A cursor for use in pagination",
+                                    ),
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: NonNull,
+                                        name: None,
+                                        of_type: Some(
+                                            FieldType {
+                                                kind: Scalar,
+                                                name: Some(
+                                                    "String",
+                                                ),
+                                                of_type: None,
+                                            },
+                                        ),
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                            ],
+                        ),
+                        input_fields: None,
+                        interfaces: Some(
+                            [],
+                        ),
+                        enum_values: None,
+                        possible_types: None,
+                        specified_by_url: None,
+                    },
+                    Type {
+                        kind: Object,
+                        name: Some(
+                            "FilmVehiclesConnection",
+                        ),
+                        description: Some(
+                            "A connection to a list of items.",
+                        ),
+                        fields: Some(
+                            [
+                                Field {
+                                    name: "pageInfo",
+                                    description: Some(
+                                        "Information to aid in pagination.",
+                                    ),
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: NonNull,
+                                        name: None,
+                                        of_type: Some(
+                                            FieldType {
+                                                kind: Object,
+                                                name: Some(
+                                                    "PageInfo",
+                                                ),
+                                                of_type: None,
+                                            },
+                                        ),
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                Field {
+                                    name: "edges",
+                                    description: Some(
+                                        "A list of edges.",
+                                    ),
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: List,
+                                        name: None,
+                                        of_type: Some(
+                                            FieldType {
+                                                kind: Object,
+                                                name: Some(
+                                                    "FilmVehiclesEdge",
+                                                ),
+                                                of_type: None,
+                                            },
+                                        ),
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                Field {
+                                    name: "totalCount",
+                                    description: Some(
+                                        "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
+                                    ),
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: Scalar,
+                                        name: Some(
+                                            "Int",
+                                        ),
+                                        of_type: None,
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                Field {
+                                    name: "vehicles",
+                                    description: Some(
+                                        "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
+                                    ),
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: List,
+                                        name: None,
+                                        of_type: Some(
+                                            FieldType {
+                                                kind: Object,
+                                                name: Some(
+                                                    "Vehicle",
+                                                ),
+                                                of_type: None,
+                                            },
+                                        ),
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                            ],
+                        ),
+                        input_fields: None,
+                        interfaces: Some(
+                            [],
+                        ),
+                        enum_values: None,
+                        possible_types: None,
+                        specified_by_url: None,
+                    },
+                    Type {
+                        kind: Object,
+                        name: Some(
+                            "FilmVehiclesEdge",
+                        ),
+                        description: Some(
+                            "An edge in a connection.",
+                        ),
+                        fields: Some(
+                            [
+                                Field {
+                                    name: "node",
+                                    description: Some(
+                                        "The item at the end of the edge",
+                                    ),
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: Object,
+                                        name: Some(
+                                            "Vehicle",
+                                        ),
+                                        of_type: None,
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                Field {
+                                    name: "cursor",
+                                    description: Some(
+                                        "A cursor for use in pagination",
+                                    ),
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: NonNull,
+                                        name: None,
+                                        of_type: Some(
+                                            FieldType {
+                                                kind: Scalar,
+                                                name: Some(
+                                                    "String",
+                                                ),
+                                                of_type: None,
+                                            },
+                                        ),
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                            ],
+                        ),
+                        input_fields: None,
+                        interfaces: Some(
+                            [],
+                        ),
+                        enum_values: None,
+                        possible_types: None,
+                        specified_by_url: None,
+                    },
+                    Type {
+                        kind: Object,
+                        name: Some(
+                            "FilmsConnection",
+                        ),
+                        description: Some(
+                            "A connection to a list of items.",
+                        ),
+                        fields: Some(
+                            [
+                                Field {
+                                    name: "pageInfo",
+                                    description: Some(
+                                        "Information to aid in pagination.",
+                                    ),
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: NonNull,
+                                        name: None,
+                                        of_type: Some(
+                                            FieldType {
+                                                kind: Object,
+                                                name: Some(
+                                                    "PageInfo",
+                                                ),
+                                                of_type: None,
+                                            },
+                                        ),
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                Field {
+                                    name: "edges",
+                                    description: Some(
+                                        "A list of edges.",
+                                    ),
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: List,
+                                        name: None,
+                                        of_type: Some(
+                                            FieldType {
+                                                kind: Object,
+                                                name: Some(
+                                                    "FilmsEdge",
+                                                ),
+                                                of_type: None,
+                                            },
+                                        ),
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                Field {
+                                    name: "totalCount",
+                                    description: Some(
+                                        "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
+                                    ),
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: Scalar,
+                                        name: Some(
+                                            "Int",
+                                        ),
+                                        of_type: None,
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                Field {
+                                    name: "films",
+                                    description: Some(
+                                        "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
+                                    ),
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: List,
+                                        name: None,
+                                        of_type: Some(
+                                            FieldType {
+                                                kind: Object,
+                                                name: Some(
+                                                    "Film",
+                                                ),
+                                                of_type: None,
+                                            },
+                                        ),
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                            ],
+                        ),
+                        input_fields: None,
+                        interfaces: Some(
+                            [],
+                        ),
+                        enum_values: None,
+                        possible_types: None,
+                        specified_by_url: None,
+                    },
+                    Type {
+                        kind: Object,
+                        name: Some(
+                            "FilmsEdge",
+                        ),
+                        description: Some(
+                            "An edge in a connection.",
+                        ),
+                        fields: Some(
+                            [
+                                Field {
+                                    name: "node",
+                                    description: Some(
+                                        "The item at the end of the edge",
+                                    ),
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: Object,
+                                        name: Some(
+                                            "Film",
+                                        ),
+                                        of_type: None,
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                Field {
+                                    name: "cursor",
+                                    description: Some(
+                                        "A cursor for use in pagination",
+                                    ),
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: NonNull,
+                                        name: None,
+                                        of_type: Some(
+                                            FieldType {
+                                                kind: Scalar,
+                                                name: Some(
+                                                    "String",
+                                                ),
+                                                of_type: None,
+                                            },
+                                        ),
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                            ],
+                        ),
+                        input_fields: None,
+                        interfaces: Some(
+                            [],
+                        ),
+                        enum_values: None,
+                        possible_types: None,
+                        specified_by_url: None,
+                    },
+                    Type {
+                        kind: Scalar,
+                        name: Some(
+                            "Float",
+                        ),
+                        description: Some(
+                            "The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](https://en.wikipedia.org/wiki/IEEE_floating_point).",
+                        ),
+                        fields: None,
+                        input_fields: None,
+                        interfaces: None,
+                        enum_values: None,
+                        possible_types: None,
+                        specified_by_url: None,
+                    },
+                    Type {
+                        kind: Scalar,
+                        name: Some(
+                            "ID",
+                        ),
+                        description: None,
+                        fields: None,
+                        input_fields: None,
+                        interfaces: None,
+                        enum_values: None,
+                        possible_types: None,
+                        specified_by_url: None,
+                    },
+                    Type {
+                        kind: Scalar,
+                        name: Some(
+                            "Int",
+                        ),
+                        description: Some(
+                            "The `Int` scalar type represents non-fractional whole numeric values.",
+                        ),
+                        fields: None,
+                        input_fields: None,
+                        interfaces: None,
+                        enum_values: None,
+                        possible_types: None,
+                        specified_by_url: None,
+                    },
+                    Type {
+                        kind: Interface,
+                        name: Some(
+                            "Node",
+                        ),
+                        description: Some(
+                            "An object with an ID",
+                        ),
+                        fields: Some(
+                            [
+                                Field {
+                                    name: "id",
+                                    description: None,
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: NonNull,
+                                        name: None,
+                                        of_type: Some(
+                                            FieldType {
+                                                kind: Scalar,
+                                                name: Some(
+                                                    "ID",
+                                                ),
+                                                of_type: None,
+                                            },
+                                        ),
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                            ],
+                        ),
+                        input_fields: None,
+                        interfaces: None,
+                        enum_values: None,
+                        possible_types: Some(
+                            [
+                                NamedType {
+                                    name: Some(
+                                        "Film",
+                                    ),
+                                },
+                                NamedType {
+                                    name: Some(
+                                        "Species",
+                                    ),
+                                },
+                                NamedType {
+                                    name: Some(
+                                        "Planet",
+                                    ),
+                                },
+                                NamedType {
+                                    name: Some(
+                                        "Person",
+                                    ),
+                                },
+                                NamedType {
+                                    name: Some(
+                                        "Starship",
+                                    ),
+                                },
+                                NamedType {
+                                    name: Some(
+                                        "Vehicle",
+                                    ),
+                                },
+                            ],
+                        ),
+                        specified_by_url: None,
+                    },
+                    Type {
+                        kind: Object,
+                        name: Some(
+                            "PageInfo",
+                        ),
+                        description: Some(
+                            "Information about pagination in a connection.",
+                        ),
+                        fields: Some(
+                            [
+                                Field {
+                                    name: "hasNextPage",
+                                    description: Some(
+                                        "When paginating forwards, are there more items?",
+                                    ),
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: NonNull,
+                                        name: None,
+                                        of_type: Some(
+                                            FieldType {
+                                                kind: Scalar,
+                                                name: Some(
+                                                    "Boolean",
+                                                ),
+                                                of_type: None,
+                                            },
+                                        ),
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                Field {
+                                    name: "hasPreviousPage",
+                                    description: Some(
+                                        "When paginating backwards, are there more items?",
+                                    ),
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: NonNull,
+                                        name: None,
+                                        of_type: Some(
+                                            FieldType {
+                                                kind: Scalar,
+                                                name: Some(
+                                                    "Boolean",
+                                                ),
+                                                of_type: None,
+                                            },
+                                        ),
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                Field {
+                                    name: "startCursor",
+                                    description: Some(
+                                        "When paginating backwards, the cursor to continue.",
+                                    ),
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: Scalar,
+                                        name: Some(
+                                            "String",
+                                        ),
+                                        of_type: None,
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                Field {
+                                    name: "endCursor",
+                                    description: Some(
+                                        "When paginating forwards, the cursor to continue.",
+                                    ),
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: Scalar,
+                                        name: Some(
+                                            "String",
+                                        ),
+                                        of_type: None,
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                            ],
+                        ),
+                        input_fields: None,
+                        interfaces: Some(
+                            [],
+                        ),
+                        enum_values: None,
+                        possible_types: None,
+                        specified_by_url: None,
+                    },
+                    Type {
+                        kind: Object,
+                        name: Some(
+                            "PeopleConnection",
+                        ),
+                        description: Some(
+                            "A connection to a list of items.",
+                        ),
+                        fields: Some(
+                            [
+                                Field {
+                                    name: "pageInfo",
+                                    description: Some(
+                                        "Information to aid in pagination.",
+                                    ),
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: NonNull,
+                                        name: None,
+                                        of_type: Some(
+                                            FieldType {
+                                                kind: Object,
+                                                name: Some(
+                                                    "PageInfo",
+                                                ),
+                                                of_type: None,
+                                            },
+                                        ),
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                Field {
+                                    name: "edges",
+                                    description: Some(
+                                        "A list of edges.",
+                                    ),
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: List,
+                                        name: None,
+                                        of_type: Some(
+                                            FieldType {
+                                                kind: Object,
+                                                name: Some(
+                                                    "PeopleEdge",
+                                                ),
+                                                of_type: None,
+                                            },
+                                        ),
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                Field {
+                                    name: "totalCount",
+                                    description: Some(
+                                        "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
+                                    ),
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: Scalar,
+                                        name: Some(
+                                            "Int",
+                                        ),
+                                        of_type: None,
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                Field {
+                                    name: "people",
                                     description: Some(
                                         "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
                                     ),
@@ -2593,7 +1802,7 @@ Some(
                     Type {
                         kind: Object,
                         name: Some(
-                            "PlanetResidentsEdge",
+                            "PeopleEdge",
                         ),
                         description: Some(
                             "An edge in a connection.",
@@ -3400,6 +2609,2539 @@ Some(
                     Type {
                         kind: Object,
                         name: Some(
+                            "PersonVehiclesConnection",
+                        ),
+                        description: Some(
+                            "A connection to a list of items.",
+                        ),
+                        fields: Some(
+                            [
+                                Field {
+                                    name: "pageInfo",
+                                    description: Some(
+                                        "Information to aid in pagination.",
+                                    ),
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: NonNull,
+                                        name: None,
+                                        of_type: Some(
+                                            FieldType {
+                                                kind: Object,
+                                                name: Some(
+                                                    "PageInfo",
+                                                ),
+                                                of_type: None,
+                                            },
+                                        ),
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                Field {
+                                    name: "edges",
+                                    description: Some(
+                                        "A list of edges.",
+                                    ),
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: List,
+                                        name: None,
+                                        of_type: Some(
+                                            FieldType {
+                                                kind: Object,
+                                                name: Some(
+                                                    "PersonVehiclesEdge",
+                                                ),
+                                                of_type: None,
+                                            },
+                                        ),
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                Field {
+                                    name: "totalCount",
+                                    description: Some(
+                                        "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
+                                    ),
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: Scalar,
+                                        name: Some(
+                                            "Int",
+                                        ),
+                                        of_type: None,
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                Field {
+                                    name: "vehicles",
+                                    description: Some(
+                                        "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
+                                    ),
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: List,
+                                        name: None,
+                                        of_type: Some(
+                                            FieldType {
+                                                kind: Object,
+                                                name: Some(
+                                                    "Vehicle",
+                                                ),
+                                                of_type: None,
+                                            },
+                                        ),
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                            ],
+                        ),
+                        input_fields: None,
+                        interfaces: Some(
+                            [],
+                        ),
+                        enum_values: None,
+                        possible_types: None,
+                        specified_by_url: None,
+                    },
+                    Type {
+                        kind: Object,
+                        name: Some(
+                            "PersonVehiclesEdge",
+                        ),
+                        description: Some(
+                            "An edge in a connection.",
+                        ),
+                        fields: Some(
+                            [
+                                Field {
+                                    name: "node",
+                                    description: Some(
+                                        "The item at the end of the edge",
+                                    ),
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: Object,
+                                        name: Some(
+                                            "Vehicle",
+                                        ),
+                                        of_type: None,
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                Field {
+                                    name: "cursor",
+                                    description: Some(
+                                        "A cursor for use in pagination",
+                                    ),
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: NonNull,
+                                        name: None,
+                                        of_type: Some(
+                                            FieldType {
+                                                kind: Scalar,
+                                                name: Some(
+                                                    "String",
+                                                ),
+                                                of_type: None,
+                                            },
+                                        ),
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                            ],
+                        ),
+                        input_fields: None,
+                        interfaces: Some(
+                            [],
+                        ),
+                        enum_values: None,
+                        possible_types: None,
+                        specified_by_url: None,
+                    },
+                    Type {
+                        kind: Object,
+                        name: Some(
+                            "Planet",
+                        ),
+                        description: Some(
+                            "A large mass, planet or planetoid in the Star Wars Universe, at the time of\n0 ABY.",
+                        ),
+                        fields: Some(
+                            [
+                                Field {
+                                    name: "name",
+                                    description: Some(
+                                        "The name of this planet.",
+                                    ),
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: Scalar,
+                                        name: Some(
+                                            "String",
+                                        ),
+                                        of_type: None,
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                Field {
+                                    name: "diameter",
+                                    description: Some(
+                                        "The diameter of this planet in kilometers.",
+                                    ),
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: Scalar,
+                                        name: Some(
+                                            "Int",
+                                        ),
+                                        of_type: None,
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                Field {
+                                    name: "rotationPeriod",
+                                    description: Some(
+                                        "The number of standard hours it takes for this planet to complete a single\nrotation on its axis.",
+                                    ),
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: Scalar,
+                                        name: Some(
+                                            "Int",
+                                        ),
+                                        of_type: None,
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                Field {
+                                    name: "orbitalPeriod",
+                                    description: Some(
+                                        "The number of standard days it takes for this planet to complete a single orbit\nof its local star.",
+                                    ),
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: Scalar,
+                                        name: Some(
+                                            "Int",
+                                        ),
+                                        of_type: None,
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                Field {
+                                    name: "gravity",
+                                    description: Some(
+                                        "A number denoting the gravity of this planet, where \"1\" is normal or 1 standard\nG. \"2\" is twice or 2 standard Gs. \"0.5\" is half or 0.5 standard Gs.",
+                                    ),
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: Scalar,
+                                        name: Some(
+                                            "String",
+                                        ),
+                                        of_type: None,
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                Field {
+                                    name: "population",
+                                    description: Some(
+                                        "The average population of sentient beings inhabiting this planet.",
+                                    ),
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: Scalar,
+                                        name: Some(
+                                            "Float",
+                                        ),
+                                        of_type: None,
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                Field {
+                                    name: "climates",
+                                    description: Some(
+                                        "The climates of this planet.",
+                                    ),
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: List,
+                                        name: None,
+                                        of_type: Some(
+                                            FieldType {
+                                                kind: Scalar,
+                                                name: Some(
+                                                    "String",
+                                                ),
+                                                of_type: None,
+                                            },
+                                        ),
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                Field {
+                                    name: "terrains",
+                                    description: Some(
+                                        "The terrains of this planet.",
+                                    ),
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: List,
+                                        name: None,
+                                        of_type: Some(
+                                            FieldType {
+                                                kind: Scalar,
+                                                name: Some(
+                                                    "String",
+                                                ),
+                                                of_type: None,
+                                            },
+                                        ),
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                Field {
+                                    name: "surfaceWater",
+                                    description: Some(
+                                        "The percentage of the planet surface that is naturally occurring water or bodies\nof water.",
+                                    ),
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: Scalar,
+                                        name: Some(
+                                            "Float",
+                                        ),
+                                        of_type: None,
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                Field {
+                                    name: "residentConnection",
+                                    description: None,
+                                    args: [
+                                        InputValue {
+                                            name: "after",
+                                            description: None,
+                                            ty: FieldType {
+                                                kind: Scalar,
+                                                name: Some(
+                                                    "String",
+                                                ),
+                                                of_type: None,
+                                            },
+                                            default_value: None,
+                                        },
+                                        InputValue {
+                                            name: "first",
+                                            description: None,
+                                            ty: FieldType {
+                                                kind: Scalar,
+                                                name: Some(
+                                                    "Int",
+                                                ),
+                                                of_type: None,
+                                            },
+                                            default_value: None,
+                                        },
+                                        InputValue {
+                                            name: "before",
+                                            description: None,
+                                            ty: FieldType {
+                                                kind: Scalar,
+                                                name: Some(
+                                                    "String",
+                                                ),
+                                                of_type: None,
+                                            },
+                                            default_value: None,
+                                        },
+                                        InputValue {
+                                            name: "last",
+                                            description: None,
+                                            ty: FieldType {
+                                                kind: Scalar,
+                                                name: Some(
+                                                    "Int",
+                                                ),
+                                                of_type: None,
+                                            },
+                                            default_value: None,
+                                        },
+                                    ],
+                                    ty: FieldType {
+                                        kind: Object,
+                                        name: Some(
+                                            "PlanetResidentsConnection",
+                                        ),
+                                        of_type: None,
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                Field {
+                                    name: "filmConnection",
+                                    description: None,
+                                    args: [
+                                        InputValue {
+                                            name: "after",
+                                            description: None,
+                                            ty: FieldType {
+                                                kind: Scalar,
+                                                name: Some(
+                                                    "String",
+                                                ),
+                                                of_type: None,
+                                            },
+                                            default_value: None,
+                                        },
+                                        InputValue {
+                                            name: "first",
+                                            description: None,
+                                            ty: FieldType {
+                                                kind: Scalar,
+                                                name: Some(
+                                                    "Int",
+                                                ),
+                                                of_type: None,
+                                            },
+                                            default_value: None,
+                                        },
+                                        InputValue {
+                                            name: "before",
+                                            description: None,
+                                            ty: FieldType {
+                                                kind: Scalar,
+                                                name: Some(
+                                                    "String",
+                                                ),
+                                                of_type: None,
+                                            },
+                                            default_value: None,
+                                        },
+                                        InputValue {
+                                            name: "last",
+                                            description: None,
+                                            ty: FieldType {
+                                                kind: Scalar,
+                                                name: Some(
+                                                    "Int",
+                                                ),
+                                                of_type: None,
+                                            },
+                                            default_value: None,
+                                        },
+                                    ],
+                                    ty: FieldType {
+                                        kind: Object,
+                                        name: Some(
+                                            "PlanetFilmsConnection",
+                                        ),
+                                        of_type: None,
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                Field {
+                                    name: "created",
+                                    description: Some(
+                                        "The ISO 8601 date format of the time that this resource was created.",
+                                    ),
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: Scalar,
+                                        name: Some(
+                                            "String",
+                                        ),
+                                        of_type: None,
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                Field {
+                                    name: "edited",
+                                    description: Some(
+                                        "The ISO 8601 date format of the time that this resource was edited.",
+                                    ),
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: Scalar,
+                                        name: Some(
+                                            "String",
+                                        ),
+                                        of_type: None,
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                Field {
+                                    name: "id",
+                                    description: Some(
+                                        "The ID of an object",
+                                    ),
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: NonNull,
+                                        name: None,
+                                        of_type: Some(
+                                            FieldType {
+                                                kind: Scalar,
+                                                name: Some(
+                                                    "ID",
+                                                ),
+                                                of_type: None,
+                                            },
+                                        ),
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                            ],
+                        ),
+                        input_fields: None,
+                        interfaces: Some(
+                            [
+                                NamedType {
+                                    name: Some(
+                                        "Node",
+                                    ),
+                                },
+                            ],
+                        ),
+                        enum_values: None,
+                        possible_types: None,
+                        specified_by_url: None,
+                    },
+                    Type {
+                        kind: Object,
+                        name: Some(
+                            "PlanetFilmsConnection",
+                        ),
+                        description: Some(
+                            "A connection to a list of items.",
+                        ),
+                        fields: Some(
+                            [
+                                Field {
+                                    name: "pageInfo",
+                                    description: Some(
+                                        "Information to aid in pagination.",
+                                    ),
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: NonNull,
+                                        name: None,
+                                        of_type: Some(
+                                            FieldType {
+                                                kind: Object,
+                                                name: Some(
+                                                    "PageInfo",
+                                                ),
+                                                of_type: None,
+                                            },
+                                        ),
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                Field {
+                                    name: "edges",
+                                    description: Some(
+                                        "A list of edges.",
+                                    ),
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: List,
+                                        name: None,
+                                        of_type: Some(
+                                            FieldType {
+                                                kind: Object,
+                                                name: Some(
+                                                    "PlanetFilmsEdge",
+                                                ),
+                                                of_type: None,
+                                            },
+                                        ),
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                Field {
+                                    name: "totalCount",
+                                    description: Some(
+                                        "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
+                                    ),
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: Scalar,
+                                        name: Some(
+                                            "Int",
+                                        ),
+                                        of_type: None,
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                Field {
+                                    name: "films",
+                                    description: Some(
+                                        "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
+                                    ),
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: List,
+                                        name: None,
+                                        of_type: Some(
+                                            FieldType {
+                                                kind: Object,
+                                                name: Some(
+                                                    "Film",
+                                                ),
+                                                of_type: None,
+                                            },
+                                        ),
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                            ],
+                        ),
+                        input_fields: None,
+                        interfaces: Some(
+                            [],
+                        ),
+                        enum_values: None,
+                        possible_types: None,
+                        specified_by_url: None,
+                    },
+                    Type {
+                        kind: Object,
+                        name: Some(
+                            "PlanetFilmsEdge",
+                        ),
+                        description: Some(
+                            "An edge in a connection.",
+                        ),
+                        fields: Some(
+                            [
+                                Field {
+                                    name: "node",
+                                    description: Some(
+                                        "The item at the end of the edge",
+                                    ),
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: Object,
+                                        name: Some(
+                                            "Film",
+                                        ),
+                                        of_type: None,
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                Field {
+                                    name: "cursor",
+                                    description: Some(
+                                        "A cursor for use in pagination",
+                                    ),
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: NonNull,
+                                        name: None,
+                                        of_type: Some(
+                                            FieldType {
+                                                kind: Scalar,
+                                                name: Some(
+                                                    "String",
+                                                ),
+                                                of_type: None,
+                                            },
+                                        ),
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                            ],
+                        ),
+                        input_fields: None,
+                        interfaces: Some(
+                            [],
+                        ),
+                        enum_values: None,
+                        possible_types: None,
+                        specified_by_url: None,
+                    },
+                    Type {
+                        kind: Object,
+                        name: Some(
+                            "PlanetResidentsConnection",
+                        ),
+                        description: Some(
+                            "A connection to a list of items.",
+                        ),
+                        fields: Some(
+                            [
+                                Field {
+                                    name: "pageInfo",
+                                    description: Some(
+                                        "Information to aid in pagination.",
+                                    ),
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: NonNull,
+                                        name: None,
+                                        of_type: Some(
+                                            FieldType {
+                                                kind: Object,
+                                                name: Some(
+                                                    "PageInfo",
+                                                ),
+                                                of_type: None,
+                                            },
+                                        ),
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                Field {
+                                    name: "edges",
+                                    description: Some(
+                                        "A list of edges.",
+                                    ),
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: List,
+                                        name: None,
+                                        of_type: Some(
+                                            FieldType {
+                                                kind: Object,
+                                                name: Some(
+                                                    "PlanetResidentsEdge",
+                                                ),
+                                                of_type: None,
+                                            },
+                                        ),
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                Field {
+                                    name: "totalCount",
+                                    description: Some(
+                                        "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
+                                    ),
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: Scalar,
+                                        name: Some(
+                                            "Int",
+                                        ),
+                                        of_type: None,
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                Field {
+                                    name: "residents",
+                                    description: Some(
+                                        "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
+                                    ),
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: List,
+                                        name: None,
+                                        of_type: Some(
+                                            FieldType {
+                                                kind: Object,
+                                                name: Some(
+                                                    "Person",
+                                                ),
+                                                of_type: None,
+                                            },
+                                        ),
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                            ],
+                        ),
+                        input_fields: None,
+                        interfaces: Some(
+                            [],
+                        ),
+                        enum_values: None,
+                        possible_types: None,
+                        specified_by_url: None,
+                    },
+                    Type {
+                        kind: Object,
+                        name: Some(
+                            "PlanetResidentsEdge",
+                        ),
+                        description: Some(
+                            "An edge in a connection.",
+                        ),
+                        fields: Some(
+                            [
+                                Field {
+                                    name: "node",
+                                    description: Some(
+                                        "The item at the end of the edge",
+                                    ),
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: Object,
+                                        name: Some(
+                                            "Person",
+                                        ),
+                                        of_type: None,
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                Field {
+                                    name: "cursor",
+                                    description: Some(
+                                        "A cursor for use in pagination",
+                                    ),
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: NonNull,
+                                        name: None,
+                                        of_type: Some(
+                                            FieldType {
+                                                kind: Scalar,
+                                                name: Some(
+                                                    "String",
+                                                ),
+                                                of_type: None,
+                                            },
+                                        ),
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                            ],
+                        ),
+                        input_fields: None,
+                        interfaces: Some(
+                            [],
+                        ),
+                        enum_values: None,
+                        possible_types: None,
+                        specified_by_url: None,
+                    },
+                    Type {
+                        kind: Object,
+                        name: Some(
+                            "PlanetsConnection",
+                        ),
+                        description: Some(
+                            "A connection to a list of items.",
+                        ),
+                        fields: Some(
+                            [
+                                Field {
+                                    name: "pageInfo",
+                                    description: Some(
+                                        "Information to aid in pagination.",
+                                    ),
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: NonNull,
+                                        name: None,
+                                        of_type: Some(
+                                            FieldType {
+                                                kind: Object,
+                                                name: Some(
+                                                    "PageInfo",
+                                                ),
+                                                of_type: None,
+                                            },
+                                        ),
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                Field {
+                                    name: "edges",
+                                    description: Some(
+                                        "A list of edges.",
+                                    ),
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: List,
+                                        name: None,
+                                        of_type: Some(
+                                            FieldType {
+                                                kind: Object,
+                                                name: Some(
+                                                    "PlanetsEdge",
+                                                ),
+                                                of_type: None,
+                                            },
+                                        ),
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                Field {
+                                    name: "totalCount",
+                                    description: Some(
+                                        "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
+                                    ),
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: Scalar,
+                                        name: Some(
+                                            "Int",
+                                        ),
+                                        of_type: None,
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                Field {
+                                    name: "planets",
+                                    description: Some(
+                                        "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
+                                    ),
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: List,
+                                        name: None,
+                                        of_type: Some(
+                                            FieldType {
+                                                kind: Object,
+                                                name: Some(
+                                                    "Planet",
+                                                ),
+                                                of_type: None,
+                                            },
+                                        ),
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                            ],
+                        ),
+                        input_fields: None,
+                        interfaces: Some(
+                            [],
+                        ),
+                        enum_values: None,
+                        possible_types: None,
+                        specified_by_url: None,
+                    },
+                    Type {
+                        kind: Object,
+                        name: Some(
+                            "PlanetsEdge",
+                        ),
+                        description: Some(
+                            "An edge in a connection.",
+                        ),
+                        fields: Some(
+                            [
+                                Field {
+                                    name: "node",
+                                    description: Some(
+                                        "The item at the end of the edge",
+                                    ),
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: Object,
+                                        name: Some(
+                                            "Planet",
+                                        ),
+                                        of_type: None,
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                Field {
+                                    name: "cursor",
+                                    description: Some(
+                                        "A cursor for use in pagination",
+                                    ),
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: NonNull,
+                                        name: None,
+                                        of_type: Some(
+                                            FieldType {
+                                                kind: Scalar,
+                                                name: Some(
+                                                    "String",
+                                                ),
+                                                of_type: None,
+                                            },
+                                        ),
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                            ],
+                        ),
+                        input_fields: None,
+                        interfaces: Some(
+                            [],
+                        ),
+                        enum_values: None,
+                        possible_types: None,
+                        specified_by_url: None,
+                    },
+                    Type {
+                        kind: Object,
+                        name: Some(
+                            "Root",
+                        ),
+                        description: None,
+                        fields: Some(
+                            [
+                                Field {
+                                    name: "allFilms",
+                                    description: None,
+                                    args: [
+                                        InputValue {
+                                            name: "after",
+                                            description: None,
+                                            ty: FieldType {
+                                                kind: Scalar,
+                                                name: Some(
+                                                    "String",
+                                                ),
+                                                of_type: None,
+                                            },
+                                            default_value: None,
+                                        },
+                                        InputValue {
+                                            name: "first",
+                                            description: None,
+                                            ty: FieldType {
+                                                kind: Scalar,
+                                                name: Some(
+                                                    "Int",
+                                                ),
+                                                of_type: None,
+                                            },
+                                            default_value: None,
+                                        },
+                                        InputValue {
+                                            name: "before",
+                                            description: None,
+                                            ty: FieldType {
+                                                kind: Scalar,
+                                                name: Some(
+                                                    "String",
+                                                ),
+                                                of_type: None,
+                                            },
+                                            default_value: None,
+                                        },
+                                        InputValue {
+                                            name: "last",
+                                            description: None,
+                                            ty: FieldType {
+                                                kind: Scalar,
+                                                name: Some(
+                                                    "Int",
+                                                ),
+                                                of_type: None,
+                                            },
+                                            default_value: None,
+                                        },
+                                    ],
+                                    ty: FieldType {
+                                        kind: Object,
+                                        name: Some(
+                                            "FilmsConnection",
+                                        ),
+                                        of_type: None,
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                Field {
+                                    name: "film",
+                                    description: None,
+                                    args: [
+                                        InputValue {
+                                            name: "id",
+                                            description: None,
+                                            ty: FieldType {
+                                                kind: Scalar,
+                                                name: Some(
+                                                    "ID",
+                                                ),
+                                                of_type: None,
+                                            },
+                                            default_value: None,
+                                        },
+                                        InputValue {
+                                            name: "filmID",
+                                            description: None,
+                                            ty: FieldType {
+                                                kind: Scalar,
+                                                name: Some(
+                                                    "ID",
+                                                ),
+                                                of_type: None,
+                                            },
+                                            default_value: None,
+                                        },
+                                    ],
+                                    ty: FieldType {
+                                        kind: Object,
+                                        name: Some(
+                                            "Film",
+                                        ),
+                                        of_type: None,
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                Field {
+                                    name: "allPeople",
+                                    description: None,
+                                    args: [
+                                        InputValue {
+                                            name: "after",
+                                            description: None,
+                                            ty: FieldType {
+                                                kind: Scalar,
+                                                name: Some(
+                                                    "String",
+                                                ),
+                                                of_type: None,
+                                            },
+                                            default_value: None,
+                                        },
+                                        InputValue {
+                                            name: "first",
+                                            description: None,
+                                            ty: FieldType {
+                                                kind: Scalar,
+                                                name: Some(
+                                                    "Int",
+                                                ),
+                                                of_type: None,
+                                            },
+                                            default_value: None,
+                                        },
+                                        InputValue {
+                                            name: "before",
+                                            description: None,
+                                            ty: FieldType {
+                                                kind: Scalar,
+                                                name: Some(
+                                                    "String",
+                                                ),
+                                                of_type: None,
+                                            },
+                                            default_value: None,
+                                        },
+                                        InputValue {
+                                            name: "last",
+                                            description: None,
+                                            ty: FieldType {
+                                                kind: Scalar,
+                                                name: Some(
+                                                    "Int",
+                                                ),
+                                                of_type: None,
+                                            },
+                                            default_value: None,
+                                        },
+                                    ],
+                                    ty: FieldType {
+                                        kind: Object,
+                                        name: Some(
+                                            "PeopleConnection",
+                                        ),
+                                        of_type: None,
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                Field {
+                                    name: "person",
+                                    description: None,
+                                    args: [
+                                        InputValue {
+                                            name: "id",
+                                            description: None,
+                                            ty: FieldType {
+                                                kind: Scalar,
+                                                name: Some(
+                                                    "ID",
+                                                ),
+                                                of_type: None,
+                                            },
+                                            default_value: None,
+                                        },
+                                        InputValue {
+                                            name: "personID",
+                                            description: None,
+                                            ty: FieldType {
+                                                kind: Scalar,
+                                                name: Some(
+                                                    "ID",
+                                                ),
+                                                of_type: None,
+                                            },
+                                            default_value: None,
+                                        },
+                                    ],
+                                    ty: FieldType {
+                                        kind: Object,
+                                        name: Some(
+                                            "Person",
+                                        ),
+                                        of_type: None,
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                Field {
+                                    name: "allPlanets",
+                                    description: None,
+                                    args: [
+                                        InputValue {
+                                            name: "after",
+                                            description: None,
+                                            ty: FieldType {
+                                                kind: Scalar,
+                                                name: Some(
+                                                    "String",
+                                                ),
+                                                of_type: None,
+                                            },
+                                            default_value: None,
+                                        },
+                                        InputValue {
+                                            name: "first",
+                                            description: None,
+                                            ty: FieldType {
+                                                kind: Scalar,
+                                                name: Some(
+                                                    "Int",
+                                                ),
+                                                of_type: None,
+                                            },
+                                            default_value: None,
+                                        },
+                                        InputValue {
+                                            name: "before",
+                                            description: None,
+                                            ty: FieldType {
+                                                kind: Scalar,
+                                                name: Some(
+                                                    "String",
+                                                ),
+                                                of_type: None,
+                                            },
+                                            default_value: None,
+                                        },
+                                        InputValue {
+                                            name: "last",
+                                            description: None,
+                                            ty: FieldType {
+                                                kind: Scalar,
+                                                name: Some(
+                                                    "Int",
+                                                ),
+                                                of_type: None,
+                                            },
+                                            default_value: None,
+                                        },
+                                    ],
+                                    ty: FieldType {
+                                        kind: Object,
+                                        name: Some(
+                                            "PlanetsConnection",
+                                        ),
+                                        of_type: None,
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                Field {
+                                    name: "planet",
+                                    description: None,
+                                    args: [
+                                        InputValue {
+                                            name: "id",
+                                            description: None,
+                                            ty: FieldType {
+                                                kind: Scalar,
+                                                name: Some(
+                                                    "ID",
+                                                ),
+                                                of_type: None,
+                                            },
+                                            default_value: None,
+                                        },
+                                        InputValue {
+                                            name: "planetID",
+                                            description: None,
+                                            ty: FieldType {
+                                                kind: Scalar,
+                                                name: Some(
+                                                    "ID",
+                                                ),
+                                                of_type: None,
+                                            },
+                                            default_value: None,
+                                        },
+                                    ],
+                                    ty: FieldType {
+                                        kind: Object,
+                                        name: Some(
+                                            "Planet",
+                                        ),
+                                        of_type: None,
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                Field {
+                                    name: "allSpecies",
+                                    description: None,
+                                    args: [
+                                        InputValue {
+                                            name: "after",
+                                            description: None,
+                                            ty: FieldType {
+                                                kind: Scalar,
+                                                name: Some(
+                                                    "String",
+                                                ),
+                                                of_type: None,
+                                            },
+                                            default_value: None,
+                                        },
+                                        InputValue {
+                                            name: "first",
+                                            description: None,
+                                            ty: FieldType {
+                                                kind: Scalar,
+                                                name: Some(
+                                                    "Int",
+                                                ),
+                                                of_type: None,
+                                            },
+                                            default_value: None,
+                                        },
+                                        InputValue {
+                                            name: "before",
+                                            description: None,
+                                            ty: FieldType {
+                                                kind: Scalar,
+                                                name: Some(
+                                                    "String",
+                                                ),
+                                                of_type: None,
+                                            },
+                                            default_value: None,
+                                        },
+                                        InputValue {
+                                            name: "last",
+                                            description: None,
+                                            ty: FieldType {
+                                                kind: Scalar,
+                                                name: Some(
+                                                    "Int",
+                                                ),
+                                                of_type: None,
+                                            },
+                                            default_value: None,
+                                        },
+                                    ],
+                                    ty: FieldType {
+                                        kind: Object,
+                                        name: Some(
+                                            "SpeciesConnection",
+                                        ),
+                                        of_type: None,
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                Field {
+                                    name: "species",
+                                    description: None,
+                                    args: [
+                                        InputValue {
+                                            name: "id",
+                                            description: None,
+                                            ty: FieldType {
+                                                kind: Scalar,
+                                                name: Some(
+                                                    "ID",
+                                                ),
+                                                of_type: None,
+                                            },
+                                            default_value: None,
+                                        },
+                                        InputValue {
+                                            name: "speciesID",
+                                            description: None,
+                                            ty: FieldType {
+                                                kind: Scalar,
+                                                name: Some(
+                                                    "ID",
+                                                ),
+                                                of_type: None,
+                                            },
+                                            default_value: None,
+                                        },
+                                    ],
+                                    ty: FieldType {
+                                        kind: Object,
+                                        name: Some(
+                                            "Species",
+                                        ),
+                                        of_type: None,
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                Field {
+                                    name: "allStarships",
+                                    description: None,
+                                    args: [
+                                        InputValue {
+                                            name: "after",
+                                            description: None,
+                                            ty: FieldType {
+                                                kind: Scalar,
+                                                name: Some(
+                                                    "String",
+                                                ),
+                                                of_type: None,
+                                            },
+                                            default_value: None,
+                                        },
+                                        InputValue {
+                                            name: "first",
+                                            description: None,
+                                            ty: FieldType {
+                                                kind: Scalar,
+                                                name: Some(
+                                                    "Int",
+                                                ),
+                                                of_type: None,
+                                            },
+                                            default_value: None,
+                                        },
+                                        InputValue {
+                                            name: "before",
+                                            description: None,
+                                            ty: FieldType {
+                                                kind: Scalar,
+                                                name: Some(
+                                                    "String",
+                                                ),
+                                                of_type: None,
+                                            },
+                                            default_value: None,
+                                        },
+                                        InputValue {
+                                            name: "last",
+                                            description: None,
+                                            ty: FieldType {
+                                                kind: Scalar,
+                                                name: Some(
+                                                    "Int",
+                                                ),
+                                                of_type: None,
+                                            },
+                                            default_value: None,
+                                        },
+                                    ],
+                                    ty: FieldType {
+                                        kind: Object,
+                                        name: Some(
+                                            "StarshipsConnection",
+                                        ),
+                                        of_type: None,
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                Field {
+                                    name: "starship",
+                                    description: None,
+                                    args: [
+                                        InputValue {
+                                            name: "id",
+                                            description: None,
+                                            ty: FieldType {
+                                                kind: Scalar,
+                                                name: Some(
+                                                    "ID",
+                                                ),
+                                                of_type: None,
+                                            },
+                                            default_value: None,
+                                        },
+                                        InputValue {
+                                            name: "starshipID",
+                                            description: None,
+                                            ty: FieldType {
+                                                kind: Scalar,
+                                                name: Some(
+                                                    "ID",
+                                                ),
+                                                of_type: None,
+                                            },
+                                            default_value: None,
+                                        },
+                                    ],
+                                    ty: FieldType {
+                                        kind: Object,
+                                        name: Some(
+                                            "Starship",
+                                        ),
+                                        of_type: None,
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                Field {
+                                    name: "allVehicles",
+                                    description: None,
+                                    args: [
+                                        InputValue {
+                                            name: "after",
+                                            description: None,
+                                            ty: FieldType {
+                                                kind: Scalar,
+                                                name: Some(
+                                                    "String",
+                                                ),
+                                                of_type: None,
+                                            },
+                                            default_value: None,
+                                        },
+                                        InputValue {
+                                            name: "first",
+                                            description: None,
+                                            ty: FieldType {
+                                                kind: Scalar,
+                                                name: Some(
+                                                    "Int",
+                                                ),
+                                                of_type: None,
+                                            },
+                                            default_value: None,
+                                        },
+                                        InputValue {
+                                            name: "before",
+                                            description: None,
+                                            ty: FieldType {
+                                                kind: Scalar,
+                                                name: Some(
+                                                    "String",
+                                                ),
+                                                of_type: None,
+                                            },
+                                            default_value: None,
+                                        },
+                                        InputValue {
+                                            name: "last",
+                                            description: None,
+                                            ty: FieldType {
+                                                kind: Scalar,
+                                                name: Some(
+                                                    "Int",
+                                                ),
+                                                of_type: None,
+                                            },
+                                            default_value: None,
+                                        },
+                                    ],
+                                    ty: FieldType {
+                                        kind: Object,
+                                        name: Some(
+                                            "VehiclesConnection",
+                                        ),
+                                        of_type: None,
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                Field {
+                                    name: "vehicle",
+                                    description: None,
+                                    args: [
+                                        InputValue {
+                                            name: "id",
+                                            description: None,
+                                            ty: FieldType {
+                                                kind: Scalar,
+                                                name: Some(
+                                                    "ID",
+                                                ),
+                                                of_type: None,
+                                            },
+                                            default_value: None,
+                                        },
+                                        InputValue {
+                                            name: "vehicleID",
+                                            description: None,
+                                            ty: FieldType {
+                                                kind: Scalar,
+                                                name: Some(
+                                                    "ID",
+                                                ),
+                                                of_type: None,
+                                            },
+                                            default_value: None,
+                                        },
+                                    ],
+                                    ty: FieldType {
+                                        kind: Object,
+                                        name: Some(
+                                            "Vehicle",
+                                        ),
+                                        of_type: None,
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                Field {
+                                    name: "node",
+                                    description: Some(
+                                        "Fetches an object given its ID",
+                                    ),
+                                    args: [
+                                        InputValue {
+                                            name: "id",
+                                            description: Some(
+                                                "The ID of an object",
+                                            ),
+                                            ty: FieldType {
+                                                kind: NonNull,
+                                                name: None,
+                                                of_type: Some(
+                                                    FieldType {
+                                                        kind: Scalar,
+                                                        name: Some(
+                                                            "ID",
+                                                        ),
+                                                        of_type: None,
+                                                    },
+                                                ),
+                                            },
+                                            default_value: None,
+                                        },
+                                    ],
+                                    ty: FieldType {
+                                        kind: Interface,
+                                        name: Some(
+                                            "Node",
+                                        ),
+                                        of_type: None,
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                            ],
+                        ),
+                        input_fields: None,
+                        interfaces: Some(
+                            [],
+                        ),
+                        enum_values: None,
+                        possible_types: None,
+                        specified_by_url: None,
+                    },
+                    Type {
+                        kind: Object,
+                        name: Some(
+                            "Species",
+                        ),
+                        description: Some(
+                            "A type of person or character within the Star Wars Universe.",
+                        ),
+                        fields: Some(
+                            [
+                                Field {
+                                    name: "name",
+                                    description: Some(
+                                        "The name of this species.",
+                                    ),
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: Scalar,
+                                        name: Some(
+                                            "String",
+                                        ),
+                                        of_type: None,
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                Field {
+                                    name: "classification",
+                                    description: Some(
+                                        "The classification of this species, such as \"mammal\" or \"reptile\".",
+                                    ),
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: Scalar,
+                                        name: Some(
+                                            "String",
+                                        ),
+                                        of_type: None,
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                Field {
+                                    name: "designation",
+                                    description: Some(
+                                        "The designation of this species, such as \"sentient\".",
+                                    ),
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: Scalar,
+                                        name: Some(
+                                            "String",
+                                        ),
+                                        of_type: None,
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                Field {
+                                    name: "averageHeight",
+                                    description: Some(
+                                        "The average height of this species in centimeters.",
+                                    ),
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: Scalar,
+                                        name: Some(
+                                            "Float",
+                                        ),
+                                        of_type: None,
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                Field {
+                                    name: "averageLifespan",
+                                    description: Some(
+                                        "The average lifespan of this species in years, null if unknown.",
+                                    ),
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: Scalar,
+                                        name: Some(
+                                            "Int",
+                                        ),
+                                        of_type: None,
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                Field {
+                                    name: "eyeColors",
+                                    description: Some(
+                                        "Common eye colors for this species, null if this species does not typically\nhave eyes.",
+                                    ),
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: List,
+                                        name: None,
+                                        of_type: Some(
+                                            FieldType {
+                                                kind: Scalar,
+                                                name: Some(
+                                                    "String",
+                                                ),
+                                                of_type: None,
+                                            },
+                                        ),
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                Field {
+                                    name: "hairColors",
+                                    description: Some(
+                                        "Common hair colors for this species, null if this species does not typically\nhave hair.",
+                                    ),
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: List,
+                                        name: None,
+                                        of_type: Some(
+                                            FieldType {
+                                                kind: Scalar,
+                                                name: Some(
+                                                    "String",
+                                                ),
+                                                of_type: None,
+                                            },
+                                        ),
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                Field {
+                                    name: "skinColors",
+                                    description: Some(
+                                        "Common skin colors for this species, null if this species does not typically\nhave skin.",
+                                    ),
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: List,
+                                        name: None,
+                                        of_type: Some(
+                                            FieldType {
+                                                kind: Scalar,
+                                                name: Some(
+                                                    "String",
+                                                ),
+                                                of_type: None,
+                                            },
+                                        ),
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                Field {
+                                    name: "language",
+                                    description: Some(
+                                        "The language commonly spoken by this species.",
+                                    ),
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: Scalar,
+                                        name: Some(
+                                            "String",
+                                        ),
+                                        of_type: None,
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                Field {
+                                    name: "homeworld",
+                                    description: Some(
+                                        "A planet that this species originates from.",
+                                    ),
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: Object,
+                                        name: Some(
+                                            "Planet",
+                                        ),
+                                        of_type: None,
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                Field {
+                                    name: "personConnection",
+                                    description: None,
+                                    args: [
+                                        InputValue {
+                                            name: "after",
+                                            description: None,
+                                            ty: FieldType {
+                                                kind: Scalar,
+                                                name: Some(
+                                                    "String",
+                                                ),
+                                                of_type: None,
+                                            },
+                                            default_value: None,
+                                        },
+                                        InputValue {
+                                            name: "first",
+                                            description: None,
+                                            ty: FieldType {
+                                                kind: Scalar,
+                                                name: Some(
+                                                    "Int",
+                                                ),
+                                                of_type: None,
+                                            },
+                                            default_value: None,
+                                        },
+                                        InputValue {
+                                            name: "before",
+                                            description: None,
+                                            ty: FieldType {
+                                                kind: Scalar,
+                                                name: Some(
+                                                    "String",
+                                                ),
+                                                of_type: None,
+                                            },
+                                            default_value: None,
+                                        },
+                                        InputValue {
+                                            name: "last",
+                                            description: None,
+                                            ty: FieldType {
+                                                kind: Scalar,
+                                                name: Some(
+                                                    "Int",
+                                                ),
+                                                of_type: None,
+                                            },
+                                            default_value: None,
+                                        },
+                                    ],
+                                    ty: FieldType {
+                                        kind: Object,
+                                        name: Some(
+                                            "SpeciesPeopleConnection",
+                                        ),
+                                        of_type: None,
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                Field {
+                                    name: "filmConnection",
+                                    description: None,
+                                    args: [
+                                        InputValue {
+                                            name: "after",
+                                            description: None,
+                                            ty: FieldType {
+                                                kind: Scalar,
+                                                name: Some(
+                                                    "String",
+                                                ),
+                                                of_type: None,
+                                            },
+                                            default_value: None,
+                                        },
+                                        InputValue {
+                                            name: "first",
+                                            description: None,
+                                            ty: FieldType {
+                                                kind: Scalar,
+                                                name: Some(
+                                                    "Int",
+                                                ),
+                                                of_type: None,
+                                            },
+                                            default_value: None,
+                                        },
+                                        InputValue {
+                                            name: "before",
+                                            description: None,
+                                            ty: FieldType {
+                                                kind: Scalar,
+                                                name: Some(
+                                                    "String",
+                                                ),
+                                                of_type: None,
+                                            },
+                                            default_value: None,
+                                        },
+                                        InputValue {
+                                            name: "last",
+                                            description: None,
+                                            ty: FieldType {
+                                                kind: Scalar,
+                                                name: Some(
+                                                    "Int",
+                                                ),
+                                                of_type: None,
+                                            },
+                                            default_value: None,
+                                        },
+                                    ],
+                                    ty: FieldType {
+                                        kind: Object,
+                                        name: Some(
+                                            "SpeciesFilmsConnection",
+                                        ),
+                                        of_type: None,
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                Field {
+                                    name: "created",
+                                    description: Some(
+                                        "The ISO 8601 date format of the time that this resource was created.",
+                                    ),
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: Scalar,
+                                        name: Some(
+                                            "String",
+                                        ),
+                                        of_type: None,
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                Field {
+                                    name: "edited",
+                                    description: Some(
+                                        "The ISO 8601 date format of the time that this resource was edited.",
+                                    ),
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: Scalar,
+                                        name: Some(
+                                            "String",
+                                        ),
+                                        of_type: None,
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                Field {
+                                    name: "id",
+                                    description: Some(
+                                        "The ID of an object",
+                                    ),
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: NonNull,
+                                        name: None,
+                                        of_type: Some(
+                                            FieldType {
+                                                kind: Scalar,
+                                                name: Some(
+                                                    "ID",
+                                                ),
+                                                of_type: None,
+                                            },
+                                        ),
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                            ],
+                        ),
+                        input_fields: None,
+                        interfaces: Some(
+                            [
+                                NamedType {
+                                    name: Some(
+                                        "Node",
+                                    ),
+                                },
+                            ],
+                        ),
+                        enum_values: None,
+                        possible_types: None,
+                        specified_by_url: None,
+                    },
+                    Type {
+                        kind: Object,
+                        name: Some(
+                            "SpeciesConnection",
+                        ),
+                        description: Some(
+                            "A connection to a list of items.",
+                        ),
+                        fields: Some(
+                            [
+                                Field {
+                                    name: "pageInfo",
+                                    description: Some(
+                                        "Information to aid in pagination.",
+                                    ),
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: NonNull,
+                                        name: None,
+                                        of_type: Some(
+                                            FieldType {
+                                                kind: Object,
+                                                name: Some(
+                                                    "PageInfo",
+                                                ),
+                                                of_type: None,
+                                            },
+                                        ),
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                Field {
+                                    name: "edges",
+                                    description: Some(
+                                        "A list of edges.",
+                                    ),
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: List,
+                                        name: None,
+                                        of_type: Some(
+                                            FieldType {
+                                                kind: Object,
+                                                name: Some(
+                                                    "SpeciesEdge",
+                                                ),
+                                                of_type: None,
+                                            },
+                                        ),
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                Field {
+                                    name: "totalCount",
+                                    description: Some(
+                                        "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
+                                    ),
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: Scalar,
+                                        name: Some(
+                                            "Int",
+                                        ),
+                                        of_type: None,
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                Field {
+                                    name: "species",
+                                    description: Some(
+                                        "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
+                                    ),
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: List,
+                                        name: None,
+                                        of_type: Some(
+                                            FieldType {
+                                                kind: Object,
+                                                name: Some(
+                                                    "Species",
+                                                ),
+                                                of_type: None,
+                                            },
+                                        ),
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                            ],
+                        ),
+                        input_fields: None,
+                        interfaces: Some(
+                            [],
+                        ),
+                        enum_values: None,
+                        possible_types: None,
+                        specified_by_url: None,
+                    },
+                    Type {
+                        kind: Object,
+                        name: Some(
+                            "SpeciesEdge",
+                        ),
+                        description: Some(
+                            "An edge in a connection.",
+                        ),
+                        fields: Some(
+                            [
+                                Field {
+                                    name: "node",
+                                    description: Some(
+                                        "The item at the end of the edge",
+                                    ),
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: Object,
+                                        name: Some(
+                                            "Species",
+                                        ),
+                                        of_type: None,
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                Field {
+                                    name: "cursor",
+                                    description: Some(
+                                        "A cursor for use in pagination",
+                                    ),
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: NonNull,
+                                        name: None,
+                                        of_type: Some(
+                                            FieldType {
+                                                kind: Scalar,
+                                                name: Some(
+                                                    "String",
+                                                ),
+                                                of_type: None,
+                                            },
+                                        ),
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                            ],
+                        ),
+                        input_fields: None,
+                        interfaces: Some(
+                            [],
+                        ),
+                        enum_values: None,
+                        possible_types: None,
+                        specified_by_url: None,
+                    },
+                    Type {
+                        kind: Object,
+                        name: Some(
+                            "SpeciesFilmsConnection",
+                        ),
+                        description: Some(
+                            "A connection to a list of items.",
+                        ),
+                        fields: Some(
+                            [
+                                Field {
+                                    name: "pageInfo",
+                                    description: Some(
+                                        "Information to aid in pagination.",
+                                    ),
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: NonNull,
+                                        name: None,
+                                        of_type: Some(
+                                            FieldType {
+                                                kind: Object,
+                                                name: Some(
+                                                    "PageInfo",
+                                                ),
+                                                of_type: None,
+                                            },
+                                        ),
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                Field {
+                                    name: "edges",
+                                    description: Some(
+                                        "A list of edges.",
+                                    ),
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: List,
+                                        name: None,
+                                        of_type: Some(
+                                            FieldType {
+                                                kind: Object,
+                                                name: Some(
+                                                    "SpeciesFilmsEdge",
+                                                ),
+                                                of_type: None,
+                                            },
+                                        ),
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                Field {
+                                    name: "totalCount",
+                                    description: Some(
+                                        "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
+                                    ),
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: Scalar,
+                                        name: Some(
+                                            "Int",
+                                        ),
+                                        of_type: None,
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                Field {
+                                    name: "films",
+                                    description: Some(
+                                        "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
+                                    ),
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: List,
+                                        name: None,
+                                        of_type: Some(
+                                            FieldType {
+                                                kind: Object,
+                                                name: Some(
+                                                    "Film",
+                                                ),
+                                                of_type: None,
+                                            },
+                                        ),
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                            ],
+                        ),
+                        input_fields: None,
+                        interfaces: Some(
+                            [],
+                        ),
+                        enum_values: None,
+                        possible_types: None,
+                        specified_by_url: None,
+                    },
+                    Type {
+                        kind: Object,
+                        name: Some(
+                            "SpeciesFilmsEdge",
+                        ),
+                        description: Some(
+                            "An edge in a connection.",
+                        ),
+                        fields: Some(
+                            [
+                                Field {
+                                    name: "node",
+                                    description: Some(
+                                        "The item at the end of the edge",
+                                    ),
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: Object,
+                                        name: Some(
+                                            "Film",
+                                        ),
+                                        of_type: None,
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                Field {
+                                    name: "cursor",
+                                    description: Some(
+                                        "A cursor for use in pagination",
+                                    ),
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: NonNull,
+                                        name: None,
+                                        of_type: Some(
+                                            FieldType {
+                                                kind: Scalar,
+                                                name: Some(
+                                                    "String",
+                                                ),
+                                                of_type: None,
+                                            },
+                                        ),
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                            ],
+                        ),
+                        input_fields: None,
+                        interfaces: Some(
+                            [],
+                        ),
+                        enum_values: None,
+                        possible_types: None,
+                        specified_by_url: None,
+                    },
+                    Type {
+                        kind: Object,
+                        name: Some(
+                            "SpeciesPeopleConnection",
+                        ),
+                        description: Some(
+                            "A connection to a list of items.",
+                        ),
+                        fields: Some(
+                            [
+                                Field {
+                                    name: "pageInfo",
+                                    description: Some(
+                                        "Information to aid in pagination.",
+                                    ),
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: NonNull,
+                                        name: None,
+                                        of_type: Some(
+                                            FieldType {
+                                                kind: Object,
+                                                name: Some(
+                                                    "PageInfo",
+                                                ),
+                                                of_type: None,
+                                            },
+                                        ),
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                Field {
+                                    name: "edges",
+                                    description: Some(
+                                        "A list of edges.",
+                                    ),
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: List,
+                                        name: None,
+                                        of_type: Some(
+                                            FieldType {
+                                                kind: Object,
+                                                name: Some(
+                                                    "SpeciesPeopleEdge",
+                                                ),
+                                                of_type: None,
+                                            },
+                                        ),
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                Field {
+                                    name: "totalCount",
+                                    description: Some(
+                                        "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
+                                    ),
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: Scalar,
+                                        name: Some(
+                                            "Int",
+                                        ),
+                                        of_type: None,
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                Field {
+                                    name: "people",
+                                    description: Some(
+                                        "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
+                                    ),
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: List,
+                                        name: None,
+                                        of_type: Some(
+                                            FieldType {
+                                                kind: Object,
+                                                name: Some(
+                                                    "Person",
+                                                ),
+                                                of_type: None,
+                                            },
+                                        ),
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                            ],
+                        ),
+                        input_fields: None,
+                        interfaces: Some(
+                            [],
+                        ),
+                        enum_values: None,
+                        possible_types: None,
+                        specified_by_url: None,
+                    },
+                    Type {
+                        kind: Object,
+                        name: Some(
+                            "SpeciesPeopleEdge",
+                        ),
+                        description: Some(
+                            "An edge in a connection.",
+                        ),
+                        fields: Some(
+                            [
+                                Field {
+                                    name: "node",
+                                    description: Some(
+                                        "The item at the end of the edge",
+                                    ),
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: Object,
+                                        name: Some(
+                                            "Person",
+                                        ),
+                                        of_type: None,
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                Field {
+                                    name: "cursor",
+                                    description: Some(
+                                        "A cursor for use in pagination",
+                                    ),
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: NonNull,
+                                        name: None,
+                                        of_type: Some(
+                                            FieldType {
+                                                kind: Scalar,
+                                                name: Some(
+                                                    "String",
+                                                ),
+                                                of_type: None,
+                                            },
+                                        ),
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                            ],
+                        ),
+                        input_fields: None,
+                        interfaces: Some(
+                            [],
+                        ),
+                        enum_values: None,
+                        possible_types: None,
+                        specified_by_url: None,
+                    },
+                    Type {
+                        kind: Object,
+                        name: Some(
                             "Starship",
                         ),
                         description: Some(
@@ -3820,166 +5562,6 @@ Some(
                     Type {
                         kind: Object,
                         name: Some(
-                            "StarshipPilotsConnection",
-                        ),
-                        description: Some(
-                            "A connection to a list of items.",
-                        ),
-                        fields: Some(
-                            [
-                                Field {
-                                    name: "pageInfo",
-                                    description: Some(
-                                        "Information to aid in pagination.",
-                                    ),
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: NonNull,
-                                        name: None,
-                                        of_type: Some(
-                                            FieldType {
-                                                kind: Object,
-                                                name: Some(
-                                                    "PageInfo",
-                                                ),
-                                                of_type: None,
-                                            },
-                                        ),
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                Field {
-                                    name: "edges",
-                                    description: Some(
-                                        "A list of edges.",
-                                    ),
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: List,
-                                        name: None,
-                                        of_type: Some(
-                                            FieldType {
-                                                kind: Object,
-                                                name: Some(
-                                                    "StarshipPilotsEdge",
-                                                ),
-                                                of_type: None,
-                                            },
-                                        ),
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                Field {
-                                    name: "totalCount",
-                                    description: Some(
-                                        "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
-                                    ),
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: Scalar,
-                                        name: Some(
-                                            "Int",
-                                        ),
-                                        of_type: None,
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                Field {
-                                    name: "pilots",
-                                    description: Some(
-                                        "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
-                                    ),
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: List,
-                                        name: None,
-                                        of_type: Some(
-                                            FieldType {
-                                                kind: Object,
-                                                name: Some(
-                                                    "Person",
-                                                ),
-                                                of_type: None,
-                                            },
-                                        ),
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                            ],
-                        ),
-                        input_fields: None,
-                        interfaces: Some(
-                            [],
-                        ),
-                        enum_values: None,
-                        possible_types: None,
-                        specified_by_url: None,
-                    },
-                    Type {
-                        kind: Object,
-                        name: Some(
-                            "StarshipPilotsEdge",
-                        ),
-                        description: Some(
-                            "An edge in a connection.",
-                        ),
-                        fields: Some(
-                            [
-                                Field {
-                                    name: "node",
-                                    description: Some(
-                                        "The item at the end of the edge",
-                                    ),
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: Object,
-                                        name: Some(
-                                            "Person",
-                                        ),
-                                        of_type: None,
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                Field {
-                                    name: "cursor",
-                                    description: Some(
-                                        "A cursor for use in pagination",
-                                    ),
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: NonNull,
-                                        name: None,
-                                        of_type: Some(
-                                            FieldType {
-                                                kind: Scalar,
-                                                name: Some(
-                                                    "String",
-                                                ),
-                                                of_type: None,
-                                            },
-                                        ),
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                            ],
-                        ),
-                        input_fields: None,
-                        interfaces: Some(
-                            [],
-                        ),
-                        enum_values: None,
-                        possible_types: None,
-                        specified_by_url: None,
-                    },
-                    Type {
-                        kind: Object,
-                        name: Some(
                             "StarshipFilmsConnection",
                         ),
                         description: Some(
@@ -4140,7 +5722,7 @@ Some(
                     Type {
                         kind: Object,
                         name: Some(
-                            "PersonVehiclesConnection",
+                            "StarshipPilotsConnection",
                         ),
                         description: Some(
                             "A connection to a list of items.",
@@ -4182,7 +5764,7 @@ Some(
                                             FieldType {
                                                 kind: Object,
                                                 name: Some(
-                                                    "PersonVehiclesEdge",
+                                                    "StarshipPilotsEdge",
                                                 ),
                                                 of_type: None,
                                             },
@@ -4208,7 +5790,7 @@ Some(
                                     deprecation_reason: None,
                                 },
                                 Field {
-                                    name: "vehicles",
+                                    name: "pilots",
                                     description: Some(
                                         "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
                                     ),
@@ -4220,7 +5802,7 @@ Some(
                                             FieldType {
                                                 kind: Object,
                                                 name: Some(
-                                                    "Vehicle",
+                                                    "Person",
                                                 ),
                                                 of_type: None,
                                             },
@@ -4242,7 +5824,7 @@ Some(
                     Type {
                         kind: Object,
                         name: Some(
-                            "PersonVehiclesEdge",
+                            "StarshipPilotsEdge",
                         ),
                         description: Some(
                             "An edge in a connection.",
@@ -4258,7 +5840,7 @@ Some(
                                     ty: FieldType {
                                         kind: Object,
                                         name: Some(
-                                            "Vehicle",
+                                            "Person",
                                         ),
                                         of_type: None,
                                     },
@@ -4293,6 +5875,181 @@ Some(
                         interfaces: Some(
                             [],
                         ),
+                        enum_values: None,
+                        possible_types: None,
+                        specified_by_url: None,
+                    },
+                    Type {
+                        kind: Object,
+                        name: Some(
+                            "StarshipsConnection",
+                        ),
+                        description: Some(
+                            "A connection to a list of items.",
+                        ),
+                        fields: Some(
+                            [
+                                Field {
+                                    name: "pageInfo",
+                                    description: Some(
+                                        "Information to aid in pagination.",
+                                    ),
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: NonNull,
+                                        name: None,
+                                        of_type: Some(
+                                            FieldType {
+                                                kind: Object,
+                                                name: Some(
+                                                    "PageInfo",
+                                                ),
+                                                of_type: None,
+                                            },
+                                        ),
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                Field {
+                                    name: "edges",
+                                    description: Some(
+                                        "A list of edges.",
+                                    ),
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: List,
+                                        name: None,
+                                        of_type: Some(
+                                            FieldType {
+                                                kind: Object,
+                                                name: Some(
+                                                    "StarshipsEdge",
+                                                ),
+                                                of_type: None,
+                                            },
+                                        ),
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                Field {
+                                    name: "totalCount",
+                                    description: Some(
+                                        "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
+                                    ),
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: Scalar,
+                                        name: Some(
+                                            "Int",
+                                        ),
+                                        of_type: None,
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                Field {
+                                    name: "starships",
+                                    description: Some(
+                                        "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
+                                    ),
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: List,
+                                        name: None,
+                                        of_type: Some(
+                                            FieldType {
+                                                kind: Object,
+                                                name: Some(
+                                                    "Starship",
+                                                ),
+                                                of_type: None,
+                                            },
+                                        ),
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                            ],
+                        ),
+                        input_fields: None,
+                        interfaces: Some(
+                            [],
+                        ),
+                        enum_values: None,
+                        possible_types: None,
+                        specified_by_url: None,
+                    },
+                    Type {
+                        kind: Object,
+                        name: Some(
+                            "StarshipsEdge",
+                        ),
+                        description: Some(
+                            "An edge in a connection.",
+                        ),
+                        fields: Some(
+                            [
+                                Field {
+                                    name: "node",
+                                    description: Some(
+                                        "The item at the end of the edge",
+                                    ),
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: Object,
+                                        name: Some(
+                                            "Starship",
+                                        ),
+                                        of_type: None,
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                Field {
+                                    name: "cursor",
+                                    description: Some(
+                                        "A cursor for use in pagination",
+                                    ),
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: NonNull,
+                                        name: None,
+                                        of_type: Some(
+                                            FieldType {
+                                                kind: Scalar,
+                                                name: Some(
+                                                    "String",
+                                                ),
+                                                of_type: None,
+                                            },
+                                        ),
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                            ],
+                        ),
+                        input_fields: None,
+                        interfaces: Some(
+                            [],
+                        ),
+                        enum_values: None,
+                        possible_types: None,
+                        specified_by_url: None,
+                    },
+                    Type {
+                        kind: Scalar,
+                        name: Some(
+                            "String",
+                        ),
+                        description: Some(
+                            "The `String` scalar type represents textual data, represented as UTF-8\ncharacter sequences. The String type is most often used by GraphQL to\nrepresent free-form human-readable text.",
+                        ),
+                        fields: None,
+                        input_fields: None,
+                        interfaces: None,
                         enum_values: None,
                         possible_types: None,
                         specified_by_url: None,
@@ -4688,166 +6445,6 @@ Some(
                     Type {
                         kind: Object,
                         name: Some(
-                            "VehiclePilotsConnection",
-                        ),
-                        description: Some(
-                            "A connection to a list of items.",
-                        ),
-                        fields: Some(
-                            [
-                                Field {
-                                    name: "pageInfo",
-                                    description: Some(
-                                        "Information to aid in pagination.",
-                                    ),
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: NonNull,
-                                        name: None,
-                                        of_type: Some(
-                                            FieldType {
-                                                kind: Object,
-                                                name: Some(
-                                                    "PageInfo",
-                                                ),
-                                                of_type: None,
-                                            },
-                                        ),
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                Field {
-                                    name: "edges",
-                                    description: Some(
-                                        "A list of edges.",
-                                    ),
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: List,
-                                        name: None,
-                                        of_type: Some(
-                                            FieldType {
-                                                kind: Object,
-                                                name: Some(
-                                                    "VehiclePilotsEdge",
-                                                ),
-                                                of_type: None,
-                                            },
-                                        ),
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                Field {
-                                    name: "totalCount",
-                                    description: Some(
-                                        "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
-                                    ),
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: Scalar,
-                                        name: Some(
-                                            "Int",
-                                        ),
-                                        of_type: None,
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                Field {
-                                    name: "pilots",
-                                    description: Some(
-                                        "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
-                                    ),
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: List,
-                                        name: None,
-                                        of_type: Some(
-                                            FieldType {
-                                                kind: Object,
-                                                name: Some(
-                                                    "Person",
-                                                ),
-                                                of_type: None,
-                                            },
-                                        ),
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                            ],
-                        ),
-                        input_fields: None,
-                        interfaces: Some(
-                            [],
-                        ),
-                        enum_values: None,
-                        possible_types: None,
-                        specified_by_url: None,
-                    },
-                    Type {
-                        kind: Object,
-                        name: Some(
-                            "VehiclePilotsEdge",
-                        ),
-                        description: Some(
-                            "An edge in a connection.",
-                        ),
-                        fields: Some(
-                            [
-                                Field {
-                                    name: "node",
-                                    description: Some(
-                                        "The item at the end of the edge",
-                                    ),
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: Object,
-                                        name: Some(
-                                            "Person",
-                                        ),
-                                        of_type: None,
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                Field {
-                                    name: "cursor",
-                                    description: Some(
-                                        "A cursor for use in pagination",
-                                    ),
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: NonNull,
-                                        name: None,
-                                        of_type: Some(
-                                            FieldType {
-                                                kind: Scalar,
-                                                name: Some(
-                                                    "String",
-                                                ),
-                                                of_type: None,
-                                            },
-                                        ),
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                            ],
-                        ),
-                        input_fields: None,
-                        interfaces: Some(
-                            [],
-                        ),
-                        enum_values: None,
-                        possible_types: None,
-                        specified_by_url: None,
-                    },
-                    Type {
-                        kind: Object,
-                        name: Some(
                             "VehicleFilmsConnection",
                         ),
                         description: Some(
@@ -5008,7 +6605,7 @@ Some(
                     Type {
                         kind: Object,
                         name: Some(
-                            "PlanetFilmsConnection",
+                            "VehiclePilotsConnection",
                         ),
                         description: Some(
                             "A connection to a list of items.",
@@ -5050,7 +6647,7 @@ Some(
                                             FieldType {
                                                 kind: Object,
                                                 name: Some(
-                                                    "PlanetFilmsEdge",
+                                                    "VehiclePilotsEdge",
                                                 ),
                                                 of_type: None,
                                             },
@@ -5076,167 +6673,7 @@ Some(
                                     deprecation_reason: None,
                                 },
                                 Field {
-                                    name: "films",
-                                    description: Some(
-                                        "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
-                                    ),
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: List,
-                                        name: None,
-                                        of_type: Some(
-                                            FieldType {
-                                                kind: Object,
-                                                name: Some(
-                                                    "Film",
-                                                ),
-                                                of_type: None,
-                                            },
-                                        ),
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                            ],
-                        ),
-                        input_fields: None,
-                        interfaces: Some(
-                            [],
-                        ),
-                        enum_values: None,
-                        possible_types: None,
-                        specified_by_url: None,
-                    },
-                    Type {
-                        kind: Object,
-                        name: Some(
-                            "PlanetFilmsEdge",
-                        ),
-                        description: Some(
-                            "An edge in a connection.",
-                        ),
-                        fields: Some(
-                            [
-                                Field {
-                                    name: "node",
-                                    description: Some(
-                                        "The item at the end of the edge",
-                                    ),
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: Object,
-                                        name: Some(
-                                            "Film",
-                                        ),
-                                        of_type: None,
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                Field {
-                                    name: "cursor",
-                                    description: Some(
-                                        "A cursor for use in pagination",
-                                    ),
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: NonNull,
-                                        name: None,
-                                        of_type: Some(
-                                            FieldType {
-                                                kind: Scalar,
-                                                name: Some(
-                                                    "String",
-                                                ),
-                                                of_type: None,
-                                            },
-                                        ),
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                            ],
-                        ),
-                        input_fields: None,
-                        interfaces: Some(
-                            [],
-                        ),
-                        enum_values: None,
-                        possible_types: None,
-                        specified_by_url: None,
-                    },
-                    Type {
-                        kind: Object,
-                        name: Some(
-                            "SpeciesPeopleConnection",
-                        ),
-                        description: Some(
-                            "A connection to a list of items.",
-                        ),
-                        fields: Some(
-                            [
-                                Field {
-                                    name: "pageInfo",
-                                    description: Some(
-                                        "Information to aid in pagination.",
-                                    ),
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: NonNull,
-                                        name: None,
-                                        of_type: Some(
-                                            FieldType {
-                                                kind: Object,
-                                                name: Some(
-                                                    "PageInfo",
-                                                ),
-                                                of_type: None,
-                                            },
-                                        ),
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                Field {
-                                    name: "edges",
-                                    description: Some(
-                                        "A list of edges.",
-                                    ),
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: List,
-                                        name: None,
-                                        of_type: Some(
-                                            FieldType {
-                                                kind: Object,
-                                                name: Some(
-                                                    "SpeciesPeopleEdge",
-                                                ),
-                                                of_type: None,
-                                            },
-                                        ),
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                Field {
-                                    name: "totalCount",
-                                    description: Some(
-                                        "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
-                                    ),
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: Scalar,
-                                        name: Some(
-                                            "Int",
-                                        ),
-                                        of_type: None,
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                Field {
-                                    name: "people",
+                                    name: "pilots",
                                     description: Some(
                                         "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
                                     ),
@@ -5270,7 +6707,7 @@ Some(
                     Type {
                         kind: Object,
                         name: Some(
-                            "SpeciesPeopleEdge",
+                            "VehiclePilotsEdge",
                         ),
                         description: Some(
                             "An edge in a connection.",
@@ -5287,1446 +6724,6 @@ Some(
                                         kind: Object,
                                         name: Some(
                                             "Person",
-                                        ),
-                                        of_type: None,
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                Field {
-                                    name: "cursor",
-                                    description: Some(
-                                        "A cursor for use in pagination",
-                                    ),
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: NonNull,
-                                        name: None,
-                                        of_type: Some(
-                                            FieldType {
-                                                kind: Scalar,
-                                                name: Some(
-                                                    "String",
-                                                ),
-                                                of_type: None,
-                                            },
-                                        ),
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                            ],
-                        ),
-                        input_fields: None,
-                        interfaces: Some(
-                            [],
-                        ),
-                        enum_values: None,
-                        possible_types: None,
-                        specified_by_url: None,
-                    },
-                    Type {
-                        kind: Object,
-                        name: Some(
-                            "SpeciesFilmsConnection",
-                        ),
-                        description: Some(
-                            "A connection to a list of items.",
-                        ),
-                        fields: Some(
-                            [
-                                Field {
-                                    name: "pageInfo",
-                                    description: Some(
-                                        "Information to aid in pagination.",
-                                    ),
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: NonNull,
-                                        name: None,
-                                        of_type: Some(
-                                            FieldType {
-                                                kind: Object,
-                                                name: Some(
-                                                    "PageInfo",
-                                                ),
-                                                of_type: None,
-                                            },
-                                        ),
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                Field {
-                                    name: "edges",
-                                    description: Some(
-                                        "A list of edges.",
-                                    ),
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: List,
-                                        name: None,
-                                        of_type: Some(
-                                            FieldType {
-                                                kind: Object,
-                                                name: Some(
-                                                    "SpeciesFilmsEdge",
-                                                ),
-                                                of_type: None,
-                                            },
-                                        ),
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                Field {
-                                    name: "totalCount",
-                                    description: Some(
-                                        "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
-                                    ),
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: Scalar,
-                                        name: Some(
-                                            "Int",
-                                        ),
-                                        of_type: None,
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                Field {
-                                    name: "films",
-                                    description: Some(
-                                        "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
-                                    ),
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: List,
-                                        name: None,
-                                        of_type: Some(
-                                            FieldType {
-                                                kind: Object,
-                                                name: Some(
-                                                    "Film",
-                                                ),
-                                                of_type: None,
-                                            },
-                                        ),
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                            ],
-                        ),
-                        input_fields: None,
-                        interfaces: Some(
-                            [],
-                        ),
-                        enum_values: None,
-                        possible_types: None,
-                        specified_by_url: None,
-                    },
-                    Type {
-                        kind: Object,
-                        name: Some(
-                            "SpeciesFilmsEdge",
-                        ),
-                        description: Some(
-                            "An edge in a connection.",
-                        ),
-                        fields: Some(
-                            [
-                                Field {
-                                    name: "node",
-                                    description: Some(
-                                        "The item at the end of the edge",
-                                    ),
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: Object,
-                                        name: Some(
-                                            "Film",
-                                        ),
-                                        of_type: None,
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                Field {
-                                    name: "cursor",
-                                    description: Some(
-                                        "A cursor for use in pagination",
-                                    ),
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: NonNull,
-                                        name: None,
-                                        of_type: Some(
-                                            FieldType {
-                                                kind: Scalar,
-                                                name: Some(
-                                                    "String",
-                                                ),
-                                                of_type: None,
-                                            },
-                                        ),
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                            ],
-                        ),
-                        input_fields: None,
-                        interfaces: Some(
-                            [],
-                        ),
-                        enum_values: None,
-                        possible_types: None,
-                        specified_by_url: None,
-                    },
-                    Type {
-                        kind: Object,
-                        name: Some(
-                            "FilmStarshipsConnection",
-                        ),
-                        description: Some(
-                            "A connection to a list of items.",
-                        ),
-                        fields: Some(
-                            [
-                                Field {
-                                    name: "pageInfo",
-                                    description: Some(
-                                        "Information to aid in pagination.",
-                                    ),
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: NonNull,
-                                        name: None,
-                                        of_type: Some(
-                                            FieldType {
-                                                kind: Object,
-                                                name: Some(
-                                                    "PageInfo",
-                                                ),
-                                                of_type: None,
-                                            },
-                                        ),
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                Field {
-                                    name: "edges",
-                                    description: Some(
-                                        "A list of edges.",
-                                    ),
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: List,
-                                        name: None,
-                                        of_type: Some(
-                                            FieldType {
-                                                kind: Object,
-                                                name: Some(
-                                                    "FilmStarshipsEdge",
-                                                ),
-                                                of_type: None,
-                                            },
-                                        ),
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                Field {
-                                    name: "totalCount",
-                                    description: Some(
-                                        "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
-                                    ),
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: Scalar,
-                                        name: Some(
-                                            "Int",
-                                        ),
-                                        of_type: None,
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                Field {
-                                    name: "starships",
-                                    description: Some(
-                                        "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
-                                    ),
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: List,
-                                        name: None,
-                                        of_type: Some(
-                                            FieldType {
-                                                kind: Object,
-                                                name: Some(
-                                                    "Starship",
-                                                ),
-                                                of_type: None,
-                                            },
-                                        ),
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                            ],
-                        ),
-                        input_fields: None,
-                        interfaces: Some(
-                            [],
-                        ),
-                        enum_values: None,
-                        possible_types: None,
-                        specified_by_url: None,
-                    },
-                    Type {
-                        kind: Object,
-                        name: Some(
-                            "FilmStarshipsEdge",
-                        ),
-                        description: Some(
-                            "An edge in a connection.",
-                        ),
-                        fields: Some(
-                            [
-                                Field {
-                                    name: "node",
-                                    description: Some(
-                                        "The item at the end of the edge",
-                                    ),
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: Object,
-                                        name: Some(
-                                            "Starship",
-                                        ),
-                                        of_type: None,
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                Field {
-                                    name: "cursor",
-                                    description: Some(
-                                        "A cursor for use in pagination",
-                                    ),
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: NonNull,
-                                        name: None,
-                                        of_type: Some(
-                                            FieldType {
-                                                kind: Scalar,
-                                                name: Some(
-                                                    "String",
-                                                ),
-                                                of_type: None,
-                                            },
-                                        ),
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                            ],
-                        ),
-                        input_fields: None,
-                        interfaces: Some(
-                            [],
-                        ),
-                        enum_values: None,
-                        possible_types: None,
-                        specified_by_url: None,
-                    },
-                    Type {
-                        kind: Object,
-                        name: Some(
-                            "FilmVehiclesConnection",
-                        ),
-                        description: Some(
-                            "A connection to a list of items.",
-                        ),
-                        fields: Some(
-                            [
-                                Field {
-                                    name: "pageInfo",
-                                    description: Some(
-                                        "Information to aid in pagination.",
-                                    ),
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: NonNull,
-                                        name: None,
-                                        of_type: Some(
-                                            FieldType {
-                                                kind: Object,
-                                                name: Some(
-                                                    "PageInfo",
-                                                ),
-                                                of_type: None,
-                                            },
-                                        ),
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                Field {
-                                    name: "edges",
-                                    description: Some(
-                                        "A list of edges.",
-                                    ),
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: List,
-                                        name: None,
-                                        of_type: Some(
-                                            FieldType {
-                                                kind: Object,
-                                                name: Some(
-                                                    "FilmVehiclesEdge",
-                                                ),
-                                                of_type: None,
-                                            },
-                                        ),
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                Field {
-                                    name: "totalCount",
-                                    description: Some(
-                                        "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
-                                    ),
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: Scalar,
-                                        name: Some(
-                                            "Int",
-                                        ),
-                                        of_type: None,
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                Field {
-                                    name: "vehicles",
-                                    description: Some(
-                                        "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
-                                    ),
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: List,
-                                        name: None,
-                                        of_type: Some(
-                                            FieldType {
-                                                kind: Object,
-                                                name: Some(
-                                                    "Vehicle",
-                                                ),
-                                                of_type: None,
-                                            },
-                                        ),
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                            ],
-                        ),
-                        input_fields: None,
-                        interfaces: Some(
-                            [],
-                        ),
-                        enum_values: None,
-                        possible_types: None,
-                        specified_by_url: None,
-                    },
-                    Type {
-                        kind: Object,
-                        name: Some(
-                            "FilmVehiclesEdge",
-                        ),
-                        description: Some(
-                            "An edge in a connection.",
-                        ),
-                        fields: Some(
-                            [
-                                Field {
-                                    name: "node",
-                                    description: Some(
-                                        "The item at the end of the edge",
-                                    ),
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: Object,
-                                        name: Some(
-                                            "Vehicle",
-                                        ),
-                                        of_type: None,
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                Field {
-                                    name: "cursor",
-                                    description: Some(
-                                        "A cursor for use in pagination",
-                                    ),
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: NonNull,
-                                        name: None,
-                                        of_type: Some(
-                                            FieldType {
-                                                kind: Scalar,
-                                                name: Some(
-                                                    "String",
-                                                ),
-                                                of_type: None,
-                                            },
-                                        ),
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                            ],
-                        ),
-                        input_fields: None,
-                        interfaces: Some(
-                            [],
-                        ),
-                        enum_values: None,
-                        possible_types: None,
-                        specified_by_url: None,
-                    },
-                    Type {
-                        kind: Object,
-                        name: Some(
-                            "FilmCharactersConnection",
-                        ),
-                        description: Some(
-                            "A connection to a list of items.",
-                        ),
-                        fields: Some(
-                            [
-                                Field {
-                                    name: "pageInfo",
-                                    description: Some(
-                                        "Information to aid in pagination.",
-                                    ),
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: NonNull,
-                                        name: None,
-                                        of_type: Some(
-                                            FieldType {
-                                                kind: Object,
-                                                name: Some(
-                                                    "PageInfo",
-                                                ),
-                                                of_type: None,
-                                            },
-                                        ),
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                Field {
-                                    name: "edges",
-                                    description: Some(
-                                        "A list of edges.",
-                                    ),
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: List,
-                                        name: None,
-                                        of_type: Some(
-                                            FieldType {
-                                                kind: Object,
-                                                name: Some(
-                                                    "FilmCharactersEdge",
-                                                ),
-                                                of_type: None,
-                                            },
-                                        ),
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                Field {
-                                    name: "totalCount",
-                                    description: Some(
-                                        "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
-                                    ),
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: Scalar,
-                                        name: Some(
-                                            "Int",
-                                        ),
-                                        of_type: None,
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                Field {
-                                    name: "characters",
-                                    description: Some(
-                                        "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
-                                    ),
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: List,
-                                        name: None,
-                                        of_type: Some(
-                                            FieldType {
-                                                kind: Object,
-                                                name: Some(
-                                                    "Person",
-                                                ),
-                                                of_type: None,
-                                            },
-                                        ),
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                            ],
-                        ),
-                        input_fields: None,
-                        interfaces: Some(
-                            [],
-                        ),
-                        enum_values: None,
-                        possible_types: None,
-                        specified_by_url: None,
-                    },
-                    Type {
-                        kind: Object,
-                        name: Some(
-                            "FilmCharactersEdge",
-                        ),
-                        description: Some(
-                            "An edge in a connection.",
-                        ),
-                        fields: Some(
-                            [
-                                Field {
-                                    name: "node",
-                                    description: Some(
-                                        "The item at the end of the edge",
-                                    ),
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: Object,
-                                        name: Some(
-                                            "Person",
-                                        ),
-                                        of_type: None,
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                Field {
-                                    name: "cursor",
-                                    description: Some(
-                                        "A cursor for use in pagination",
-                                    ),
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: NonNull,
-                                        name: None,
-                                        of_type: Some(
-                                            FieldType {
-                                                kind: Scalar,
-                                                name: Some(
-                                                    "String",
-                                                ),
-                                                of_type: None,
-                                            },
-                                        ),
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                            ],
-                        ),
-                        input_fields: None,
-                        interfaces: Some(
-                            [],
-                        ),
-                        enum_values: None,
-                        possible_types: None,
-                        specified_by_url: None,
-                    },
-                    Type {
-                        kind: Object,
-                        name: Some(
-                            "FilmPlanetsConnection",
-                        ),
-                        description: Some(
-                            "A connection to a list of items.",
-                        ),
-                        fields: Some(
-                            [
-                                Field {
-                                    name: "pageInfo",
-                                    description: Some(
-                                        "Information to aid in pagination.",
-                                    ),
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: NonNull,
-                                        name: None,
-                                        of_type: Some(
-                                            FieldType {
-                                                kind: Object,
-                                                name: Some(
-                                                    "PageInfo",
-                                                ),
-                                                of_type: None,
-                                            },
-                                        ),
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                Field {
-                                    name: "edges",
-                                    description: Some(
-                                        "A list of edges.",
-                                    ),
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: List,
-                                        name: None,
-                                        of_type: Some(
-                                            FieldType {
-                                                kind: Object,
-                                                name: Some(
-                                                    "FilmPlanetsEdge",
-                                                ),
-                                                of_type: None,
-                                            },
-                                        ),
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                Field {
-                                    name: "totalCount",
-                                    description: Some(
-                                        "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
-                                    ),
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: Scalar,
-                                        name: Some(
-                                            "Int",
-                                        ),
-                                        of_type: None,
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                Field {
-                                    name: "planets",
-                                    description: Some(
-                                        "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
-                                    ),
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: List,
-                                        name: None,
-                                        of_type: Some(
-                                            FieldType {
-                                                kind: Object,
-                                                name: Some(
-                                                    "Planet",
-                                                ),
-                                                of_type: None,
-                                            },
-                                        ),
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                            ],
-                        ),
-                        input_fields: None,
-                        interfaces: Some(
-                            [],
-                        ),
-                        enum_values: None,
-                        possible_types: None,
-                        specified_by_url: None,
-                    },
-                    Type {
-                        kind: Object,
-                        name: Some(
-                            "FilmPlanetsEdge",
-                        ),
-                        description: Some(
-                            "An edge in a connection.",
-                        ),
-                        fields: Some(
-                            [
-                                Field {
-                                    name: "node",
-                                    description: Some(
-                                        "The item at the end of the edge",
-                                    ),
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: Object,
-                                        name: Some(
-                                            "Planet",
-                                        ),
-                                        of_type: None,
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                Field {
-                                    name: "cursor",
-                                    description: Some(
-                                        "A cursor for use in pagination",
-                                    ),
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: NonNull,
-                                        name: None,
-                                        of_type: Some(
-                                            FieldType {
-                                                kind: Scalar,
-                                                name: Some(
-                                                    "String",
-                                                ),
-                                                of_type: None,
-                                            },
-                                        ),
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                            ],
-                        ),
-                        input_fields: None,
-                        interfaces: Some(
-                            [],
-                        ),
-                        enum_values: None,
-                        possible_types: None,
-                        specified_by_url: None,
-                    },
-                    Type {
-                        kind: Object,
-                        name: Some(
-                            "PeopleConnection",
-                        ),
-                        description: Some(
-                            "A connection to a list of items.",
-                        ),
-                        fields: Some(
-                            [
-                                Field {
-                                    name: "pageInfo",
-                                    description: Some(
-                                        "Information to aid in pagination.",
-                                    ),
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: NonNull,
-                                        name: None,
-                                        of_type: Some(
-                                            FieldType {
-                                                kind: Object,
-                                                name: Some(
-                                                    "PageInfo",
-                                                ),
-                                                of_type: None,
-                                            },
-                                        ),
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                Field {
-                                    name: "edges",
-                                    description: Some(
-                                        "A list of edges.",
-                                    ),
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: List,
-                                        name: None,
-                                        of_type: Some(
-                                            FieldType {
-                                                kind: Object,
-                                                name: Some(
-                                                    "PeopleEdge",
-                                                ),
-                                                of_type: None,
-                                            },
-                                        ),
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                Field {
-                                    name: "totalCount",
-                                    description: Some(
-                                        "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
-                                    ),
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: Scalar,
-                                        name: Some(
-                                            "Int",
-                                        ),
-                                        of_type: None,
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                Field {
-                                    name: "people",
-                                    description: Some(
-                                        "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
-                                    ),
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: List,
-                                        name: None,
-                                        of_type: Some(
-                                            FieldType {
-                                                kind: Object,
-                                                name: Some(
-                                                    "Person",
-                                                ),
-                                                of_type: None,
-                                            },
-                                        ),
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                            ],
-                        ),
-                        input_fields: None,
-                        interfaces: Some(
-                            [],
-                        ),
-                        enum_values: None,
-                        possible_types: None,
-                        specified_by_url: None,
-                    },
-                    Type {
-                        kind: Object,
-                        name: Some(
-                            "PeopleEdge",
-                        ),
-                        description: Some(
-                            "An edge in a connection.",
-                        ),
-                        fields: Some(
-                            [
-                                Field {
-                                    name: "node",
-                                    description: Some(
-                                        "The item at the end of the edge",
-                                    ),
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: Object,
-                                        name: Some(
-                                            "Person",
-                                        ),
-                                        of_type: None,
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                Field {
-                                    name: "cursor",
-                                    description: Some(
-                                        "A cursor for use in pagination",
-                                    ),
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: NonNull,
-                                        name: None,
-                                        of_type: Some(
-                                            FieldType {
-                                                kind: Scalar,
-                                                name: Some(
-                                                    "String",
-                                                ),
-                                                of_type: None,
-                                            },
-                                        ),
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                            ],
-                        ),
-                        input_fields: None,
-                        interfaces: Some(
-                            [],
-                        ),
-                        enum_values: None,
-                        possible_types: None,
-                        specified_by_url: None,
-                    },
-                    Type {
-                        kind: Object,
-                        name: Some(
-                            "PlanetsConnection",
-                        ),
-                        description: Some(
-                            "A connection to a list of items.",
-                        ),
-                        fields: Some(
-                            [
-                                Field {
-                                    name: "pageInfo",
-                                    description: Some(
-                                        "Information to aid in pagination.",
-                                    ),
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: NonNull,
-                                        name: None,
-                                        of_type: Some(
-                                            FieldType {
-                                                kind: Object,
-                                                name: Some(
-                                                    "PageInfo",
-                                                ),
-                                                of_type: None,
-                                            },
-                                        ),
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                Field {
-                                    name: "edges",
-                                    description: Some(
-                                        "A list of edges.",
-                                    ),
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: List,
-                                        name: None,
-                                        of_type: Some(
-                                            FieldType {
-                                                kind: Object,
-                                                name: Some(
-                                                    "PlanetsEdge",
-                                                ),
-                                                of_type: None,
-                                            },
-                                        ),
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                Field {
-                                    name: "totalCount",
-                                    description: Some(
-                                        "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
-                                    ),
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: Scalar,
-                                        name: Some(
-                                            "Int",
-                                        ),
-                                        of_type: None,
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                Field {
-                                    name: "planets",
-                                    description: Some(
-                                        "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
-                                    ),
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: List,
-                                        name: None,
-                                        of_type: Some(
-                                            FieldType {
-                                                kind: Object,
-                                                name: Some(
-                                                    "Planet",
-                                                ),
-                                                of_type: None,
-                                            },
-                                        ),
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                            ],
-                        ),
-                        input_fields: None,
-                        interfaces: Some(
-                            [],
-                        ),
-                        enum_values: None,
-                        possible_types: None,
-                        specified_by_url: None,
-                    },
-                    Type {
-                        kind: Object,
-                        name: Some(
-                            "PlanetsEdge",
-                        ),
-                        description: Some(
-                            "An edge in a connection.",
-                        ),
-                        fields: Some(
-                            [
-                                Field {
-                                    name: "node",
-                                    description: Some(
-                                        "The item at the end of the edge",
-                                    ),
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: Object,
-                                        name: Some(
-                                            "Planet",
-                                        ),
-                                        of_type: None,
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                Field {
-                                    name: "cursor",
-                                    description: Some(
-                                        "A cursor for use in pagination",
-                                    ),
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: NonNull,
-                                        name: None,
-                                        of_type: Some(
-                                            FieldType {
-                                                kind: Scalar,
-                                                name: Some(
-                                                    "String",
-                                                ),
-                                                of_type: None,
-                                            },
-                                        ),
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                            ],
-                        ),
-                        input_fields: None,
-                        interfaces: Some(
-                            [],
-                        ),
-                        enum_values: None,
-                        possible_types: None,
-                        specified_by_url: None,
-                    },
-                    Type {
-                        kind: Object,
-                        name: Some(
-                            "SpeciesConnection",
-                        ),
-                        description: Some(
-                            "A connection to a list of items.",
-                        ),
-                        fields: Some(
-                            [
-                                Field {
-                                    name: "pageInfo",
-                                    description: Some(
-                                        "Information to aid in pagination.",
-                                    ),
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: NonNull,
-                                        name: None,
-                                        of_type: Some(
-                                            FieldType {
-                                                kind: Object,
-                                                name: Some(
-                                                    "PageInfo",
-                                                ),
-                                                of_type: None,
-                                            },
-                                        ),
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                Field {
-                                    name: "edges",
-                                    description: Some(
-                                        "A list of edges.",
-                                    ),
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: List,
-                                        name: None,
-                                        of_type: Some(
-                                            FieldType {
-                                                kind: Object,
-                                                name: Some(
-                                                    "SpeciesEdge",
-                                                ),
-                                                of_type: None,
-                                            },
-                                        ),
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                Field {
-                                    name: "totalCount",
-                                    description: Some(
-                                        "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
-                                    ),
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: Scalar,
-                                        name: Some(
-                                            "Int",
-                                        ),
-                                        of_type: None,
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                Field {
-                                    name: "species",
-                                    description: Some(
-                                        "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
-                                    ),
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: List,
-                                        name: None,
-                                        of_type: Some(
-                                            FieldType {
-                                                kind: Object,
-                                                name: Some(
-                                                    "Species",
-                                                ),
-                                                of_type: None,
-                                            },
-                                        ),
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                            ],
-                        ),
-                        input_fields: None,
-                        interfaces: Some(
-                            [],
-                        ),
-                        enum_values: None,
-                        possible_types: None,
-                        specified_by_url: None,
-                    },
-                    Type {
-                        kind: Object,
-                        name: Some(
-                            "SpeciesEdge",
-                        ),
-                        description: Some(
-                            "An edge in a connection.",
-                        ),
-                        fields: Some(
-                            [
-                                Field {
-                                    name: "node",
-                                    description: Some(
-                                        "The item at the end of the edge",
-                                    ),
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: Object,
-                                        name: Some(
-                                            "Species",
-                                        ),
-                                        of_type: None,
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                Field {
-                                    name: "cursor",
-                                    description: Some(
-                                        "A cursor for use in pagination",
-                                    ),
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: NonNull,
-                                        name: None,
-                                        of_type: Some(
-                                            FieldType {
-                                                kind: Scalar,
-                                                name: Some(
-                                                    "String",
-                                                ),
-                                                of_type: None,
-                                            },
-                                        ),
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                            ],
-                        ),
-                        input_fields: None,
-                        interfaces: Some(
-                            [],
-                        ),
-                        enum_values: None,
-                        possible_types: None,
-                        specified_by_url: None,
-                    },
-                    Type {
-                        kind: Object,
-                        name: Some(
-                            "StarshipsConnection",
-                        ),
-                        description: Some(
-                            "A connection to a list of items.",
-                        ),
-                        fields: Some(
-                            [
-                                Field {
-                                    name: "pageInfo",
-                                    description: Some(
-                                        "Information to aid in pagination.",
-                                    ),
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: NonNull,
-                                        name: None,
-                                        of_type: Some(
-                                            FieldType {
-                                                kind: Object,
-                                                name: Some(
-                                                    "PageInfo",
-                                                ),
-                                                of_type: None,
-                                            },
-                                        ),
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                Field {
-                                    name: "edges",
-                                    description: Some(
-                                        "A list of edges.",
-                                    ),
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: List,
-                                        name: None,
-                                        of_type: Some(
-                                            FieldType {
-                                                kind: Object,
-                                                name: Some(
-                                                    "StarshipsEdge",
-                                                ),
-                                                of_type: None,
-                                            },
-                                        ),
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                Field {
-                                    name: "totalCount",
-                                    description: Some(
-                                        "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
-                                    ),
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: Scalar,
-                                        name: Some(
-                                            "Int",
-                                        ),
-                                        of_type: None,
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                Field {
-                                    name: "starships",
-                                    description: Some(
-                                        "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
-                                    ),
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: List,
-                                        name: None,
-                                        of_type: Some(
-                                            FieldType {
-                                                kind: Object,
-                                                name: Some(
-                                                    "Starship",
-                                                ),
-                                                of_type: None,
-                                            },
-                                        ),
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                            ],
-                        ),
-                        input_fields: None,
-                        interfaces: Some(
-                            [],
-                        ),
-                        enum_values: None,
-                        possible_types: None,
-                        specified_by_url: None,
-                    },
-                    Type {
-                        kind: Object,
-                        name: Some(
-                            "StarshipsEdge",
-                        ),
-                        description: Some(
-                            "An edge in a connection.",
-                        ),
-                        fields: Some(
-                            [
-                                Field {
-                                    name: "node",
-                                    description: Some(
-                                        "The item at the end of the edge",
-                                    ),
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: Object,
-                                        name: Some(
-                                            "Starship",
                                         ),
                                         of_type: None,
                                     },
@@ -6928,794 +6925,10 @@ Some(
                     Type {
                         kind: Object,
                         name: Some(
-                            "__Schema",
-                        ),
-                        description: Some(
-                            "A GraphQL Schema defines the capabilities of a GraphQL server. It exposes all available types and directives on the server, as well as the entry points for query, mutation, and subscription operations.",
-                        ),
-                        fields: Some(
-                            [
-                                Field {
-                                    name: "types",
-                                    description: Some(
-                                        "A list of all types supported by this server.",
-                                    ),
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: NonNull,
-                                        name: None,
-                                        of_type: Some(
-                                            FieldType {
-                                                kind: List,
-                                                name: None,
-                                                of_type: Some(
-                                                    FieldType {
-                                                        kind: NonNull,
-                                                        name: None,
-                                                        of_type: Some(
-                                                            FieldType {
-                                                                kind: Object,
-                                                                name: Some(
-                                                                    "__Type",
-                                                                ),
-                                                                of_type: None,
-                                                            },
-                                                        ),
-                                                    },
-                                                ),
-                                            },
-                                        ),
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                Field {
-                                    name: "queryType",
-                                    description: Some(
-                                        "The type that query operations will be rooted at.",
-                                    ),
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: NonNull,
-                                        name: None,
-                                        of_type: Some(
-                                            FieldType {
-                                                kind: Object,
-                                                name: Some(
-                                                    "__Type",
-                                                ),
-                                                of_type: None,
-                                            },
-                                        ),
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                Field {
-                                    name: "mutationType",
-                                    description: Some(
-                                        "If this server supports mutation, the type that mutation operations will be rooted at.",
-                                    ),
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: Object,
-                                        name: Some(
-                                            "__Type",
-                                        ),
-                                        of_type: None,
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                Field {
-                                    name: "subscriptionType",
-                                    description: Some(
-                                        "If this server support subscription, the type that subscription operations will be rooted at.",
-                                    ),
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: Object,
-                                        name: Some(
-                                            "__Type",
-                                        ),
-                                        of_type: None,
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                Field {
-                                    name: "directives",
-                                    description: Some(
-                                        "A list of all directives supported by this server.",
-                                    ),
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: NonNull,
-                                        name: None,
-                                        of_type: Some(
-                                            FieldType {
-                                                kind: List,
-                                                name: None,
-                                                of_type: Some(
-                                                    FieldType {
-                                                        kind: NonNull,
-                                                        name: None,
-                                                        of_type: Some(
-                                                            FieldType {
-                                                                kind: Object,
-                                                                name: Some(
-                                                                    "__Directive",
-                                                                ),
-                                                                of_type: None,
-                                                            },
-                                                        ),
-                                                    },
-                                                ),
-                                            },
-                                        ),
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                            ],
-                        ),
-                        input_fields: None,
-                        interfaces: Some(
-                            [],
-                        ),
-                        enum_values: None,
-                        possible_types: None,
-                        specified_by_url: None,
-                    },
-                    Type {
-                        kind: Object,
-                        name: Some(
-                            "__Type",
-                        ),
-                        description: Some(
-                            "The fundamental unit of any GraphQL Schema is the type. There are many kinds of types in GraphQL as represented by the `__TypeKind` enum.\n\nDepending on the kind of a type, certain fields describe information about that type. Scalar types provide no information beyond a name and description, while Enum types provide their values. Object and Interface types provide the fields they describe. Abstract types, Union and Interface, provide the Object types possible at runtime. List and NonNull types compose other types.",
-                        ),
-                        fields: Some(
-                            [
-                                Field {
-                                    name: "kind",
-                                    description: None,
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: NonNull,
-                                        name: None,
-                                        of_type: Some(
-                                            FieldType {
-                                                kind: Enum,
-                                                name: Some(
-                                                    "__TypeKind",
-                                                ),
-                                                of_type: None,
-                                            },
-                                        ),
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                Field {
-                                    name: "name",
-                                    description: None,
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: Scalar,
-                                        name: Some(
-                                            "String",
-                                        ),
-                                        of_type: None,
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                Field {
-                                    name: "description",
-                                    description: None,
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: Scalar,
-                                        name: Some(
-                                            "String",
-                                        ),
-                                        of_type: None,
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                Field {
-                                    name: "fields",
-                                    description: None,
-                                    args: [
-                                        InputValue {
-                                            name: "includeDeprecated",
-                                            description: None,
-                                            ty: FieldType {
-                                                kind: Scalar,
-                                                name: Some(
-                                                    "Boolean",
-                                                ),
-                                                of_type: None,
-                                            },
-                                            default_value: Some(
-                                                "false",
-                                            ),
-                                        },
-                                    ],
-                                    ty: FieldType {
-                                        kind: List,
-                                        name: None,
-                                        of_type: Some(
-                                            FieldType {
-                                                kind: NonNull,
-                                                name: None,
-                                                of_type: Some(
-                                                    FieldType {
-                                                        kind: Object,
-                                                        name: Some(
-                                                            "__Field",
-                                                        ),
-                                                        of_type: None,
-                                                    },
-                                                ),
-                                            },
-                                        ),
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                Field {
-                                    name: "interfaces",
-                                    description: None,
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: List,
-                                        name: None,
-                                        of_type: Some(
-                                            FieldType {
-                                                kind: NonNull,
-                                                name: None,
-                                                of_type: Some(
-                                                    FieldType {
-                                                        kind: Object,
-                                                        name: Some(
-                                                            "__Type",
-                                                        ),
-                                                        of_type: None,
-                                                    },
-                                                ),
-                                            },
-                                        ),
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                Field {
-                                    name: "possibleTypes",
-                                    description: None,
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: List,
-                                        name: None,
-                                        of_type: Some(
-                                            FieldType {
-                                                kind: NonNull,
-                                                name: None,
-                                                of_type: Some(
-                                                    FieldType {
-                                                        kind: Object,
-                                                        name: Some(
-                                                            "__Type",
-                                                        ),
-                                                        of_type: None,
-                                                    },
-                                                ),
-                                            },
-                                        ),
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                Field {
-                                    name: "enumValues",
-                                    description: None,
-                                    args: [
-                                        InputValue {
-                                            name: "includeDeprecated",
-                                            description: None,
-                                            ty: FieldType {
-                                                kind: Scalar,
-                                                name: Some(
-                                                    "Boolean",
-                                                ),
-                                                of_type: None,
-                                            },
-                                            default_value: Some(
-                                                "false",
-                                            ),
-                                        },
-                                    ],
-                                    ty: FieldType {
-                                        kind: List,
-                                        name: None,
-                                        of_type: Some(
-                                            FieldType {
-                                                kind: NonNull,
-                                                name: None,
-                                                of_type: Some(
-                                                    FieldType {
-                                                        kind: Object,
-                                                        name: Some(
-                                                            "__EnumValue",
-                                                        ),
-                                                        of_type: None,
-                                                    },
-                                                ),
-                                            },
-                                        ),
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                Field {
-                                    name: "inputFields",
-                                    description: None,
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: List,
-                                        name: None,
-                                        of_type: Some(
-                                            FieldType {
-                                                kind: NonNull,
-                                                name: None,
-                                                of_type: Some(
-                                                    FieldType {
-                                                        kind: Object,
-                                                        name: Some(
-                                                            "__InputValue",
-                                                        ),
-                                                        of_type: None,
-                                                    },
-                                                ),
-                                            },
-                                        ),
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                Field {
-                                    name: "ofType",
-                                    description: None,
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: Object,
-                                        name: Some(
-                                            "__Type",
-                                        ),
-                                        of_type: None,
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                            ],
-                        ),
-                        input_fields: None,
-                        interfaces: Some(
-                            [],
-                        ),
-                        enum_values: None,
-                        possible_types: None,
-                        specified_by_url: None,
-                    },
-                    Type {
-                        kind: Enum,
-                        name: Some(
-                            "__TypeKind",
-                        ),
-                        description: Some(
-                            "An enum describing what kind of type a given `__Type` is.",
-                        ),
-                        fields: None,
-                        input_fields: None,
-                        interfaces: None,
-                        enum_values: Some(
-                            [
-                                EnumValue {
-                                    name: "SCALAR",
-                                    description: Some(
-                                        "Indicates this type is a scalar.",
-                                    ),
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                EnumValue {
-                                    name: "OBJECT",
-                                    description: Some(
-                                        "Indicates this type is an object. `fields` and `interfaces` are valid fields.",
-                                    ),
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                EnumValue {
-                                    name: "INTERFACE",
-                                    description: Some(
-                                        "Indicates this type is an interface. `fields` and `possibleTypes` are valid fields.",
-                                    ),
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                EnumValue {
-                                    name: "UNION",
-                                    description: Some(
-                                        "Indicates this type is a union. `possibleTypes` is a valid field.",
-                                    ),
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                EnumValue {
-                                    name: "ENUM",
-                                    description: Some(
-                                        "Indicates this type is an enum. `enumValues` is a valid field.",
-                                    ),
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                EnumValue {
-                                    name: "INPUT_OBJECT",
-                                    description: Some(
-                                        "Indicates this type is an input object. `inputFields` is a valid field.",
-                                    ),
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                EnumValue {
-                                    name: "LIST",
-                                    description: Some(
-                                        "Indicates this type is a list. `ofType` is a valid field.",
-                                    ),
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                EnumValue {
-                                    name: "NON_NULL",
-                                    description: Some(
-                                        "Indicates this type is a non-null. `ofType` is a valid field.",
-                                    ),
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                            ],
-                        ),
-                        possible_types: None,
-                        specified_by_url: None,
-                    },
-                    Type {
-                        kind: Object,
-                        name: Some(
-                            "__Field",
-                        ),
-                        description: Some(
-                            "Object and Interface types are described by a list of Fields, each of which has a name, potentially a list of arguments, and a return type.",
-                        ),
-                        fields: Some(
-                            [
-                                Field {
-                                    name: "name",
-                                    description: None,
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: NonNull,
-                                        name: None,
-                                        of_type: Some(
-                                            FieldType {
-                                                kind: Scalar,
-                                                name: Some(
-                                                    "String",
-                                                ),
-                                                of_type: None,
-                                            },
-                                        ),
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                Field {
-                                    name: "description",
-                                    description: None,
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: Scalar,
-                                        name: Some(
-                                            "String",
-                                        ),
-                                        of_type: None,
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                Field {
-                                    name: "args",
-                                    description: None,
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: NonNull,
-                                        name: None,
-                                        of_type: Some(
-                                            FieldType {
-                                                kind: List,
-                                                name: None,
-                                                of_type: Some(
-                                                    FieldType {
-                                                        kind: NonNull,
-                                                        name: None,
-                                                        of_type: Some(
-                                                            FieldType {
-                                                                kind: Object,
-                                                                name: Some(
-                                                                    "__InputValue",
-                                                                ),
-                                                                of_type: None,
-                                                            },
-                                                        ),
-                                                    },
-                                                ),
-                                            },
-                                        ),
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                Field {
-                                    name: "type",
-                                    description: None,
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: NonNull,
-                                        name: None,
-                                        of_type: Some(
-                                            FieldType {
-                                                kind: Object,
-                                                name: Some(
-                                                    "__Type",
-                                                ),
-                                                of_type: None,
-                                            },
-                                        ),
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                Field {
-                                    name: "isDeprecated",
-                                    description: None,
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: NonNull,
-                                        name: None,
-                                        of_type: Some(
-                                            FieldType {
-                                                kind: Scalar,
-                                                name: Some(
-                                                    "Boolean",
-                                                ),
-                                                of_type: None,
-                                            },
-                                        ),
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                Field {
-                                    name: "deprecationReason",
-                                    description: None,
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: Scalar,
-                                        name: Some(
-                                            "String",
-                                        ),
-                                        of_type: None,
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                            ],
-                        ),
-                        input_fields: None,
-                        interfaces: Some(
-                            [],
-                        ),
-                        enum_values: None,
-                        possible_types: None,
-                        specified_by_url: None,
-                    },
-                    Type {
-                        kind: Object,
-                        name: Some(
-                            "__InputValue",
-                        ),
-                        description: Some(
-                            "Arguments provided to Fields or Directives and the input fields of an InputObject are represented as Input Values which describe their type and optionally a default value.",
-                        ),
-                        fields: Some(
-                            [
-                                Field {
-                                    name: "name",
-                                    description: None,
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: NonNull,
-                                        name: None,
-                                        of_type: Some(
-                                            FieldType {
-                                                kind: Scalar,
-                                                name: Some(
-                                                    "String",
-                                                ),
-                                                of_type: None,
-                                            },
-                                        ),
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                Field {
-                                    name: "description",
-                                    description: None,
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: Scalar,
-                                        name: Some(
-                                            "String",
-                                        ),
-                                        of_type: None,
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                Field {
-                                    name: "type",
-                                    description: None,
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: NonNull,
-                                        name: None,
-                                        of_type: Some(
-                                            FieldType {
-                                                kind: Object,
-                                                name: Some(
-                                                    "__Type",
-                                                ),
-                                                of_type: None,
-                                            },
-                                        ),
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                Field {
-                                    name: "defaultValue",
-                                    description: Some(
-                                        "A GraphQL-formatted string representing the default value for this input value.",
-                                    ),
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: Scalar,
-                                        name: Some(
-                                            "String",
-                                        ),
-                                        of_type: None,
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                            ],
-                        ),
-                        input_fields: None,
-                        interfaces: Some(
-                            [],
-                        ),
-                        enum_values: None,
-                        possible_types: None,
-                        specified_by_url: None,
-                    },
-                    Type {
-                        kind: Object,
-                        name: Some(
-                            "__EnumValue",
-                        ),
-                        description: Some(
-                            "One possible value for a given Enum. Enum values are unique values, not a placeholder for a string or numeric value. However an Enum value is returned in a JSON response as a string.",
-                        ),
-                        fields: Some(
-                            [
-                                Field {
-                                    name: "name",
-                                    description: None,
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: NonNull,
-                                        name: None,
-                                        of_type: Some(
-                                            FieldType {
-                                                kind: Scalar,
-                                                name: Some(
-                                                    "String",
-                                                ),
-                                                of_type: None,
-                                            },
-                                        ),
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                Field {
-                                    name: "description",
-                                    description: None,
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: Scalar,
-                                        name: Some(
-                                            "String",
-                                        ),
-                                        of_type: None,
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                Field {
-                                    name: "isDeprecated",
-                                    description: None,
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: NonNull,
-                                        name: None,
-                                        of_type: Some(
-                                            FieldType {
-                                                kind: Scalar,
-                                                name: Some(
-                                                    "Boolean",
-                                                ),
-                                                of_type: None,
-                                            },
-                                        ),
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                                Field {
-                                    name: "deprecationReason",
-                                    description: None,
-                                    args: [],
-                                    ty: FieldType {
-                                        kind: Scalar,
-                                        name: Some(
-                                            "String",
-                                        ),
-                                        of_type: None,
-                                    },
-                                    is_deprecated: false,
-                                    deprecation_reason: None,
-                                },
-                            ],
-                        ),
-                        input_fields: None,
-                        interfaces: Some(
-                            [],
-                        ),
-                        enum_values: None,
-                        possible_types: None,
-                        specified_by_url: None,
-                    },
-                    Type {
-                        kind: Object,
-                        name: Some(
                             "__Directive",
                         ),
                         description: Some(
-                            "A Directive provides a way to describe alternate runtime execution and type validation behavior in a GraphQL document.\n\nIn some cases, you need to provide options to alter GraphQL's execution behavior in ways field arguments will not suffice, such as conditionally including or skipping a field. Directives provide this by describing additional information to the executor.",
+                            "A Directive provides a way to describe alternate runtime execution and type\nvalidation behavior in a GraphQL document.\n\nIn some cases, you need to provide options to alter GraphQL's execution\nbehavior in ways field arguments will not suffice, such as conditionally\nincluding or skipping a field. Directives provide this by describing\nadditional information to the executor.",
                         ),
                         fields: Some(
                             [
@@ -7817,6 +7030,26 @@ Some(
                                     is_deprecated: false,
                                     deprecation_reason: None,
                                 },
+                                Field {
+                                    name: "isRepeatable",
+                                    description: None,
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: NonNull,
+                                        name: None,
+                                        of_type: Some(
+                                            FieldType {
+                                                kind: Scalar,
+                                                name: Some(
+                                                    "Boolean",
+                                                ),
+                                                of_type: None,
+                                            },
+                                        ),
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
                             ],
                         ),
                         input_fields: None,
@@ -7833,7 +7066,7 @@ Some(
                             "__DirectiveLocation",
                         ),
                         description: Some(
-                            "A Directive can be adjacent to many parts of the GraphQL language, a __DirectiveLocation describes one such possible adjacencies.",
+                            "A Directive can be adjacent to many parts of the GraphQL language, a\n__DirectiveLocation describes one such possible adjacencies.",
                         ),
                         fields: None,
                         input_fields: None,
@@ -7997,6 +7230,828 @@ Some(
                         possible_types: None,
                         specified_by_url: None,
                     },
+                    Type {
+                        kind: Object,
+                        name: Some(
+                            "__EnumValue",
+                        ),
+                        description: Some(
+                            "One possible value for a given Enum. Enum values are unique values, not a\nplaceholder for a string or numeric value. However an Enum value is returned\nin a JSON response as a string.",
+                        ),
+                        fields: Some(
+                            [
+                                Field {
+                                    name: "name",
+                                    description: None,
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: NonNull,
+                                        name: None,
+                                        of_type: Some(
+                                            FieldType {
+                                                kind: Scalar,
+                                                name: Some(
+                                                    "String",
+                                                ),
+                                                of_type: None,
+                                            },
+                                        ),
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                Field {
+                                    name: "description",
+                                    description: None,
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: Scalar,
+                                        name: Some(
+                                            "String",
+                                        ),
+                                        of_type: None,
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                Field {
+                                    name: "isDeprecated",
+                                    description: None,
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: NonNull,
+                                        name: None,
+                                        of_type: Some(
+                                            FieldType {
+                                                kind: Scalar,
+                                                name: Some(
+                                                    "Boolean",
+                                                ),
+                                                of_type: None,
+                                            },
+                                        ),
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                Field {
+                                    name: "deprecationReason",
+                                    description: None,
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: Scalar,
+                                        name: Some(
+                                            "String",
+                                        ),
+                                        of_type: None,
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                            ],
+                        ),
+                        input_fields: None,
+                        interfaces: Some(
+                            [],
+                        ),
+                        enum_values: None,
+                        possible_types: None,
+                        specified_by_url: None,
+                    },
+                    Type {
+                        kind: Object,
+                        name: Some(
+                            "__Field",
+                        ),
+                        description: Some(
+                            "Object and Interface types are described by a list of Fields, each of which\nhas a name, potentially a list of arguments, and a return type.",
+                        ),
+                        fields: Some(
+                            [
+                                Field {
+                                    name: "name",
+                                    description: None,
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: NonNull,
+                                        name: None,
+                                        of_type: Some(
+                                            FieldType {
+                                                kind: Scalar,
+                                                name: Some(
+                                                    "String",
+                                                ),
+                                                of_type: None,
+                                            },
+                                        ),
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                Field {
+                                    name: "description",
+                                    description: None,
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: Scalar,
+                                        name: Some(
+                                            "String",
+                                        ),
+                                        of_type: None,
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                Field {
+                                    name: "args",
+                                    description: None,
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: NonNull,
+                                        name: None,
+                                        of_type: Some(
+                                            FieldType {
+                                                kind: List,
+                                                name: None,
+                                                of_type: Some(
+                                                    FieldType {
+                                                        kind: NonNull,
+                                                        name: None,
+                                                        of_type: Some(
+                                                            FieldType {
+                                                                kind: Object,
+                                                                name: Some(
+                                                                    "__InputValue",
+                                                                ),
+                                                                of_type: None,
+                                                            },
+                                                        ),
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                Field {
+                                    name: "type",
+                                    description: None,
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: NonNull,
+                                        name: None,
+                                        of_type: Some(
+                                            FieldType {
+                                                kind: Object,
+                                                name: Some(
+                                                    "__Type",
+                                                ),
+                                                of_type: None,
+                                            },
+                                        ),
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                Field {
+                                    name: "isDeprecated",
+                                    description: None,
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: NonNull,
+                                        name: None,
+                                        of_type: Some(
+                                            FieldType {
+                                                kind: Scalar,
+                                                name: Some(
+                                                    "Boolean",
+                                                ),
+                                                of_type: None,
+                                            },
+                                        ),
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                Field {
+                                    name: "deprecationReason",
+                                    description: None,
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: Scalar,
+                                        name: Some(
+                                            "String",
+                                        ),
+                                        of_type: None,
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                            ],
+                        ),
+                        input_fields: None,
+                        interfaces: Some(
+                            [],
+                        ),
+                        enum_values: None,
+                        possible_types: None,
+                        specified_by_url: None,
+                    },
+                    Type {
+                        kind: Object,
+                        name: Some(
+                            "__InputValue",
+                        ),
+                        description: Some(
+                            "Arguments provided to Fields or Directives and the input fields of an\nInputObject are represented as Input Values which describe their type and\noptionally a default value.",
+                        ),
+                        fields: Some(
+                            [
+                                Field {
+                                    name: "name",
+                                    description: None,
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: NonNull,
+                                        name: None,
+                                        of_type: Some(
+                                            FieldType {
+                                                kind: Scalar,
+                                                name: Some(
+                                                    "String",
+                                                ),
+                                                of_type: None,
+                                            },
+                                        ),
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                Field {
+                                    name: "description",
+                                    description: None,
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: Scalar,
+                                        name: Some(
+                                            "String",
+                                        ),
+                                        of_type: None,
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                Field {
+                                    name: "type",
+                                    description: None,
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: NonNull,
+                                        name: None,
+                                        of_type: Some(
+                                            FieldType {
+                                                kind: Object,
+                                                name: Some(
+                                                    "__Type",
+                                                ),
+                                                of_type: None,
+                                            },
+                                        ),
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                Field {
+                                    name: "defaultValue",
+                                    description: None,
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: Scalar,
+                                        name: Some(
+                                            "String",
+                                        ),
+                                        of_type: None,
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                            ],
+                        ),
+                        input_fields: None,
+                        interfaces: Some(
+                            [],
+                        ),
+                        enum_values: None,
+                        possible_types: None,
+                        specified_by_url: None,
+                    },
+                    Type {
+                        kind: Object,
+                        name: Some(
+                            "__Schema",
+                        ),
+                        description: Some(
+                            "A GraphQL Schema defines the capabilities of a GraphQL server. It exposes\nall available types and directives on the server, as well as the entry\npoints for query, mutation, and subscription operations.",
+                        ),
+                        fields: Some(
+                            [
+                                Field {
+                                    name: "types",
+                                    description: Some(
+                                        "A list of all types supported by this server.",
+                                    ),
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: NonNull,
+                                        name: None,
+                                        of_type: Some(
+                                            FieldType {
+                                                kind: List,
+                                                name: None,
+                                                of_type: Some(
+                                                    FieldType {
+                                                        kind: NonNull,
+                                                        name: None,
+                                                        of_type: Some(
+                                                            FieldType {
+                                                                kind: Object,
+                                                                name: Some(
+                                                                    "__Type",
+                                                                ),
+                                                                of_type: None,
+                                                            },
+                                                        ),
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                Field {
+                                    name: "queryType",
+                                    description: Some(
+                                        "The type that query operations will be rooted at.",
+                                    ),
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: NonNull,
+                                        name: None,
+                                        of_type: Some(
+                                            FieldType {
+                                                kind: Object,
+                                                name: Some(
+                                                    "__Type",
+                                                ),
+                                                of_type: None,
+                                            },
+                                        ),
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                Field {
+                                    name: "mutationType",
+                                    description: Some(
+                                        "If this server supports mutation, the type that mutation operations will\nbe rooted at.",
+                                    ),
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: Object,
+                                        name: Some(
+                                            "__Type",
+                                        ),
+                                        of_type: None,
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                Field {
+                                    name: "subscriptionType",
+                                    description: Some(
+                                        "If this server support subscription, the type that subscription\noperations will be rooted at.",
+                                    ),
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: Object,
+                                        name: Some(
+                                            "__Type",
+                                        ),
+                                        of_type: None,
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                Field {
+                                    name: "directives",
+                                    description: Some(
+                                        "A list of all directives supported by this server.",
+                                    ),
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: NonNull,
+                                        name: None,
+                                        of_type: Some(
+                                            FieldType {
+                                                kind: List,
+                                                name: None,
+                                                of_type: Some(
+                                                    FieldType {
+                                                        kind: NonNull,
+                                                        name: None,
+                                                        of_type: Some(
+                                                            FieldType {
+                                                                kind: Object,
+                                                                name: Some(
+                                                                    "__Directive",
+                                                                ),
+                                                                of_type: None,
+                                                            },
+                                                        ),
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                            ],
+                        ),
+                        input_fields: None,
+                        interfaces: Some(
+                            [],
+                        ),
+                        enum_values: None,
+                        possible_types: None,
+                        specified_by_url: None,
+                    },
+                    Type {
+                        kind: Object,
+                        name: Some(
+                            "__Type",
+                        ),
+                        description: Some(
+                            "The fundamental unit of any GraphQL Schema is the type. There are many kinds\nof types in GraphQL as represented by the `__TypeKind` enum.\n\nDepending on the kind of a type, certain fields describe information about\nthat type. Scalar types provide no information beyond a name and\ndescription, while Enum types provide their values. Object and Interface\ntypes provide the fields they describe. Abstract types, Union and Interface,\nprovide the Object types possible at runtime. List and NonNull types compose\nother types.",
+                        ),
+                        fields: Some(
+                            [
+                                Field {
+                                    name: "kind",
+                                    description: None,
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: NonNull,
+                                        name: None,
+                                        of_type: Some(
+                                            FieldType {
+                                                kind: Enum,
+                                                name: Some(
+                                                    "__TypeKind",
+                                                ),
+                                                of_type: None,
+                                            },
+                                        ),
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                Field {
+                                    name: "name",
+                                    description: None,
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: Scalar,
+                                        name: Some(
+                                            "String",
+                                        ),
+                                        of_type: None,
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                Field {
+                                    name: "description",
+                                    description: None,
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: Scalar,
+                                        name: Some(
+                                            "String",
+                                        ),
+                                        of_type: None,
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                Field {
+                                    name: "fields",
+                                    description: None,
+                                    args: [
+                                        InputValue {
+                                            name: "includeDeprecated",
+                                            description: None,
+                                            ty: FieldType {
+                                                kind: NonNull,
+                                                name: None,
+                                                of_type: Some(
+                                                    FieldType {
+                                                        kind: Scalar,
+                                                        name: Some(
+                                                            "Boolean",
+                                                        ),
+                                                        of_type: None,
+                                                    },
+                                                ),
+                                            },
+                                            default_value: Some(
+                                                "false",
+                                            ),
+                                        },
+                                    ],
+                                    ty: FieldType {
+                                        kind: List,
+                                        name: None,
+                                        of_type: Some(
+                                            FieldType {
+                                                kind: NonNull,
+                                                name: None,
+                                                of_type: Some(
+                                                    FieldType {
+                                                        kind: Object,
+                                                        name: Some(
+                                                            "__Field",
+                                                        ),
+                                                        of_type: None,
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                Field {
+                                    name: "interfaces",
+                                    description: None,
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: List,
+                                        name: None,
+                                        of_type: Some(
+                                            FieldType {
+                                                kind: NonNull,
+                                                name: None,
+                                                of_type: Some(
+                                                    FieldType {
+                                                        kind: Object,
+                                                        name: Some(
+                                                            "__Type",
+                                                        ),
+                                                        of_type: None,
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                Field {
+                                    name: "possibleTypes",
+                                    description: None,
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: List,
+                                        name: None,
+                                        of_type: Some(
+                                            FieldType {
+                                                kind: NonNull,
+                                                name: None,
+                                                of_type: Some(
+                                                    FieldType {
+                                                        kind: Object,
+                                                        name: Some(
+                                                            "__Type",
+                                                        ),
+                                                        of_type: None,
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                Field {
+                                    name: "enumValues",
+                                    description: None,
+                                    args: [
+                                        InputValue {
+                                            name: "includeDeprecated",
+                                            description: None,
+                                            ty: FieldType {
+                                                kind: NonNull,
+                                                name: None,
+                                                of_type: Some(
+                                                    FieldType {
+                                                        kind: Scalar,
+                                                        name: Some(
+                                                            "Boolean",
+                                                        ),
+                                                        of_type: None,
+                                                    },
+                                                ),
+                                            },
+                                            default_value: Some(
+                                                "false",
+                                            ),
+                                        },
+                                    ],
+                                    ty: FieldType {
+                                        kind: List,
+                                        name: None,
+                                        of_type: Some(
+                                            FieldType {
+                                                kind: NonNull,
+                                                name: None,
+                                                of_type: Some(
+                                                    FieldType {
+                                                        kind: Object,
+                                                        name: Some(
+                                                            "__EnumValue",
+                                                        ),
+                                                        of_type: None,
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                Field {
+                                    name: "inputFields",
+                                    description: None,
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: List,
+                                        name: None,
+                                        of_type: Some(
+                                            FieldType {
+                                                kind: NonNull,
+                                                name: None,
+                                                of_type: Some(
+                                                    FieldType {
+                                                        kind: Object,
+                                                        name: Some(
+                                                            "__InputValue",
+                                                        ),
+                                                        of_type: None,
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                Field {
+                                    name: "ofType",
+                                    description: None,
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: Object,
+                                        name: Some(
+                                            "__Type",
+                                        ),
+                                        of_type: None,
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                Field {
+                                    name: "specifiedByURL",
+                                    description: None,
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: Scalar,
+                                        name: Some(
+                                            "String",
+                                        ),
+                                        of_type: None,
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                Field {
+                                    name: "isOneOf",
+                                    description: None,
+                                    args: [],
+                                    ty: FieldType {
+                                        kind: Scalar,
+                                        name: Some(
+                                            "Boolean",
+                                        ),
+                                        of_type: None,
+                                    },
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                            ],
+                        ),
+                        input_fields: None,
+                        interfaces: Some(
+                            [],
+                        ),
+                        enum_values: None,
+                        possible_types: None,
+                        specified_by_url: None,
+                    },
+                    Type {
+                        kind: Enum,
+                        name: Some(
+                            "__TypeKind",
+                        ),
+                        description: Some(
+                            "An enum describing what kind of type a given `__Type` is.",
+                        ),
+                        fields: None,
+                        input_fields: None,
+                        interfaces: None,
+                        enum_values: Some(
+                            [
+                                EnumValue {
+                                    name: "SCALAR",
+                                    description: Some(
+                                        "Indicates this type is a scalar.",
+                                    ),
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                EnumValue {
+                                    name: "OBJECT",
+                                    description: Some(
+                                        "Indicates this type is an object. `fields` and `interfaces` are valid\nfields.",
+                                    ),
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                EnumValue {
+                                    name: "INTERFACE",
+                                    description: Some(
+                                        "Indicates this type is an interface. `fields` and `possibleTypes` are\nvalid fields.",
+                                    ),
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                EnumValue {
+                                    name: "UNION",
+                                    description: Some(
+                                        "Indicates this type is a union. `possibleTypes` is a valid field.",
+                                    ),
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                EnumValue {
+                                    name: "ENUM",
+                                    description: Some(
+                                        "Indicates this type is an enum. `enumValues` is a valid field.",
+                                    ),
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                EnumValue {
+                                    name: "INPUT_OBJECT",
+                                    description: Some(
+                                        "Indicates this type is an input object. `inputFields` is a valid field.",
+                                    ),
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                EnumValue {
+                                    name: "LIST",
+                                    description: Some(
+                                        "Indicates this type is a list. `ofType` is a valid field.",
+                                    ),
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                                EnumValue {
+                                    name: "NON_NULL",
+                                    description: Some(
+                                        "Indicates this type is a non-null. `ofType` is a valid field.",
+                                    ),
+                                    is_deprecated: false,
+                                    deprecation_reason: None,
+                                },
+                            ],
+                        ),
+                        possible_types: None,
+                        specified_by_url: None,
+                    },
                 ],
                 directives: [
                     Directive {
@@ -8063,34 +8118,6 @@ Some(
                             Field,
                             FragmentSpread,
                             InlineFragment,
-                        ],
-                    },
-                    Directive {
-                        name: "deprecated",
-                        description: Some(
-                            "Marks an element of a GraphQL schema as no longer supported.",
-                        ),
-                        args: [
-                            InputValue {
-                                name: "reason",
-                                description: Some(
-                                    "Explains why this element was deprecated, usually also including a suggestion for how to access supported similar data. Formatted using the Markdown syntax (as specified by [CommonMark](https://commonmark.org/).",
-                                ),
-                                ty: FieldType {
-                                    kind: Scalar,
-                                    name: Some(
-                                        "String",
-                                    ),
-                                    of_type: None,
-                                },
-                                default_value: Some(
-                                    "\"No longer supported\"",
-                                ),
-                            },
-                        ],
-                        locations: [
-                            FieldDefinition,
-                            EnumValue,
                         ],
                     },
                 ],

--- a/cynic-introspection/tests/tests.rs
+++ b/cynic-introspection/tests/tests.rs
@@ -1,5 +1,6 @@
-use cynic::GraphQlResponse;
+use cynic::{http::ReqwestExt, GraphQlResponse};
 use cynic_introspection::{query::IntrospectionQuery, SchemaError, SpecificationVersion};
+use graphql_mocks::mocks;
 use serde_json::json;
 
 #[test]
@@ -13,15 +14,16 @@ fn build_2018_query() -> cynic::Operation<IntrospectionQuery, ()> {
     IntrospectionQuery::build(())
 }
 
-#[test]
-fn test_running_2018_query() {
-    use cynic::http::ReqwestBlockingExt;
+#[tokio::test]
+async fn test_running_2018_query() {
+    let mock_server = mocks::swapi::serve().await;
 
     let query = build_2018_query();
 
-    let result = reqwest::blocking::Client::new()
-        .post("https://swapi-graphql.netlify.app/.netlify/functions/index")
+    let result = reqwest::Client::new()
+        .post(mock_server.url())
         .run_graphql(query)
+        .await
         .unwrap();
 
     if result.errors.is_some() {
@@ -31,15 +33,16 @@ fn test_running_2018_query() {
     insta::assert_debug_snapshot!(result.data);
 }
 
-#[test]
-fn test_2018_schema_conversion() {
-    use cynic::http::ReqwestBlockingExt;
+#[tokio::test]
+async fn test_2018_schema_conversion() {
+    let mock_server = mocks::swapi::serve().await;
 
     let query = build_2018_query();
 
-    let result = reqwest::blocking::Client::new()
-        .post("https://swapi-graphql.netlify.app/.netlify/functions/index")
+    let result = reqwest::Client::new()
+        .post(mock_server.url())
         .run_graphql(query)
+        .await
         .unwrap();
 
     if result.errors.is_some() {

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -28,5 +28,8 @@ github-schema = { path = "../schemas/github" }
 [dev-dependencies]
 insta = "1.17"
 
-[build-dependencies]
+# Used for the mock starwars API used by some of the examples
+graphql-mocks.workspace = true
+
+[build-dependencies] # Required to fake the Swapi server used in most of these tests
 cynic-codegen = { path = "../cynic-codegen" }

--- a/examples/examples/manual-reqwest.rs
+++ b/examples/examples/manual-reqwest.rs
@@ -24,7 +24,7 @@ struct FilmDirectorQuery {
 }
 
 fn main() {
-    match run_query().data {
+    match run_query("https://swapi-graphql.netlify.app/.netlify/functions/index").data {
         Some(FilmDirectorQuery { film: Some(film) }) => {
             println!("{:?} was directed by {:?}", film.title, film.director)
         }
@@ -34,11 +34,11 @@ fn main() {
     }
 }
 
-fn run_query() -> cynic::GraphQlResponse<FilmDirectorQuery> {
+fn run_query(url: &str) -> cynic::GraphQlResponse<FilmDirectorQuery> {
     let query = build_query();
 
     let response = reqwest::blocking::Client::new()
-        .post("https://swapi-graphql.netlify.app/.netlify/functions/index")
+        .post(url)
         .json(&query)
         .send()
         .unwrap();
@@ -56,6 +56,8 @@ fn build_query() -> cynic::Operation<FilmDirectorQuery, FilmArguments> {
 
 #[cfg(test)]
 mod test {
+    use tokio::task::spawn_blocking;
+
     use super::*;
 
     #[test]
@@ -69,9 +71,14 @@ mod test {
         insta::assert_snapshot!(query.query);
     }
 
-    #[test]
-    fn test_running_query() {
-        let result = run_query();
+    #[tokio::test]
+    async fn test_running_query() {
+        let mock_server = graphql_mocks::mocks::swapi::serve().await;
+
+        let result = spawn_blocking(move || run_query(&mock_server.url().to_string()))
+            .await
+            .unwrap();
+
         if result.errors.is_some() {
             assert_eq!(result.errors.unwrap().len(), 0);
         }

--- a/examples/examples/reqwest-async.rs
+++ b/examples/examples/reqwest-async.rs
@@ -27,7 +27,10 @@ struct FilmDirectorQuery {
 
 #[tokio::main]
 async fn main() {
-    match run_query().await.data {
+    match run_query("https://swapi-graphql.netlify.app/.netlify/functions/index")
+        .await
+        .data
+    {
         Some(FilmDirectorQuery { film: Some(film) }) => {
             println!("{:?} was directed by {:?}", film.title, film.director)
         }
@@ -37,13 +40,13 @@ async fn main() {
     }
 }
 
-async fn run_query() -> cynic::GraphQlResponse<FilmDirectorQuery> {
+async fn run_query(url: &str) -> cynic::GraphQlResponse<FilmDirectorQuery> {
     use cynic::http::ReqwestExt;
 
     let query = build_query();
 
     reqwest::Client::new()
-        .post("https://swapi-graphql.netlify.app/.netlify/functions/index")
+        .post(url)
         .run_graphql(query)
         .await
         .unwrap()
@@ -74,7 +77,9 @@ mod test {
 
     #[tokio::test]
     async fn test_running_query() {
-        let result = run_query().await;
+        let mock_server = graphql_mocks::mocks::swapi::serve().await;
+
+        let result = run_query(&mock_server.url().to_string()).await;
         if result.errors.is_some() {
             assert_eq!(result.errors.unwrap().len(), 0);
         }

--- a/examples/examples/spread.rs
+++ b/examples/examples/spread.rs
@@ -40,7 +40,7 @@ struct FilmDirectorQuery {
 }
 
 fn main() {
-    match run_query().data {
+    match run_query("https://swapi-graphql.netlify.app/.netlify/functions/index").data {
         Some(FilmDirectorQuery { film: Some(film) }) => {
             println!("Id: {:?}", film.id);
             println!(
@@ -56,13 +56,13 @@ fn main() {
     }
 }
 
-fn run_query() -> cynic::GraphQlResponse<FilmDirectorQuery> {
+fn run_query(url: &str) -> cynic::GraphQlResponse<FilmDirectorQuery> {
     use cynic::http::ReqwestBlockingExt;
 
     let query = build_query();
 
     reqwest::blocking::Client::new()
-        .post("https://swapi-graphql.netlify.app/.netlify/functions/index")
+        .post(url)
         .run_graphql(query)
         .unwrap()
 }
@@ -77,6 +77,8 @@ fn build_query() -> cynic::Operation<FilmDirectorQuery, FilmArguments> {
 
 #[cfg(test)]
 mod test {
+    use tokio::task::spawn_blocking;
+
     use super::*;
 
     #[test]
@@ -90,11 +92,21 @@ mod test {
         insta::assert_snapshot!(query.query);
     }
 
-    #[test]
-    fn test_running_query() {
-        let result = run_query();
+    #[tokio::test]
+    async fn test_running_query() {
+        let mock_server = graphql_mocks::mocks::swapi::serve().await;
+
+        let result = spawn_blocking(move || run_query(&mock_server.url().to_string()))
+            .await
+            .unwrap();
+
         if result.errors.is_some() {
-            assert_eq!(result.errors.unwrap().len(), 0);
+            assert_eq!(
+                result.errors.as_ref().unwrap().len(),
+                0,
+                "Server Errored: {:?}",
+                result.errors
+            );
         }
         insta::assert_debug_snapshot!(result.data);
     }

--- a/examples/examples/surf-client.rs
+++ b/examples/examples/surf-client.rs
@@ -27,7 +27,10 @@ struct FilmDirectorQuery {
 
 fn main() {
     async_std::task::block_on(async {
-        match run_query().await.data {
+        match run_query("https://swapi-graphql.netlify.app/.netlify/functions/index")
+            .await
+            .data
+        {
             Some(FilmDirectorQuery { film: Some(film) }) => {
                 println!("{:?} was directed by {:?}", film.title, film.director)
             }
@@ -38,15 +41,12 @@ fn main() {
     })
 }
 
-async fn run_query() -> cynic::GraphQlResponse<FilmDirectorQuery> {
+async fn run_query(url: &str) -> cynic::GraphQlResponse<FilmDirectorQuery> {
     use cynic::http::SurfExt;
 
     let operation = build_query();
 
-    surf::post("https://swapi-graphql.netlify.app/.netlify/functions/index")
-        .run_graphql(operation)
-        .await
-        .unwrap()
+    surf::post(url).run_graphql(operation).await.unwrap()
 }
 
 fn build_query() -> cynic::Operation<FilmDirectorQuery, FilmArguments> {

--- a/graphql-mocks/Cargo.toml
+++ b/graphql-mocks/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "graphql-mocks"
+publish = false
+edition.workspace = true
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+async-graphql-axum = "7"
+async-graphql = { version = "7", features = ["dynamic-schema"] }
+async-trait = "0.1"
+axum = "0.7"
+cynic-parser.workspace = true
+cynic-parser.features = ["report"]
+futures-lite = "2"
+headers = "0.4"
+serde = "1"
+serde_json = "1"
+tokio = "1"
+crossbeam-queue = "0.3"
+http = "1"
+url = "2"

--- a/graphql-mocks/src/dynamic/builder.rs
+++ b/graphql-mocks/src/dynamic/builder.rs
@@ -1,0 +1,357 @@
+#![allow(clippy::panic)]
+
+use std::collections::HashMap;
+
+use async_graphql::dynamic::{FieldValue, ResolverContext};
+use cynic_parser::{common::WrappingType, type_system as parser};
+use serde::Deserialize;
+
+use crate::{MockGraphQlServer, MockGraphQlServerBuilder};
+
+use super::{resolvers::Resolver, DynamicSchema};
+
+pub struct DynamicSchemaBuilder {
+    sdl: String,
+    field_resolvers: ResolverMap,
+}
+
+type ResolverMap = HashMap<(String, String), Box<dyn Resolver>>;
+
+impl DynamicSchemaBuilder {
+    pub fn new(sdl: &str) -> Self {
+        DynamicSchemaBuilder {
+            sdl: sdl.into(),
+            field_resolvers: Default::default(),
+        }
+    }
+
+    pub fn with_resolver(
+        mut self,
+        ty: &str,
+        field: &str,
+        resolver: impl Resolver + 'static,
+    ) -> Self {
+        self.field_resolvers
+            .insert((ty.into(), field.into()), Box::new(resolver));
+        self
+    }
+
+    pub fn into_server_builder(self) -> MockGraphQlServerBuilder {
+        let Self {
+            sdl,
+            mut field_resolvers,
+        } = self;
+
+        let schema = cynic_parser::parse_type_system_document(&sdl)
+            .map_err(|e| e.to_report(&sdl))
+            .expect("a valid document");
+
+        let mut builder = schema_builder(&schema);
+
+        for definition in schema.definitions() {
+            match definition {
+                parser::Definition::Type(def) => {
+                    builder = builder.register(convert_type(def, &mut field_resolvers));
+                }
+                parser::Definition::TypeExtension(_) => {
+                    unimplemented!("this is just for tests, extensions aren't supported")
+                }
+                _ => {}
+            }
+        }
+
+        let schema = builder.finish().unwrap();
+
+        MockGraphQlServer::builder(DynamicSchema { schema, sdl })
+    }
+}
+
+fn convert_type(
+    def: parser::TypeDefinition<'_>,
+    resolvers: &mut ResolverMap,
+) -> async_graphql::dynamic::Type {
+    match def {
+        parser::TypeDefinition::Scalar(def) => {
+            async_graphql::dynamic::Scalar::new(def.name()).into()
+        }
+        parser::TypeDefinition::Object(def) => convert_object(def, resolvers),
+        parser::TypeDefinition::Interface(def) => convert_iface(def),
+        parser::TypeDefinition::Union(def) => convert_union(def),
+        parser::TypeDefinition::Enum(def) => convert_enum(def),
+        parser::TypeDefinition::InputObject(def) => convert_input_object(def),
+    }
+}
+
+fn convert_object(
+    def: parser::ObjectDefinition<'_>,
+    resolvers: &mut ResolverMap,
+) -> async_graphql::dynamic::Type {
+    use async_graphql::dynamic::*;
+
+    let mut object = Object::new(def.name());
+
+    if let Some(description) = def.description() {
+        object = object.description(description.to_cow());
+    }
+
+    for name in def.implements_interfaces() {
+        object = object.implement(name);
+    }
+
+    for field_def in def.fields() {
+        let type_ref = convert_type_ref(field_def.ty());
+        let resolver = std::sync::Mutex::new(
+            resolvers
+                .remove(&(def.name().into(), field_def.name().into()))
+                .unwrap_or_else(|| Box::new(default_field_resolver(field_def.name()))),
+        );
+
+        let mut field = Field::new(field_def.name(), type_ref, move |context| {
+            let mut resolver = resolver.lock().expect("mutex to be unpoisoned");
+            FieldFuture::Value(resolver.resolve(context).map(|value| {
+                let value = async_graphql::Value::deserialize(value).unwrap();
+                transform_into_field_value(value)
+            }))
+        });
+
+        if let Some(description) = field_def.description() {
+            field = field.description(description.to_cow());
+        }
+
+        for argument in field_def.arguments() {
+            field = field.argument(convert_input_value(argument));
+        }
+
+        object = object.field(field);
+    }
+
+    object.into()
+}
+
+fn transform_into_field_value(mut value: async_graphql::Value) -> FieldValue<'static> {
+    match value {
+        async_graphql::Value::Object(ref mut fields) => {
+            if let Some(async_graphql::Value::String(ty)) = fields.swap_remove("__typename") {
+                FieldValue::from(value).with_type(ty)
+            } else {
+                FieldValue::from(value)
+            }
+        }
+        async_graphql::Value::List(values) => {
+            FieldValue::list(values.into_iter().map(transform_into_field_value))
+        }
+        value => FieldValue::from(value),
+    }
+}
+
+fn convert_iface(def: parser::InterfaceDefinition<'_>) -> async_graphql::dynamic::Type {
+    use async_graphql::dynamic::*;
+    let mut interface = Interface::new(def.name());
+
+    if let Some(description) = def.description() {
+        interface = interface.description(description.to_cow());
+    }
+
+    for field_def in def.fields() {
+        let type_ref = convert_type_ref(field_def.ty());
+
+        let mut field = InterfaceField::new(field_def.name(), type_ref);
+
+        for argument in field_def.arguments() {
+            field = field.argument(convert_input_value(argument));
+        }
+
+        interface = interface.field(field);
+    }
+
+    interface.into()
+}
+
+fn convert_union(def: parser::UnionDefinition<'_>) -> async_graphql::dynamic::Type {
+    use async_graphql::dynamic::*;
+
+    let mut output = Union::new(def.name());
+
+    if let Some(description) = def.description() {
+        output = output.description(description.to_cow());
+    }
+
+    for member in def.members() {
+        output = output.possible_type(member.name());
+    }
+
+    output.into()
+}
+
+fn convert_enum(def: parser::EnumDefinition<'_>) -> async_graphql::dynamic::Type {
+    use async_graphql::dynamic::*;
+
+    let mut output = Enum::new(def.name()).items(def.values().map(|value| {
+        let mut item = EnumItem::new(value.value());
+
+        if let Some(desc) = value.description() {
+            item = item.description(desc.to_cow());
+        }
+
+        item
+    }));
+
+    if let Some(description) = def.description() {
+        output = output.description(description.to_cow());
+    }
+
+    output.into()
+}
+
+fn convert_input_object(def: parser::InputObjectDefinition<'_>) -> async_graphql::dynamic::Type {
+    use async_graphql::dynamic::*;
+
+    let mut object = InputObject::new(def.name());
+
+    if let Some(description) = def.description() {
+        object = object.description(description.to_cow());
+    }
+
+    for field_def in def.fields() {
+        object = object.field(convert_input_value(field_def))
+    }
+
+    object.into()
+}
+
+fn convert_type_ref(ty: parser::Type<'_>) -> async_graphql::dynamic::TypeRef {
+    use async_graphql::dynamic::TypeRef;
+
+    let mut output = TypeRef::named(ty.name());
+
+    for wrapper in ty.wrappers() {
+        match wrapper {
+            WrappingType::NonNull => {
+                output = TypeRef::NonNull(Box::new(output));
+            }
+            WrappingType::List => {
+                output = TypeRef::List(Box::new(output));
+            }
+        }
+    }
+
+    output
+}
+
+fn convert_input_value(
+    value_def: parser::InputValueDefinition<'_>,
+) -> async_graphql::dynamic::InputValue {
+    use async_graphql::dynamic::InputValue;
+
+    let mut value = InputValue::new(value_def.name(), convert_type_ref(value_def.ty()));
+
+    if let Some(description) = value_def.description() {
+        value = value.description(description.to_cow());
+    }
+
+    if let Some(default) = value_def.default_value() {
+        value = value.default_value(convert_value(default))
+    }
+
+    value
+}
+
+fn convert_value(value: cynic_parser::ConstValue<'_>) -> async_graphql::Value {
+    match value {
+        cynic_parser::ConstValue::Int(inner) => async_graphql::Value::Number(inner.as_i64().into()),
+        cynic_parser::ConstValue::Float(inner) => {
+            async_graphql::Value::Number(serde_json::Number::from_f64(inner.as_f64()).unwrap())
+        }
+        cynic_parser::ConstValue::String(inner) => {
+            async_graphql::Value::String(inner.as_str().into())
+        }
+        cynic_parser::ConstValue::Boolean(inner) => async_graphql::Value::Boolean(inner.as_bool()),
+        cynic_parser::ConstValue::Null(_) => async_graphql::Value::Null,
+        cynic_parser::ConstValue::Enum(inner) => {
+            async_graphql::Value::Enum(async_graphql::Name::new(inner.name()))
+        }
+        cynic_parser::ConstValue::List(inner) => {
+            async_graphql::Value::List(inner.items().map(convert_value).collect())
+        }
+        cynic_parser::ConstValue::Object(inner) => async_graphql::Value::Object(
+            inner
+                .fields()
+                .map(|field| {
+                    (
+                        async_graphql::Name::new(field.name()),
+                        convert_value(field.value()),
+                    )
+                })
+                .collect(),
+        ),
+    }
+}
+
+fn schema_builder(
+    schema: &cynic_parser::TypeSystemDocument,
+) -> async_graphql::dynamic::SchemaBuilder {
+    let (query_name, mutation_name, subscription_name) = root_types(schema);
+    async_graphql::dynamic::Schema::build(query_name, mutation_name, subscription_name)
+}
+
+fn root_types(schema: &cynic_parser::TypeSystemDocument) -> (&str, Option<&str>, Option<&str>) {
+    use parser::Definition;
+
+    let mut query_name = "Query";
+    let mut mutation_name = None;
+    let mut subscription_name = None;
+    let mut found_schema_def = false;
+    let mut mutation_present = false;
+    let mut subscription_present = false;
+    for definition in schema.definitions() {
+        if let Definition::Schema(_) = definition {
+            found_schema_def = true;
+        }
+        match definition {
+            Definition::Schema(schema) | Definition::SchemaExtension(schema) => {
+                if let Some(def) = schema.query_type() {
+                    query_name = def.named_type();
+                }
+                if let Some(def) = schema.mutation_type() {
+                    mutation_name = Some(def.named_type());
+                }
+                if let Some(def) = schema.subscription_type() {
+                    subscription_name = Some(def.named_type());
+                }
+            }
+            Definition::Type(ty) | Definition::TypeExtension(ty) if ty.name() == "Mutation" => {
+                mutation_present = true
+            }
+            Definition::Type(ty) | Definition::TypeExtension(ty) if ty.name() == "Subscription" => {
+                subscription_present = true
+            }
+            _ => {}
+        }
+    }
+    if !found_schema_def {
+        if mutation_present {
+            mutation_name = Some("Mutation");
+        }
+        if subscription_present {
+            mutation_name = Some("Subscription");
+        }
+    }
+
+    (query_name, mutation_name, subscription_name)
+}
+
+fn default_field_resolver(field_name: &str) -> impl Resolver {
+    let field_name = async_graphql::Name::new(field_name);
+
+    move |context: ResolverContext<'_>| {
+        if let Some(value) = context.parent_value.as_value() {
+            return match value {
+                async_graphql::Value::Object(map) => map
+                    .get(&field_name)
+                    .map(|value| value.clone().into_json().unwrap()),
+                _ => None,
+            };
+        }
+        panic!("Unexpected parent value for tests",)
+    }
+}

--- a/graphql-mocks/src/dynamic/mod.rs
+++ b/graphql-mocks/src/dynamic/mod.rs
@@ -1,0 +1,42 @@
+mod builder;
+mod resolvers;
+
+pub use self::builder::DynamicSchemaBuilder;
+
+use futures_lite::stream;
+
+/// async-graphql powered dynamic schemas for tests.
+///
+/// Occasionally its just easier to write SDL & resolvers, this lets you do that.
+pub struct DynamicSchema {
+    schema: async_graphql::dynamic::Schema,
+    sdl: String,
+}
+
+impl DynamicSchema {
+    pub fn builder(sdl: impl AsRef<str>) -> DynamicSchemaBuilder {
+        DynamicSchemaBuilder::new(sdl.as_ref())
+    }
+}
+
+#[async_trait::async_trait]
+impl super::Schema for DynamicSchema {
+    async fn execute(
+        &self,
+        _headers: Vec<(String, String)>,
+        request: async_graphql::Request,
+    ) -> async_graphql::Response {
+        self.schema.execute(request).await
+    }
+
+    fn execute_stream(
+        &self,
+        request: async_graphql::Request,
+    ) -> stream::Boxed<async_graphql::Response> {
+        Box::pin(self.schema.execute_stream(request))
+    }
+
+    fn sdl(&self) -> String {
+        self.sdl.clone()
+    }
+}

--- a/graphql-mocks/src/dynamic/resolvers.rs
+++ b/graphql-mocks/src/dynamic/resolvers.rs
@@ -1,0 +1,33 @@
+use async_graphql::{dynamic::ResolverContext, ServerError};
+
+pub trait Resolver: Send + Sync {
+    fn resolve(&mut self, context: ResolverContext<'_>) -> Option<serde_json::Value>;
+}
+
+impl<F> Resolver for F
+where
+    for<'a> F: FnMut(ResolverContext<'a>) -> Option<serde_json::Value> + Send + Sync,
+{
+    fn resolve(&mut self, context: ResolverContext<'_>) -> Option<serde_json::Value> {
+        self(context)
+    }
+}
+
+impl Resolver for serde_json::Value {
+    fn resolve(&mut self, _context: ResolverContext<'_>) -> Option<serde_json::Value> {
+        Some(self.clone())
+    }
+}
+
+impl Resolver for ServerError {
+    fn resolve(&mut self, context: ResolverContext<'_>) -> Option<serde_json::Value> {
+        context.add_error(self.clone());
+        None
+    }
+}
+
+impl Resolver for Option<serde_json::Value> {
+    fn resolve(&mut self, _context: ResolverContext<'_>) -> Option<serde_json::Value> {
+        self.clone()
+    }
+}

--- a/graphql-mocks/src/lib.rs
+++ b/graphql-mocks/src/lib.rs
@@ -1,0 +1,89 @@
+//! A mock GraphQL server for use in tests
+
+use futures_lite::stream;
+
+use std::sync::Arc;
+
+use serde::ser::SerializeMap;
+
+mod dynamic;
+pub mod mocks;
+mod server;
+
+pub use async_graphql::dynamic::ResolverContext;
+pub use dynamic::{DynamicSchema, DynamicSchemaBuilder};
+pub use server::{builder::MockGraphQlServerBuilder, MockGraphQlServer};
+
+#[derive(Debug)]
+pub struct ReceivedRequest {
+    pub headers: http::HeaderMap,
+    pub body: async_graphql::Request,
+}
+
+impl serde::Serialize for ReceivedRequest {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut map = serializer.serialize_map(Some(2))?;
+        let mut headers = self
+            .headers
+            .iter()
+            .map(|(name, value)| {
+                (
+                    name.to_string(),
+                    String::from_utf8_lossy(value.as_bytes()).into_owned(),
+                )
+            })
+            .collect::<Vec<_>>();
+        headers.sort_unstable();
+        map.serialize_entry("headers", &headers)?;
+        map.serialize_entry("body", &self.body)?;
+        map.end()
+    }
+}
+
+impl std::ops::Deref for ReceivedRequest {
+    type Target = async_graphql::Request;
+    fn deref(&self) -> &Self::Target {
+        &self.body
+    }
+}
+
+/// Creating a trait for schema so we can use it as a trait object and avoid
+/// making everything generic over Query, Mutation & Subscription params
+#[async_trait::async_trait]
+pub trait Schema: Send + Sync {
+    async fn execute(
+        &self,
+        headers: Vec<(String, String)>,
+        request: async_graphql::Request,
+    ) -> async_graphql::Response;
+
+    fn execute_stream(
+        &self,
+        request: async_graphql::Request,
+    ) -> stream::Boxed<async_graphql::Response>;
+
+    fn sdl(&self) -> String;
+}
+
+#[derive(Clone)]
+pub struct SchemaExecutor(Arc<dyn Schema>);
+
+#[async_trait::async_trait]
+impl async_graphql::Executor for SchemaExecutor {
+    /// Execute a GraphQL query.
+    async fn execute(&self, request: async_graphql::Request) -> async_graphql::Response {
+        self.0.execute(Default::default(), request).await
+    }
+
+    /// Execute a GraphQL subscription with session data.
+    fn execute_stream(
+        &self,
+        request: async_graphql::Request,
+        _session_data: Option<Arc<async_graphql::Data>>,
+    ) -> stream::Boxed<async_graphql::Response> {
+        self.0.execute_stream(request)
+    }
+}

--- a/graphql-mocks/src/mocks/mod.rs
+++ b/graphql-mocks/src/mocks/mod.rs
@@ -1,0 +1,1 @@
+pub mod swapi;

--- a/graphql-mocks/src/mocks/swapi.rs
+++ b/graphql-mocks/src/mocks/swapi.rs
@@ -1,0 +1,49 @@
+use serde_json::{json, Value};
+
+use crate::{DynamicSchema, MockGraphQlServer, ResolverContext};
+
+pub async fn serve() -> MockGraphQlServer {
+    DynamicSchema::builder(include_str!("../../../schemas/starwars.schema.graphql"))
+        .with_resolver("Root", "film", film_resolver)
+        .with_resolver("Root", "node", node_resolver)
+        .into_server_builder()
+        .await
+}
+
+fn film_resolver(context: ResolverContext) -> Option<Value> {
+    let id = context.args.get("id")?.string().ok()?;
+    match id {
+        "ZmlsbXM6MQ==" => Some(json!({
+            "id": "ZmlsbXM6MQ==",
+            "title": "A New Hope",
+            "director": "George Lucas",
+            "releaseDate": "1977-05-25",
+            "producers": ["Gary Kurtz", "Rick McCallum"]
+        })),
+        _ => None,
+    }
+}
+
+fn node_resolver(context: ResolverContext) -> Option<Value> {
+    let id = context.args.get("id")?.string().ok()?;
+    match id {
+        "ZmlsbXM6MQ==" => Some(json!({
+            "__typename": "Film",
+            "id": "ZmlsbXM6MQ==",
+            "title": "A New Hope",
+            "director": "George Lucas",
+            "releaseDate": "1977-05-25",
+            "producers": ["Gary Kurtz", "Rick McCallum"]
+        })),
+        "cGxhbmV0czo0OQ==" => Some(json!({
+            "__typename": "Planet",
+            "id": "cGxhbmV0czo0OQ==",
+            "name": "Dorin"
+        })),
+        "c3RhcnNoaXBzOjY1" => Some(json!({
+            "__typename": "Starship",
+            "id": "c3RhcnNoaXBzOjY1"
+        })),
+        _ => None,
+    }
+}

--- a/graphql-mocks/src/server.rs
+++ b/graphql-mocks/src/server.rs
@@ -1,0 +1,95 @@
+use std::{sync::Arc, time::Duration};
+
+use async_graphql_axum::GraphQLSubscription;
+use axum::{routing::post, Router};
+use builder::MockGraphQlServerBuilder;
+use handler::graphql_handler;
+use url::Url;
+
+use crate::{ReceivedRequest, Schema, SchemaExecutor};
+
+pub(crate) mod builder;
+mod handler;
+
+pub struct MockGraphQlServer {
+    state: AppState,
+    shutdown: Option<tokio::sync::oneshot::Sender<()>>,
+    port: u16,
+}
+
+impl Drop for MockGraphQlServer {
+    fn drop(&mut self) {
+        if let Some(shutdown) = self.shutdown.take() {
+            shutdown.send(()).ok();
+        }
+    }
+}
+
+impl MockGraphQlServer {
+    pub(crate) fn builder(schema: impl Schema + 'static) -> MockGraphQlServerBuilder {
+        MockGraphQlServerBuilder::new(Arc::new(schema))
+    }
+
+    async fn new_impl(schema: Arc<dyn Schema>, port: Option<u16>) -> Self {
+        let state = AppState {
+            schema: schema.clone(),
+            received_requests: Default::default(),
+        };
+
+        let app = Router::new()
+            .route("/", post(graphql_handler))
+            .route_service("/ws", GraphQLSubscription::new(SchemaExecutor(schema)))
+            .with_state(state.clone());
+
+        let listener = tokio::net::TcpListener::bind(format!("127.0.0.1:{}", port.unwrap_or(0)))
+            .await
+            .unwrap();
+        let port = listener.local_addr().unwrap().port();
+
+        let (shutdown_sender, shutdown_receiver) = tokio::sync::oneshot::channel::<()>();
+
+        tokio::spawn(async move {
+            axum::serve(listener, app)
+                .with_graceful_shutdown(async move {
+                    shutdown_receiver.await.ok();
+                })
+                .await
+                .unwrap();
+        });
+
+        // Give the server time to start
+        tokio::time::sleep(Duration::from_millis(20)).await;
+
+        MockGraphQlServer {
+            state,
+            shutdown: Some(shutdown_sender),
+            port,
+        }
+    }
+
+    pub fn port(&self) -> u16 {
+        self.port
+    }
+
+    pub fn url(&self) -> Url {
+        format!("http://127.0.0.1:{}", self.port).parse().unwrap()
+    }
+
+    pub fn sdl(&self) -> String {
+        self.state.schema.sdl()
+    }
+
+    pub fn websocket_url(&self) -> Url {
+        format!("ws://127.0.0.1:{}/ws", self.port).parse().unwrap()
+    }
+
+    pub fn drain_received_requests(&self) -> impl Iterator<Item = ReceivedRequest> + '_ {
+        std::iter::from_fn(|| self.state.received_requests.pop())
+    }
+}
+
+#[derive(Clone)]
+struct AppState {
+    schema: Arc<dyn Schema>,
+    received_requests: Arc<crossbeam_queue::SegQueue<ReceivedRequest>>,
+}

--- a/graphql-mocks/src/server/builder.rs
+++ b/graphql-mocks/src/server/builder.rs
@@ -1,0 +1,37 @@
+use std::{future::IntoFuture, sync::Arc};
+
+use futures_lite::{future, FutureExt};
+
+use crate::Schema;
+
+use super::MockGraphQlServer;
+
+pub struct MockGraphQlServerBuilder {
+    schema: Arc<dyn Schema>,
+    port: Option<u16>,
+}
+
+impl MockGraphQlServerBuilder {
+    pub(super) fn new(schema: Arc<dyn Schema>) -> Self {
+        MockGraphQlServerBuilder { schema, port: None }
+    }
+
+    pub fn with_port(mut self, port: u16) -> Self {
+        self.port = Some(port);
+        self
+    }
+
+    pub async fn build(self) -> MockGraphQlServer {
+        MockGraphQlServer::new_impl(self.schema, self.port).await
+    }
+}
+
+impl IntoFuture for MockGraphQlServerBuilder {
+    type Output = MockGraphQlServer;
+
+    type IntoFuture = future::Boxed<Self::Output>;
+
+    fn into_future(self) -> Self::IntoFuture {
+        self.build().boxed()
+    }
+}

--- a/graphql-mocks/src/server/handler.rs
+++ b/graphql-mocks/src/server/handler.rs
@@ -1,0 +1,36 @@
+use async_graphql_axum::{GraphQLRequest, GraphQLResponse};
+use axum::{extract::State, response::IntoResponse};
+use http::HeaderMap;
+
+use crate::ReceivedRequest;
+
+use super::AppState;
+
+pub(super) async fn graphql_handler(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    req: GraphQLRequest,
+) -> axum::response::Response {
+    let req = req.into_inner();
+
+    // Record the request incase tests want to inspect it.
+    // async_graphql::Request isn't clone so we do a deser roundtrip instead
+    state.received_requests.push(ReceivedRequest {
+        headers: headers.clone(),
+        body: serde_json::from_value(serde_json::to_value(&req).unwrap()).unwrap(),
+    });
+
+    let headers = headers
+        .iter()
+        .map(|(name, value)| {
+            (
+                name.to_string(),
+                String::from_utf8_lossy(value.as_bytes()).to_string(),
+            )
+        })
+        .collect();
+
+    let response: GraphQLResponse = state.schema.execute(headers, req).await.into();
+
+    response.into_response()
+}

--- a/tests/querygen-compile-run/Cargo.toml
+++ b/tests/querygen-compile-run/Cargo.toml
@@ -10,9 +10,11 @@ publish = false
 [dependencies]
 cynic = { path = "../../cynic" }
 serde_json = "1.0"
-ureq = { version = "2.4", features = ["json"] }
+reqwest = { version = "0.12", features = ["json"] }
 
 [dev-dependencies]
+graphql-mocks.workspace = true
+tokio = { version = "1", features = ["macros"] }
 trybuild = "1.0.80"
 
 [build-dependencies]


### PR DESCRIPTION
The hosted swapi GraphQL endpoint doesn't seem to be working at the moment, and it's causing all the tests to fail.  Not ideal.

This adds a graphql-mocks crate (ported & simplified from an implementation in the grafbase repo - probably not the cleanest since I did the port quick n dirty, but it works) and updates the tests to use that.