### PR TITLE
feat: add directive support to generator

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,12 +40,14 @@ version = "3.10.0"
 rust-version = "1.80"
 
 [workspace.dependencies]
-cynic-parser = { path = "cynic-parser", version = "0.9" }
-cynic-parser-deser-macros = { path = "cynic-parser-deser-macros", version = "0.9" }
 darling = "0.20"
-graphql-mocks.path = "graphql-mocks"
+insta = { version = "1", features = ["yaml", "json"] }
 rstest = "0.23"
 syn = "2"
+
+cynic-parser = { path = "cynic-parser", version = "0.9" }
+cynic-parser-deser-macros = { path = "cynic-parser-deser-macros", version = "0.9" }
+graphql-mocks.path = "graphql-mocks"
 
 [profile.dev]
 # Disabling debug info speeds up builds a bunch,

--- a/cynic-codegen/Cargo.toml
+++ b/cynic-codegen/Cargo.toml
@@ -26,14 +26,14 @@ ouroboros = "0.18"
 proc-macro2 = "1.0"
 quote = "1.0"
 strsim = "0.10.0"
-syn = { workspace = true , features = ["visit-mut"] }
+syn = { workspace = true, features = ["visit-mut"] }
 thiserror = "1"
 
 rkyv = { version = "0.7.41", features = ["validation"], optional = true }
 
 [dev-dependencies]
 assert_matches = "1.4.0"
-insta = "1.17"
+insta.workspace = true
 maplit = "1.0.2"
 rstest.workspace = true
 

--- a/cynic-introspection/Cargo.toml
+++ b/cynic-introspection/Cargo.toml
@@ -28,7 +28,7 @@ version = "3"
 [dev-dependencies]
 assert_matches = "1.4"
 graphql-mocks.workspace = true
-insta = "1.4"
+insta.workspace = true
 maplit = "1.0.2"
 tokio = { version = "1", features = ["macros"] }
 reqwest = "0.12"

--- a/cynic-parser/Cargo.toml
+++ b/cynic-parser/Cargo.toml
@@ -32,7 +32,7 @@ ariadne = { version = "0.4", optional = true }
 pretty = { version = "0.12", optional = true }
 
 [dev-dependencies]
-insta = "1.29"
+insta.workspace = true
 similar-asserts = "1.5"
 
 # Tests need the `pretty` functionality so enable it here

--- a/cynic-querygen/Cargo.toml
+++ b/cynic-querygen/Cargo.toml
@@ -23,5 +23,5 @@ cynic-parser.workspace = true
 
 [dev-dependencies]
 assert_matches = "1.4"
-insta = "1.17.1"
+insta.workspace = true
 rstest.workspace = true

--- a/cynic-querygen/src/lib.rs
+++ b/cynic-querygen/src/lib.rs
@@ -29,6 +29,9 @@ pub enum Error {
     #[error("could not find type `{0}`")]
     UnknownType(String),
 
+    #[error("could not find directive `{0}`")]
+    UnknownDirective(String),
+
     #[error("expected type `{0}` to be an object")]
     ExpectedObject(String),
 

--- a/cynic-querygen/src/query_parsing/mod.rs
+++ b/cynic-querygen/src/query_parsing/mod.rs
@@ -9,7 +9,7 @@ mod variables;
 
 use variables::VariableStructDetails;
 
-pub use normalisation::Variable;
+pub use normalisation::{Directive, Variable};
 pub use value::{LiteralContext, TypedValue};
 
 use cynic_parser::{executable as parser, ExecutableDocument};
@@ -121,11 +121,12 @@ fn make_query_fragment<'text>(
                     arguments: field
                         .arguments
                         .iter()
-                        .map(|(name, value)| -> Result<FieldArgument, Error> {
-                            Ok(FieldArgument::new(name, value.clone()))
+                        .map(|argument| -> Result<FieldArgument, Error> {
+                            Ok(FieldArgument::new(argument.name, argument.value.clone()))
                         })
                         .collect::<Result<Vec<_>, _>>()
                         .unwrap(),
+                    directives: field.directives.clone(),
                 }
             })
             .collect(),

--- a/cynic-querygen/src/query_parsing/normalisation.rs
+++ b/cynic-querygen/src/query_parsing/normalisation.rs
@@ -59,6 +59,8 @@ pub struct FieldSelection<'query, 'schema> {
 
     pub arguments: Vec<(&'schema str, TypedValue<'query, 'schema>)>,
 
+    pub directives: Vec<(&'schema str, TypedValue<'query, 'schema>)>,
+
     pub field: Field<'query, 'schema>,
 }
 
@@ -95,6 +97,7 @@ impl<'query, 'schema> FieldSelection<'query, 'schema> {
         name: &'query str,
         alias: Option<&'query str>,
         arguments: Vec<(&'schema str, TypedValue<'query, 'schema>)>,
+        directives: Vec<(&'schema str, TypedValue<'query, 'schema>)>,
         schema_field: OutputField<'schema>,
         field: Field<'query, 'schema>,
     ) -> FieldSelection<'query, 'schema> {
@@ -102,6 +105,7 @@ impl<'query, 'schema> FieldSelection<'query, 'schema> {
             name,
             alias,
             arguments,
+            directives,
             schema_field,
             field,
         }
@@ -297,10 +301,21 @@ impl<'a, 'docs> Normaliser<'a, 'docs> {
                     ));
                 }
 
+                let directives = field
+                    .directives()
+                    .map(|directive| {
+                        let name = directive.name();
+                        let schema_directive = self.type_index.directive(name)?;
+
+                        (schema_directive.name(), todo!())
+                    })
+                    .collect::<Result<_, _>>()?;
+
                 Ok(vec![Selection::Field(FieldSelection::new(
                     field.name(),
                     field.alias(),
                     arguments,
+                    directives,
                     schema_field,
                     inner_field,
                 ))])

--- a/cynic-querygen/src/query_parsing/snapshots/cynic_querygen__query_parsing__normalisation__tests__check_fragment_spread_output.snap
+++ b/cynic-querygen/src/query_parsing/snapshots/cynic_querygen__query_parsing__normalisation__tests__check_fragment_spread_output.snap
@@ -1,7 +1,7 @@
 ---
 source: cynic-querygen/src/query_parsing/normalisation.rs
-assertion_line: 700
-expression: film_selections.get(0).unwrap().selections
+expression: film_selections.first().unwrap().selections
+snapshot_kind: text
 ---
 [
     Field(
@@ -20,6 +20,7 @@ expression: film_selections.get(0).unwrap().selections
                 arguments: [],
             },
             arguments: [],
+            directives: [],
             field: Leaf,
         },
     ),
@@ -37,6 +38,7 @@ expression: film_selections.get(0).unwrap().selections
                 arguments: [],
             },
             arguments: [],
+            directives: [],
             field: Leaf,
         },
     ),

--- a/cynic-querygen/src/query_parsing/snapshots/cynic_querygen__query_parsing__normalisation__tests__check_inline_fragment_output.snap
+++ b/cynic-querygen/src/query_parsing/snapshots/cynic_querygen__query_parsing__normalisation__tests__check_inline_fragment_output.snap
@@ -1,7 +1,7 @@
 ---
 source: cynic-querygen/src/query_parsing/normalisation.rs
-assertion_line: 815
-expression: film_selections.get(0).unwrap().selections
+expression: film_selections.first().unwrap().selections
+snapshot_kind: text
 ---
 [
     Field(
@@ -20,6 +20,7 @@ expression: film_selections.get(0).unwrap().selections
                 arguments: [],
             },
             arguments: [],
+            directives: [],
             field: Leaf,
         },
     ),
@@ -37,6 +38,7 @@ expression: film_selections.get(0).unwrap().selections
                 arguments: [],
             },
             arguments: [],
+            directives: [],
             field: Leaf,
         },
     ),

--- a/cynic-querygen/src/query_parsing/snapshots/cynic_querygen__query_parsing__normalisation__tests__check_output_makes_sense.snap
+++ b/cynic-querygen/src/query_parsing/snapshots/cynic_querygen__query_parsing__normalisation__tests__check_output_makes_sense.snap
@@ -1,6 +1,7 @@
 ---
 source: cynic-querygen/src/query_parsing/normalisation.rs
 expression: normalised
+snapshot_kind: text
 ---
 NormalisedDocument {
     selection_sets: {
@@ -340,6 +341,7 @@ NormalisedDocument {
                             arguments: [],
                         },
                         arguments: [],
+                        directives: [],
                         field: Leaf,
                     },
                 ),
@@ -357,6 +359,7 @@ NormalisedDocument {
                             arguments: [],
                         },
                         arguments: [],
+                        directives: [],
                         field: Leaf,
                     },
                 ),
@@ -696,6 +699,7 @@ NormalisedDocument {
                             arguments: [],
                         },
                         arguments: [],
+                        directives: [],
                         field: Leaf,
                     },
                 ),
@@ -780,6 +784,7 @@ NormalisedDocument {
                             arguments: [],
                         },
                         arguments: [],
+                        directives: [],
                         field: Composite(
                             SelectionSet {
                                 target_type: Object(
@@ -1117,6 +1122,7 @@ NormalisedDocument {
                                                 arguments: [],
                                             },
                                             arguments: [],
+                                            directives: [],
                                             field: Leaf,
                                         },
                                     ),
@@ -1134,6 +1140,7 @@ NormalisedDocument {
                                                 arguments: [],
                                             },
                                             arguments: [],
+                                            directives: [],
                                             field: Leaf,
                                         },
                                     ),
@@ -1640,6 +1647,7 @@ NormalisedDocument {
                             ],
                         },
                         arguments: [],
+                        directives: [],
                         field: Composite(
                             SelectionSet {
                                 target_type: Object(
@@ -1720,6 +1728,7 @@ NormalisedDocument {
                                                 arguments: [],
                                             },
                                             arguments: [],
+                                            directives: [],
                                             field: Composite(
                                                 SelectionSet {
                                                     target_type: Object(
@@ -2057,6 +2066,7 @@ NormalisedDocument {
                                                                     arguments: [],
                                                                 },
                                                                 arguments: [],
+                                                                directives: [],
                                                                 field: Leaf,
                                                             },
                                                         ),
@@ -2074,6 +2084,7 @@ NormalisedDocument {
                                                                     arguments: [],
                                                                 },
                                                                 arguments: [],
+                                                                directives: [],
                                                                 field: Leaf,
                                                             },
                                                         ),
@@ -2118,9 +2129,9 @@ NormalisedDocument {
                             ],
                         },
                         arguments: [
-                            (
-                                "id",
-                                String(
+                            Argument {
+                                name: "id",
+                                value: String(
                                     "abcd",
                                     NamedType(
                                         InputTypeRef {
@@ -2128,8 +2139,9 @@ NormalisedDocument {
                                         },
                                     ),
                                 ),
-                            ),
+                            },
                         ],
+                        directives: [],
                         field: Composite(
                             SelectionSet {
                                 target_type: Object(
@@ -2465,6 +2477,7 @@ NormalisedDocument {
                                                 arguments: [],
                                             },
                                             arguments: [],
+                                            directives: [],
                                             field: Leaf,
                                         },
                                     ),
@@ -2975,6 +2988,7 @@ NormalisedDocument {
                                 ],
                             },
                             arguments: [],
+                            directives: [],
                             field: Composite(
                                 SelectionSet {
                                     target_type: Object(
@@ -3055,6 +3069,7 @@ NormalisedDocument {
                                                     arguments: [],
                                                 },
                                                 arguments: [],
+                                                directives: [],
                                                 field: Composite(
                                                     SelectionSet {
                                                         target_type: Object(
@@ -3392,6 +3407,7 @@ NormalisedDocument {
                                                                         arguments: [],
                                                                     },
                                                                     arguments: [],
+                                                                    directives: [],
                                                                     field: Leaf,
                                                                 },
                                                             ),
@@ -3409,6 +3425,7 @@ NormalisedDocument {
                                                                         arguments: [],
                                                                     },
                                                                     arguments: [],
+                                                                    directives: [],
                                                                     field: Leaf,
                                                                 },
                                                             ),
@@ -3453,9 +3470,9 @@ NormalisedDocument {
                                 ],
                             },
                             arguments: [
-                                (
-                                    "id",
-                                    String(
+                                Argument {
+                                    name: "id",
+                                    value: String(
                                         "abcd",
                                         NamedType(
                                             InputTypeRef {
@@ -3463,8 +3480,9 @@ NormalisedDocument {
                                             },
                                         ),
                                     ),
-                                ),
+                                },
                             ],
+                            directives: [],
                             field: Composite(
                                 SelectionSet {
                                     target_type: Object(
@@ -3800,6 +3818,7 @@ NormalisedDocument {
                                                     arguments: [],
                                                 },
                                                 arguments: [],
+                                                directives: [],
                                                 field: Leaf,
                                             },
                                         ),

--- a/cynic-querygen/src/query_parsing/variables.rs
+++ b/cynic-querygen/src/query_parsing/variables.rs
@@ -47,9 +47,16 @@ impl<'query, 'schema> SelectionArguments<'query, 'schema> {
         let mut fields = Vec::new();
         for selection in &selection_set.selections {
             let Selection::Field(field) = selection;
-            for (_, value) in &field.arguments {
-                for variable in value.variables() {
+            for arg in &field.arguments {
+                for variable in arg.value.variables() {
                     fields.push(SelectionArgument::VariableArgument(variable));
+                }
+            }
+            for directive in &field.directives {
+                for argument in &directive.arguments {
+                    for variable in argument.value.variables() {
+                        fields.push(SelectionArgument::VariableArgument(variable));
+                    }
                 }
             }
 

--- a/cynic-querygen/src/schema/fields.rs
+++ b/cynic-querygen/src/schema/fields.rs
@@ -244,7 +244,7 @@ fn input_type_spec_imp(
 macro_rules! impl_field_type_from_parser_type {
     ($target:ident, $ref_type:ident) => {
         impl<'schema> $target<'schema> {
-            fn from_parser(
+            pub fn from_parser(
                 parser_type: parser::Type<'schema>,
                 type_index: &Rc<TypeIndex<'schema>>,
             ) -> Self {

--- a/cynic-querygen/src/schema/type_index.rs
+++ b/cynic-querygen/src/schema/type_index.rs
@@ -1,5 +1,4 @@
 use cynic_parser::{
-    executable::Directive,
     type_system::{
         self, ids::FieldDefinitionId, Definition, DirectiveDefinition, FieldDefinition,
         TypeDefinition,

--- a/cynic-querygen/tests/github-tests.rs
+++ b/cynic-querygen/tests/github-tests.rs
@@ -35,5 +35,6 @@ test_query!(input_object_arguments, "input-object-arguments.graphql");
 test_query!(input_object_literals, "input-object-literals.graphql");
 test_query!(literal_enums, "literal-enums.graphql");
 test_query!(queries_with_typename, "queries-with-typename.graphql");
-
-test_query!(issue_786, "issue-786.graphql");
+test_query!(query_with_all_derives, "query-with-all-derives.graphql");
+test_query!(test_include, "test-include.graphql");
+test_query!(test_skip, "test-skip.graphql");

--- a/cynic-querygen/tests/queries/github/test-include.graphql
+++ b/cynic-querygen/tests/queries/github/test-include.graphql
@@ -1,0 +1,15 @@
+query ($includeAll: Boolean!) {
+  repository(owner: "obmarg", name: "cynic") @include(if: $includeAll) {
+    issueOrPullRequest(number: 1) @include(if: false) {
+      ... on Issue {
+        id
+        title
+        lastEditedAt
+      }
+      ... on PullRequest {
+        id
+        title
+      }
+    }
+  }
+}

--- a/cynic-querygen/tests/queries/github/test-skip.graphql
+++ b/cynic-querygen/tests/queries/github/test-skip.graphql
@@ -1,0 +1,15 @@
+query ($skipAll: Boolean!) {
+  repository(owner: "obmarg", name: "cynic") @skip(if: $skipAll) {
+    issueOrPullRequest(number: 1) @skip(if: false) {
+      ... on Issue {
+        id
+        title
+        lastEditedAt
+      }
+      ... on PullRequest {
+        id
+        title
+      }
+    }
+  }
+}

--- a/cynic-querygen/tests/queries/starwars/include.graphql
+++ b/cynic-querygen/tests/queries/starwars/include.graphql
@@ -1,0 +1,6 @@
+query IncludeTest($filmId: ID!, $includeTitle: Boolean!) {
+  film(id: $filmId) {
+    title @include(if: $includeTitle)
+    director
+  }
+}

--- a/cynic-querygen/tests/queries/starwars/skip.graphql
+++ b/cynic-querygen/tests/queries/starwars/skip.graphql
@@ -1,0 +1,6 @@
+query SkipTest($filmId: ID!, $skipTitle: Boolean!) {
+  film(id: $filmId) {
+    title @skip(if: $skipTitle)
+    director
+  }
+}

--- a/cynic-querygen/tests/snapshots/github_tests__include.snap
+++ b/cynic-querygen/tests/snapshots/github_tests__include.snap
@@ -1,0 +1,48 @@
+---
+source: cynic-querygen/tests/github-tests.rs
+expression: "document_to_fragment_structs(query, schema,\n        &QueryGenOptions::default()).expect(\"QueryGen Failed\")"
+snapshot_kind: text
+---
+#[derive(cynic::QueryVariables, Debug)]
+pub struct UnnamedQueryVariables {
+    pub include_all: bool,
+}
+
+#[derive(cynic::QueryFragment, Debug)]
+#[cynic(graphql_type = "Query", variables = "UnnamedQueryVariables")]
+pub struct UnnamedQuery {
+    #[arguments(owner: "obmarg", name: "cynic")]
+    #[directives(include(if: $include_all))]
+    pub repository: Option<Repository>,
+}
+
+#[derive(cynic::QueryFragment, Debug)]
+pub struct Repository {
+    #[arguments(number: 1)]
+    #[directives(include(if: false))]
+    pub issue_or_pull_request: Option<IssueOrPullRequest>,
+}
+
+#[derive(cynic::QueryFragment, Debug)]
+pub struct PullRequest {
+    pub id: cynic::Id,
+    pub title: String,
+}
+
+#[derive(cynic::QueryFragment, Debug)]
+pub struct Issue {
+    pub id: cynic::Id,
+    pub title: String,
+    pub last_edited_at: Option<DateTime>,
+}
+
+#[derive(cynic::InlineFragments, Debug)]
+pub enum IssueOrPullRequest {
+    Issue(Issue),
+    PullRequest(PullRequest),
+    #[cynic(fallback)]
+    Unknown
+}
+
+#[derive(cynic::Scalar, Debug, Clone)]
+pub struct DateTime(pub String);

--- a/cynic-querygen/tests/snapshots/github_tests__query_with_all_derives.snap
+++ b/cynic-querygen/tests/snapshots/github_tests__query_with_all_derives.snap
@@ -1,0 +1,62 @@
+---
+source: cynic-querygen/tests/github-tests.rs
+expression: "document_to_fragment_structs(query, schema,\n        &QueryGenOptions::default()).expect(\"QueryGen Failed\")"
+snapshot_kind: text
+---
+#[derive(cynic::QueryVariables, Debug)]
+pub struct IssueOrPRVariables {
+    pub assignee_count: i32,
+}
+
+#[derive(cynic::QueryFragment, Debug)]
+#[cynic(graphql_type = "Query", variables = "IssueOrPRVariables")]
+pub struct IssueOrPR {
+    #[arguments(owner: "obmarg", name: "cynic")]
+    pub repository: Option<Repository>,
+}
+
+#[derive(cynic::QueryFragment, Debug)]
+#[cynic(variables = "IssueOrPRVariables")]
+pub struct Repository {
+    #[arguments(number: 1)]
+    pub issue_or_pull_request: Option<IssueOrPullRequest>,
+}
+
+#[derive(cynic::QueryFragment, Debug)]
+#[cynic(variables = "IssueOrPRVariables")]
+pub struct PullRequest {
+    pub id: cynic::Id,
+    pub title: String,
+    #[arguments(first: $assignee_count)]
+    pub assignees: UserConnection,
+}
+
+#[derive(cynic::QueryFragment, Debug)]
+#[cynic(variables = "IssueOrPRVariables")]
+pub struct Issue {
+    pub id: cynic::Id,
+    pub title: String,
+    pub state: IssueState,
+    #[arguments(first: $assignee_count)]
+    pub assignees: UserConnection,
+}
+
+#[derive(cynic::QueryFragment, Debug)]
+pub struct UserConnection {
+    pub total_count: i32,
+}
+
+#[derive(cynic::InlineFragments, Debug)]
+#[cynic(variables = "IssueOrPRVariables")]
+pub enum IssueOrPullRequest {
+    Issue(Issue),
+    PullRequest(PullRequest),
+    #[cynic(fallback)]
+    Unknown
+}
+
+#[derive(cynic::Enum, Clone, Copy, Debug)]
+pub enum IssueState {
+    Closed,
+    Open,
+}

--- a/cynic-querygen/tests/snapshots/github_tests__skip.snap
+++ b/cynic-querygen/tests/snapshots/github_tests__skip.snap
@@ -1,0 +1,48 @@
+---
+source: cynic-querygen/tests/github-tests.rs
+expression: "document_to_fragment_structs(query, schema,\n        &QueryGenOptions::default()).expect(\"QueryGen Failed\")"
+snapshot_kind: text
+---
+#[derive(cynic::QueryVariables, Debug)]
+pub struct UnnamedQueryVariables {
+    pub skip_all: bool,
+}
+
+#[derive(cynic::QueryFragment, Debug)]
+#[cynic(graphql_type = "Query", variables = "UnnamedQueryVariables")]
+pub struct UnnamedQuery {
+    #[arguments(owner: "obmarg", name: "cynic")]
+    #[directives(skip(if: $skip_all))]
+    pub repository: Option<Repository>,
+}
+
+#[derive(cynic::QueryFragment, Debug)]
+pub struct Repository {
+    #[arguments(number: 1)]
+    #[directives(skip(if: false))]
+    pub issue_or_pull_request: Option<IssueOrPullRequest>,
+}
+
+#[derive(cynic::QueryFragment, Debug)]
+pub struct PullRequest {
+    pub id: cynic::Id,
+    pub title: String,
+}
+
+#[derive(cynic::QueryFragment, Debug)]
+pub struct Issue {
+    pub id: cynic::Id,
+    pub title: String,
+    pub last_edited_at: Option<DateTime>,
+}
+
+#[derive(cynic::InlineFragments, Debug)]
+pub enum IssueOrPullRequest {
+    Issue(Issue),
+    PullRequest(PullRequest),
+    #[cynic(fallback)]
+    Unknown
+}
+
+#[derive(cynic::Scalar, Debug, Clone)]
+pub struct DateTime(pub String);

--- a/cynic-querygen/tests/snapshots/starwars_tests__include.snap
+++ b/cynic-querygen/tests/snapshots/starwars_tests__include.snap
@@ -1,0 +1,25 @@
+---
+source: cynic-querygen/tests/starwars-tests.rs
+expression: "document_to_fragment_structs(query, schema,\n        &QueryGenOptions::default()).expect(\"QueryGen Failed\")"
+snapshot_kind: text
+---
+#[derive(cynic::QueryVariables, Debug)]
+pub struct IncludeTestVariables<'a> {
+    pub film_id: &'a cynic::Id,
+    pub include_title: bool,
+}
+
+#[derive(cynic::QueryFragment, Debug)]
+#[cynic(graphql_type = "Root", variables = "IncludeTestVariables")]
+pub struct IncludeTest {
+    #[arguments(id: $film_id)]
+    pub film: Option<Film>,
+}
+
+#[derive(cynic::QueryFragment, Debug)]
+#[cynic(variables = "IncludeTestVariables")]
+pub struct Film {
+    #[directives(include(if: $include_title))]
+    pub title: Option<String>,
+    pub director: Option<String>,
+}

--- a/cynic-querygen/tests/snapshots/starwars_tests__skip.snap
+++ b/cynic-querygen/tests/snapshots/starwars_tests__skip.snap
@@ -1,0 +1,25 @@
+---
+source: cynic-querygen/tests/starwars-tests.rs
+expression: "document_to_fragment_structs(query, schema,\n        &QueryGenOptions::default()).expect(\"QueryGen Failed\")"
+snapshot_kind: text
+---
+#[derive(cynic::QueryVariables, Debug)]
+pub struct SkipTestVariables<'a> {
+    pub film_id: &'a cynic::Id,
+    pub skip_title: bool,
+}
+
+#[derive(cynic::QueryFragment, Debug)]
+#[cynic(graphql_type = "Root", variables = "SkipTestVariables")]
+pub struct SkipTest {
+    #[arguments(id: $film_id)]
+    pub film: Option<Film>,
+}
+
+#[derive(cynic::QueryFragment, Debug)]
+#[cynic(variables = "SkipTestVariables")]
+pub struct Film {
+    #[directives(skip(if: $skip_title))]
+    pub title: Option<String>,
+    pub director: Option<String>,
+}

--- a/cynic-querygen/tests/starwars-tests.rs
+++ b/cynic-querygen/tests/starwars-tests.rs
@@ -22,7 +22,9 @@ macro_rules! test_query_file {
 test_query_file!(sanity_test_starwars_query, "sanity.graphql");
 test_query_file!(test_nested_arguments, "nested-arguments.graphql");
 test_query_file!(bare_selection_sets, "bare-selection-set.graphql");
+test_query_file!(include, "include.graphql");
 test_query_file!(multiple_queries, "multiple-queries.graphql");
 test_query_file!(fragment_spreads, "fragment-spreads.graphql");
 test_query_file!(aliases, "aliases.graphql");
 test_query_file!(float, "float.graphql");
+test_query_file!(skip, "skip.graphql");

--- a/cynic/Cargo.toml
+++ b/cynic/Cargo.toml
@@ -27,7 +27,7 @@ directives = ["cynic-proc-macros/directives"]
 [dependencies]
 cynic-proc-macros = { path = "../cynic-proc-macros", version = "3.10.0" }
 ref-cast = "1.0.15"
-serde = { version = "1.0.136", features = [ "derive" ] }
+serde = { version = "1.0.136", features = ["derive"] }
 serde_json = { version = "1.0", optional = true }
 static_assertions = "1"
 thiserror = "1.0.30"
@@ -36,13 +36,15 @@ thiserror = "1.0.30"
 surf = { version = "2.3", default-features = false, optional = true }
 
 # Reqwest feature deps
-reqwest = { version = "0.12", optional = true, features = ["json"], default-features = false }
+reqwest = { version = "0.12", optional = true, features = [
+    "json",
+], default-features = false }
 
 [dev-dependencies]
 assert_matches = "1.4"
 chrono = { version = "0.4.19", features = ["serde"] }
 graphql-parser = "0.4"
-insta = { version = "1.17", features = ["yaml", "json"] }
+insta.workspace = true
 maplit = "1.0.2"
 mockito = "1.4.0"
 rstest.workspace = true
@@ -55,6 +57,3 @@ cynic = { path = ".", features = ["http-reqwest"] }
 [package.metadata.docs.rs]
 features = ["all"]
 rustdoc-args = ["--cfg", "docsrs"]
-
-
-

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -26,7 +26,7 @@ chrono = { version = "0.4", features = ["serde"] }
 github-schema = { path = "../schemas/github" }
 
 [dev-dependencies]
-insta = "1.17"
+insta.workspace = true
 
 # Used for the mock starwars API used by some of the examples
 graphql-mocks.workspace = true


### PR DESCRIPTION
In #900 I added directives support to the QueryFragment derive.  However I didn't add support to the generator.  This adds that support.

Fixes #1137 