### PR TITLE
feat: get reference for `run_graphql` function

### DIFF
--- a/cynic-cli/src/introspect.rs
+++ b/cynic-cli/src/introspect.rs
@@ -17,7 +17,7 @@ pub(crate) fn introspect(args: IntrospectArgs) -> Result<(), IntrospectError> {
 
     let response = client
         .build(&args)?
-        .run_graphql(IntrospectionQuery::with_capabilities(capabilities))?;
+        .run_graphql(&IntrospectionQuery::with_capabilities(capabilities))?;
 
     let errors = response.errors.unwrap_or_default();
     if !errors.is_empty() {
@@ -86,7 +86,7 @@ fn detect_capabilities(
 
     let capabilities = client
         .build(args)?
-        .run_graphql(CapabilitiesQuery::build(()))?
+        .run_graphql(&CapabilitiesQuery::build(()))?
         .data
         .ok_or(IntrospectError::GraphQlError)?
         .capabilities();

--- a/cynic-introspection/src/detection.rs
+++ b/cynic-introspection/src/detection.rs
@@ -25,7 +25,7 @@ use super::query::schema;
 ///
 /// let data = reqwest::Client::new()
 ///     .post(url)
-///     .run_graphql(CapabilitiesQuery::build(()))
+///     .run_graphql(&CapabilitiesQuery::build(()))
 ///     .await
 ///     .unwrap()
 ///     .data

--- a/cynic-introspection/src/lib.rs
+++ b/cynic-introspection/src/lib.rs
@@ -21,7 +21,7 @@
 //! // We can run an introspection query and unwrap the data contained within
 //! let introspection_data = reqwest::Client::new()
 //!     .post(url)
-//!     .run_graphql(IntrospectionQuery::build(()))
+//!     .run_graphql(&IntrospectionQuery::build(()))
 //!     .await
 //!     .unwrap()
 //!     .data
@@ -54,7 +54,7 @@
 //! let introspection_data = reqwest::blocking::Client::new()
 //!     .post("https://spacex-production.up.railway.app/")
 //!     .run_graphql(
-//!         IntrospectionQuery::with_capabilities(
+//!         &IntrospectionQuery::with_capabilities(
 //!             SpecificationVersion::October2021.capabilities()
 //!         )
 //!     )
@@ -86,7 +86,7 @@
 //! // First we run a capabilites query to check what the server supports
 //! let capabilities = reqwest::Client::new()
 //!     .post(url)
-//!     .run_graphql(CapabilitiesQuery::build(()))
+//!     .run_graphql(&CapabilitiesQuery::build(()))
 //!     .await
 //!     .unwrap()
 //!     .data
@@ -96,7 +96,7 @@
 //! // Now we can safely run introspection, only querying for what the server supports.
 //! let introspection_data = reqwest::Client::new()
 //!     .post(url)
-//!     .run_graphql(IntrospectionQuery::with_capabilities(capabilities))
+//!     .run_graphql(&IntrospectionQuery::with_capabilities(capabilities))
 //!     .await
 //!     .unwrap()
 //!     .data

--- a/cynic-introspection/tests/sdl_tests.rs
+++ b/cynic-introspection/tests/sdl_tests.rs
@@ -11,7 +11,7 @@ async fn test_starwars_sdl_conversion() {
 
     let result = reqwest::Client::new()
         .post(mock_server.url())
-        .run_graphql(query)
+        .run_graphql(&query)
         .await
         .unwrap();
 
@@ -31,7 +31,7 @@ fn test_spacex_sdl_conversion() {
 
     let result = reqwest::blocking::Client::new()
         .post("https://spacex-production.up.railway.app/")
-        .run_graphql(query)
+        .run_graphql(&query)
         .unwrap();
 
     if result.errors.is_some() {

--- a/cynic-introspection/tests/tests.rs
+++ b/cynic-introspection/tests/tests.rs
@@ -22,7 +22,7 @@ async fn test_running_2018_query() {
 
     let result = reqwest::Client::new()
         .post(mock_server.url())
-        .run_graphql(query)
+        .run_graphql(&query)
         .await
         .unwrap();
 
@@ -41,7 +41,7 @@ async fn test_2018_schema_conversion() {
 
     let result = reqwest::Client::new()
         .post(mock_server.url())
-        .run_graphql(query)
+        .run_graphql(&query)
         .await
         .unwrap();
 
@@ -69,7 +69,7 @@ async fn test_running_2021_query() {
 
     let result = reqwest::Client::new()
         .post(mock_server.url())
-        .run_graphql(query)
+        .run_graphql(&query)
         .await
         .unwrap();
 
@@ -88,7 +88,7 @@ async fn test_2021_schema_conversion() {
 
     let result = reqwest::Client::new()
         .post(mock_server.url())
-        .run_graphql(query)
+        .run_graphql(&query)
         .await
         .unwrap();
 

--- a/cynic/src/http.rs
+++ b/cynic/src/http.rs
@@ -57,7 +57,7 @@ mod surf_ext {
     /// let operation = FilmDirectorQuery::build(());
     ///
     /// let response = surf::post("https://swapi-graphql.netlify.app/.netlify/functions/index")
-    ///     .run_graphql(operation)
+    ///     .run_graphql(&operation)
     ///     .await
     ///     .unwrap();
     ///
@@ -76,7 +76,7 @@ mod surf_ext {
         /// the response and returns the result.
         fn run_graphql<ResponseData, Vars>(
             self,
-            operation: Operation<ResponseData, Vars>,
+            operation: &Operation<ResponseData, Vars>,
         ) -> BoxFuture<'static, Result<GraphQlResponse<ResponseData>, surf::Error>>
         where
             Vars: serde::Serialize,
@@ -86,13 +86,13 @@ mod surf_ext {
     impl SurfExt for surf::RequestBuilder {
         fn run_graphql<ResponseData, Vars>(
             self,
-            operation: Operation<ResponseData, Vars>,
+            operation: &Operation<ResponseData, Vars>,
         ) -> BoxFuture<'static, Result<GraphQlResponse<ResponseData>, surf::Error>>
         where
             Vars: serde::Serialize,
             ResponseData: serde::de::DeserializeOwned + 'static,
         {
-            let operation = json!(&operation);
+            let operation = json!(operation);
             Box::pin(async move {
                 let mut response = self.body(operation).await?;
 
@@ -175,7 +175,7 @@ mod reqwest_ext {
     ///
     /// let client = reqwest::Client::new();
     /// let response = client.post("https://swapi-graphql.netlify.app/.netlify/functions/index")
-    ///     .run_graphql(operation)
+    ///     .run_graphql(&operation)
     ///     .await
     ///     .unwrap();
     ///
@@ -194,7 +194,7 @@ mod reqwest_ext {
         /// the and returns the result.
         fn run_graphql<ResponseData, Vars>(
             self,
-            operation: Operation<ResponseData, Vars>,
+            operation: &Operation<ResponseData, Vars>,
         ) -> CynicReqwestBuilder<ResponseData>
         where
             Vars: serde::Serialize,
@@ -287,13 +287,13 @@ mod reqwest_ext {
     impl ReqwestExt for reqwest::RequestBuilder {
         fn run_graphql<ResponseData, Vars>(
             self,
-            operation: Operation<ResponseData, Vars>,
+            operation: &Operation<ResponseData, Vars>,
         ) -> CynicReqwestBuilder<ResponseData>
         where
             Vars: serde::Serialize,
             ResponseData: serde::de::DeserializeOwned + 'static,
         {
-            CynicReqwestBuilder::new(self.json(&operation))
+            CynicReqwestBuilder::new(self.json(operation))
         }
     }
 }
@@ -337,7 +337,7 @@ mod reqwest_blocking_ext {
     ///
     /// let client = reqwest::blocking::Client::new();
     /// let response = client.post("https://swapi-graphql.netlify.app/.netlify/functions/index")
-    ///     .run_graphql(operation)
+    ///     .run_graphql(&operation)
     ///     .unwrap();
     ///
     /// println!(
@@ -354,7 +354,7 @@ mod reqwest_blocking_ext {
         /// the and returns the result.
         fn run_graphql<ResponseData, Vars>(
             self,
-            operation: Operation<ResponseData, Vars>,
+            operation: &Operation<ResponseData, Vars>,
         ) -> Result<GraphQlResponse<ResponseData>, CynicReqwestError>
         where
             Vars: serde::Serialize,
@@ -364,13 +364,13 @@ mod reqwest_blocking_ext {
     impl ReqwestBlockingExt for reqwest::blocking::RequestBuilder {
         fn run_graphql<ResponseData, Vars>(
             self,
-            operation: Operation<ResponseData, Vars>,
+            operation: &Operation<ResponseData, Vars>,
         ) -> Result<GraphQlResponse<ResponseData>, CynicReqwestError>
         where
             Vars: serde::Serialize,
             ResponseData: serde::de::DeserializeOwned + 'static,
         {
-            let response = self.json(&operation).send()?;
+            let response = self.json(operation).send()?;
 
             let status = response.status();
             if !status.is_success() {

--- a/cynic/tests/http.rs
+++ b/cynic/tests/http.rs
@@ -51,7 +51,7 @@ async fn test_reqwest_extensions() {
     let client = reqwest::Client::new();
     let output = client
         .get(format!("http://{}/graphql", graphql.host_with_port()))
-        .run_graphql(FieldWithString::build(FieldWithStringVariables {
+        .run_graphql(&FieldWithString::build(FieldWithStringVariables {
             input: "InputGoesHere",
         }))
         .retain_extensions::<Extensions>()
@@ -98,7 +98,7 @@ async fn test_reqwest_ignored() {
     let client = reqwest::Client::new();
     let output = client
         .get(format!("http://{}/graphql", graphql.host_with_port()))
-        .run_graphql(FieldWithString::build(FieldWithStringVariables {
+        .run_graphql(&FieldWithString::build(FieldWithStringVariables {
             input: "InputGoesHere",
         }))
         .await;

--- a/examples/examples/chrono-scalars.rs
+++ b/examples/examples/chrono-scalars.rs
@@ -39,7 +39,7 @@ fn run_query() -> cynic::GraphQlResponse<JobsQuery> {
 
     reqwest::blocking::Client::new()
         .post("https://api.graphql.jobs")
-        .run_graphql(query)
+        .run_graphql(&query)
         .unwrap()
 }
 

--- a/examples/examples/github-mutation.rs
+++ b/examples/examples/github-mutation.rs
@@ -27,7 +27,7 @@ fn run_query() -> cynic::GraphQlResponse<CommentOnMutationSupportIssue> {
         .post("https://api.github.com/graphql")
         .header("Authorization", format!("Bearer {}", token))
         .header("User-Agent", "obmarg")
-        .run_graphql(query)
+        .run_graphql(&query)
         .unwrap()
 }
 

--- a/examples/examples/github.rs
+++ b/examples/examples/github.rs
@@ -27,7 +27,7 @@ fn run_query() -> cynic::GraphQlResponse<PullRequestTitles> {
         .post("https://api.github.com/graphql")
         .header("Authorization", format!("Bearer {}", token))
         .header("User-Agent", "obmarg")
-        .run_graphql(query)
+        .run_graphql(&query)
         .unwrap()
 }
 

--- a/examples/examples/querying-interfaces.rs
+++ b/examples/examples/querying-interfaces.rs
@@ -77,7 +77,7 @@ fn run_query(url: &str, id: cynic::Id) -> cynic::GraphQlResponse<Query> {
 
     reqwest::blocking::Client::new()
         .post(url)
-        .run_graphql(query)
+        .run_graphql(&query)
         .unwrap()
 }
 

--- a/examples/examples/reqwest-async.rs
+++ b/examples/examples/reqwest-async.rs
@@ -47,7 +47,7 @@ async fn run_query(url: &str) -> cynic::GraphQlResponse<FilmDirectorQuery> {
 
     reqwest::Client::new()
         .post(url)
-        .run_graphql(query)
+        .run_graphql(&query)
         .await
         .unwrap()
 }

--- a/examples/examples/spread.rs
+++ b/examples/examples/spread.rs
@@ -63,7 +63,7 @@ fn run_query(url: &str) -> cynic::GraphQlResponse<FilmDirectorQuery> {
 
     reqwest::blocking::Client::new()
         .post(url)
-        .run_graphql(query)
+        .run_graphql(&query)
         .unwrap()
 }
 

--- a/examples/examples/starwars.rs
+++ b/examples/examples/starwars.rs
@@ -40,7 +40,7 @@ fn run_query(url: &str) -> cynic::GraphQlResponse<FilmDirectorQuery> {
 
     reqwest::blocking::Client::new()
         .post(url)
-        .run_graphql(query)
+        .run_graphql(&query)
         .unwrap()
 }
 

--- a/examples/examples/surf-client.rs
+++ b/examples/examples/surf-client.rs
@@ -46,7 +46,7 @@ async fn run_query(url: &str) -> cynic::GraphQlResponse<FilmDirectorQuery> {
 
     let operation = build_query();
 
-    surf::post(url).run_graphql(operation).await.unwrap()
+    surf::post(url).run_graphql(&operation).await.unwrap()
 }
 
 fn build_query() -> cynic::Operation<FilmDirectorQuery, FilmArguments> {


### PR DESCRIPTION
#### Why are we making this change?

I want to retry with sleep in case the server return 5xx.
I tried couple of things:
1. clone the operation `cynic::Operation` but it is not clonable.
2. Copy `ReqwestExt` and change it to get a reference - I can't because `CynicReqwestBuilder` is internal

#### What effects does this change have?

This is a breaking change!


----

I now see there is an example of how to do manual request, but I still think this should get a ref so keeping the PR