### PR TITLE
fix: support `&str` for `String` input fields

### DIFF
--- a/cynic-codegen/tests/snapshots/use_schema__test_cases.graphql.snap
+++ b/cynic-codegen/tests/snapshots/use_schema__test_cases.graphql.snap
@@ -1,6 +1,7 @@
 ---
 source: cynic-codegen/tests/use-schema.rs
 expression: "format_code(format!(\"{}\", tokens))"
+snapshot_kind: text
 ---
 impl cynic::schema::QueryRoot for Foo {}
 impl cynic::schema::MutationRoot for MutationRoot {}
@@ -104,6 +105,15 @@ pub mod __fields {
             const NAME: &'static ::core::primitive::str = "aString";
         }
         impl cynic::schema::HasInputField<aString, super::super::String> for super::super::Baz {}
+        pub struct anOptionalString;
+        impl cynic::schema::Field for anOptionalString {
+            type Type = Option<super::super::String>;
+            const NAME: &'static ::core::primitive::str = "anOptionalString";
+        }
+        impl cynic::schema::HasInputField<anOptionalString, Option<super::super::String>>
+            for super::super::Baz
+        {
+        }
     }
     pub mod FieldNameClashes {
         pub struct str;
@@ -426,4 +436,3 @@ pub mod variable {
         const TYPE: VariableType = VariableType::Named("ID");
     }
 }
-

--- a/cynic-parser/tests/snapshots/actual_schemas__test_cases__snapshot.snap
+++ b/cynic-parser/tests/snapshots/actual_schemas__test_cases__snapshot.snap
@@ -1,6 +1,7 @@
 ---
 source: cynic-parser/tests/actual_schemas.rs
 expression: parsed.to_sdl_pretty()
+snapshot_kind: text
 ---
 schema {
   query: Foo
@@ -70,5 +71,5 @@ type MutationRoot {
 input Baz {
   id: ID!
   aString: String!
+  anOptionalString: String
 }
-

--- a/schemas/test_cases.graphql
+++ b/schemas/test_cases.graphql
@@ -68,5 +68,6 @@ type MutationRoot {
 }
 input Baz {
   id: ID!
-  aString: String! # TODO fix the nullable string case here
+  aString: String!
+  anOptionalString: String
 }


### PR DESCRIPTION
Previously this would cause a compile error as we generated a type marker of `&Option<str>` rather than `Option<&str>` - which would fail as the `Option<T>` has a `T: Sized` bound.