### PR TITLE
fix: lifetime propagation on recursive input types 

### DIFF
--- a/cynic-querygen/src/output/variables_struct.rs
+++ b/cynic-querygen/src/output/variables_struct.rs
@@ -34,7 +34,6 @@ impl VariablesStructField<'_, '_> {
         match self {
             VariablesStructField::Variable(var) => var.value_type.type_spec(
                 false,
-                false,
                 input_objects_need_lifetime
                     .get(&*var.value_type.inner_name())
                     .copied()

--- a/cynic-querygen/src/query_parsing/leaf_types.rs
+++ b/cynic-querygen/src/query_parsing/leaf_types.rs
@@ -1,7 +1,7 @@
 //! Handles "leaf types" - i.e. enums & scalars that don't have any nested fields.
 use std::collections::HashSet;
 
-use super::{inputs::InputObjectSet, normalisation::NormalisedDocument};
+use super::{inputs::InputObjects, normalisation::NormalisedDocument};
 use crate::{
     output::Scalar,
     schema::{EnumDetails, Type, TypeRef},
@@ -10,7 +10,7 @@ use crate::{
 
 pub fn extract_leaf_types<'schema>(
     doc: &NormalisedDocument<'_, 'schema>,
-    inputs: &InputObjectSet<'schema>,
+    inputs: &InputObjects<'schema>,
 ) -> Result<(Vec<EnumDetails<'schema>>, Vec<Scalar<'schema>>), Error> {
     let mut leaf_types = doc
         .selection_sets
@@ -33,12 +33,7 @@ pub fn extract_leaf_types<'schema>(
             .flat_map(|selection_set| selection_set.required_input_types())
             .map(TypeRef::from),
     );
-    leaf_types.extend(
-        inputs
-            .iter()
-            .flat_map(|input_object| input_object.required_input_types())
-            .map(TypeRef::from),
-    );
+    leaf_types.extend(inputs.required_input_types().map(TypeRef::from));
 
     let mut enums = Vec::new();
     let mut scalars = Vec::new();

--- a/cynic-querygen/src/query_parsing/value.rs
+++ b/cynic-querygen/src/query_parsing/value.rs
@@ -39,8 +39,6 @@ impl<'query, 'schema> TypedValue<'query, 'schema> {
             cynic_parser::Value::Variable(variable) => {
                 let name = variable.name();
 
-                dbg!(variable_definitions);
-
                 // If this is just a variable then we'll take it's type as our value type.
                 let value_type = variable_definitions
                     .iter()

--- a/cynic-querygen/src/schema/mod.rs
+++ b/cynic-querygen/src/schema/mod.rs
@@ -25,7 +25,7 @@ pub enum Type<'schema> {
     InputObject(InputObjectDetails<'schema>),
 }
 
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
 pub struct ScalarDetails<'schema> {
     pub name: &'schema str,
 }
@@ -61,7 +61,7 @@ pub struct InputObjectDetails<'schema> {
     pub fields: Vec<InputField<'schema>>,
 }
 
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
 pub enum InputType<'schema> {
     Scalar(ScalarDetails<'schema>),
     Enum(EnumDetails<'schema>),

--- a/cynic-querygen/tests/misc-tests.rs
+++ b/cynic-querygen/tests/misc-tests.rs
@@ -143,3 +143,14 @@ fn test_keyword_arguments() {
             .expect("QueryGen Failed")
     )
 }
+
+#[test]
+fn test_recursive_input_lifetimes() {
+    let schema = include_str!("schemas/recursive_input_lifetimes_schema.graphql");
+    let query = include_str!("queries/misc/recursive_input_lifetimes_query.graphql");
+
+    assert_snapshot!(
+        document_to_fragment_structs(query, schema, &QueryGenOptions::default())
+            .expect("QueryGen Failed for recursive input lifetimes test")
+    )
+}

--- a/cynic-querygen/tests/queries/misc/recursive_input_lifetimes_query.graphql
+++ b/cynic-querygen/tests/queries/misc/recursive_input_lifetimes_query.graphql
@@ -1,0 +1,17 @@
+mutation TestRecursiveInputLifetimes(
+  $direct: ComplexRecursiveInput!
+  $optDirect: ComplexRecursiveInput
+  $listDirect: [ComplexRecursiveInput!]!
+  $optListDirect: [ComplexRecursiveInput!]
+  $listOpt: [ComplexRecursiveInput]!
+  $optListOpt: [ComplexRecursiveInput]
+) {
+  complexRecursiveMutation(
+    direct: $direct
+    optDirect: $optDirect
+    listDirect: $listDirect
+    optListDirect: $optListDirect
+    listOpt: $listOpt
+    optListOpt: $optListOpt
+  )
+}

--- a/cynic-querygen/tests/schemas/recursive_input_lifetimes_schema.graphql
+++ b/cynic-querygen/tests/schemas/recursive_input_lifetimes_schema.graphql
@@ -1,0 +1,31 @@
+schema {
+  mutation: Mutation
+}
+
+type Query {
+  "Ensures Query is not empty if Mutation is not used for a test case"
+  _dummy: Boolean
+}
+
+type Mutation {
+  complexRecursiveMutation(
+    direct: ComplexRecursiveInput!
+    optDirect: ComplexRecursiveInput
+    listDirect: [ComplexRecursiveInput!]!
+    optListDirect: [ComplexRecursiveInput!]
+    listOpt: [ComplexRecursiveInput]!
+    optListOpt: [ComplexRecursiveInput]
+  ): Boolean
+}
+
+input ComplexRecursiveInput {
+  name: String! # Ensures the struct needs a lifetime 'a
+  value: Int
+  # Recursive fields demonstrating boxing and lifetime propagation
+  directNext: ComplexRecursiveInput
+  optNext: ComplexRecursiveInput
+  listNext: [ComplexRecursiveInput!]
+  optListNext: [ComplexRecursiveInput!]
+  listOptNext: [ComplexRecursiveInput]
+  optListOptNext: [ComplexRecursiveInput]
+}

--- a/cynic-querygen/tests/snapshots/misc_tests__recursive_input_lifetimes.snap
+++ b/cynic-querygen/tests/snapshots/misc_tests__recursive_input_lifetimes.snap
@@ -1,0 +1,33 @@
+---
+source: cynic-querygen/tests/misc-tests.rs
+expression: "document_to_fragment_structs(query, schema,\n        &QueryGenOptions::default()).expect(\"QueryGen Failed for recursive input lifetimes test\")"
+snapshot_kind: text
+---
+#[derive(cynic::QueryVariables, Debug)]
+pub struct TestRecursiveInputLifetimesVariables<'a> {
+    pub direct: ComplexRecursiveInput<'a>,
+    pub list_direct: Vec<ComplexRecursiveInput<'a>>,
+    pub list_opt: Vec<Option<ComplexRecursiveInput<'a>>>,
+    pub opt_direct: Option<ComplexRecursiveInput<'a>>,
+    pub opt_list_direct: Option<Vec<ComplexRecursiveInput<'a>>>,
+    pub opt_list_opt: Option<Vec<Option<ComplexRecursiveInput<'a>>>>,
+}
+
+#[derive(cynic::QueryFragment, Debug)]
+#[cynic(graphql_type = "Mutation", variables = "TestRecursiveInputLifetimesVariables")]
+pub struct TestRecursiveInputLifetimes {
+    #[arguments(direct: $direct, optDirect: $opt_direct, listDirect: $list_direct, optListDirect: $opt_list_direct, listOpt: $list_opt, optListOpt: $opt_list_opt)]
+    pub complex_recursive_mutation: Option<bool>,
+}
+
+#[derive(cynic::InputObject, Debug)]
+pub struct ComplexRecursiveInput<'a> {
+    pub name: &'a str,
+    pub value: Option<i32>,
+    pub direct_next: Option<Box<ComplexRecursiveInput<'a>>>,
+    pub opt_next: Option<Box<ComplexRecursiveInput<'a>>>,
+    pub list_next: Option<Vec<ComplexRecursiveInput<'a>>>,
+    pub opt_list_next: Option<Vec<ComplexRecursiveInput<'a>>>,
+    pub list_opt_next: Option<Vec<Option<ComplexRecursiveInput<'a>>>>,
+    pub opt_list_opt_next: Option<Vec<Option<ComplexRecursiveInput<'a>>>>,
+}

--- a/cynic-querygen/tests/snapshots/misc_tests__recursive_inputs.snap
+++ b/cynic-querygen/tests/snapshots/misc_tests__recursive_inputs.snap
@@ -1,6 +1,7 @@
 ---
 source: cynic-querygen/tests/misc-tests.rs
 expression: "document_to_fragment_structs(query, schema,\n        &QueryGenOptions::default()).expect(\"QueryGen Failed\")"
+snapshot_kind: text
 ---
 #[derive(cynic::QueryVariables, Debug)]
 pub struct MyQueryVariables {
@@ -16,11 +17,6 @@ pub struct MyQuery {
 }
 
 #[derive(cynic::InputObject, Debug)]
-pub struct SelfRecursiveInput {
-    pub recurse: Option<Box<SelfRecursiveInput>>,
-}
-
-#[derive(cynic::InputObject, Debug)]
 pub struct RecursiveInputParent {
     pub recurse: Option<RecursiveInputChild>,
 }
@@ -30,4 +26,7 @@ pub struct RecursiveInputChild {
     pub recurse: Option<Box<RecursiveInputParent>>,
 }
 
-
+#[derive(cynic::InputObject, Debug)]
+pub struct SelfRecursiveInput {
+    pub recurse: Option<Box<SelfRecursiveInput>>,
+}


### PR DESCRIPTION
Input objects generated by cynic-querygen were missing the 'a lifetime
parameter when they were also recursive.

I've fixed this by splitting the code that determines whether we need a
lifetime out from the code that determines whether we're recursive or
not - they require two different types of recursion to perform correctly
so I don't think it made sense to have them done in the same code.

I've also simplified the input object handling a bit: there's now one
less layer of transforms that we need to go through.

Fixes #1150 