### PR TITLE
fix(querygen): Correct lifetime propagation for wrapped recursive inp…

### DIFF
--- a/cynic-querygen/tests/misc-tests.rs
+++ b/cynic-querygen/tests/misc-tests.rs
@@ -143,3 +143,14 @@ fn test_keyword_arguments() {
             .expect("QueryGen Failed")
     )
 }
+
+#[test]
+fn test_recursive_input_lifetimes() {
+    let schema = include_str!("schemas/recursive_input_lifetimes_schema.graphql");
+    let query = include_str!("queries/misc/recursive_input_lifetimes_query.graphql");
+
+    assert_snapshot!(
+        document_to_fragment_structs(query, schema, &QueryGenOptions::default())
+            .expect("QueryGen Failed for recursive input lifetimes test")
+    )
+}

--- a/cynic-querygen/tests/queries/misc/recursive_input_lifetimes_query.graphql
+++ b/cynic-querygen/tests/queries/misc/recursive_input_lifetimes_query.graphql
@@ -1,0 +1,17 @@
+mutation TestRecursiveInputLifetimes(
+  $direct: ComplexRecursiveInput!
+  $optDirect: ComplexRecursiveInput
+  $listDirect: [ComplexRecursiveInput!]!
+  $optListDirect: [ComplexRecursiveInput!]
+  $listOpt: [ComplexRecursiveInput]!
+  $optListOpt: [ComplexRecursiveInput]
+) {
+  complexRecursiveMutation(
+    direct: $direct
+    optDirect: $optDirect
+    listDirect: $listDirect
+    optListDirect: $optListDirect
+    listOpt: $listOpt
+    optListOpt: $optListOpt
+  )
+}

--- a/cynic-querygen/tests/schemas/recursive_input_lifetimes_schema.graphql
+++ b/cynic-querygen/tests/schemas/recursive_input_lifetimes_schema.graphql
@@ -1,0 +1,31 @@
+schema {
+  mutation: Mutation
+}
+
+type Query {
+  "Ensures Query is not empty if Mutation is not used for a test case"
+  _dummy: Boolean
+}
+
+type Mutation {
+  complexRecursiveMutation(
+    direct: ComplexRecursiveInput!
+    optDirect: ComplexRecursiveInput
+    listDirect: [ComplexRecursiveInput!]!
+    optListDirect: [ComplexRecursiveInput!]
+    listOpt: [ComplexRecursiveInput]!
+    optListOpt: [ComplexRecursiveInput]
+  ): Boolean
+}
+
+input ComplexRecursiveInput {
+  name: String! # Ensures the struct needs a lifetime 'a
+  value: Int
+  # Recursive fields demonstrating boxing and lifetime propagation
+  directNext: ComplexRecursiveInput
+  optNext: ComplexRecursiveInput
+  listNext: [ComplexRecursiveInput!]
+  optListNext: [ComplexRecursiveInput!]
+  listOptNext: [ComplexRecursiveInput]
+  optListOptNext: [ComplexRecursiveInput]
+}

--- a/cynic-querygen/tests/snapshots/misc_tests__recursive_input_lifetimes.snap
+++ b/cynic-querygen/tests/snapshots/misc_tests__recursive_input_lifetimes.snap
@@ -1,0 +1,32 @@
+---
+source: cynic-querygen/tests/misc-tests.rs
+expression: "document_to_fragment_structs(query, schema,\n        &QueryGenOptions::default()).expect(\"QueryGen Failed for recursive input lifetimes test\")"
+---
+#[derive(cynic::QueryVariables, Debug)]
+pub struct TestRecursiveInputLifetimesVariables<'a> {
+    pub direct: ComplexRecursiveInput<'a>,
+    pub list_direct: Vec<ComplexRecursiveInput<'a>>,
+    pub list_opt: Vec<Option<ComplexRecursiveInput<'a>>>,
+    pub opt_direct: Option<ComplexRecursiveInput<'a>>,
+    pub opt_list_direct: Option<Vec<ComplexRecursiveInput<'a>>>,
+    pub opt_list_opt: Option<Vec<Option<ComplexRecursiveInput<'a>>>>,
+}
+
+#[derive(cynic::QueryFragment, Debug)]
+#[cynic(graphql_type = "Mutation", variables = "TestRecursiveInputLifetimesVariables")]
+pub struct TestRecursiveInputLifetimes {
+    #[arguments(direct: $direct, optDirect: $opt_direct, listDirect: $list_direct, optListDirect: $opt_list_direct, listOpt: $list_opt, optListOpt: $opt_list_opt)]
+    pub complex_recursive_mutation: Option<bool>,
+}
+
+#[derive(cynic::InputObject, Debug)]
+pub struct ComplexRecursiveInput<'a> {
+    pub name: &'a str,
+    pub value: Option<i32>,
+    pub direct_next: Option<Box<ComplexRecursiveInput<'a>>>,
+    pub opt_next: Option<Box<ComplexRecursiveInput<'a>>>,
+    pub list_next: Option<Vec<Box<ComplexRecursiveInput<'a>>>>,
+    pub opt_list_next: Option<Vec<Box<ComplexRecursiveInput<'a>>>>,
+    pub list_opt_next: Option<Vec<Option<Box<ComplexRecursiveInput<'a>>>>>,
+    pub opt_list_opt_next: Option<Vec<Option<Box<ComplexRecursiveInput<'a>>>>>,
+}


### PR DESCRIPTION
fix(querygen): Correct lifetime propagation for wrapped recursive input objects
    
Input object types generated by `cynic-querygen` were missing the `'a` lifetime parameter in certain scenarios involving wrappers like `Box`, `Vec`, and `Option`, particularly when the wrapped type was recursive.
    
If an input object `MyInput` required a lifetime (e.g., due to containing a `String!` field) and was used recursively within itself (e.g., `field: MyInput`), types like `Box<MyInput>`, `Option<Box<MyInput>>`, or `Option<Vec<Option<Box<MyInput>>>>` were incorrectly generated without the `<'a>` parameter (e.g., `Box<MyInput>`).
    
This commit addresses the issue by:
    1. Implementing a heuristic in the input object analysis (`query_parsing/inputs.rs`) to better determine if a *recursive* input object type definition implies a lifetime. This check now considers direct String/ID fields and shallowly inspects non-recursive nested input object fields within the recursive type's definition.
    2. Ensuring the type generation logic (`schema/fields.rs`) correctly passes the `needs_boxed` flag down when processing list elements, so `Vec<Box<MyInput<'a>>>` can be generated correctly. (The propagation for `Option` and `Box` themselves was already handled correctly in the last accepted state).
    3. Adding a new test (`test_recursive_input_lifetimes` in `misc-tests.rs`) with a dedicated schema, query, and snapshot to verify the fix for complex recursive types involving various combinations of `Box`, `Vec`, and `Option` wrappers.

#### Why are we making this change?

This fixes an issue with Option<Box<T>>, Box<T>, Vec<T>, maybe other stuff not having lifetimes. I used gemini-2.5-pro-exp-03-25 for this. Feel free to take the code and rewrite it etc. I just needed a fix quickly.

#### What effects does this change have?

See commit message
