### PR TITLE
fix: expose more of the queries::builders types.

### DIFF
--- a/cynic/src/queries/builders.rs
+++ b/cynic/src/queries/builders.rs
@@ -285,6 +285,7 @@ impl<'a, SchemaType, VariablesFields> InlineFragmentBuilder<'a, SchemaType, Vari
     }
 }
 
+/// Builds an input (usually an argument or a type nested inside an argument) in a query
 pub struct InputBuilder<'a, SchemaType, VariablesFields> {
     destination: InputLiteralContainer<'a>,
     context: BuilderContext<'a>,
@@ -464,6 +465,7 @@ impl<'a> InputLiteralContainer<'a> {
     }
 }
 
+/// Builds a directive in a query
 pub struct DirectiveBuilder<'a, DirectiveMarker, VariablesFields> {
     arguments: &'a mut Vec<Argument>,
     context: BuilderContext<'a>,

--- a/cynic/src/queries/mod.rs
+++ b/cynic/src/queries/mod.rs
@@ -15,7 +15,10 @@ use crate::QueryVariableLiterals;
 
 pub use self::{
     ast::{Argument, InputLiteral, SelectionSet},
-    builders::{SelectionBuilder, VariableMatch},
+    builders::{
+        DirectiveBuilder, FieldSelectionBuilder, InlineFragmentBuilder, InputBuilder,
+        SelectionBuilder, VariableMatch,
+    },
     flatten::FlattensInto,
     input_literal_ser::to_input_literal,
     recurse::Recursable,


### PR DESCRIPTION
A lot of these are used by the derives and will be useful for generating dynamic queries, but don't appear in the documentation because they're not public enough.