### PR TITLE
docs: import derive rust docs from book

### DIFF
--- a/cynic-proc-macros/src/lib.rs
+++ b/cynic-proc-macros/src/lib.rs
@@ -39,6 +39,8 @@ pub fn use_schema(input: TokenStream) -> TokenStream {
 /// Derives `cynic::QueryFragment`
 ///
 /// See [the book for usage details](https://cynic-rs.dev/derives/query-fragments.html)
+///
+#[doc = include_str!("../../cynic-book/src/derives/query-fragments.md")]
 #[proc_macro_derive(QueryFragment, attributes(cynic, arguments, directives))]
 pub fn query_fragment_derive(input: TokenStream) -> TokenStream {
     let ast = syn::parse_macro_input!(input as syn::DeriveInput);


### PR DESCRIPTION
For ages the book has been the canonical source of documentation for cynic.  However, it's a bit annoying having the rust documentation completely empty and just linked to the book.  Particularly since every version of the crate links to just a single version of the rust docs.

This is an attempt to somewhat fix that: instead of just linking to the book, we'll pull in the docs using the (relatively) new `include_str!` support inside attribute macros.

This will require a bit of a reworking of the book, since there's a lot of relative links to the book (and also parts of the book that won't make sense as rust docs).  But it seems like a good idea generally.