### PR TITLE
feat(derive): support rename_all on `#[derive(QueryFragment)]`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ## Unreleased - xxxx-xx-xx
 
+### New features
+
+- The `QueryFragment` derive now supports the `rename_all` attribute
+
 ## v3.12.0 - 2025-08-19
 
 ### New Features

--- a/cynic-book/src/derives/query-fragments.md
+++ b/cynic-book/src/derives/query-fragments.md
@@ -212,6 +212,14 @@ Cynic provides build in support for the `skip` & `include` directives. Any
 other field directives can also be used, provided they don't require special
 support from the client.
 
+### Field Naming
+
+It's a common GraphQL convention for fields to be named in `camelCase`. To
+handle this smoothly, Cynic matches rust fields up to their equivalent
+`camelCase` GraphQL fields. This behaviour can be disabled by
+specifying a `rename_all = "None"` attribute, or customised via alternative
+`rename_all` values or individual `rename` attributes on the fields.
+
 #### Struct Attributes
 
 A QueryFragment can be configured with several attributes on the struct itself:
@@ -233,6 +241,9 @@ A QueryFragment can be configured with several attributes on the struct itself:
   cases where you wish to do this yourself. Note that it is your responsibility
   to ensure the Deserialize impl is correct: many of cynics guarantees only hold
   when cynic generates the Deserialize impl.
+- `rename_all="camelCase"` tells cynic to rename all the rust field names with
+  a particular rule to match their GraphQL counterparts. If not provided this
+  defaults to camelCase to be consistent with GraphQL conventions.
 
 #### Field Attributes
 

--- a/cynic/tests/query-fragment-field-renames.rs
+++ b/cynic/tests/query-fragment-field-renames.rs
@@ -1,0 +1,92 @@
+#![allow(non_snake_case)]
+
+mod schema {
+    cynic::use_schema!("../schemas/renames.graphql");
+}
+
+#[derive(Debug, PartialEq, cynic::QueryFragment)]
+#[cynic(
+    schema_path = "../schemas/renames.graphql",
+    graphql_type = "TestStruct"
+)]
+struct DefaultCamelCaseNames {
+    #[cynic(rename = "is_snake_case")]
+    renamed: i32,
+    is_camel_case: i32,
+}
+
+#[derive(Debug, PartialEq, cynic::QueryFragment)]
+#[cynic(
+    schema_path = "../schemas/renames.graphql",
+    graphql_type = "TestStruct",
+    rename_all = "camelCase"
+)]
+struct ExplicitCamelCaseNames {
+    #[cynic(rename = "is_snake_case")]
+    renamed: i32,
+    is_camel_case: i32,
+}
+
+#[derive(Debug, PartialEq, cynic::QueryFragment)]
+#[cynic(
+    schema_path = "../schemas/renames.graphql",
+    graphql_type = "TestStruct",
+    rename_all = "snake_case"
+)]
+struct SnakeCaseNames {
+    isSnakeCase: i32,
+    #[cynic(rename = "isCamelCase")]
+    renamed: i32,
+}
+
+#[derive(Debug, PartialEq, cynic::QueryFragment)]
+#[cynic(
+    schema_path = "../schemas/renames.graphql",
+    graphql_type = "TestStruct",
+    rename_all = "none"
+)]
+struct NoRenameAllNames {
+    is_snake_case: i32,
+    #[cynic(rename = "isCamelCase")]
+    renamed: i32,
+}
+
+#[test]
+fn test_renames() {
+    let val = serde_json::json!({
+        "is_snake_case": 1,
+        "isCamelCase": 2
+    });
+
+    assert_eq!(
+        serde_json::from_value::<DefaultCamelCaseNames>(val.clone()).unwrap(),
+        DefaultCamelCaseNames {
+            renamed: 1,
+            is_camel_case: 2,
+        }
+    );
+
+    assert_eq!(
+        serde_json::from_value::<ExplicitCamelCaseNames>(val.clone()).unwrap(),
+        ExplicitCamelCaseNames {
+            renamed: 1,
+            is_camel_case: 2,
+        }
+    );
+
+    assert_eq!(
+        serde_json::from_value::<SnakeCaseNames>(val.clone()).unwrap(),
+        SnakeCaseNames {
+            isSnakeCase: 1,
+            renamed: 2,
+        }
+    );
+
+    assert_eq!(
+        serde_json::from_value::<NoRenameAllNames>(val.clone()).unwrap(),
+        NoRenameAllNames {
+            is_snake_case: 1,
+            renamed: 2,
+        }
+    );
+}

--- a/schemas/renames.graphql
+++ b/schemas/renames.graphql
@@ -1,0 +1,8 @@
+type TestStruct {
+  is_snake_case: Int!
+  isCamelCase: Int!
+}
+
+type Query {
+  test: TestStruct!
+}


### PR DESCRIPTION
#### Why are we making this change?

Closes #374 

Makes the `rename_all` attribute uniformly available on all derives

<!-- Provide details of the context of and justification for this change -->

#### What effects does this change have?

The `QueryFragment` derive now supports the `rename_all` attribute, like the `InputObject` and `Enum` ones

```rust
#[derive(Debug, PartialEq, cynic::QueryFragment)]
#[cynic(
    schema_path = "../schemas/renames.graphql",
    graphql_type = "TestStruct",
    rename_all = "none"
)]
struct NoRenameAllNames {
    is_snake_case: i32,
    #[cynic(rename = "isCamelCase")]
    renamed: i32,
}
```

Default `camelCase` behavior is preserved, no breaking changes 

<!-- Provide details of what this change contains, any new features it introduces (or how it changes existing ones) and any usage details -->
