### PR TITLE
feat!: rework extension handling on errors & responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ## Unreleased - xxxx-xx-xx
 
+### Breaking Changes
+
+- Removed the `ErrorExtensions` generic parameter from `GraphQlResponse`
+- `GraphQlResponse::new` no longer accepts error extensions - use the new
+  `set_extensions` or `with_extensions` functions to set these
+- The `extensions` field of `GraphQlError` is now private.
+- Removed `CynicReqwestBuilder::retain_extensions` - users should use the
+  `GraphQlError::extensions` instead.
+
+### New Features
+
+- Added new methods for deserializing extensions in responses:
+  - `GraphQlResponse::extensions` for deserializing response extensions.
+  - `GraphQlError::extensions` for reading error extensions
+
 ## v3.10.0 - 2025-02-10
 
 ### New Features

--- a/cynic/src/lib.rs
+++ b/cynic/src/lib.rs
@@ -173,7 +173,7 @@ mod builders;
 mod core;
 mod id;
 mod operation;
-mod result;
+mod response;
 
 pub mod coercions;
 pub mod queries;
@@ -190,7 +190,7 @@ pub use {
     builders::{MutationBuilder, QueryBuilder, SubscriptionBuilder},
     id::Id,
     operation::{Operation, OperationBuildError, OperationBuilder, StreamingOperation},
-    result::*,
+    response::*,
     variables::{QueryVariableLiterals, QueryVariables, QueryVariablesFields},
 };
 


### PR DESCRIPTION
#### Why are we making this change?

GraphQl allows a server to provide arbitrary extensions on responses & errors within a response.  Currently cynic only supports decoding these extensions on errors.  It does this with generic parameters on the response & error type.  

These generic parameters are a little awkward when using the cynic http code - as we need a way to pass through the expected extension types.  This led to the addition of a `retain_extensions` function.

Some users would also like to access extensions on the response itself.

#### What effects does this change have?

Adds support for extensions on the response type.  Rather than adding this as a new generic parameter we now store extensions in a `serde_json::Value` and provide functionality for deserialising from that.  This saves us from adding _another_ generic parameter everywhere, and saves us from having to implement functions like `retain_extensions` in the http layer.

Fixes #1016 


