### PR TITLE
docs: fix example for interface fallback

### DIFF
--- a/cynic-book/src/derives/inline-fragments.md
+++ b/cynic-book/src/derives/inline-fragments.md
@@ -61,7 +61,7 @@ pub enum Actor {
 }
 
 #[derive(cynic::QueryFragment)]
-enum ActorFallback {
+struct ActorFallback {
     pub login: String
 }
 ```


### PR DESCRIPTION
#### Why are we making this change?

the rust code is invalid

#### What effects does this change have?
none