### PR TITLE
Provide API for users to be able to use generics in variables even if nested

### DIFF
--- a/cynic-codegen/src/query_variables_derive/input.rs
+++ b/cynic-codegen/src/query_variables_derive/input.rs
@@ -24,7 +24,7 @@ pub(super) struct QueryVariableField {
     pub(super) ty: syn::Type,
 
     #[darling(default)]
-    pub(super) graphql_type: Option<syn::Ident>,
+    pub(super) graphql_type: Option<syn::Path>,
 
     #[darling(default)]
     pub(super) skip_serializing_if: Option<SpannedValue<syn::Path>>,

--- a/cynic-codegen/tests/snapshots/use_schema__test_cases.graphql.snap
+++ b/cynic-codegen/tests/snapshots/use_schema__test_cases.graphql.snap
@@ -1,13 +1,16 @@
 ---
 source: cynic-codegen/tests/use-schema.rs
 expression: "format_code(format!(\"{}\", tokens))"
-snapshot_kind: text
 ---
 impl cynic::schema::QueryRoot for Foo {}
+impl cynic::schema::MutationRoot for MutationRoot {}
 pub struct Bar;
+pub struct Baz;
+impl cynic::schema::InputObjectMarker for Baz {}
 pub struct FieldNameClashes;
 pub struct FlattenableEnums;
 pub struct Foo;
+pub struct MutationRoot;
 pub struct RecursiveInputChild;
 impl cynic::schema::InputObjectMarker for RecursiveInputChild {}
 pub struct RecursiveInputParent;
@@ -57,6 +60,9 @@ impl cynic::schema::NamedType for FlattenableEnums {
 impl cynic::schema::NamedType for Foo {
     const NAME: &'static ::core::primitive::str = "Foo";
 }
+impl cynic::schema::NamedType for MutationRoot {
+    const NAME: &'static ::core::primitive::str = "MutationRoot";
+}
 #[allow(non_snake_case, non_camel_case_types)]
 pub mod __fields {
     pub mod Bar {
@@ -84,6 +90,20 @@ pub mod __fields {
         impl cynic::schema::HasField<__typename> for super::super::Bar {
             type Type = super::super::String;
         }
+    }
+    pub mod Baz {
+        pub struct id;
+        impl cynic::schema::Field for id {
+            type Type = super::super::ID;
+            const NAME: &'static ::core::primitive::str = "id";
+        }
+        impl cynic::schema::HasInputField<id, super::super::ID> for super::super::Baz {}
+        pub struct aString;
+        impl cynic::schema::Field for aString {
+            type Type = super::super::String;
+            const NAME: &'static ::core::primitive::str = "aString";
+        }
+        impl cynic::schema::HasInputField<aString, super::super::String> for super::super::Baz {}
     }
     pub mod FieldNameClashes {
         pub struct str;
@@ -268,6 +288,31 @@ pub mod __fields {
             type Type = super::super::String;
         }
     }
+    pub mod MutationRoot {
+        pub struct sendManyBaz;
+        impl cynic::schema::Field for sendManyBaz {
+            type Type = super::super::Int;
+            const NAME: &'static ::core::primitive::str = "sendManyBaz";
+        }
+        impl cynic::schema::HasField<sendManyBaz> for super::super::MutationRoot {
+            type Type = super::super::Int;
+        }
+        pub mod _send_many_baz_arguments {
+            pub struct many_baz;
+            impl cynic::schema::HasArgument<many_baz> for super::sendManyBaz {
+                type ArgumentType = Vec<super::super::super::Baz>;
+                const NAME: &'static ::core::primitive::str = "many_baz";
+            }
+        }
+        pub struct __typename;
+        impl cynic::schema::Field for __typename {
+            type Type = super::super::String;
+            const NAME: &'static ::core::primitive::str = "__typename";
+        }
+        impl cynic::schema::HasField<__typename> for super::super::MutationRoot {
+            type Type = super::super::String;
+        }
+    }
     pub mod RecursiveInputChild {
         pub struct recurse;
         impl cynic::schema::Field for recurse {
@@ -381,3 +426,4 @@ pub mod variable {
         const TYPE: VariableType = VariableType::Named("ID");
     }
 }
+

--- a/cynic-parser/tests/snapshots/actual_schemas__test_cases__snapshot.snap
+++ b/cynic-parser/tests/snapshots/actual_schemas__test_cases__snapshot.snap
@@ -1,10 +1,10 @@
 ---
 source: cynic-parser/tests/actual_schemas.rs
 expression: parsed.to_sdl_pretty()
-snapshot_kind: text
 ---
 schema {
   query: Foo
+  mutation: MutationRoot
 }
 
 type Foo {
@@ -62,3 +62,13 @@ type FieldNameClashes {
   i32: Int
   u32: Int
 }
+
+type MutationRoot {
+  sendManyBaz(many_baz: [Baz!]!): Int!
+}
+
+input Baz {
+  id: ID!
+  aString: String!
+}
+

--- a/cynic/tests/mutation_generics.rs
+++ b/cynic/tests/mutation_generics.rs
@@ -1,56 +1,41 @@
+use cynic::MutationBuilder;
 use std::borrow::Cow;
 
 #[allow(non_snake_case, non_camel_case_types)]
-mod schema {
+mod raindancer {
     cynic::use_schema!("../schemas/raindancer.graphql");
 }
 
-#[derive(cynic::QueryVariables, Debug)]
-pub struct SignInVariables<'a> {
-    pub input: SignInInput<'a, Cow<'a, str>>,
-}
-
-#[derive(cynic::QueryVariables, Debug)]
-pub struct SignInVariablesMoreGeneric<'a, Username: cynic::schema::IsScalar<String>> {
-    #[cynic(graphql_type = "SignInInput")]
-    pub input: SignInInput<'a, Username>,
-}
-
 #[derive(cynic::InputObject, Debug)]
-#[cynic(schema_path = "../schemas/raindancer.graphql")]
+#[cynic(
+    schema_path = "../schemas/raindancer.graphql",
+    schema_module = "raindancer"
+)]
 pub struct SignInInput<'a, Username: cynic::schema::IsScalar<String>> {
     pub password: &'a str,
     pub username: Username,
 }
 
-#[derive(cynic::QueryFragment, Debug)]
-#[cynic(
-    graphql_type = "MutationRoot",
-    variables = "SignInVariables",
-    schema_path = "../schemas/raindancer.graphql"
-)]
-pub struct SignIn {
-    #[arguments(input: $input)]
-    pub sign_in: String,
-}
-
-#[derive(cynic::QueryFragment, Debug)]
-#[cynic(
-    graphql_type = "MutationRoot",
-    variables = "SignInVariablesMoreGeneric",
-    schema_path = "../schemas/raindancer.graphql"
-)]
-pub struct SignInMoreGeneric<SI: cynic::schema::IsScalar<String>>
-where
-    <SI as cynic::schema::IsScalar<String>>::SchemaType: cynic::queries::IsFieldType<String>,
-{
-    #[arguments(input: $input)]
-    pub sign_in: SI,
-}
-
 #[test]
 fn test_query_building() {
-    use cynic::MutationBuilder;
+    #[derive(cynic::QueryFragment, Debug)]
+    #[cynic(
+        graphql_type = "MutationRoot",
+        variables = "SignInVariables",
+        schema_path = "../schemas/raindancer.graphql",
+        schema_module = "raindancer"
+    )]
+    pub struct SignIn {
+        #[arguments(input: $input)]
+        #[allow(dead_code)]
+        pub sign_in: String,
+    }
+
+    #[derive(cynic::QueryVariables, Debug)]
+    #[cynic(schema_module = "raindancer")]
+    pub struct SignInVariables<'a> {
+        pub input: SignInInput<'a, Cow<'a, str>>,
+    }
 
     let operation = SignIn::build(SignInVariables {
         input: SignInInput {
@@ -66,11 +51,80 @@ fn test_query_building() {
 fn test_query_building_more_generic() {
     use cynic::MutationBuilder;
 
+    #[derive(cynic::QueryFragment, Debug)]
+    #[cynic(
+        graphql_type = "MutationRoot",
+        variables = "SignInVariablesMoreGeneric",
+        schema_path = "../schemas/raindancer.graphql",
+        schema_module = "raindancer"
+    )]
+    pub struct SignInMoreGeneric<SI: cynic::schema::IsScalar<String>>
+    where
+        <SI as cynic::schema::IsScalar<String>>::SchemaType: cynic::queries::IsFieldType<String>,
+    {
+        #[arguments(input: $input)]
+        #[allow(dead_code)]
+        pub sign_in: SI,
+    }
+    #[derive(cynic::QueryVariables, Debug)]
+    #[cynic(schema_module = "raindancer")]
+    pub struct SignInVariablesMoreGeneric<'a, Username: cynic::schema::IsScalar<String>> {
+        #[cynic(graphql_type = "SignInInput")]
+        pub input: SignInInput<'a, Username>,
+    }
+
     let operation = SignInMoreGeneric::<Cow<'static, str>>::build(SignInVariablesMoreGeneric {
         input: SignInInput {
             password: "password!",
             username: &&&"username",
         },
+    });
+
+    insta::assert_snapshot!(operation.query);
+}
+
+#[allow(non_snake_case, non_camel_case_types)]
+mod test_cases {
+    cynic::use_schema!("../schemas/test_cases.graphql");
+}
+
+#[test]
+fn test_query_building_nested_generic_in_vec() {
+    #[derive(cynic::QueryFragment, Debug)]
+    #[cynic(
+        graphql_type = "MutationRoot",
+        variables = "SendManyBazVariables",
+        schema_path = "../schemas/test_cases.graphql",
+        schema_module = "test_cases"
+    )]
+    pub struct SendManyBaz {
+        #[arguments(many_baz: $many_baz)]
+        #[allow(dead_code)]
+        pub send_many_baz: Option<i32>,
+    }
+
+    #[derive(cynic::QueryVariables, Debug)]
+    #[cynic(schema_module = "test_cases")]
+    pub struct SendManyBazVariables<'a, Id: cynic::schema::IsScalar<cynic::Id>> {
+        #[cynic(graphql_type = "Vec<test_cases::Baz>")]
+        pub many_baz: Vec<Baz<'a, Id>>,
+    }
+
+    #[derive(cynic::InputObject, Debug)]
+    #[cynic(
+        schema_path = "../schemas/test_cases.graphql",
+        schema_module = "test_cases"
+    )]
+    pub struct Baz<'a, Id: cynic::schema::IsScalar<cynic::Id>> {
+        pub id: Id,
+        pub a_string: &'a str,
+    }
+
+    let operation = SendManyBaz::build(SendManyBazVariables {
+        many_baz: vec![Baz {
+            id: cynic::Id::new("some-totally-correct-id"),
+            a_string: "baz",
+        }],
     });
 
     insta::assert_snapshot!(operation.query);

--- a/cynic/tests/snapshots/mutation_generics__query_building_nested_generic_in_vec.snap
+++ b/cynic/tests/snapshots/mutation_generics__query_building_nested_generic_in_vec.snap
@@ -1,0 +1,8 @@
+---
+source: cynic/tests/mutation_generics.rs
+expression: operation.query
+---
+mutation SendManyBaz($manyBaz: [Baz!]!) {
+  sendManyBaz(many_baz: $manyBaz)
+}
+

--- a/schemas/test_cases.graphql
+++ b/schemas/test_cases.graphql
@@ -1,5 +1,6 @@
 schema {
   query: Foo
+  mutation: MutationRoot
 }
 
 type Foo {
@@ -60,4 +61,12 @@ type FieldNameClashes {
   bool: Boolean
   i32: Int
   u32: Int
+}
+
+type MutationRoot {
+  sendManyBaz(many_baz: [Baz!]!): Int!
+}
+input Baz {
+  id: ID!
+  aString: String! # TODO fix the nullable string case here
 }


### PR DESCRIPTION
#### Why are we making this change?

Prior to this change there would be no way to have QueryVariables have nested generics (specifically `Vec` or `Option`), it could only be directly the generic type itself.

#### What effects does this change have?

This extends support of the `#[cynic(graphql_type = _)]` to all paths instead of just idents, so that we can now specify e.g. `Vec<schema::Baz>`:
```rust
    #[derive(cynic::QueryVariables, Debug)]
    #[cynic(schema_module = "test_cases")]
    pub struct SendManyBazVariables<'a, Id: cynic::schema::IsScalar<cynic::Id>> {
        #[cynic(graphql_type = "Vec<test_cases::Baz>")]
        pub many_baz: Vec<Baz<'a, Id>>,
    }
```
