### PR TITLE
feat: `#[cynic(default)]` attribute on fields

### DIFF
--- a/cynic-book/src/derives/query-fragments.md
+++ b/cynic-book/src/derives/query-fragments.md
@@ -210,7 +210,7 @@ struct FilmQuery {
 
 Cynic provides build in support for the `skip` & `include` directives.  Any
 other field directives can also be used, provided they don't require special
-support from the client.  
+support from the client.
 
 #### Struct Attributes
 
@@ -255,6 +255,8 @@ Each field can also have it's own attributes:
 - The `feature` attribute can be used to feature flag parts of a query,
   allowing cynic to support different versions of a schema with the same
   `QueryFragments`.  See [feature flagging queries][2] for more details.
+- The `default` attribute tells cynic to use a fields `Default` impl instead of
+  `Option::None` when a field is null.
 
 ### Related
 

--- a/cynic-codegen/src/types/alignment.rs
+++ b/cynic-codegen/src/types/alignment.rs
@@ -49,6 +49,14 @@ fn align_output_type_impl<'a>(
     }
 }
 
+pub fn align_defaulted_output_type(
+    ty: &syn::Type,
+    gql_ty: &TypeRef<'_, OutputType<'_>>,
+) -> syn::Type {
+    let inner = align_output_type(ty, gql_ty);
+    parse_quote! { Option<#inner> }
+}
+
 pub fn align_input_type(
     ty: &syn::Type,
     gql_ty: &TypeRef<'_, InputType<'_>>,

--- a/cynic-codegen/src/types/mod.rs
+++ b/cynic-codegen/src/types/mod.rs
@@ -6,7 +6,7 @@ mod parsing;
 mod validation;
 
 pub use self::{
-    alignment::{align_input_type, align_output_type},
+    alignment::{align_defaulted_output_type, align_input_type, align_output_type},
     validation::{
         check_input_types_are_compatible, check_spread_type, check_types_are_compatible,
         outer_type_is_option, CheckMode,

--- a/cynic/src/private/mod.rs
+++ b/cynic/src/private/mod.rs
@@ -10,6 +10,6 @@ mod inline_fragment_de;
 mod key_de;
 mod spread_de;
 
-pub use flatten_de::Flattened;
-pub use inline_fragment_de::InlineFragmentVisitor;
-pub use spread_de::Spreadable;
+pub use self::{
+    flatten_de::Flattened, inline_fragment_de::InlineFragmentVisitor, spread_de::Spreadable,
+};

--- a/cynic/tests/default-values-tests.rs
+++ b/cynic/tests/default-values-tests.rs
@@ -68,3 +68,30 @@ fn test_input_object_auth_skip_serializing_on_default_fields() {
 
     assert_eq!(with_value, json!({ "requiredWithDefault": 123 }));
 }
+
+#[test]
+fn test_default_directive_deserialize() {
+    #[derive(cynic::QueryFragment, Debug)]
+    #[cynic(graphql_type = "Query", schema_path = "tests/test-schema.graphql")]
+    struct Query {
+        #[arguments(id: "hello")]
+        #[cynic(default)]
+        #[allow(dead_code)]
+        post: BlogPost,
+    }
+
+    #[derive(cynic::QueryFragment, Default, Debug)]
+    #[cynic(schema_path = "tests/test-schema.graphql")]
+    struct BlogPost {
+        #[allow(dead_code)]
+        id: Option<cynic::Id>,
+    }
+
+    insta::assert_debug_snapshot!(serde_json::from_value::<Query>(json!({"post": null})).unwrap(), @r"
+    Query {
+        post: BlogPost {
+            id: None,
+        },
+    }
+    ");
+}


### PR DESCRIPTION
Cynic currently expects all optional fields to be `Option<T>`.  This is often fine, but some users would like to fall back to a default value in these cases.  

This commit adds support for a default attribute on fields: when present we'll deserialize to the `Default` impl for that type if we see a null, and we won't enforce that field is wrapped in an Option.

Fixes #1143