### PR TITLE
feat: implement tristate optionals (some, null, undefined)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1200,6 +1200,7 @@ name = "cynic"
 version = "3.10.0"
 dependencies = [
  "assert_matches",
+ "async-graphql",
  "chrono",
  "cynic",
  "cynic-proc-macros",
@@ -1337,6 +1338,7 @@ version = "3.10.0"
 dependencies = [
  "Inflector",
  "assert_matches",
+ "async-graphql",
  "cynic-parser",
  "insta",
  "once_cell",

--- a/cynic-codegen/src/types/parsing.rs
+++ b/cynic-codegen/src/types/parsing.rs
@@ -78,7 +78,7 @@ pub fn parse_rust_type(ty: &syn::Type) -> RustType<'_> {
                             };
                         }
                     }
-                    "Option" => {
+                    "MaybeUndefined" | "Option" => {
                         if let Some(inner_type) = extract_generic_argument(last_segment) {
                             return RustType::Optional {
                                 syn: Cow::Borrowed(type_path),

--- a/cynic-codegen/src/types/validation.rs
+++ b/cynic-codegen/src/types/validation.rs
@@ -230,9 +230,9 @@ impl From<TypeValidationError> for syn::Error {
         let span = err.span();
         let message = match err {
             TypeValidationError::FieldIsOptional { provided_type, .. } =>
-                format!("This field is nullable but you're not wrapping the type in Option.  Did you mean Option<{}>", provided_type),
+                format!("This field is nullable but you're not wrapping the type in MaybeUndefined or Option.  Did you mean cynic::MaybeUndefined<{}> or Option<{}>", provided_type, provided_type),
             TypeValidationError::FieldIsRequired { provided_type, .. } =>
-                format!("This field is not nullable but you're wrapping the type in Option.  Did you mean {}", provided_type),
+                format!("This field is not nullable but you're wrapping the type in Option or MaybeUndefined.  Did you mean {}", provided_type),
             TypeValidationError::FieldIsList { provided_type, .. } => {
                 format!("This field is a list but you're not wrapping the type in Vec.  Did you mean Vec<{}>", provided_type)
             },
@@ -240,7 +240,7 @@ impl From<TypeValidationError> for syn::Error {
                 format!("This field is not a list but you're wrapping the type in Vec.  Did you mean {}", provided_type)
             },
             TypeValidationError::RecursiveFieldWithoutOption { provided_type, .. } => {
-                format!("Recursive types must be wrapped in Option.  Did you mean Option<{}>", provided_type)
+                format!("Recursive types must be wrapped in MaybeUndefined or Option.  Did you mean cynic::MaybeUndefined<{}> or Option<{}>", provided_type, provided_type)
             }
             TypeValidationError::SpreadOnOption { .. } => "You can't spread on an optional field".to_string(),
             TypeValidationError::SpreadOnVec { .. } => "You can't spread on a list field".to_string(),

--- a/cynic-codegen/src/use_schema/mod.rs
+++ b/cynic-codegen/src/use_schema/mod.rs
@@ -151,6 +151,13 @@ pub(crate) fn use_schema_impl(schema: &Schema<'_, Validated>) -> Result<TokenStr
                 const TYPE: VariableType = VariableType::Nullable(&T::TYPE);
             }
 
+            impl<T> Variable for cynic::MaybeUndefined<T>
+            where
+                T: Variable
+            {
+                const TYPE: VariableType = VariableType::Nullable(&T::TYPE);
+            }
+
             impl<T> Variable for [T]
             where
                 T: Variable,

--- a/cynic-querygen/Cargo.toml
+++ b/cynic-querygen/Cargo.toml
@@ -18,6 +18,7 @@ once_cell = "1.9"
 rust_decimal = "1.22"
 thiserror = "1.0.30"
 uuid = { version = "1", features = ["v4"] }
+async-graphql = { version = "7" }
 
 cynic-parser.workspace = true
 

--- a/cynic-querygen/src/output/field.rs
+++ b/cynic-querygen/src/output/field.rs
@@ -44,6 +44,12 @@ impl std::fmt::Display for Field<'_> {
         if let Some(rename) = self.rename() {
             writeln!(f, r#"#[cynic(rename = "{}")]"#, rename)?;
         }
+        if self.type_spec.name.starts_with("cynic::MaybeUndefined<") {
+            writeln!(
+                f,
+                r#"#[cynic(skip_serializing_if = "cynic::MaybeUndefined::is_undefined")]"#
+            )?;
+        }
         writeln!(f, "pub {}: {},", self.name(), self.type_spec.name)
     }
 }

--- a/cynic-querygen/src/schema/fields.rs
+++ b/cynic-querygen/src/schema/fields.rs
@@ -193,7 +193,7 @@ fn input_type_spec_imp(
             needs_owned,
             is_subobject_with_lifetime,
         )
-        .map(|type_spec| format!("Option<{type_spec}>",));
+        .map(|type_spec| format!("cynic::MaybeUndefined<{type_spec}>",));
     }
 
     match ty {

--- a/cynic/Cargo.toml
+++ b/cynic/Cargo.toml
@@ -31,6 +31,7 @@ serde = { version = "1.0.136", features = ["derive"] }
 serde_json = { version = "1.0", optional = true }
 static_assertions = "1"
 thiserror = "1.0.30"
+async-graphql = { version = "7", default-features = false }
 
 # Surf feature deps
 surf = { version = "2.3", default-features = false, optional = true }

--- a/cynic/src/core.rs
+++ b/cynic/src/core.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 
-use crate::{queries::SelectionBuilder, QueryVariablesFields};
+use crate::{queries::SelectionBuilder, MaybeUndefined, QueryVariablesFields};
 
 /// A trait that marks a type as part of a GraphQL query.
 ///
@@ -26,6 +26,18 @@ pub trait QueryFragment: Sized {
 }
 
 impl<T> QueryFragment for Option<T>
+where
+    T: QueryFragment,
+{
+    type SchemaType = Option<T::SchemaType>;
+    type VariablesFields = T::VariablesFields;
+
+    fn query(builder: SelectionBuilder<'_, Self::SchemaType, Self::VariablesFields>) {
+        T::query(builder.into_inner())
+    }
+}
+
+impl<T> QueryFragment for MaybeUndefined<T>
 where
     T: QueryFragment,
 {
@@ -157,6 +169,13 @@ pub trait InputObject: serde::Serialize {
 }
 
 impl<T> InputObject for Option<T>
+where
+    T: InputObject,
+{
+    type SchemaType = Option<T::SchemaType>;
+}
+
+impl<T> InputObject for MaybeUndefined<T>
 where
     T: InputObject,
 {

--- a/cynic/src/lib.rs
+++ b/cynic/src/lib.rs
@@ -172,6 +172,7 @@
 mod builders;
 mod core;
 mod id;
+mod maybe_undefined;
 mod operation;
 mod result;
 
@@ -189,6 +190,7 @@ pub use {
     self::core::{Enum, InlineFragments, InputObject, QueryFragment},
     builders::{MutationBuilder, QueryBuilder, SubscriptionBuilder},
     id::Id,
+    maybe_undefined::MaybeUndefined,
     operation::{Operation, OperationBuildError, OperationBuilder, StreamingOperation},
     result::*,
     variables::{QueryVariableLiterals, QueryVariables, QueryVariablesFields},

--- a/cynic/src/maybe_undefined.rs
+++ b/cynic/src/maybe_undefined.rs
@@ -47,10 +47,13 @@ impl<T> DerefMut for MaybeUndefined<T> {
     }
 }
 
-impl<T> From<Option<T>> for MaybeUndefined<T> {
-    fn from(value: Option<T>) -> Self {
+impl<T1, T2> From<Option<T1>> for MaybeUndefined<T2>
+where
+    T2: From<T1>,
+{
+    fn from(value: Option<T1>) -> Self {
         Self(match value {
-            Some(value) => async_graphql::MaybeUndefined::Value(value),
+            Some(value) => async_graphql::MaybeUndefined::Value(T2::from(value)),
             None => async_graphql::MaybeUndefined::Null,
         })
     }
@@ -69,7 +72,7 @@ mod tests {
     #[test]
     fn test() {
         assert_eq!(
-            MaybeUndefined::from(None),
+            MaybeUndefined::from(None::<bool>),
             MaybeUndefined(async_graphql::MaybeUndefined::<bool>::Null)
         );
         assert_eq!(

--- a/cynic/src/maybe_undefined.rs
+++ b/cynic/src/maybe_undefined.rs
@@ -1,0 +1,84 @@
+use serde::{Deserialize, Serialize};
+
+use std::ops::{Deref, DerefMut};
+
+/// A wrapper around async-graphql's [`MaybeUndefined`](https://docs.rs/async-graphql/latest/async_graphql/types/enum.MaybeUndefined.html).
+///
+/// You can initialize it from:
+/// - `From<Option<T>>` will become T or null.
+/// - `Default` will become undefined.
+#[derive(Serialize, Deserialize, Copy, Clone, PartialEq, PartialOrd, Eq, Ord, Debug, Hash)]
+pub struct MaybeUndefined<T>(async_graphql::MaybeUndefined<T>);
+
+impl<T> MaybeUndefined<T> {
+    fn inner(&self) -> &async_graphql::MaybeUndefined<T> {
+        &self.0
+    }
+
+    fn inner_mut(&mut self) -> &mut async_graphql::MaybeUndefined<T> {
+        &mut self.0
+    }
+
+    /// Returns true if the `MaybeUndefined<T>` is undefined.
+    ///
+    /// Deserialization ought to be skipped for this when used as a field.
+    pub fn is_undefined(&self) -> bool {
+        self.0.is_undefined()
+    }
+}
+
+impl<T> From<async_graphql::MaybeUndefined<T>> for MaybeUndefined<T> {
+    fn from(value: async_graphql::MaybeUndefined<T>) -> Self {
+        Self(value)
+    }
+}
+
+impl<T> Deref for MaybeUndefined<T> {
+    type Target = async_graphql::MaybeUndefined<T>;
+
+    fn deref(&self) -> &Self::Target {
+        self.inner()
+    }
+}
+
+impl<T> DerefMut for MaybeUndefined<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.inner_mut()
+    }
+}
+
+impl<T> From<Option<T>> for MaybeUndefined<T> {
+    fn from(value: Option<T>) -> Self {
+        Self(match value {
+            Some(value) => async_graphql::MaybeUndefined::Value(value),
+            None => async_graphql::MaybeUndefined::Null,
+        })
+    }
+}
+
+impl<T> Default for MaybeUndefined<T> {
+    fn default() -> Self {
+        Self(async_graphql::MaybeUndefined::Undefined)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test() {
+        assert_eq!(
+            MaybeUndefined::from(None),
+            MaybeUndefined(async_graphql::MaybeUndefined::<bool>::Null)
+        );
+        assert_eq!(
+            MaybeUndefined::from(Some(true)),
+            MaybeUndefined(async_graphql::MaybeUndefined::Value(true))
+        );
+        assert_eq!(
+            MaybeUndefined::<bool>::default(),
+            MaybeUndefined(async_graphql::MaybeUndefined::Undefined)
+        );
+    }
+}

--- a/cynic/src/queries/flatten.rs
+++ b/cynic/src/queries/flatten.rs
@@ -1,3 +1,5 @@
+// use crate::MaybeUndefined;
+
 /// Encodes the rules for what types can be flattened into other types
 /// via the `#[cynic(flatten)]` attribute.
 ///
@@ -5,15 +7,25 @@
 pub trait FlattensInto<T>: private::Sealed<T> {}
 
 impl<T> FlattensInto<Vec<T>> for Vec<Option<T>> {}
+
 impl<T> FlattensInto<Vec<T>> for Option<Vec<T>> {}
 impl<T> FlattensInto<Option<Vec<T>>> for Option<Vec<Option<T>>> {}
 impl<T> FlattensInto<Vec<T>> for Option<Vec<Option<T>>> {}
+
+// impl<T> FlattensInto<Vec<T>> for MaybeUndefined<Vec<T>> {}
+// impl<T> FlattensInto<Option<Vec<T>>> for MaybeUndefined<Vec<Option<T>>> {}
+// impl<T> FlattensInto<Vec<T>> for MaybeUndefined<Vec<Option<T>>> {}
 
 mod private {
     pub trait Sealed<T> {}
 
     impl<T> Sealed<Vec<T>> for Vec<Option<T>> {}
+
     impl<T> Sealed<Vec<T>> for Option<Vec<T>> {}
     impl<T> Sealed<Option<Vec<T>>> for Option<Vec<Option<T>>> {}
     impl<T> Sealed<Vec<T>> for Option<Vec<Option<T>>> {}
+
+    // impl<T> Sealed<Vec<T>> for MaybeUndefined<Vec<T>> {}
+    // impl<T> Sealed<Option<Vec<T>>> for MaybeUndefined<Vec<Option<T>>> {}
+    // impl<T> Sealed<Vec<T>> for MaybeUndefined<Vec<Option<T>>> {}
 }

--- a/cynic/src/schema.rs
+++ b/cynic/src/schema.rs
@@ -11,6 +11,8 @@
 //! usually be marker types and the associated types will also usually be
 //! markers.
 
+use crate::MaybeUndefined;
+
 /// Indicates that a struct represents a Field in a graphql schema.
 pub trait Field {
     /// The schema marker type of this field.
@@ -68,6 +70,20 @@ where
 }
 
 impl<T, U> IsScalar<Option<T>> for Option<U>
+where
+    U: IsScalar<T>,
+{
+    type SchemaType = Option<U::SchemaType>;
+}
+
+impl<T, U> IsScalar<MaybeUndefined<T>> for MaybeUndefined<U>
+where
+    U: IsScalar<T>,
+{
+    type SchemaType = MaybeUndefined<U::SchemaType>;
+}
+
+impl<T, U> IsScalar<Option<T>> for MaybeUndefined<U>
 where
     U: IsScalar<T>,
 {

--- a/cynic/tests/maybe_undefined.rs
+++ b/cynic/tests/maybe_undefined.rs
@@ -1,0 +1,63 @@
+use cynic::MaybeUndefined;
+
+mod schema {
+    cynic::use_schema!("../schemas/simple.graphql");
+}
+
+#[derive(cynic::QueryVariables)]
+struct TestArgs<'a> {
+    #[cynic(skip_serializing_if = "MaybeUndefined::is_undefined")]
+    a_str: MaybeUndefined<&'a str>,
+}
+
+#[derive(cynic::QueryFragment, PartialEq, Debug)]
+#[cynic(schema_path = "../schemas/simple.graphql", variables = "TestArgs")]
+struct TestStruct {
+    field_one: String,
+}
+
+#[derive(cynic::QueryFragment, PartialEq, Debug)]
+#[cynic(
+    schema_path = "../schemas/simple.graphql",
+    graphql_type = "Query",
+    variables = "TestArgs"
+)]
+struct TestQuery {
+    test_struct: MaybeUndefined<TestStruct>,
+}
+
+#[test]
+fn test_query_building_null() {
+    use cynic::QueryBuilder;
+
+    insta::assert_snapshot!(serde_json::to_string(
+        &TestQuery::build(TestArgs { a_str: None.into() }).variables
+    )
+    .unwrap());
+}
+
+#[test]
+fn test_query_building_some() {
+    use cynic::QueryBuilder;
+
+    insta::assert_snapshot!(serde_json::to_string(
+        &TestQuery::build(TestArgs {
+            a_str: Some("1").into(),
+        })
+        .variables
+    )
+    .unwrap());
+}
+
+#[test]
+fn test_query_building_undefined() {
+    use cynic::QueryBuilder;
+
+    insta::assert_snapshot!(serde_json::to_string(
+        &TestQuery::build(TestArgs {
+            a_str: Default::default(),
+        })
+        .variables
+    )
+    .unwrap());
+}

--- a/cynic/tests/maybe_undefined.rs
+++ b/cynic/tests/maybe_undefined.rs
@@ -31,7 +31,10 @@ fn test_query_building_null() {
     use cynic::QueryBuilder;
 
     insta::assert_snapshot!(serde_json::to_string(
-        &TestQuery::build(TestArgs { a_str: None.into() }).variables
+        &TestQuery::build(TestArgs {
+            a_str: None::<&str>.into(),
+        })
+        .variables
     )
     .unwrap());
 }

--- a/cynic/tests/snapshots/maybe_undefined__query_building_null.snap
+++ b/cynic/tests/snapshots/maybe_undefined__query_building_null.snap
@@ -1,0 +1,5 @@
+---
+source: cynic/tests/maybe_undefined.rs
+expression: "serde_json::to_string(&TestQuery::build(TestArgs {\n                        a_str: None.into(),\n                    }).variables).unwrap()"
+---
+{"aStr":null}

--- a/cynic/tests/snapshots/maybe_undefined__query_building_some.snap
+++ b/cynic/tests/snapshots/maybe_undefined__query_building_some.snap
@@ -1,0 +1,5 @@
+---
+source: cynic/tests/maybe_undefined.rs
+expression: "serde_json::to_string(&TestQuery::build(TestArgs {\n                        a_str: Some(\"1\").into(),\n                    }).variables).unwrap()"
+---
+{"aStr":"1"}

--- a/cynic/tests/snapshots/maybe_undefined__query_building_undefined.snap
+++ b/cynic/tests/snapshots/maybe_undefined__query_building_undefined.snap
@@ -1,0 +1,5 @@
+---
+source: cynic/tests/maybe_undefined.rs
+expression: "serde_json::to_string(&TestQuery::build(TestArgs {\n                        a_str: Default::default(),\n                    }).variables).unwrap()"
+---
+{}

--- a/tests/querygen-compile-run/build.rs
+++ b/tests/querygen-compile-run/build.rs
@@ -37,7 +37,7 @@ fn main() {
             "../../cynic-querygen/tests/queries/starwars/sanity.graphql",
             r#"SanityCheckQuery::build(
                 SanityCheckQueryVariables {
-                    film_id: Some((&String::from("ZmlsbXM6MQ==")).into())
+                    film_id: Some((&String::from("ZmlsbXM6MQ==")).into()).into()
                 }
             )"#,
         ),
@@ -166,7 +166,7 @@ fn main() {
             "tests/queries/github/optional-input-object-argument.graphql",
             r#"PullRequestTitles::build(
                 PullRequestTitlesVariables {
-                    pr_order: None
+                    pr_order: None.into()
                 },
             )"#,
         ),
@@ -217,8 +217,8 @@ fn main() {
             &test_schema,
             "tests/queries/misc/recursive-inputs.graphql",
             r#"RecursiveInputQuery::build(RecursiveInputQueryVariables {
-                input: None,
-                input2: None
+                input: None.into(),
+                input2: None.into()
             })"#,
         ),
         TestCase::query(

--- a/tests/querygen-compile-run/build.rs
+++ b/tests/querygen-compile-run/build.rs
@@ -37,7 +37,7 @@ fn main() {
             "../../cynic-querygen/tests/queries/starwars/sanity.graphql",
             r#"SanityCheckQuery::build(
                 SanityCheckQueryVariables {
-                    film_id: Some((&String::from("ZmlsbXM6MQ==")).into()).into()
+                    film_id: Some::<&String>(&String::from("ZmlsbXM6MQ==")).into()
                 }
             )"#,
         ),


### PR DESCRIPTION
Fixes #125

#### Why are we making this change?

This allows for specifying a little extra information for optional types (some, null, default) instead of Option which cannot provide a default value.

In my use case I run the codegen in a build script. I don't want to tweak my input objects at all. Having this type makes my code more flexible.

#### What effects does this change have?

Creating an cynic::MaybeUndefined type which behaves a lot like option, but wraps async_graphql::MaybeUndefined and currently forwards that type. It might be a good idea to not wrap that type if we are worried about increasing the API surface or compile times or something else.

You can still use Option. The codegen will use MaybeUndefined instead and includes `skip_serializing_if` to exclude the value when it shouldn't be serialized.