### PR TITLE
fix: proper behavior of const_safe for list & objects

### DIFF
--- a/cynic-parser/src/type_system/mod.rs
+++ b/cynic-parser/src/type_system/mod.rs
@@ -71,7 +71,7 @@ pub struct TypeSystemDocument {
     values: crate::values::ValueStore,
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum DirectiveLocation {
     Query,
     Mutation,

--- a/cynic-parser/src/values/const_value.rs
+++ b/cynic-parser/src/values/const_value.rs
@@ -234,7 +234,7 @@ fn const_safe(value: Value<'_>) -> bool {
         | Value::Boolean(_)
         | Value::Null(_)
         | Value::Enum(_) => true,
-        Value::List(items) => items.items().any(const_safe),
-        Value::Object(object) => object.fields().any(|field| const_safe(field.value())),
+        Value::List(items) => items.items().all(const_safe),
+        Value::Object(object) => object.fields().all(|field| const_safe(field.value())),
     }
 }


### PR DESCRIPTION
Long overdue first PR!

`const_safe` uses `any` instead of all `all`, so we end up with a wrong result.
Also added `PartialEq, Eq, Hash` on DirectiveLocation enum as I needed them.
